### PR TITLE
Samza-1187 : TestZkProcessorLatch tests share state causing transient failures in CI builds

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/zk/ZkCoordinationServiceFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkCoordinationServiceFactory.java
@@ -26,6 +26,7 @@ import org.apache.samza.coordinator.CoordinationServiceFactory;
 
 
 public class ZkCoordinationServiceFactory implements CoordinationServiceFactory {
+  // TODO - Why should this method be synchronized?
   synchronized public CoordinationUtils getCoordinationService(String groupId, String participantId, Config config) {
     ZkConfig zkConfig = new ZkConfig(config);
     ZkClient zkClient = new ZkClient(zkConfig.getZkConnect(), zkConfig.getZkSessionTimeoutMs(), zkConfig.getZkConnectionTimeoutMs());

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkCoordinationUtils.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkCoordinationUtils.java
@@ -52,7 +52,7 @@ public class ZkCoordinationUtils implements CoordinationUtils {
 
   @Override
   public Latch getLatch(int size, String latchId) {
-    return new ZkProcessorLatch(size, latchId, processorIdStr, zkConfig, zkUtils);
+    return new ZkProcessorLatch(size, latchId, processorIdStr, zkUtils);
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkProcessorLatch.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkProcessorLatch.java
@@ -39,7 +39,7 @@ public class ZkProcessorLatch implements Latch {
   private final String latchPath;
   private final String targetPath;
 
-  private final static String LATCH_PATH = "latch";
+  public final static String LATCH_PATH = "latch";
   private final int size; // latch size
 
   public ZkProcessorLatch(int size, String latchId, String participantId, ZkConfig zkConfig, ZkUtils zkUtils) {

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkProcessorLatch.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkProcessorLatch.java
@@ -32,21 +32,16 @@ public class ZkProcessorLatch implements Latch {
 
   private final ZkUtils zkUtils;
   private final String processorIdStr;
-  private final ZkKeyBuilder keyBuilder;
-  private final String latchId;
 
   private final String latchPath;
   private final String targetPath;
 
   public final static String LATCH_PATH = "latch";
-  private final int size; // latch size
 
   public ZkProcessorLatch(int size, String latchId, String participantId, ZkUtils zkUtils) {
     this.zkUtils = zkUtils;
     this.processorIdStr = participantId;
-    this.latchId = latchId;
-    this.keyBuilder = this.zkUtils.getKeyBuilder();
-    this.size = size;
+    ZkKeyBuilder keyBuilder = this.zkUtils.getKeyBuilder();
 
     latchPath = String.format("%s/%s", keyBuilder.getRootPath(), LATCH_PATH + "_" + latchId);
     zkUtils.makeSurePersistentPathsExists(new String[] {latchPath});

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkProcessorLatch.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkProcessorLatch.java
@@ -43,6 +43,7 @@ public class ZkProcessorLatch implements Latch {
     ZkKeyBuilder keyBuilder = this.zkUtils.getKeyBuilder();
 
     latchPath = String.format("%s/%s", keyBuilder.getRootPath(), LATCH_PATH + "_" + latchId);
+    // TODO: Verify that makeSurePersistentPathsExists doesn't fail with exceptions!
     zkUtils.makeSurePersistentPathsExists(new String[] {latchPath});
     targetPath =  String.format("%s/%010d", latchPath, size - 1);
     System.out.println("targetPath " + targetPath);

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkProcessorLatch.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkProcessorLatch.java
@@ -19,9 +19,8 @@
 package org.apache.samza.zk;
 
 import java.util.concurrent.TimeUnit;
-import org.apache.samza.config.ZkConfig;
-import org.apache.samza.coordinator.Latch;
 
+import org.apache.samza.coordinator.Latch;
 
 /*
  * Latch of the sizeN is open when countDown() was called N times.
@@ -31,7 +30,7 @@ import org.apache.samza.coordinator.Latch;
 public class ZkProcessorLatch implements Latch {
 
   private final ZkUtils zkUtils;
-  private final String processorIdStr;
+  private final String participantId;
 
   private final String latchPath;
   private final String targetPath;
@@ -40,7 +39,7 @@ public class ZkProcessorLatch implements Latch {
 
   public ZkProcessorLatch(int size, String latchId, String participantId, ZkUtils zkUtils) {
     this.zkUtils = zkUtils;
-    this.processorIdStr = participantId;
+    this.participantId = participantId;
     ZkKeyBuilder keyBuilder = this.zkUtils.getKeyBuilder();
 
     latchPath = String.format("%s/%s", keyBuilder.getRootPath(), LATCH_PATH + "_" + latchId);
@@ -57,7 +56,7 @@ public class ZkProcessorLatch implements Latch {
   @Override
   public void countDown() {
     // create persistent (should be ephemeral? Probably not)
-    String path = zkUtils.getZkClient().createPersistentSequential(latchPath + "/", processorIdStr);
+    String path = zkUtils.getZkClient().createPersistentSequential(latchPath + "/", participantId);
     System.out.println("countDown created " + path);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkProcessorLatch.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkProcessorLatch.java
@@ -21,6 +21,8 @@ package org.apache.samza.zk;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.samza.coordinator.Latch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /*
  * Latch of the sizeN is open when countDown() was called N times.
@@ -28,10 +30,10 @@ import org.apache.samza.coordinator.Latch;
  * When Nth node is created await() call returns.
  */
 public class ZkProcessorLatch implements Latch {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZkProcessorLatch.class);
 
   private final ZkUtils zkUtils;
   private final String participantId;
-
   private final String latchPath;
   private final String targetPath;
 
@@ -43,10 +45,11 @@ public class ZkProcessorLatch implements Latch {
     ZkKeyBuilder keyBuilder = this.zkUtils.getKeyBuilder();
 
     latchPath = String.format("%s/%s", keyBuilder.getRootPath(), LATCH_PATH + "_" + latchId);
-    // TODO: Verify that makeSurePersistentPathsExists doesn't fail with exceptions!
+    // TODO: Verify that makeSurePersistentPathsExists doesn't fail with exceptions
     zkUtils.makeSurePersistentPathsExists(new String[] {latchPath});
     targetPath =  String.format("%s/%010d", latchPath, size - 1);
-    System.out.println("targetPath " + targetPath);
+
+    LOGGER.debug("ZkProcessorLatch targetPath " + targetPath);
   }
 
   @Override
@@ -58,6 +61,6 @@ public class ZkProcessorLatch implements Latch {
   public void countDown() {
     // create persistent (should be ephemeral? Probably not)
     String path = zkUtils.getZkClient().createPersistentSequential(latchPath + "/", participantId);
-    System.out.println("countDown created " + path);
+    LOGGER.debug("ZKProcessorLatch countDown created " + path);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkProcessorLatch.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkProcessorLatch.java
@@ -30,7 +30,6 @@ import org.apache.samza.coordinator.Latch;
  */
 public class ZkProcessorLatch implements Latch {
 
-  private final ZkConfig zkConfig;
   private final ZkUtils zkUtils;
   private final String processorIdStr;
   private final ZkKeyBuilder keyBuilder;
@@ -42,8 +41,7 @@ public class ZkProcessorLatch implements Latch {
   public final static String LATCH_PATH = "latch";
   private final int size; // latch size
 
-  public ZkProcessorLatch(int size, String latchId, String participantId, ZkConfig zkConfig, ZkUtils zkUtils) {
-    this.zkConfig = zkConfig;
+  public ZkProcessorLatch(int size, String latchId, String participantId, ZkUtils zkUtils) {
     this.zkUtils = zkUtils;
     this.processorIdStr = participantId;
     this.latchId = latchId;

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkLeaderElector.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkLeaderElector.java
@@ -18,22 +18,10 @@
  */
 package org.apache.samza.zk;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.I0Itec.zkclient.IZkDataListener;
 import org.I0Itec.zkclient.ZkConnection;
 import org.I0Itec.zkclient.exception.ZkNodeExistsException;
 import org.apache.samza.SamzaException;
-import org.apache.samza.config.Config;
-import org.apache.samza.config.MapConfig;
-import org.apache.samza.config.ZkConfig;
-import org.apache.samza.coordinator.CoordinationUtils;
-import org.apache.samza.coordinator.CoordinationServiceFactory;
 import org.apache.samza.coordinator.LeaderElectorListener;
 import org.apache.samza.testUtils.EmbeddedZookeeper;
 import org.junit.After;
@@ -44,6 +32,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -58,7 +52,6 @@ public class TestZkLeaderElector {
   private ZkUtils testZkUtils = null;
   private static final int SESSION_TIMEOUT_MS = 20000;
   private static final int CONNECTION_TIMEOUT_MS = 10000;
-  private final CoordinationServiceFactory factory = new ZkCoordinationServiceFactory();
 
   @BeforeClass
   public static void setup() throws InterruptedException {
@@ -151,17 +144,6 @@ public class TestZkLeaderElector {
     }
   }
 
-  private CoordinationUtils getZkCoordinationService(String groupId, String processorId) {
-
-    Map<String, String> map = new HashMap<>();
-    map.put(ZkConfig.ZK_CONNECT, testZkConnectionString);
-    Config config = new MapConfig(map);
-
-    CoordinationUtils coordinationUtils = factory.getCoordinationService(groupId, processorId, config);
-    
-    return coordinationUtils;
-  }
-
   /**
    * Test starts 3 processors and verifies the state of the Zk tree after all processors participate in LeaderElection
    */
@@ -211,7 +193,6 @@ public class TestZkLeaderElector {
     Assert.assertFalse(TestZkUtils.testWithDelayBackOff(() -> isLeader3.res, 2, 100));
 
     Assert.assertEquals(3, testZkUtils.getSortedActiveProcessors().size());
-
 
     // Clean up
     zkUtils1.close();

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkProcessorLatch.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkProcessorLatch.java
@@ -35,6 +35,11 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+/**
+ * The ZkProcessorLatch uses a shared Znode as a latch. Each participant await existence of a target znode under the
+ * shared latch, which is a persistent, sequential target znode with value (latchSize - 1). latchSize is the minimum
+ * number of participants that need to join the latch.
+ */
 public class TestZkProcessorLatch {
   private static final ZkKeyBuilder KEY_BUILDER = new ZkKeyBuilder("test");
   private static EmbeddedZookeeper zkServer = null;
@@ -165,7 +170,7 @@ public class TestZkProcessorLatch {
 
   @Test
   public void testLatchSizeN() {
-    final int latchSize = 1;
+    final int latchSize = 3;
     final String latchId = "testLatchSizeN";
 
     ExecutorService pool = Executors.newFixedThreadPool(3);
@@ -212,7 +217,6 @@ public class TestZkProcessorLatch {
   private ZkUtils getZkUtilsWithNewClient(String processorId) {
     ZkConnection zkConnection = ZkUtils.createZkConnection(testZkConnectionString, SESSION_TIMEOUT_MS);
     return new ZkUtils(
-        processorId,
         KEY_BUILDER,
         ZkUtils.createZkClient(zkConnection, CONNECTION_TIMEOUT_MS),
         CONNECTION_TIMEOUT_MS);

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkProcessorLatch.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkProcessorLatch.java
@@ -79,23 +79,23 @@ public class TestZkProcessorLatch {
 
     ExecutorService pool = Executors.newFixedThreadPool(3);
     Future processor = pool.submit(
-        () -> {
-          ZkUtils zkUtils = getZkUtilsWithNewClient(participant1);
-          zkUtils.connect();
-          ZkProcessorLatch latch = new ZkProcessorLatch(
-              latchSize, latchId, participant1, zkUtils);
-          latch.countDown();
-          try {
-            latch.await(30, TimeUnit.SECONDS);
-          } catch (Exception e) {
-            Assert.fail("Threw an exception while waiting for latch completion in participant1!" + e.getLocalizedMessage());
-          } finally {
-            zkUtils.close();
-          }
+      () -> {
+        ZkUtils zkUtils = getZkUtilsWithNewClient(participant1);
+        zkUtils.connect();
+        ZkProcessorLatch latch = new ZkProcessorLatch(
+            latchSize, latchId, participant1, zkUtils);
+        latch.countDown();
+        try {
+          latch.await(30, TimeUnit.SECONDS);
+        } catch (Exception e) {
+          Assert.fail("Threw an exception while waiting for latch completion in participant1!" + e.getLocalizedMessage());
+        } finally {
+          zkUtils.close();
+        }
       });
 
     try {
-       processor.get(30, TimeUnit.SECONDS);
+      processor.get(30, TimeUnit.SECONDS);
     } catch (Exception e) {
       Assert.fail("failed to get future." + e.getLocalizedMessage());
     } finally {
@@ -122,19 +122,19 @@ public class TestZkProcessorLatch {
 
     ExecutorService pool = Executors.newFixedThreadPool(3);
     Future f1 = pool.submit(
-        () -> {
-          ZkUtils zkUtils = getZkUtilsWithNewClient(participant1);
-          zkUtils.connect();
-          Latch latch = new ZkProcessorLatch(latchSize, latchId, participant1, zkUtils);
-          //latch.countDown(); only one thread counts down
-          try {
-            latch.await(30, TimeUnit.SECONDS);
-          } catch (TimeoutException e) {
-            Assert.fail(String.format("await timed out from  %s - %s", participant1, e.getLocalizedMessage()));
-          } finally {
-            zkUtils.close();
-          }
-        });
+      () -> {
+        ZkUtils zkUtils = getZkUtilsWithNewClient(participant1);
+        zkUtils.connect();
+        Latch latch = new ZkProcessorLatch(latchSize, latchId, participant1, zkUtils);
+        //latch.countDown(); only one thread counts down
+        try {
+          latch.await(30, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+          Assert.fail(String.format("await timed out from  %s - %s", participant1, e.getLocalizedMessage()));
+        } finally {
+          zkUtils.close();
+        }
+      });
 
     Future f2 = pool.submit(
       () -> {

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkProcessorLatch.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkProcessorLatch.java
@@ -43,12 +43,12 @@ public class TestZkProcessorLatch {
   private static final int SESSION_TIMEOUT_MS = 20000;
   private static final int CONNECTION_TIMEOUT_MS = 10000;
 
-
   @BeforeClass
   public static void setup() throws InterruptedException {
     zkServer = new EmbeddedZookeeper();
     zkServer.setup();
   }
+
   @Before
   public void testSetup() {
     testZkConnectionString = "127.0.0.1:" + zkServer.getPort();

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkProcessorLatch.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkProcessorLatch.java
@@ -18,18 +18,12 @@
  */
 package org.apache.samza.zk;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import org.I0Itec.zkclient.ZkConnection;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.MapConfig;
 import org.apache.samza.config.ZkConfig;
-import org.apache.samza.coordinator.CoordinationUtils;
 import org.apache.samza.coordinator.CoordinationServiceFactory;
+import org.apache.samza.coordinator.CoordinationUtils;
 import org.apache.samza.coordinator.Latch;
 import org.apache.samza.testUtils.EmbeddedZookeeper;
 import org.junit.After;
@@ -38,39 +32,57 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
 
-
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class TestZkProcessorLatch {
+  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(TestZkLeaderElector.class);
+
+  private static final ZkKeyBuilder KEY_BUILDER = new ZkKeyBuilder("test");
   private static EmbeddedZookeeper zkServer = null;
   private static String zkConnectionString;
+  private String testZkConnectionString = null;
+  private ZkUtils testZkUtils = null;
+  private static final int SESSION_TIMEOUT_MS = 20000;
+  private static final int CONNECTION_TIMEOUT_MS = 10000;
+
   private final CoordinationServiceFactory factory = new ZkCoordinationServiceFactory();
-  private CoordinationUtils coordinationUtils;
 
   @BeforeClass
   public static void setup() throws InterruptedException {
     zkServer = new EmbeddedZookeeper();
     zkServer.setup();
-
     zkConnectionString = "localhost:" + zkServer.getPort();
-    System.out.println("ZK port = " + zkServer.getPort());
   }
-
   @Before
   public void testSetup() {
-    String groupId = "group1";
-    String processorId = "p1";
-    Map<String, String> map = new HashMap<>();
-    map.put(ZkConfig.ZK_CONNECT, zkConnectionString);
-    Config config = new MapConfig(map);
-
-
-    coordinationUtils = factory.getCoordinationService(groupId, processorId, config);
-    coordinationUtils.reset();
+    testZkConnectionString = "127.0.0.1:" + zkServer.getPort();
+    try {
+      testZkUtils = getZkUtilsWithNewClient("testZkUtils");
+    } catch (Exception e) {
+      Assert.fail("Client connection setup failed. Aborting tests..");
+    }
+    testZkUtils.connect();
   }
 
   @After
-  public void testTearDown() {
+  public void testTeardown() {
+    testZkUtils.deleteRoot();
+    testZkUtils.close();
+  }
+
+  private Config getConfig() {
+    Map<String, String> map = new HashMap<>();
+    map.put(ZkConfig.ZK_CONNECT, zkConnectionString);
+    return new MapConfig(map);
   }
 
   @AfterClass
@@ -79,50 +91,67 @@ public class TestZkProcessorLatch {
   }
 
   @Test
-  public void testSingleLatch1() {
-    System.out.println("Started 1");
-    int latchSize = 1;
-    String latchId = "l2";
+  public void testLatchSizeOne() {
+    final int latchSize = 1;
+    final String latchId = "latchSizeOne";
+    final String participant1 = "participant1";
+
     ExecutorService pool = Executors.newFixedThreadPool(3);
-    Future f1 = pool.submit(
-      () -> {
-        Latch latch = coordinationUtils.getLatch(latchSize, latchId);
-        latch.countDown();
-        try {
-          latch.await(100000, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException e) {
-          Assert.fail("await timed out. " + e.getLocalizedMessage());
-        }
+    Future processor = pool.submit(
+        () -> {
+          ZkUtils zkUtils = getZkUtilsWithNewClient(participant1);
+          zkUtils.connect();
+          ZkProcessorLatch latch = new ZkProcessorLatch(
+              latchSize, latchId, participant1, new ZkConfig(getConfig()), zkUtils);
+          latch.countDown();
+          try {
+            latch.await(30, TimeUnit.SECONDS);
+          } catch (Exception e) {
+            Assert.fail("Threw an exception while waiting for latch completion in participant1!" + e.getLocalizedMessage());
+          } finally {
+            zkUtils.close();
+          }
       });
 
     try {
-      f1.get(30000, TimeUnit.MILLISECONDS);
+       processor.get(30, TimeUnit.SECONDS);
     } catch (Exception e) {
       Assert.fail("failed to get future." + e.getLocalizedMessage());
+    } finally {
+      pool.shutdownNow();
     }
-    pool.shutdownNow();
+    try {
+      List<String> latchParticipants =
+          testZkUtils.getZkClient().getChildren(
+              String.format("%s/%s_%s", KEY_BUILDER.getRootPath(), ZkProcessorLatch.LATCH_PATH, latchId));
+      Assert.assertNotNull(latchParticipants);
+      Assert.assertEquals(1, latchParticipants.size());
+      Assert.assertEquals("0000000000", latchParticipants.get(0));
+    } catch (Exception e) {
+      Assert.fail("Failed to read the latch status from ZK directly" + e.getLocalizedMessage());
+    }
   }
 
-  @Test
-  public void testSingleLatch2() {
-    System.out.println("Started 1");
+//  @Test
+  public void testLatchSizeOneWithTwoParticipants() {
     int latchSize = 1;
-    String latchId = "l2";
-
+    String latchId = "testLatchSizeOneWithTwoParticipants";
     ExecutorService pool = Executors.newFixedThreadPool(3);
     Future f1 = pool.submit(
-      () -> {
-        Latch latch = coordinationUtils.getLatch(latchSize, latchId);
-        //latch.countDown(); only one thread counts down
-        try {
-          latch.await(100000, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException e) {
-          Assert.fail("await timed out. " + e.getLocalizedMessage());
-        }
-      });
+        () -> {
+          CoordinationUtils coordinationUtils = factory.getCoordinationService("groupId", "participant1", getConfig());
+          Latch latch = coordinationUtils.getLatch(latchSize, latchId);
+          //latch.countDown(); only one thread counts down
+          try {
+            latch.await(100000, TimeUnit.MILLISECONDS);
+          } catch (TimeoutException e) {
+            Assert.fail("await timed out. " + e.getLocalizedMessage());
+          }
+        });
 
     Future f2 = pool.submit(
       () -> {
+        CoordinationUtils coordinationUtils = factory.getCoordinationService("groupId", "participant2", getConfig());
         Latch latch = coordinationUtils.getLatch(latchSize, latchId);
         latch.countDown();
         try {
@@ -141,63 +170,87 @@ public class TestZkProcessorLatch {
     pool.shutdownNow();
   }
 
-  @Test
-  public void testNSizeLatch() {
-    System.out.println("Started N");
-    String latchId = "l1";
+//  @Test
+  public void testLatchSizeN() {
     int latchSize = 3;
+    String latchId = "testLatchSizeN";
 
     ExecutorService pool = Executors.newFixedThreadPool(3);
     Future f1 = pool.submit(
       () -> {
-        Latch latch = coordinationUtils.getLatch(latchSize, latchId);
-        latch.countDown();
+        CoordinationUtils coordinationUtils;
+        Latch latch = null;
+        try {
+          coordinationUtils = factory.getCoordinationService("groupId", "participant1", getConfig());
+          latch = coordinationUtils.getLatch(latchSize, latchId);
+          latch.countDown();
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
         try {
           latch.await(100000, TimeUnit.MILLISECONDS);
         } catch (TimeoutException e) {
+          System.out.println("######## Future 1 #############");
+          e.printStackTrace();
           Assert.fail("await timed out " + e.getLocalizedMessage());
         }
       });
     Future f2 = pool.submit(
       () -> {
+        CoordinationUtils coordinationUtils = factory.getCoordinationService("groupId", "participant2", getConfig());
         Latch latch = coordinationUtils.getLatch(latchSize, latchId);
         latch.countDown();
         try {
           latch.await(100000, TimeUnit.MILLISECONDS);
         } catch (TimeoutException e) {
+          System.out.println("######## Future 2 #############");
+          e.printStackTrace();
           Assert.fail("await timed out. " + e.getLocalizedMessage());
         }
       });
     Future f3 = pool.submit(
       () -> {
+        CoordinationUtils coordinationUtils = factory.getCoordinationService("groupId", "participant3", getConfig());
         Latch latch = coordinationUtils.getLatch(latchSize, latchId);
         latch.countDown();
         try {
           latch.await(100000, TimeUnit.MILLISECONDS);
         } catch (TimeoutException e) {
+          System.out.println("######## Future 3 #############");
+          e.printStackTrace();
           Assert.fail("await timed out. " + e.getLocalizedMessage());
         }
       });
 
     try {
       f1.get(300, TimeUnit.MILLISECONDS);
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assert.fail("failed to get future1 " + e.getLocalizedMessage());
+    }
+    try {
       f2.get(300, TimeUnit.MILLISECONDS);
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assert.fail("failed to get future2 " + e.getLocalizedMessage());
+    }
+    try {
       f3.get(300, TimeUnit.MILLISECONDS);
     } catch (Exception e) {
-      Assert.fail("failed to get future. " + e.getLocalizedMessage());
+      e.printStackTrace();
+      Assert.fail("failed to get future3 " + e.getLocalizedMessage());
     }
   }
 
-  @Test
+//  @Test
   public void testLatchExpires() {
-    System.out.println("Started expiring");
     String latchId = "l4";
-
     int latchSize = 3;
 
     ExecutorService pool = Executors.newFixedThreadPool(3);
     Future f1 = pool.submit(
       () -> {
+        CoordinationUtils coordinationUtils = factory.getCoordinationService("groupId", "participant1", getConfig());
         Latch latch = coordinationUtils.getLatch(latchSize, latchId);
         latch.countDown();
         try {
@@ -208,6 +261,7 @@ public class TestZkProcessorLatch {
       });
     Future f2 = pool.submit(
       () -> {
+        CoordinationUtils coordinationUtils = factory.getCoordinationService("groupId", "participant2", getConfig());
         Latch latch = coordinationUtils.getLatch(latchSize, latchId);
         latch.countDown();
         try {
@@ -218,6 +272,7 @@ public class TestZkProcessorLatch {
       });
     Future f3 = pool.submit(
       () -> {
+        CoordinationUtils coordinationUtils = factory.getCoordinationService("groupId", "participant3", getConfig());
         Latch latch = coordinationUtils.getLatch(latchSize, latchId);
         // This processor never completes its task
         //latch.countDown();
@@ -241,54 +296,12 @@ public class TestZkProcessorLatch {
     }
     pool.shutdownNow();
   }
-
-  @Test
-  public void testSingleCountdown() {
-    System.out.println("Started single countdown");
-    String latchId = "l1";
-    int latchSize = 3;
-
-    ExecutorService pool = Executors.newFixedThreadPool(3);
-    // Only one thread invokes countDown
-    Future f1 = pool.submit(
-      () -> {
-        Latch latch = coordinationUtils.getLatch(latchSize, latchId);
-        latch.countDown();
-        TestZkUtils.sleepMs(100);
-        latch.countDown();
-        TestZkUtils.sleepMs(100);
-        latch.countDown();
-        try {
-          latch.await(100000, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException e) {
-          Assert.fail("await timed out. " + e.getLocalizedMessage());
-        }
-      });
-    Future f2 = pool.submit(
-      () -> {
-        Latch latch = coordinationUtils.getLatch(latchSize, latchId);
-        try {
-          latch.await(100000, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException e) {
-          Assert.fail("await timed out. " + e.getLocalizedMessage());
-        }
-      });
-    Future f3 = pool.submit(
-      () -> {
-        Latch latch = coordinationUtils.getLatch(latchSize, latchId);
-        try {
-          latch.await(100000, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException e) {
-          Assert.fail("await timed out. " + e.getLocalizedMessage());
-        }
-      });
-    try {
-      f1.get(600, TimeUnit.MILLISECONDS);
-      f2.get(600, TimeUnit.MILLISECONDS);
-      f3.get(600, TimeUnit.MILLISECONDS);
-    } catch (Exception e) {
-      Assert.fail("Failed to get.");
-    }
-    pool.shutdownNow();
+  private ZkUtils getZkUtilsWithNewClient(String processorId) {
+    ZkConnection zkConnection = ZkUtils.createZkConnection(testZkConnectionString, SESSION_TIMEOUT_MS);
+    return new ZkUtils(
+        processorId,
+        KEY_BUILDER,
+        ZkUtils.createZkClient(zkConnection, CONNECTION_TIMEOUT_MS),
+        CONNECTION_TIMEOUT_MS);
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkUtils.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkUtils.java
@@ -76,7 +76,6 @@ public class TestZkUtils {
 
   }
 
-
   @After
   public void testTeardown() {
     zkUtils.close();


### PR DESCRIPTION
* Removed testSingleCountdown - didn't understand what was being tested
* The timeout behavior for ZkProcessorLatch has not been documented. Hence, I have fixed testLatchExpires as best I could understand. 
* Removed redundant/unused member variables from ZkProcessorLatch