### PR TITLE
SAMZA-1089: Enable YarnJob and ClientHelper to kill a job by name rather than YARN ApplicationID

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,11 @@ allprojects {
   }
 }
 
+tasks.withType(ScalaCompile) {
+    scalaCompileOptions.additionalParameters = [ scalaOptions ]
+    scalaCompileOptions.fork = false
+  }
+
 apply from: file("gradle/dependency-versions.gradle")
 apply from: file("gradle/dependency-versions-scala-" + scalaVersion + ".gradle")
 apply from: file("gradle/release.gradle")

--- a/build.gradle
+++ b/build.gradle
@@ -32,11 +32,6 @@ allprojects {
   }
 }
 
-tasks.withType(ScalaCompile) {
-    scalaCompileOptions.additionalParameters = [ scalaOptions ]
-    scalaCompileOptions.fork = false
-  }
-
 apply from: file("gradle/dependency-versions.gradle")
 apply from: file("gradle/dependency-versions-scala-" + scalaVersion + ".gradle")
 apply from: file("gradle/release.gradle")

--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/ClientHelper.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/ClientHelper.scala
@@ -220,6 +220,20 @@ class ClientHelper(conf: Configuration) extends Logging {
     appId
   }
 
+  def getActiveApplicationIds(appName: String): List[ApplicationId] = {
+    val getAppsRsp = yarnClient.getApplications
+
+    getAppsRsp
+      .asScala
+        .filter(appRep => ((
+            Running.equals(convertState(appRep.getYarnApplicationState, appRep.getFinalApplicationStatus).get)
+            || New.equals(convertState(appRep.getYarnApplicationState, appRep.getFinalApplicationStatus).get)
+            )
+          && appName.equals(appRep.getName)))
+        .map(appRep => appRep.getApplicationId)
+        .toList
+  }
+
   def status(appId: ApplicationId): Option[ApplicationStatus] = {
     val statusResponse = yarnClient.getApplicationReport(appId)
     convertState(statusResponse.getYarnApplicationState, statusResponse.getFinalApplicationStatus)
@@ -251,7 +265,7 @@ class ClientHelper(conf: Configuration) extends Logging {
   private def convertState(state: YarnApplicationState, status: FinalApplicationStatus): Option[ApplicationStatus] = {
     (state, status) match {
       case (YarnApplicationState.FINISHED, FinalApplicationStatus.SUCCEEDED) => Some(SuccessfulFinish)
-      case (YarnApplicationState.KILLED, _) | (YarnApplicationState.FAILED, _) => Some(UnsuccessfulFinish)
+      case (YarnApplicationState.KILLED, _) | (YarnApplicationState.FAILED, _) | (YarnApplicationState.FINISHED, _) => Some(UnsuccessfulFinish)
       case (YarnApplicationState.NEW, _) | (YarnApplicationState.SUBMITTED, _) => Some(New)
       case _ => Some(Running)
     }
@@ -337,6 +351,8 @@ class ClientHelper(conf: Configuration) extends Logging {
     * Cleanup application staging directory.
     */
   def cleanupStagingDir(): Unit = {
-    YarnJobUtil.cleanupStagingDir(jobContext, FileSystem.get(conf))
+    if (jobContext != null) {
+      YarnJobUtil.cleanupStagingDir(jobContext, FileSystem.get(conf))
+    }
   }
 }

--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/ClientHelper.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/ClientHelper.scala
@@ -220,6 +220,21 @@ class ClientHelper(conf: Configuration) extends Logging {
     appId
   }
 
+  /**
+    * Gets the list of Yarn [[org.apache.hadoop.yarn.api.records.ApplicationId]]
+    * corresponding to the specified appName and are "active".
+    * <p>
+    * In this context, "active" means that the application is starting or running
+    * and is not in any terminated state.
+    * <p>
+    * In Samza, an appName should be unique and there should only be one active
+    * applicationId for a given appName, but this can be violated in unusual cases
+    * like while troubleshooting a new application. So, this method returns as many
+    * active application ids as it finds.
+    *
+    * @param appName the app name as found in the Name column in the Yarn application list.
+    * @return        the active application ids.
+    */
   def getActiveApplicationIds(appName: String): List[ApplicationId] = {
     val getAppsRsp = yarnClient.getApplications
 


### PR DESCRIPTION
Missed a couple files in the previous commit to enable YarnJob to kill and get status of a Job based on the job name rather than the YARN ApplicationName. 

These changes have been manually verified in a Yarn cluster at LI. 