### PR TITLE
Inability to create configured producer should be logged as error

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -195,8 +195,7 @@ object SamzaContainer extends Logging {
             (systemName, systemFactory.getProducer(systemName, config, samzaContainerMetrics.registry))
           } catch {
             case e: Exception =>
-              info("Failed to create a producer for %s, so skipping." format systemName)
-              debug("Exception detail:", e)
+              error("Failed to create a producer for %s, so skipping.".format(systemName), e)
               (systemName, null)
           }
       }


### PR DESCRIPTION
Inability to create configured producer should be logged as error
Also, do not drop the original exception, it makes troubleshooting frustrating.
