### PR TITLE
SAMZA-1047: testEndOfStreamWithOutOfOrderProcess is flaky

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/task/AsyncRunLoop.java
+++ b/samza-core/src/main/java/org/apache/samza/task/AsyncRunLoop.java
@@ -313,7 +313,6 @@ public class AsyncRunLoop implements Runnable, Throttleable {
     private final TaskInstance<AsyncStreamTask> task;
     private final TaskCallbackManager callbackManager;
     private volatile AsyncTaskState state;
-    private volatile boolean completed = false;
 
 
     AsyncTaskWorker(TaskInstance<AsyncStreamTask> task) {

--- a/samza-core/src/test/java/org/apache/samza/task/TestAsyncRunLoop.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestAsyncRunLoop.java
@@ -367,8 +367,15 @@ public class TestAsyncRunLoop {
     tasks.put(taskName1, t1);
 
     AsyncRunLoop runLoop = createRunLoop();
-    when(consumerMultiplexer.choose(false)).thenReturn(envelope0).thenReturn(envelope1).thenReturn(ssp0EndOfStream).thenReturn(ssp1EndOfStream);
+    when(consumerMultiplexer.choose(false))
+      .thenReturn(envelope0)
+      .thenReturn(envelope1)
+      .thenReturn(ssp0EndOfStream)
+      .thenReturn(ssp1EndOfStream)
+      .thenReturn(null);
+
     runLoop.run();
+
     callbackExecutor.awaitTermination(100, TimeUnit.MILLISECONDS);
     assertEquals(1, task0.processed);
     assertEquals(1, task0.completed.get());
@@ -398,7 +405,8 @@ public class TestAsyncRunLoop {
         .thenReturn(envelope1)
         .thenReturn(null)
         .thenReturn(ssp0EndOfStream)
-        .thenReturn(ssp1EndOfStream);
+        .thenReturn(ssp1EndOfStream)
+        .thenReturn(null);
 
     runLoop.run();
 
@@ -427,7 +435,8 @@ public class TestAsyncRunLoop {
         .thenReturn(envelope1)
         .thenReturn(null)
         .thenReturn(ssp0EndOfStream)
-        .thenReturn(ssp1EndOfStream);
+        .thenReturn(ssp1EndOfStream)
+        .thenReturn(null);
     runLoop.run();
     callbackExecutor.awaitTermination(100, TimeUnit.MILLISECONDS);
     verify(offsetManager).checkpoint(taskName0);

--- a/samza-core/src/test/java/org/apache/samza/task/TestAsyncRunLoop.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestAsyncRunLoop.java
@@ -381,7 +381,6 @@ public class TestAsyncRunLoop {
     assertEquals(1, task0.completed.get());
     assertEquals(1, task1.processed);
     assertEquals(1, task1.completed.get());
-
     assertEquals(4L, containerMetrics.envelopes().getCount());
     assertEquals(2L, containerMetrics.processes().getCount());
   }
@@ -437,7 +436,9 @@ public class TestAsyncRunLoop {
         .thenReturn(ssp0EndOfStream)
         .thenReturn(ssp1EndOfStream)
         .thenReturn(null);
+
     runLoop.run();
+
     callbackExecutor.awaitTermination(100, TimeUnit.MILLISECONDS);
     verify(offsetManager).checkpoint(taskName0);
     verify(offsetManager).checkpoint(taskName1);


### PR DESCRIPTION
Chooser always pools end of stream message until final callback is trigered so process-enelopes metrics didn't match. Changed the test methods to return null envelopes after end of stream message.

Deleted unused boolean variable "completed" in AsyncTaskWorker