### PR TITLE
SAMZA-1140 : Non blocking commit in Async Runloop

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/container/RunLoopFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/container/RunLoopFactory.java
@@ -87,6 +87,8 @@ public class RunLoopFactory {
     } else {
       Integer taskMaxConcurrency = config.getMaxConcurrency().getOrElse(defaultValue(1));
 
+      boolean isAsyncCommitEnabled = config.getAsyncCommit().getOrElse(defaultValue(false));
+
       log.info("Got max messages in flight: " + taskMaxConcurrency);
 
       Long callbackTimeout = config.getCallbackTimeoutMs().getOrElse(defaultValue(DEFAULT_CALLBACK_TIMEOUT_MS));
@@ -105,7 +107,8 @@ public class RunLoopFactory {
         callbackTimeout,
         maxThrottlingDelayMs,
         containerMetrics,
-        clock);
+        clock,
+        isAsyncCommitEnabled);
     }
   }
 

--- a/samza-core/src/main/scala/org/apache/samza/config/TaskConfig.scala
+++ b/samza-core/src/main/scala/org/apache/samza/config/TaskConfig.scala
@@ -40,6 +40,7 @@ object TaskConfig {
   val GROUPER_FACTORY = "task.name.grouper.factory" // class name for task grouper
   val MAX_CONCURRENCY = "task.max.concurrency" // max number of concurrent process for a AsyncStreamTask
   val CALLBACK_TIMEOUT_MS = "task.callback.timeout.ms"  // timeout period for triggering a callback
+  val ASYNC_COMMIT = "task.async.commit" // to enable async commit in a AsyncStreamTask
 
   /**
    * Samza's container polls for more messages under two conditions. The first
@@ -126,6 +127,11 @@ class TaskConfig(config: Config) extends ScalaMapConfig(config) with Logging {
 
   def getCallbackTimeoutMs: Option[Long] = getOption(TaskConfig.CALLBACK_TIMEOUT_MS) match {
     case Some(ms) => Some(ms.toLong)
+    case _ => None
+  }
+
+  def getAsyncCommit: Option[Boolean] = getOption(TaskConfig.ASYNC_COMMIT) match {
+    case Some(asyncCommit) => Some(asyncCommit.toBoolean)
     case _ => None
   }
 }


### PR DESCRIPTION
Adds non blocking commit into AsyncRunLoop. Clients can enable it by setting an opt-in config task.async.commit (which is disabled by default). Contains the following list of changes for AsyncStreamTask type of tasks.

a) Enable commit for a task,  when there're uncompleted callbacks from a task. Progressive commit of finished callbacks, when there are messages in flight for a task.
b) Enable processing of messages for a task, when there're commits in progress from a task.

Documentation for this change will be done in a separate PR.