### PR TITLE
SAMZA-1209: Improve error handling in LocalStoreMonitor

### DIFF
--- a/samza-rest/src/main/java/org/apache/samza/monitor/LocalStoreMonitor.java
+++ b/samza-rest/src/main/java/org/apache/samza/monitor/LocalStoreMonitor.java
@@ -81,25 +81,33 @@ public class LocalStoreMonitor implements Monitor {
     for (JobInstance jobInstance : getHostAffinityEnabledJobs(localStoreDir)) {
       File jobDir = new File(localStoreDir,
                              String.format("%s-%s", jobInstance.getJobName(), jobInstance.getJobId()));
-      JobStatus jobStatus = jobsClient.getJobStatus(jobInstance);
-      for (Task task : jobsClient.getTasks(jobInstance)) {
-        for (String storeName : jobDir.list(DirectoryFileFilter.DIRECTORY)) {
-          LOG.info("Job: {} has the running status: {} with preferred host:  {}", jobInstance, jobStatus, task.getPreferredHost());
-          /**
-           *  A task store is active if all of the following conditions are true:
-           *  a) If the store is amongst the active stores of the task.
-           *  b) If the job has been started.
-           *  c) If the preferred host of the task is the localhost on which the monitor is run.
-           */
-          if (jobStatus.hasBeenStarted()
-              && task.getStoreNames().contains(storeName)
-              && task.getPreferredHost().equals(localHostName)) {
-            LOG.info(String.format("Store %s is actively used by the task: %s.", storeName, task.getTaskName()));
-          } else {
-            LOG.info(String.format("Store %s not used by the task: %s.", storeName, task.getTaskName()));
-            markSweepTaskStore(TaskStorageManager.getStorePartitionDir(jobDir, storeName, new TaskName(task.getTaskName())));
+      try {
+        JobStatus jobStatus = jobsClient.getJobStatus(jobInstance);
+        for (Task task : jobsClient.getTasks(jobInstance)) {
+          for (String storeName : jobDir.list(DirectoryFileFilter.DIRECTORY)) {
+            LOG.info("Job: {} has the running status: {} with preferred host:  {}", jobInstance, jobStatus, task.getPreferredHost());
+            /**
+             *  A task store is active if all of the following conditions are true:
+             *  a) If the store is amongst the active stores of the task.
+             *  b) If the job has been started.
+             *  c) If the preferred host of the task is the localhost on which the monitor is run.
+             */
+            if (jobStatus.hasBeenStarted()
+                && task.getStoreNames().contains(storeName)
+                && task.getPreferredHost().equals(localHostName)) {
+              LOG.info(String.format("Store %s is actively used by the task: %s.", storeName, task.getTaskName()));
+            } else {
+              LOG.info(String.format("Store %s not used by the task: %s.", storeName, task.getTaskName()));
+              markSweepTaskStore(TaskStorageManager.getStorePartitionDir(jobDir, storeName, new TaskName(task.getTaskName())));
+            }
           }
         }
+      } catch (Exception ex) {
+        if (!config.getIgnoreFailures()) {
+          throw ex;
+        }
+        LOG.warn("Local store cleanup for job: {} resulted in exception: {}. Config: {} turned on, failures are ignored.",
+                 new Object[]{jobInstance, ex, LocalStoreMonitorConfig.CONFIG_IGNORE_FAILURES});
       }
     }
   }

--- a/samza-rest/src/main/java/org/apache/samza/monitor/LocalStoreMonitor.java
+++ b/samza-rest/src/main/java/org/apache/samza/monitor/LocalStoreMonitor.java
@@ -85,7 +85,7 @@ public class LocalStoreMonitor implements Monitor {
         JobStatus jobStatus = jobsClient.getJobStatus(jobInstance);
         for (Task task : jobsClient.getTasks(jobInstance)) {
           for (String storeName : jobDir.list(DirectoryFileFilter.DIRECTORY)) {
-            LOG.info("Job: {} has the running status: {} with preferred host:  {}", jobInstance, jobStatus, task.getPreferredHost());
+            LOG.info("Job: {} has the running status: {} with preferred host: {}.", jobInstance, jobStatus, task.getPreferredHost());
             /**
              *  A task store is active if all of the following conditions are true:
              *  a) If the store is amongst the active stores of the task.
@@ -106,8 +106,8 @@ public class LocalStoreMonitor implements Monitor {
         if (!config.getIgnoreFailures()) {
           throw ex;
         }
-        LOG.warn("Local store cleanup for job: {} resulted in exception: {}. Config: {} turned on, failures are ignored.",
-                 new Object[]{jobInstance, ex, LocalStoreMonitorConfig.CONFIG_IGNORE_FAILURES});
+        LOG.warn("Config: {} turned on, failures will be ignored. Local store cleanup for job: {} resulted in exception: {}.",
+                 new Object[]{LocalStoreMonitorConfig.CONFIG_IGNORE_FAILURES, jobInstance, ex});
       }
     }
   }
@@ -151,14 +151,14 @@ public class LocalStoreMonitor implements Monitor {
     String taskStorePath = taskStoreDir.getAbsolutePath();
     File offsetFile = new File(taskStoreDir, OFFSET_FILE_NAME);
     if (!offsetFile.exists()) {
-      LOG.info("Deleting the task store : {}, since it has no offset file.", taskStorePath);
+      LOG.info("Deleting the task store: {}, since it has no offset file.", taskStorePath);
       long taskStoreSizeInBytes = taskStoreDir.getTotalSpace();
       FileUtils.deleteDirectory(taskStoreDir);
       localStoreMonitorMetrics.diskSpaceFreedInBytes.inc(taskStoreSizeInBytes);
       localStoreMonitorMetrics.noOfDeletedTaskPartitionStores.inc();
     } else if ((CLOCK.currentTimeMillis() - offsetFile.lastModified()) >= config.getOffsetFileTTL()) {
-      LOG.info("Deleting the offset file from the store : {}, since the last modified timestamp : {} "
-                   + "of the offset file is older than config file ttl : {}.",
+      LOG.info("Deleting the offset file from the store: {}, since the last modified timestamp: {} "
+                   + "of the offset file is older than config file ttl: {}.",
                   taskStorePath, offsetFile.lastModified(), config.getOffsetFileTTL());
       offsetFile.delete();
     }

--- a/samza-rest/src/main/java/org/apache/samza/monitor/LocalStoreMonitorConfig.java
+++ b/samza-rest/src/main/java/org/apache/samza/monitor/LocalStoreMonitorConfig.java
@@ -54,8 +54,8 @@ public class LocalStoreMonitorConfig extends MapConfig {
   private static final long DEFAULT_OFFSET_FILE_TTL_MS = 1000 * 60 * 60 * 24 * 7;
 
   /**
-   * Boolean variable if set to true will make LocalStoreMonitor to ignore failures
-   * during store clean ups. By default, this is turned off.
+   * Will make LocalStoreMonitor ignore failures during store clean ups.
+   * By default, this is turned off.
    */
   public static final String CONFIG_IGNORE_FAILURES = "ignore.failures";
 
@@ -90,7 +90,7 @@ public class LocalStoreMonitorConfig extends MapConfig {
   }
 
   /**
-   *
+   * Determines if failures in store cleanup of individual jobs should be ignored in {@link LocalStoreMonitor}.
    * @return true, if store cleanup failures should be ignored in {@link LocalStoreMonitor} implementation.
    *         false, otherwise.
    */

--- a/samza-rest/src/main/java/org/apache/samza/monitor/LocalStoreMonitorConfig.java
+++ b/samza-rest/src/main/java/org/apache/samza/monitor/LocalStoreMonitorConfig.java
@@ -53,6 +53,12 @@ public class LocalStoreMonitorConfig extends MapConfig {
    */
   private static final long DEFAULT_OFFSET_FILE_TTL_MS = 1000 * 60 * 60 * 24 * 7;
 
+  /**
+   * Boolean variable if set to true will make LocalStoreMonitor to ignore failures
+   * during store clean ups. By default, this is turned off.
+   */
+  public static final String CONFIG_IGNORE_FAILURES = "ignore.failures";
+
   public LocalStoreMonitorConfig(Config config) {
     super(config);
   }
@@ -80,6 +86,15 @@ public class LocalStoreMonitorConfig extends MapConfig {
    *         on the job status server.
    */
   public List<String> getJobStatusServers() {
-     return Arrays.asList(StringUtils.split(get(CONFIG_JOB_STATUS_SERVERS), '.'));
+     return Arrays.asList(StringUtils.split(get(CONFIG_JOB_STATUS_SERVERS), ','));
+  }
+
+  /**
+   *
+   * @return true, if store cleanup failures should be ignored in {@link LocalStoreMonitor} implementation.
+   *         false, otherwise.
+   */
+  public boolean getIgnoreFailures() {
+    return getBoolean(CONFIG_IGNORE_FAILURES, false);
   }
 }

--- a/samza-rest/src/main/java/org/apache/samza/rest/resources/ResourceConstants.java
+++ b/samza-rest/src/main/java/org/apache/samza/rest/resources/ResourceConstants.java
@@ -20,7 +20,7 @@ package org.apache.samza.rest.resources;
 
 public class ResourceConstants {
 
-  public static final String GET_TASKS_URL = "http://%s/%s/%s/tasks/";
+  public static final String GET_TASKS_URL = "http://%s/v1/jobs/%s/%s/tasks/";
 
   public static final String GET_JOBS_URL = "http://%s/v1/jobs/%s/%s/";
 }

--- a/samza-rest/src/test/java/org/apache/samza/monitor/TestLocalStoreMonitor.java
+++ b/samza-rest/src/test/java/org/apache/samza/monitor/TestLocalStoreMonitor.java
@@ -36,6 +36,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
@@ -44,6 +46,8 @@ public class TestLocalStoreMonitor {
 
   private static File jobDir = new File(System.getProperty("java.io.tmpdir") + File.separator + "samza-test-job/",
                                         "test-jobName-jobId");
+
+  private static Logger LOG = LoggerFactory.getLogger(TestLocalStoreMonitor.class);
 
   private File taskStoreDir = new File(new File(jobDir, "test-store"), "test-task");
 
@@ -88,7 +92,8 @@ public class TestLocalStoreMonitor {
       FileUtils.deleteDirectory(taskStoreDir);
     } catch (IOException e) {
       // Happens when task store can't be deleted after test finishes.
-      Assert.fail();
+      LOG.error("Deletion of directory: {} resulted in the exception: {}.", new Object[]{taskStoreDir, e});
+      Assert.fail(e.getMessage());
     }
   }
 


### PR DESCRIPTION
Changes:

1. Add opt-in configuration to continue garbage collection of local stores
   when there’s a failure in garbage collecting one local store.
2. Handle failures gracefully. In getJobModel, JobModel is expected as return response.
   Incase of failures, returned error-message Map is deserialized to JobModel
   resulting in ClassCastException. Handle 2xx, failures separately. Log error
   messages returned properly in httpGet call.
3. Fix getTasks url format.
4. Minor code cleanup(Switch to using ',' as seperator for job.status.servers configuration
   instead of '.' for ease of use).
5. Fix disabled tests in TestLocalStoreMonitor.