### PR TITLE
Add REST endpoint under /ws/v1/samza at tracking url

### DIFF
--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/SamzaAppMasterService.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/SamzaAppMasterService.scala
@@ -50,6 +50,7 @@ class SamzaAppMasterService(config: Config, state: SamzaAppMasterState, registry
 
     webApp = new HttpServer(resourceBasePath = "scalate")
     webApp.addServlet("/*", new ApplicationMasterWebServlet(config, state))
+    webApp.addServlet("/ws/v1/samza/*", new ApplicationMasterRestServlet(config, state, registry))
     webApp.start
 
     state.jobCoordinator.start


### PR DESCRIPTION
The Samza AM REST endpoint is currently not available from the RM REST api.  This may be a bug with the RM, but note that:

a) this is not the way the MapReduce AM exposes it's REST endpoint
b) the Samza REST endpoint is currently unversioned (also unlike the RM and MapReduce REST endpoints)
c) the Samza REST endpoint is not using the RM proxy mechanism for security.
