### PR TITLE
SAMZA-1121: StreamAppender should not propagate exceptions to the caller

### DIFF
--- a/samza-log4j/src/main/java/org/apache/samza/logging/log4j/StreamAppender.java
+++ b/samza-log4j/src/main/java/org/apache/samza/logging/log4j/StreamAppender.java
@@ -20,7 +20,6 @@
 package org.apache.samza.logging.log4j;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -115,8 +114,9 @@ public class StreamAppender extends AppenderSkeleton {
               new OutgoingMessageEnvelope(systemStream, key.getBytes("UTF-8"), serde.toBytes(subLog(event)));
           systemProducer.send(SOURCE, outgoingMessageEnvelope);
         }
-      } catch (UnsupportedEncodingException e) {
-        throw new SamzaException("can not send the log messages", e);
+      } catch (Exception e) {
+        System.err.println("[StreamAppender] Error sending log message:");
+        e.printStackTrace();
       } finally {
         recursiveCall.set(false);
       }


### PR DESCRIPTION
StreamAppender#append currently propagates any exceptions while sending messages to the underlying logging system to the calling code. Since users don't expect log statements to throw exceptions, this can cause unexpected failures scenarios. We should catch exceptions and log to stderr instead.