### PR TITLE
SAMZA-1117 set up certificate signing request in the context for resource localization

### DIFF
--- a/samza-yarn/src/main/java/org/apache/samza/config/YarnConfig.java
+++ b/samza-yarn/src/main/java/org/apache/samza/config/YarnConfig.java
@@ -26,6 +26,8 @@ public class YarnConfig extends MapConfig {
    * (Required) URL from which the job package can be downloaded
    */
   public static final String PACKAGE_PATH = "yarn.package.path";
+  public static final String CSR_SSL_REQUEST_PATH = "csr.ssl.request.path";
+  public static final String CSR_SSL_APPCERT_NAME = "csr.ssl.appcert.name";
 
   // Configs related to each yarn container
   /**
@@ -33,6 +35,11 @@ public class YarnConfig extends MapConfig {
    */
   public static final String CONTAINER_MAX_MEMORY_MB = "yarn.container.memory.mb";
   private static final int DEFAULT_CONTAINER_MEM = 1024;
+
+  /**
+   * default App certificate name used for the samza applications
+   */
+  private static final String DEFAULT_APP_CERT_NAME = "identity";
 
   /**
    * Name of YARN queue to run jobs on
@@ -184,6 +191,18 @@ public class YarnConfig extends MapConfig {
       throw new SamzaException("No YARN package path defined in config.");
     }
     return packagePath;
+  }
+
+  public String getAppCertificateRequestPath() {
+    String certificateRequestPath = get(CSR_SSL_REQUEST_PATH);
+    if (certificateRequestPath == null) {
+      throw new SamzaException("No Samza app certificate request path defined in config.");
+    }
+    return certificateRequestPath;
+  }
+
+  public String getAppCertificateName() {
+    return get(CSR_SSL_APPCERT_NAME, DEFAULT_APP_CERT_NAME);
   }
 
   public int getAMContainerMaxMemoryMb() {

--- a/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnClusterResourceManager.java
+++ b/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnClusterResourceManager.java
@@ -36,7 +36,6 @@ import org.apache.samza.config.ShellCommandConfig;
 import org.apache.samza.config.YarnConfig;
 import org.apache.samza.coordinator.JobModelManager;
 import org.apache.samza.job.CommandBuilder;
-import org.apache.samza.job.yarn.YarnContainer;
 import org.apache.samza.metrics.MetricsRegistryMap;
 import org.apache.samza.util.hadoop.HttpFileSystem;
 import org.slf4j.Logger;
@@ -119,6 +118,11 @@ public class YarnClusterResourceManager extends ClusterResourceManager implement
     super(callback);
     hConfig = new YarnConfiguration();
     hConfig.set("fs.http.impl", HttpFileSystem.class.getName());
+
+    if (config.containsKey("fs.certfs.impl.override")) { //TODO: change to use constants from CertFSConstants once that CertFSConstants.java is in
+      hConfig.set("fs.certfs.impl", config.get("fs.certfs.impl.override"));
+      log.info("samza job config fs.certfs.impl.override is used for yarn.");
+    }
 
     MetricsRegistryMap registry = new MetricsRegistryMap();
     metrics = new SamzaAppMasterMetrics(config, samzaAppState, registry);

--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/YarnJobFactory.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/YarnJobFactory.scala
@@ -39,7 +39,7 @@ class YarnJobFactory extends StreamJobFactory with Logging {
       hConfig.set(YarnConfiguration.RM_ADDRESS, config.get(YarnConfiguration.RM_ADDRESS, "0.0.0.0:8032"))
     }
 
-    if (config.containsKey("fs.certfs.impl.override")) { //TODO: change to use constants from CertFSConstants once that CertFSConstants.java is in
+    if (config.containsKey("fs.certfs.impl.override")) { // TODO: change to use constants from CertFSConstants once that CertFSConstants.java is in
       hConfig.set("fs.certfs.impl", config.get("fs.certfs.impl.override"))
       logger.info("samza job config fs.certfs.impl.override is used for yarn.")
     }

--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/YarnJobFactory.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/YarnJobFactory.scala
@@ -25,8 +25,9 @@ import org.apache.samza.job.StreamJobFactory
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.samza.config.Config
 import org.apache.samza.util.hadoop.HttpFileSystem
+import org.apache.samza.util.Logging
 
-class YarnJobFactory extends StreamJobFactory {
+class YarnJobFactory extends StreamJobFactory with Logging {
   def getJob(config: Config) = {
     // TODO fix this. needed to support http package locations.
     val hConfig = new YarnConfiguration
@@ -37,6 +38,12 @@ class YarnJobFactory extends StreamJobFactory {
     if (config.containsKey(YarnConfiguration.RM_ADDRESS)) {
       hConfig.set(YarnConfiguration.RM_ADDRESS, config.get(YarnConfiguration.RM_ADDRESS, "0.0.0.0:8032"))
     }
+
+    if (config.containsKey("fs.certfs.impl.override")) { //TODO: change to use constants from CertFSConstants once that CertFSConstants.java is in
+      hConfig.set("fs.certfs.impl", config.get("fs.certfs.impl.override"))
+      logger.info("samza job config fs.certfs.impl.override is used for yarn.")
+    }
+
     new YarnJob(config, hConfig)
   }
 }


### PR DESCRIPTION
Tested manually with the following samza configuration:
"csr.ssl.request.path" => "certfs://mytestserver.com:10180/request_service_certificate"

and the localization for the certificate signing request happens as expected by checking the log. 