### PR TITLE
SAMZA-1122: Rename ExecutionEnvironment to ApplicationRunner

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/runtime/ApplicationRunner.java
+++ b/samza-api/src/main/java/org/apache/samza/runtime/ApplicationRunner.java
@@ -16,58 +16,60 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.samza.system;
+package org.apache.samza.runtime;
 
 import java.lang.reflect.Constructor;
 import org.apache.samza.annotation.InterfaceStability;
 import org.apache.samza.config.ConfigException;
 import org.apache.samza.operators.StreamGraphBuilder;
 import org.apache.samza.config.Config;
+import org.apache.samza.system.StreamSpec;
 
 
 /**
  * Interface to be implemented by physical execution engine to deploy the config and jobs to run the {@link org.apache.samza.operators.StreamGraph}
  *
  * Implementations of this interface must define a constructor with a single {@link Config} as the argument in order
- * to support the {@link ExecutionEnvironment#fromConfig(Config)} static constructor.
+ * to support the {@link ApplicationRunner#fromConfig(Config)} static constructor.
  */
 @InterfaceStability.Unstable
-public interface ExecutionEnvironment {
+public interface ApplicationRunner {
 
-  String ENVIRONMENT_CONFIG = "job.execution.environment.class";
-  String DEFAULT_ENVIRONMENT_CLASS = "org.apache.samza.system.StandaloneExecutionEnvironment";
+  String RUNNER_CONFIG = "job.runner.class";
+  String DEFAULT_RUNNER_CLASS = "org.apache.samza.runtime.RemoteApplicationRunner";
 
   /**
-   * Static method to load the local standalone environment
+   * Static method to create the local {@link ApplicationRunner}.
    *
-   * @param config  configuration passed in to initialize the Samza standalone process
-   * @return  the standalone {@link ExecutionEnvironment} to run the user-defined stream applications
+   * @param config  configuration passed in to initialize the Samza local process
+   * @return  the local {@link ApplicationRunner} to run the user-defined stream applications
    */
-  static ExecutionEnvironment getLocalEnvironment(Config config) {
+  static ApplicationRunner getLocalRunner(Config config) {
     return null;
   }
 
   /**
-   * Static method to load the non-standalone environment.
+   * Static method to load the {@link ApplicationRunner}
    *
    * Requires the implementation class to define a constructor with a single {@link Config} as the argument.
    *
    * @param config  configuration passed in to initialize the Samza processes
-   * @return  the configure-driven {@link ExecutionEnvironment} to run the user-defined stream applications
+   * @return  the configure-driven {@link ApplicationRunner} to run the user-defined stream applications
    */
-  static ExecutionEnvironment fromConfig(Config config) {
+  static ApplicationRunner fromConfig(Config config) {
     try {
-      Class<?> environmentClass = Class.forName(config.get(ENVIRONMENT_CONFIG, DEFAULT_ENVIRONMENT_CLASS));
-      if (ExecutionEnvironment.class.isAssignableFrom(environmentClass)) {
-        Constructor<?> constructor = environmentClass.getConstructor(Config.class); // *sigh*
-        return (ExecutionEnvironment) constructor.newInstance(config);
+      Class<?> runnerClass = Class.forName(config.get(RUNNER_CONFIG, DEFAULT_RUNNER_CLASS));
+      if (ApplicationRunner.class.isAssignableFrom(runnerClass)) {
+        Constructor<?> constructor = runnerClass.getConstructor(Config.class); // *sigh*
+        return (ApplicationRunner) constructor.newInstance(config);
       }
     } catch (Exception e) {
-      throw new ConfigException(String.format("Problem in loading ExecutionEnvironment class %s", config.get(ENVIRONMENT_CONFIG)), e);
+      throw new ConfigException(String.format("Problem in loading ApplicationRunner class %s", config.get(
+          RUNNER_CONFIG)), e);
     }
     throw new ConfigException(String.format(
-        "Class %s does not implement interface ExecutionEnvironment properly",
-        config.get(ENVIRONMENT_CONFIG)));
+        "Class %s does not implement interface ApplicationRunner properly",
+        config.get(RUNNER_CONFIG)));
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/runtime/AbstractApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/AbstractApplicationRunner.java
@@ -16,18 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.samza.system;
+package org.apache.samza.runtime;
 
 import java.util.Map;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.StreamConfig;
+import org.apache.samza.system.StreamSpec;
 
 
-public abstract class AbstractExecutionEnvironment implements ExecutionEnvironment {
+public abstract class AbstractApplicationRunner implements ApplicationRunner {
 
   private final Config config;
 
-  public AbstractExecutionEnvironment(Config config) {
+  public AbstractApplicationRunner(Config config) {
     if (config == null) {
       throw new NullPointerException("Parameter 'config' cannot be null.");
     }

--- a/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.samza.system;
+package org.apache.samza.runtime;
 
 import org.apache.samza.operators.StreamGraph;
 import org.apache.samza.operators.StreamGraphBuilder;
@@ -26,11 +26,11 @@ import org.apache.samza.operators.StreamGraphImpl;
 
 
 /**
- * This class implements the {@link ExecutionEnvironment} that runs the applications in standalone environment
+ * This class implements the {@link ApplicationRunner} that runs the applications in standalone environment
  */
-public class StandaloneExecutionEnvironment extends AbstractExecutionEnvironment {
+public class LocalApplicationRunner extends AbstractApplicationRunner {
 
-  public StandaloneExecutionEnvironment(Config config) {
+  public LocalApplicationRunner(Config config) {
     super(config);
   }
 

--- a/samza-core/src/main/java/org/apache/samza/runtime/RemoteApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/RemoteApplicationRunner.java
@@ -16,17 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.samza.system;
+package org.apache.samza.runtime;
 
 import org.apache.samza.operators.StreamGraphBuilder;
 import org.apache.samza.config.Config;
 
-/**
- * This class implements the {@link ExecutionEnvironment} that runs the applications in YARN environment
- */
-public class RemoteExecutionEnvironment extends AbstractExecutionEnvironment {
 
-  public RemoteExecutionEnvironment(Config config) {
+/**
+ * This class implements the {@link ApplicationRunner} that runs the applications in a remote cluster
+ */
+public class RemoteApplicationRunner extends AbstractApplicationRunner {
+
+  public RemoteApplicationRunner(Config config) {
     super(config);
   }
 

--- a/samza-core/src/test/java/org/apache/samza/example/KeyValueStoreExample.java
+++ b/samza-core/src/test/java/org/apache/samza/example/KeyValueStoreExample.java
@@ -31,7 +31,7 @@ import org.apache.samza.operators.functions.FlatMapFunction;
 import org.apache.samza.serializers.JsonSerde;
 import org.apache.samza.serializers.StringSerde;
 import org.apache.samza.storage.kv.KeyValueStore;
-import org.apache.samza.system.ExecutionEnvironment;
+import org.apache.samza.runtime.ApplicationRunner;
 import org.apache.samza.system.StreamSpec;
 import org.apache.samza.task.TaskContext;
 import org.apache.samza.util.CommandLine;
@@ -43,15 +43,14 @@ import org.apache.samza.util.CommandLine;
 public class KeyValueStoreExample implements StreamGraphBuilder {
 
   /**
-   * used by remote execution environment to launch the job in remote program. The remote program should follow the similar
-   * invoking context as in standalone:
+   * used by remote application runner to launch the job in remote program. The remote program should follow the similar
+   * invoking context as in local runner:
    *
    *   public static void main(String args[]) throws Exception {
    *     CommandLine cmdLine = new CommandLine();
    *     Config config = cmdLine.loadConfig(cmdLine.parser().parse(args));
-   *     ExecutionEnvironment remoteEnv = ExecutionEnvironment.getRemoteEnvironment(config);
-   *     UserMainExample runnableApp = new UserMainExample();
-   *     runnableApp.run(remoteEnv, config);
+   *     ApplicationRunner runner = ApplicationRunner.fromConfig(config);
+   *     runner.run(new UserMainExample(), config)
    *   }
    *
    */
@@ -67,12 +66,12 @@ public class KeyValueStoreExample implements StreamGraphBuilder {
 
   }
 
-  // standalone local program model
+  // local program model
   public static void main(String[] args) throws Exception {
     CommandLine cmdLine = new CommandLine();
     Config config = cmdLine.loadConfig(cmdLine.parser().parse(args));
-    ExecutionEnvironment standaloneEnv = ExecutionEnvironment.getLocalEnvironment(config);
-    standaloneEnv.run(new KeyValueStoreExample(), config);
+    ApplicationRunner localRunner = ApplicationRunner.getLocalRunner(config);
+    localRunner.run(new KeyValueStoreExample(), config);
   }
 
   class MyStatsCounter implements FlatMapFunction<PageViewEvent, StatsOutput> {

--- a/samza-core/src/test/java/org/apache/samza/example/NoContextStreamExample.java
+++ b/samza-core/src/test/java/org/apache/samza/example/NoContextStreamExample.java
@@ -27,7 +27,7 @@ import org.apache.samza.operators.data.Offset;
 import org.apache.samza.operators.functions.JoinFunction;
 import org.apache.samza.serializers.JsonSerde;
 import org.apache.samza.serializers.StringSerde;
-import org.apache.samza.system.ExecutionEnvironment;
+import org.apache.samza.runtime.ApplicationRunner;
 import org.apache.samza.system.StreamSpec;
 import org.apache.samza.system.SystemStreamPartition;
 import org.apache.samza.util.CommandLine;
@@ -89,15 +89,16 @@ public class NoContextStreamExample implements StreamGraphBuilder {
     }
   }
 
+
   /**
-   * used by remote execution environment to launch the job in remote program. The remote program should follow the similar
-   * invoking context as in standalone:
+   * used by remote application runner to launch the job in remote program. The remote program should follow the similar
+   * invoking context as in local:
    *
    *   public static void main(String args[]) throws Exception {
    *     CommandLine cmdLine = new CommandLine();
    *     Config config = cmdLine.loadConfig(cmdLine.parser().parse(args));
-   *     ExecutionEnvironment remoteEnv = ExecutionEnvironment.fromConfig(config);
-   *     remoteEnv.run(new NoContextStreamExample(), config);
+   *     ApplicationRunner runner = ApplicationRunner.fromConfig(config);
+   *     runner.run(new NoContextStreamExample(), config);
    *   }
    *
    */
@@ -119,8 +120,8 @@ public class NoContextStreamExample implements StreamGraphBuilder {
   public static void main(String[] args) throws Exception {
     CommandLine cmdLine = new CommandLine();
     Config config = cmdLine.loadConfig(cmdLine.parser().parse(args));
-    ExecutionEnvironment standaloneEnv = ExecutionEnvironment.getLocalEnvironment(config);
-    standaloneEnv.run(new NoContextStreamExample(), config);
+    ApplicationRunner localRunner = ApplicationRunner.getLocalRunner(config);
+    localRunner.run(new NoContextStreamExample(), config);
   }
 
 }

--- a/samza-core/src/test/java/org/apache/samza/example/OrderShipmentJoinExample.java
+++ b/samza-core/src/test/java/org/apache/samza/example/OrderShipmentJoinExample.java
@@ -27,7 +27,7 @@ import org.apache.samza.operators.data.MessageEnvelope;
 import org.apache.samza.operators.functions.JoinFunction;
 import org.apache.samza.serializers.JsonSerde;
 import org.apache.samza.serializers.StringSerde;
-import org.apache.samza.system.ExecutionEnvironment;
+import org.apache.samza.runtime.ApplicationRunner;
 import org.apache.samza.system.StreamSpec;
 import org.apache.samza.util.CommandLine;
 
@@ -38,15 +38,14 @@ import org.apache.samza.util.CommandLine;
 public class OrderShipmentJoinExample implements StreamGraphBuilder {
 
   /**
-   * used by remote execution environment to launch the job in remote program. The remote program should follow the similar
-   * invoking context as in standalone:
+   * used by remote application runner to launch the job in remote program. The remote program should follow the similar
+   * invoking context as in local runner:
    *
    *   public static void main(String args[]) throws Exception {
    *     CommandLine cmdLine = new CommandLine();
    *     Config config = cmdLine.loadConfig(cmdLine.parser().parse(args));
-   *     ExecutionEnvironment remoteEnv = ExecutionEnvironment.getRemoteEnvironment(config);
-   *     UserMainExample runnableApp = new UserMainExample();
-   *     runnableApp.run(remoteEnv, config);
+   *     ApplicationRunner runner = ApplicationRunner.fromConfig(config);
+   *     runner.run(new UserMainExample(), config);
    *   }
    *
    */
@@ -64,8 +63,8 @@ public class OrderShipmentJoinExample implements StreamGraphBuilder {
   public static void main(String[] args) throws Exception {
     CommandLine cmdLine = new CommandLine();
     Config config = cmdLine.loadConfig(cmdLine.parser().parse(args));
-    ExecutionEnvironment standaloneEnv = ExecutionEnvironment.getLocalEnvironment(config);
-    standaloneEnv.run(new OrderShipmentJoinExample(), config);
+    ApplicationRunner localRunner = ApplicationRunner.getLocalRunner(config);
+    localRunner.run(new OrderShipmentJoinExample(), config);
   }
 
   StreamSpec input1 = new StreamSpec("orderStream", "OrderEvent", "kafka");

--- a/samza-core/src/test/java/org/apache/samza/example/PageViewCounterExample.java
+++ b/samza-core/src/test/java/org/apache/samza/example/PageViewCounterExample.java
@@ -28,7 +28,7 @@ import org.apache.samza.operators.windows.WindowPane;
 import org.apache.samza.operators.windows.Windows;
 import org.apache.samza.serializers.JsonSerde;
 import org.apache.samza.serializers.StringSerde;
-import org.apache.samza.system.ExecutionEnvironment;
+import org.apache.samza.runtime.ApplicationRunner;
 import org.apache.samza.system.StreamSpec;
 import org.apache.samza.util.CommandLine;
 
@@ -57,8 +57,8 @@ public class PageViewCounterExample implements StreamGraphBuilder {
   public static void main(String[] args) {
     CommandLine cmdLine = new CommandLine();
     Config config = cmdLine.loadConfig(cmdLine.parser().parse(args));
-    ExecutionEnvironment standaloneEnv = ExecutionEnvironment.getLocalEnvironment(config);
-    standaloneEnv.run(new PageViewCounterExample(), config);
+    ApplicationRunner localRunner = ApplicationRunner.getLocalRunner(config);
+    localRunner.run(new PageViewCounterExample(), config);
   }
 
   StreamSpec input1 = new StreamSpec("pageViewEventStream", "PageViewEvent", "kafka");

--- a/samza-core/src/test/java/org/apache/samza/example/RepartitionExample.java
+++ b/samza-core/src/test/java/org/apache/samza/example/RepartitionExample.java
@@ -26,7 +26,7 @@ import org.apache.samza.operators.windows.WindowPane;
 import org.apache.samza.operators.windows.Windows;
 import org.apache.samza.serializers.JsonSerde;
 import org.apache.samza.serializers.StringSerde;
-import org.apache.samza.system.ExecutionEnvironment;
+import org.apache.samza.runtime.ApplicationRunner;
 import org.apache.samza.system.StreamSpec;
 import org.apache.samza.util.CommandLine;
 
@@ -37,6 +37,19 @@ import java.time.Duration;
  * Example {@link StreamGraphBuilder} code to test the API methods with re-partition operator
  */
 public class RepartitionExample implements StreamGraphBuilder {
+
+  /**
+   * used by remote application runner to launch the job in remote program. The remote program should follow the similar
+   * invoking context as in local runner:
+   *
+   *   public static void main(String args[]) throws Exception {
+   *     CommandLine cmdLine = new CommandLine();
+   *     Config config = cmdLine.loadConfig(cmdLine.parser().parse(args));
+   *     ApplicationRunner runner = ApplicationRunner.fromConfig(config);
+   *     runner.run(new UserMainExample(), config);
+   *   }
+   *
+   */
 
   /**
    * used by remote execution environment to launch the job in remote program. The remote program should follow the similar
@@ -68,8 +81,8 @@ public class RepartitionExample implements StreamGraphBuilder {
   public static void main(String[] args) throws Exception {
     CommandLine cmdLine = new CommandLine();
     Config config = cmdLine.loadConfig(cmdLine.parser().parse(args));
-    ExecutionEnvironment standaloneEnv = ExecutionEnvironment.getLocalEnvironment(config);
-    standaloneEnv.run(new RepartitionExample(), config);
+    ApplicationRunner localRunner = ApplicationRunner.getLocalRunner(config);
+    localRunner.run(new RepartitionExample(), config);
   }
 
   StreamSpec input1 = new StreamSpec("pageViewEventStream", "PageViewEvent", "kafka");

--- a/samza-core/src/test/java/org/apache/samza/runtime/TestAbstractExecutionEnvironment.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestAbstractExecutionEnvironment.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.samza.system;
+package org.apache.samza.runtime;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -25,9 +25,11 @@ import org.apache.samza.config.JobConfig;
 import org.apache.samza.config.MapConfig;
 import org.apache.samza.config.StreamConfig;
 import org.apache.samza.operators.StreamGraphBuilder;
+import org.apache.samza.system.StreamSpec;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 public class TestAbstractExecutionEnvironment {
   private static final String STREAM_ID = "t3st-Stream_Id";
   private static final String STREAM_ID_INVALID = "test#Str3amId!";
@@ -45,7 +47,7 @@ public class TestAbstractExecutionEnvironment {
 
   @Test(expected = NullPointerException.class)
   public void testConfigValidation() {
-    new TestAbstractExecutionEnvironmentImpl(null);
+    new TestAbstractApplicationRunnerImpl(null);
   }
 
   // The physical name should be pulled from the StreamConfig.PHYSICAL_NAME property value.
@@ -55,7 +57,7 @@ public class TestAbstractExecutionEnvironment {
                                       StreamConfig.PHYSICAL_NAME(), TEST_PHYSICAL_NAME,
                                       StreamConfig.SYSTEM(), TEST_SYSTEM);
 
-    AbstractExecutionEnvironment env = new TestAbstractExecutionEnvironmentImpl(config);
+    AbstractApplicationRunner env = new TestAbstractApplicationRunnerImpl(config);
     StreamSpec spec = env.streamFromConfig(STREAM_ID);
 
     assertEquals(TEST_PHYSICAL_NAME, spec.getPhysicalName());
@@ -68,7 +70,7 @@ public class TestAbstractExecutionEnvironment {
     Config config = buildStreamConfig(STREAM_ID,
                                       StreamConfig.SYSTEM(), TEST_SYSTEM);
 
-    AbstractExecutionEnvironment env = new TestAbstractExecutionEnvironmentImpl(config);
+    AbstractApplicationRunner env = new TestAbstractApplicationRunnerImpl(config);
     StreamSpec spec = env.streamFromConfig(STREAM_ID);
 
     assertEquals(STREAM_ID, spec.getPhysicalName());
@@ -81,7 +83,7 @@ public class TestAbstractExecutionEnvironment {
                                       StreamConfig.PHYSICAL_NAME(), TEST_PHYSICAL_NAME,
                                       StreamConfig.SYSTEM(), TEST_SYSTEM);
 
-    AbstractExecutionEnvironment env = new TestAbstractExecutionEnvironmentImpl(config);
+    AbstractApplicationRunner env = new TestAbstractApplicationRunnerImpl(config);
     StreamSpec spec = env.streamFromConfig(STREAM_ID);
 
     assertEquals(TEST_SYSTEM, spec.getSystemName());
@@ -94,7 +96,7 @@ public class TestAbstractExecutionEnvironment {
                                                   StreamConfig.PHYSICAL_NAME(), TEST_PHYSICAL_NAME),
                                 JobConfig.JOB_DEFAULT_SYSTEM(), TEST_DEFAULT_SYSTEM);
 
-    AbstractExecutionEnvironment env = new TestAbstractExecutionEnvironmentImpl(config);
+    AbstractApplicationRunner env = new TestAbstractApplicationRunnerImpl(config);
     StreamSpec spec = env.streamFromConfig(STREAM_ID);
 
     assertEquals(TEST_DEFAULT_SYSTEM, spec.getSystemName());
@@ -108,7 +110,7 @@ public class TestAbstractExecutionEnvironment {
                                                 StreamConfig.SYSTEM(), TEST_SYSTEM),
                                 JobConfig.JOB_DEFAULT_SYSTEM(), TEST_DEFAULT_SYSTEM);
 
-    AbstractExecutionEnvironment env = new TestAbstractExecutionEnvironmentImpl(config);
+    AbstractApplicationRunner env = new TestAbstractApplicationRunnerImpl(config);
     StreamSpec spec = env.streamFromConfig(STREAM_ID);
 
     assertEquals(TEST_SYSTEM, spec.getSystemName());
@@ -120,7 +122,7 @@ public class TestAbstractExecutionEnvironment {
     Config config = buildStreamConfig(STREAM_ID,
                                       StreamConfig.PHYSICAL_NAME(), TEST_PHYSICAL_NAME);
 
-    AbstractExecutionEnvironment env = new TestAbstractExecutionEnvironmentImpl(config);
+    AbstractApplicationRunner env = new TestAbstractApplicationRunnerImpl(config);
     StreamSpec spec = env.streamFromConfig(STREAM_ID);
 
     assertEquals(TEST_SYSTEM, spec.getSystemName());
@@ -136,7 +138,7 @@ public class TestAbstractExecutionEnvironment {
                                     "systemProperty2", "systemValue2",
                                     "systemProperty3", "systemValue3");
 
-    AbstractExecutionEnvironment env = new TestAbstractExecutionEnvironmentImpl(config);
+    AbstractApplicationRunner env = new TestAbstractApplicationRunnerImpl(config);
     StreamSpec spec = env.streamFromConfig(STREAM_ID);
 
     Map<String, String> properties = spec.getConfig();
@@ -159,7 +161,7 @@ public class TestAbstractExecutionEnvironment {
                                     "systemProperty2", "systemValue2",
                                     "systemProperty3", "systemValue3");
 
-    AbstractExecutionEnvironment env = new TestAbstractExecutionEnvironmentImpl(config);
+    AbstractApplicationRunner env = new TestAbstractApplicationRunnerImpl(config);
     StreamSpec spec = env.streamFromConfig(STREAM_ID);
 
     Map<String, String> properties = spec.getConfig();
@@ -177,7 +179,7 @@ public class TestAbstractExecutionEnvironment {
                                       StreamConfig.PHYSICAL_NAME(), TEST_PHYSICAL_NAME2, // This should be ignored because of the explicit arg
                                       StreamConfig.SYSTEM(), TEST_SYSTEM);
 
-    AbstractExecutionEnvironment env = new TestAbstractExecutionEnvironmentImpl(config);
+    AbstractApplicationRunner env = new TestAbstractApplicationRunnerImpl(config);
     StreamSpec spec = env.streamFromConfig(STREAM_ID, TEST_PHYSICAL_NAME);
 
     assertEquals(STREAM_ID, spec.getId());
@@ -192,7 +194,7 @@ public class TestAbstractExecutionEnvironment {
                                       StreamConfig.PHYSICAL_NAME(), TEST_PHYSICAL_NAME2,
                                       StreamConfig.SYSTEM(), TEST_SYSTEM);
 
-    AbstractExecutionEnvironment env = new TestAbstractExecutionEnvironmentImpl(config);
+    AbstractApplicationRunner env = new TestAbstractApplicationRunnerImpl(config);
     StreamSpec spec = env.streamFromConfig(STREAM_ID, TEST_PHYSICAL_NAME_SPECIAL_CHARS);
     assertEquals(TEST_PHYSICAL_NAME_SPECIAL_CHARS, spec.getPhysicalName());
   }
@@ -204,7 +206,7 @@ public class TestAbstractExecutionEnvironment {
                                       StreamConfig.PHYSICAL_NAME(), TEST_PHYSICAL_NAME2,
                                       StreamConfig.SYSTEM(), TEST_SYSTEM);
 
-    AbstractExecutionEnvironment env = new TestAbstractExecutionEnvironmentImpl(config);
+    AbstractApplicationRunner env = new TestAbstractApplicationRunnerImpl(config);
     StreamSpec spec = env.streamFromConfig(STREAM_ID, null);
     assertNull(spec.getPhysicalName());
   }
@@ -216,7 +218,7 @@ public class TestAbstractExecutionEnvironment {
                                       StreamConfig.PHYSICAL_NAME(), TEST_PHYSICAL_NAME2, // This should be ignored because of the explicit arg
                                       StreamConfig.SYSTEM(), TEST_SYSTEM2);              // This too
 
-    AbstractExecutionEnvironment env = new TestAbstractExecutionEnvironmentImpl(config);
+    AbstractApplicationRunner env = new TestAbstractApplicationRunnerImpl(config);
     StreamSpec spec = env.streamFromConfig(STREAM_ID, TEST_PHYSICAL_NAME, TEST_SYSTEM);
 
     assertEquals(STREAM_ID, spec.getId());
@@ -231,7 +233,7 @@ public class TestAbstractExecutionEnvironment {
                                       StreamConfig.PHYSICAL_NAME(), TEST_PHYSICAL_NAME2,
                                       StreamConfig.SYSTEM(), TEST_SYSTEM2);
 
-    AbstractExecutionEnvironment env = new TestAbstractExecutionEnvironmentImpl(config);
+    AbstractApplicationRunner env = new TestAbstractApplicationRunnerImpl(config);
     env.streamFromConfig(STREAM_ID, TEST_PHYSICAL_NAME, TEST_SYSTEM_INVALID);
   }
 
@@ -242,7 +244,7 @@ public class TestAbstractExecutionEnvironment {
         StreamConfig.PHYSICAL_NAME(), TEST_PHYSICAL_NAME2,
         StreamConfig.SYSTEM(), TEST_SYSTEM2);
 
-    AbstractExecutionEnvironment env = new TestAbstractExecutionEnvironmentImpl(config);
+    AbstractApplicationRunner env = new TestAbstractApplicationRunnerImpl(config);
     env.streamFromConfig(STREAM_ID, TEST_PHYSICAL_NAME, "");
   }
 
@@ -253,7 +255,7 @@ public class TestAbstractExecutionEnvironment {
                                       StreamConfig.PHYSICAL_NAME(), TEST_PHYSICAL_NAME2,
                                       StreamConfig.SYSTEM(), TEST_SYSTEM2);
 
-    AbstractExecutionEnvironment env = new TestAbstractExecutionEnvironmentImpl(config);
+    AbstractApplicationRunner env = new TestAbstractApplicationRunnerImpl(config);
     env.streamFromConfig(STREAM_ID, TEST_PHYSICAL_NAME, null);
   }
 
@@ -263,7 +265,7 @@ public class TestAbstractExecutionEnvironment {
     Config config = buildStreamConfig(STREAM_ID_INVALID,
         StreamConfig.SYSTEM(), TEST_SYSTEM);
 
-    AbstractExecutionEnvironment env = new TestAbstractExecutionEnvironmentImpl(config);
+    AbstractApplicationRunner env = new TestAbstractApplicationRunnerImpl(config);
     env.streamFromConfig(STREAM_ID_INVALID);
   }
 
@@ -273,7 +275,7 @@ public class TestAbstractExecutionEnvironment {
     Config config = buildStreamConfig("",
         StreamConfig.SYSTEM(), TEST_SYSTEM);
 
-    AbstractExecutionEnvironment env = new TestAbstractExecutionEnvironmentImpl(config);
+    AbstractApplicationRunner env = new TestAbstractApplicationRunnerImpl(config);
     env.streamFromConfig("");
   }
 
@@ -283,7 +285,7 @@ public class TestAbstractExecutionEnvironment {
     Config config = buildStreamConfig(null,
         StreamConfig.SYSTEM(), TEST_SYSTEM);
 
-    AbstractExecutionEnvironment env = new TestAbstractExecutionEnvironmentImpl(config);
+    AbstractApplicationRunner env = new TestAbstractApplicationRunnerImpl(config);
     env.streamFromConfig(null);
   }
 
@@ -317,9 +319,9 @@ public class TestAbstractExecutionEnvironment {
     return new MapConfig(result);
   }
 
-  private class TestAbstractExecutionEnvironmentImpl extends AbstractExecutionEnvironment {
+  private class TestAbstractApplicationRunnerImpl extends AbstractApplicationRunner {
 
-    public TestAbstractExecutionEnvironmentImpl(Config config) {
+    public TestAbstractApplicationRunnerImpl(Config config) {
       super(config);
     }
 


### PR DESCRIPTION
Some refactoring/cleanup:

- rename ExecutionEnvironment to ApplicationRunner, including all the subclasses.
- rename the package to be org.apache.samza.runtime
- rename the StandalondApplicationRunner to be LocalApplicationRunner