### PR TITLE
SAMZA-1198: disable the flaky test TestZkBarrierForVersionUpgrade.testZkBarrierForVersionUpgrade

### DIFF
--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkBarrierForVersionUpgrade.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkBarrierForVersionUpgrade.java
@@ -34,6 +34,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 
@@ -74,6 +75,7 @@ public class TestZkBarrierForVersionUpgrade {
     zkServer.teardown();
   }
 
+  @Ignore("The test is flaky, see SAMZA-1193")
   @Test
   public void testZkBarrierForVersionUpgrade() {
     String barrierId = "b1";

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkBarrierForVersionUpgrade.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkBarrierForVersionUpgrade.java
@@ -74,6 +74,7 @@ public class TestZkBarrierForVersionUpgrade {
     zkServer.teardown();
   }
 
+  // TODO: SAMZA-1193 fix the following flaky test and re-enable it
   // @Test
   public void testZkBarrierForVersionUpgrade() {
     String barrierId = "b1";

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkBarrierForVersionUpgrade.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkBarrierForVersionUpgrade.java
@@ -34,7 +34,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 
@@ -75,8 +74,7 @@ public class TestZkBarrierForVersionUpgrade {
     zkServer.teardown();
   }
 
-  @Ignore("The test is flaky, see SAMZA-1193")
-  @Test
+  // @Test
   public void testZkBarrierForVersionUpgrade() {
     String barrierId = "b1";
     String ver = "1";


### PR DESCRIPTION
We are seeing the fails sometimes from this test, disabling it for build success first. See details in SAMZA-1198, and the JIRA for fix is in SAMZA-1193.