### PR TITLE
SAMZA-1085: adding the samza-yarn dependency on httpClient and bouncyCastle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -320,6 +320,10 @@ project(":samza-yarn_$scalaVersion") {
     compile "org.scala-lang:scala-compiler:$scalaLibVersion"
     compile "org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion"
     compile "commons-httpclient:commons-httpclient:$commonsHttpClientVersion"
+    compile "org.apache.httpcomponents:httpcore:$httpClientVersion"
+    compile "org.apache.httpcomponents:httpclient:$httpClientVersion"
+    compile "org.bouncycastle:bcpkix-jdk15on:$bouncyCastleVersion"
+    compile "org.bouncycastle:bcprov-jdk15on:$bouncyCastleVersion"
     compile("org.apache.hadoop:hadoop-yarn-api:$yarnVersion") {
       exclude module: 'slf4j-log4j12'
     }

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -39,4 +39,5 @@
   commonsCollectionVersion = "3.2.1"
   httpClientVersion="4.4.1"
   commonsLang3Version="3.4"
+  bouncyCastleVersion="1.54"
 }


### PR DESCRIPTION
httpClient-4.4.1 and httpCore-4.4.1 are used for https post request in CSR.
bcpkix-jdk15on-1.54 and bcprov-jdk15on-1.54 from bouncyCastle are used for json parsing on CSR request/response. 