### PR TITLE
SAMZA-1100: Exception when using a stream as both bootstrap and broadcast.

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -354,7 +354,7 @@ object SamzaContainer extends Logging {
 
     val chooserFactory = Util.getObj[MessageChooserFactory](chooserFactoryClassName)
 
-    val chooser = DefaultChooser(inputStreamMetadata, chooserFactory, config, samzaContainerMetrics.registry)
+    val chooser = DefaultChooser(inputStreamMetadata, chooserFactory, config, samzaContainerMetrics.registry, systemAdmins)
 
     info("Setting up metrics reporters.")
 

--- a/samza-core/src/main/scala/org/apache/samza/system/chooser/BootstrappingChooser.scala
+++ b/samza-core/src/main/scala/org/apache/samza/system/chooser/BootstrappingChooser.scala
@@ -19,7 +19,6 @@
 
 package org.apache.samza.system.chooser
 
-import java.util.concurrent.atomic.AtomicInteger
 import org.apache.samza.system.SystemStream
 import org.apache.samza.system.SystemStreamPartition
 import org.apache.samza.system.IncomingMessageEnvelope
@@ -28,9 +27,11 @@ import org.apache.samza.metrics.MetricsHelper
 import org.apache.samza.metrics.MetricsRegistryMap
 import org.apache.samza.metrics.MetricsRegistry
 import org.apache.samza.system.SystemStreamMetadata
+
 import scala.collection.JavaConversions._
-import org.apache.samza.SamzaException
 import org.apache.samza.system.SystemStreamMetadata.OffsetType
+
+import scala.collection.mutable
 
 /**
  * BootstrappingChooser is a composable MessageChooser that only chooses
@@ -69,7 +70,13 @@ class BootstrappingChooser(
   /**
    * An object that holds all of the metrics related to bootstrapping.
    */
-  metrics: BootstrappingChooserMetrics = new BootstrappingChooserMetrics) extends MessageChooser with Logging {
+  metrics: BootstrappingChooserMetrics = new BootstrappingChooserMetrics,
+
+  /**
+   * A map from system stream name to SystemAdmin that is used for
+   * offset comparisons.
+   */
+  systemAdmins: mutable.Map[String, SystemAdmin] = mutable.Map()) extends MessageChooser with Logging {
 
   /**
    * The number of lagging partitions for each SystemStream that's behind.
@@ -93,7 +100,7 @@ class BootstrappingChooser(
   /**
    * Store all the systemStreamPartitions registered
    */
-  var registeredSystemStreamPartitions = Set[SystemStreamPartition]()
+  var registeredSystemStreamPartitions: mutable.Map[SystemStreamPartition, String] = mutable.Map[SystemStreamPartition, String]()
 
   /**
    * The number of lagging partitions that the underlying wrapped chooser has
@@ -102,8 +109,16 @@ class BootstrappingChooser(
   var updatedSystemStreams = Map[SystemStream, Int]()
 
   def start = {
+    for ((systemStreamPartition, offset) <- registeredSystemStreamPartitions) {
+      // If the offset we're starting to consume from is the same as the upcoming
+      // offset for this system stream partition, then we've already read all
+      // messages in the stream, and we're at head for this system stream
+      // partition.
+      checkOffset(systemStreamPartition, offset, OffsetType.UPCOMING)
+    }
+
     // remove the systemStreamPartitions not registered.
-    laggingSystemStreamPartitions = laggingSystemStreamPartitions.filter(registeredSystemStreamPartitions.contains(_))
+    laggingSystemStreamPartitions = laggingSystemStreamPartitions.filter(registeredSystemStreamPartitions.keys.contains(_))
     systemStreamLagCounts = laggingSystemStreamPartitions.groupBy(_.getSystemStream).map {case (systemStream, ssps) => systemStream -> ssps.size}
 
     debug("Starting bootstrapping chooser with bootstrap metadata: %s" format bootstrapStreamMetadata)
@@ -120,15 +135,25 @@ class BootstrappingChooser(
   override def register(systemStreamPartition: SystemStreamPartition, offset: String) {
     debug("Registering stream partition with offset: %s, %s" format (systemStreamPartition, offset))
 
-    // If the offset we're starting to consume from is the same as the upcoming 
-    // offset for this system stream partition, then we've already read all
-    // messages in the stream, and we're at head for this system stream 
-    // partition.
-    checkOffset(systemStreamPartition, offset, OffsetType.UPCOMING)
-
     wrapped.register(systemStreamPartition, offset)
 
-    registeredSystemStreamPartitions += systemStreamPartition
+    val systemStream = systemStreamPartition.getSystem
+    val systemAdmin: SystemAdmin = systemAdmins.getOrElse(systemStream,
+                                                          throw new SamzaException("SystemAdmin is undefined for SystemStream: %s" format systemStream))
+    /**
+     * SAMZA-1100: When a input SystemStream is consumed as both bootstrap and broadcast
+     * BootstrappingChooser should record the lowest offset for each registered SystemStreamPartition.
+     * When multiple tasks processing a SystemStreamPartition runs within a container
+     * and share the same chooser, then the lowest offset should be chosen as starting offset.
+     */
+    if (!registeredSystemStreamPartitions.contains(systemStreamPartition)) {
+      registeredSystemStreamPartitions += systemStreamPartition -> offset
+    } else if (offset != null) {
+      val comparatorResult: Integer = systemAdmin.offsetComparator(registeredSystemStreamPartitions(systemStreamPartition), offset)
+      if (comparatorResult != null && comparatorResult > 0) {
+        registeredSystemStreamPartitions += systemStreamPartition -> offset
+      }
+    }
   }
 
   def update(envelope: IncomingMessageEnvelope) {

--- a/samza-core/src/test/scala/org/apache/samza/system/chooser/TestDefaultChooser.scala
+++ b/samza-core/src/test/scala/org/apache/samza/system/chooser/TestDefaultChooser.scala
@@ -21,6 +21,8 @@ package org.apache.samza.system.chooser
 
 import org.apache.samza.Partition
 import org.apache.samza.config.{DefaultChooserConfig, MapConfig}
+import org.apache.samza.container.MockSystemAdmin
+import org.apache.samza.metrics.MetricsRegistryMap
 import org.apache.samza.system.SystemStreamMetadata.SystemStreamPartitionMetadata
 import org.apache.samza.system.{IncomingMessageEnvelope, SystemStream, SystemStreamMetadata, SystemStreamPartition}
 import org.apache.samza.util.BlockingEnvelopeMap
@@ -66,7 +68,9 @@ class TestDefaultChooser {
         1 -> mock2),
       Map(
         envelope1.getSystemStreamPartition.getSystemStream -> streamMetadata,
-        envelope8.getSystemStreamPartition.getSystemStream -> stream3Metadata))
+        envelope8.getSystemStreamPartition.getSystemStream -> stream3Metadata),
+      new MetricsRegistryMap(),
+      Map("kafka" -> new MockSystemAdmin()))
 
     chooser.register(envelope1.getSystemStreamPartition, null)
     chooser.register(envelope2.getSystemStreamPartition, null)


### PR DESCRIPTION
When a task input stream is used as both broadcast and bootstrap stream in a samza job, Bootstrappingchooser marks the stream as bootstrapped when a single task finishes consuming all the SystemStreamPartitions(This happens when all the starting offset for each partition in the input stream is of type upcoming). This patch fixes this, by marking a stream as bootstrapped, only when all the systemStreamPartitions in a input stream is consumed by all the expected tasks.

More details here : https://issues.apache.org/jira/browse/SAMZA-1100 