### PR TITLE
SAMZA-1191: Fixed flaky test: TestExponentialSleepStrategy testThreadInterruptInRetryLoop

### DIFF
--- a/samza-core/src/test/scala/org/apache/samza/util/TestExponentialSleepStrategy.scala
+++ b/samza-core/src/test/scala/org/apache/samza/util/TestExponentialSleepStrategy.scala
@@ -140,8 +140,6 @@ class TestExponentialSleepStrategy {
         (exception, loop) => throw exception
       )
     }
-    assertEquals(1, iterations)
-    assertEquals(1, loopObject.sleepCount)
     assertEquals(classOf[InterruptedException], exception.get.getClass)
   }
 
@@ -155,8 +153,6 @@ class TestExponentialSleepStrategy {
         (exception, loop) => throw exception
       )
     }
-    assertEquals(1, iterations)
-    assertEquals(0, loopObject.sleepCount)
     assertEquals(classOf[InterruptedException], exception.get.getClass)
   }
 }


### PR DESCRIPTION
It's possible that the interruptee thread (see `#interruptedThread`) gets pre-empted before it has a chance to run the operation (increment `iterations`) and then gets interrupted, causing these assertions to fail.

I think these assertions also aren't critical for the tests which I presume want to test interrupt propagation behavior, so removing them in this change.

@vjagadish1989 & @xinyuiscool, please take a look.