### PR TITLE
Removed setting log4j-console.xml as default

### DIFF
--- a/samza-shell/src/main/bash/run-job.sh
+++ b/samza-shell/src/main/bash/run-job.sh
@@ -16,6 +16,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-[[ $JAVA_OPTS != *-Dlog4j.configuration* ]] && export JAVA_OPTS="$JAVA_OPTS -Dlog4j.configuration=file:$(dirname $0)/log4j-console.xml"
-
 exec $(dirname $0)/run-class.sh org.apache.samza.job.JobRunner "$@"


### PR DESCRIPTION
According to the documentation (https://samza.apache.org/learn/documentation/0.10/jobs/logging.html) the `run-class.sh` script should set the default logging behaviour in case custom `log4j.xml` is not previously set. The line that is now removed from `run-job.sh` set the default logging to use the `log4j-console.xml`. This prevented the `run-class.sh` script to set the default logging configuration.