### PR TITLE
added new config for job.changelog.system

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/config/StorageConfig.scala
+++ b/samza-core/src/main/scala/org/apache/samza/config/StorageConfig.scala
@@ -19,6 +19,9 @@
 
 package org.apache.samza.config
 
+
+import org.apache.samza.SamzaException
+
 import scala.collection.JavaConversions._
 import org.apache.samza.util.Logging
 import org.apache.samza.util.Util
@@ -49,8 +52,11 @@ class StorageConfig(config: Config) extends ScalaMapConfig(config) with Logging 
             && ! systemStream.getOrElse("").contains('.') // contains only stream name
             && changelogSystem.isDefined) {
       // get the system name
-      Some(changelogSystem.get + "." + systemStream)
+      Some(changelogSystem.get + "." + systemStream.get)
     } else {
+      if(systemStream.isDefined && ! systemStream.getOrElse("").contains('.') && !changelogSystem.isDefined)
+        throw new SamzaException("changelog system is not defined:" + systemStream.get)
+
       systemStream
     }
     systemStreamRes

--- a/samza-core/src/main/scala/org/apache/samza/config/StorageConfig.scala
+++ b/samza-core/src/main/scala/org/apache/samza/config/StorageConfig.scala
@@ -48,17 +48,18 @@ class StorageConfig(config: Config) extends ScalaMapConfig(config) with Logging 
     // these values will be combined into <asystem>.<astream>
     val systemStream = getOption(CHANGELOG_STREAM format name)
     val changelogSystem = getOption(CHANGELOG_SYSTEM)
-    val systemStreamRes = if ( systemStream.isDefined
-            && ! systemStream.getOrElse("").contains('.') // contains only stream name
-            && changelogSystem.isDefined) {
-      // get the system name
-      Some(changelogSystem.get + "." + systemStream.get)
-    } else {
-      if(systemStream.isDefined && ! systemStream.getOrElse("").contains('.') && !changelogSystem.isDefined)
-        throw new SamzaException("changelog system is not defined:" + systemStream.get)
-
-      systemStream
-    }
+    val systemStreamRes =
+      if ( systemStream.isDefined  && ! systemStream.getOrElse("").contains('.')) {
+        // contains only stream name
+        if (changelogSystem.isDefined) {
+          Some(changelogSystem.get + "." + systemStream.get)
+        }
+        else {
+          throw new SamzaException("changelog system is not defined:" + systemStream.get)
+        }
+      } else {
+        systemStream
+      }
     systemStreamRes
   }
 

--- a/samza-core/src/test/scala/org/apache/samza/config/TestStorageConfig.scala
+++ b/samza-core/src/test/scala/org/apache/samza/config/TestStorageConfig.scala
@@ -19,11 +19,15 @@
 
 package org.apache.samza.config
 
+
+import org.junit.Test
+
 import scala.collection.JavaConversions._
 import org.apache.samza.config.StorageConfig._
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
 
 class TestStorageConfig {
   @Test
@@ -45,10 +49,24 @@ class TestStorageConfig {
       CHANGELOG_STREAM.format("store1") -> "system1.stream1",
       CHANGELOG_SYSTEM -> "system2",
       CHANGELOG_STREAM.format("store2") -> "stream2",
+      CHANGELOG_STREAM.format("store4") -> "stream4",
       FACTORY.format("store2") -> "some.factory.Class")
     val config = new MapConfig(configMap)
     assertFalse(config.isChangelogSystem("system3"))
     assertTrue(config.isChangelogSystem("system2"))
     assertTrue(config.isChangelogSystem("system1"))
+
+    assertEquals("system1.stream1", config.getChangelogStream("store1").getOrElse(""));
+    assertEquals("system2.stream2", config.getChangelogStream("store2").getOrElse(""));
+
+    val configMapErr = Map[String, String](CHANGELOG_STREAM.format("store4")->"stream4")
+    val configErr = new MapConfig(configMapErr)
+
+    try {
+      configErr.getChangelogStream("store4").getOrElse("")
+      fail("store4 has no system defined. Should've failed.");
+    } catch {
+       case e: Exception => // do nothing, it is expected
+    }
   }
 }

--- a/samza-core/src/test/scala/org/apache/samza/config/TestStorageConfig.scala
+++ b/samza-core/src/test/scala/org/apache/samza/config/TestStorageConfig.scala
@@ -29,12 +29,26 @@ class TestStorageConfig {
   @Test
   def testIsChangelogSystem {
     val configMap = Map[String, String](
-      FACTORY.format("system1") -> "some.factory.Class",
-      CHANGELOG_STREAM.format("system1") -> "system1.stream1",
-      FACTORY.format("system2") -> "some.factory.Class")
+      FACTORY.format("store1") -> "some.factory.Class",
+      CHANGELOG_STREAM.format("store1") -> "system1.stream1",
+      FACTORY.format("store2") -> "some.factory.Class")
     val config = new MapConfig(configMap)
     assertFalse(config.isChangelogSystem("system3"))
     assertFalse(config.isChangelogSystem("system2"))
+    assertTrue(config.isChangelogSystem("system1"))
+  }
+
+  @Test
+  def testIsChangelogSystemSetting {
+    val configMap = Map[String, String](
+      FACTORY.format("store1") -> "some.factory.Class",
+      CHANGELOG_STREAM.format("store1") -> "system1.stream1",
+      CHANGELOG_SYSTEM -> "system2",
+      CHANGELOG_STREAM.format("store2") -> "stream2",
+      FACTORY.format("store2") -> "some.factory.Class")
+    val config = new MapConfig(configMap)
+    assertFalse(config.isChangelogSystem("system3"))
+    assertTrue(config.isChangelogSystem("system2"))
     assertTrue(config.isChangelogSystem("system1"))
   }
 }


### PR DESCRIPTION
SAMZA-1060.
Allow to specify a changelog system separately, so user can only specify stream name for each store.
If user specifies both (system and stream) it overwrites the job.changelog.system setting.