### PR TITLE
SAMZA-1136: If latest offset <= 0 then SystemStreamMetadata is incorrect

### DIFF
--- a/samza-kafka/src/main/scala/org/apache/samza/system/kafka/KafkaSystemAdmin.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/system/kafka/KafkaSystemAdmin.scala
@@ -241,12 +241,7 @@ class KafkaSystemAdmin(
                   debug("Stripping newest offsets for %s because the topic appears empty." format topicAndPartition)
                   newestOffsets -= topicAndPartition
                   debug("Setting oldest offset to 0 to consume from beginning")
-                  oldestOffsets.get(topicAndPartition) match {
-                    case Some(s) =>
-                      oldestOffsets.updated(topicAndPartition, "0")
-                    case None =>
-                      oldestOffsets.put(topicAndPartition, "0")
-                  }
+                  oldestOffsets += (topicAndPartition -> "0")
                 }
             }
           } finally {


### PR DESCRIPTION
Debug log says "Setting oldest offset to 0 to consume from beginning", but actually current code just adds element to immutable map but do nothing with the result of addition.
```scala
oldestOffsets.get(topicAndPartition) match {
  case Some(s) =>
    oldestOffsets.updated(topicAndPartition, "0")
  case None =>
    oldestOffsets.put(topicAndPartition, "0")
}
```