### PR TITLE
SAMZA-1213 - StreamProcessorLifeCycleAware interface should not use processorId

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,6 +161,7 @@ project(":samza-core_$scalaVersion") {
     compile "org.eclipse.jetty:jetty-webapp:$jettyVersion"
     compile "com.101tec:zkclient:$zkClientVersion"
     compile "org.apache.commons:commons-collections4:$apacheCommonsCollections4Version"
+    compile "org.apache.commons:commons-lang3:$commonsLang3Version"
     testCompile project(":samza-api").sourceSets.test.output
     testCompile "junit:junit:$junitVersion"
     testCompile "org.mockito:mockito-all:$mockitoVersion"

--- a/samza-core/src/main/java/org/apache/samza/processor/SamzaContainerController.java
+++ b/samza-core/src/main/java/org/apache/samza/processor/SamzaContainerController.java
@@ -48,7 +48,7 @@ public class SamzaContainerController {
   private final Map<String, MetricsReporter> metricsReporterMap;
   private final Object taskFactory;
   private final long containerShutdownMs;
-  private final StreamProcessorLifeCycleAware lifeCycleAware;
+  private final StreamProcessorLifecycleListener lifecycleListener;
 
   // Internal Member Variables
   private Future containerFuture;
@@ -61,13 +61,13 @@ public class SamzaContainerController {
    *                            {@link org.apache.samza.task.AsyncStreamTask}
    * @param containerShutdownMs How long the Samza container should wait for an orderly shutdown of task instances
    * @param metricsReporterMap  Map of metric reporter name and {@link MetricsReporter} instance
-   * @param lifeCycleAware {@link StreamProcessorLifeCycleAware}
+   * @param lifecycleListener {@link StreamProcessorLifecycleListener}
    */
   public SamzaContainerController(
       Object taskFactory,
       long containerShutdownMs,
       Map<String, MetricsReporter> metricsReporterMap,
-      StreamProcessorLifeCycleAware lifeCycleAware) {
+      StreamProcessorLifecycleListener lifecycleListener) {
     this.taskFactory = taskFactory;
     this.metricsReporterMap = metricsReporterMap;
     if (containerShutdownMs == -1) {
@@ -76,7 +76,7 @@ public class SamzaContainerController {
       this.containerShutdownMs = containerShutdownMs;
     }
     // life cycle callbacks when shutdown and failure happens
-    this.lifeCycleAware = lifeCycleAware;
+    this.lifecycleListener = lifecycleListener;
   }
 
   /**
@@ -112,9 +112,9 @@ public class SamzaContainerController {
     containerFuture = executorService.submit(() -> {
         try {
           container.run();
-          lifeCycleAware.onShutdown();
+          lifecycleListener.onShutdown();
         } catch (Throwable t) {
-          lifeCycleAware.onFailure(t);
+          lifecycleListener.onFailure(t);
         }
       });
   }

--- a/samza-core/src/main/java/org/apache/samza/processor/SamzaContainerController.java
+++ b/samza-core/src/main/java/org/apache/samza/processor/SamzaContainerController.java
@@ -48,7 +48,6 @@ public class SamzaContainerController {
   private final Map<String, MetricsReporter> metricsReporterMap;
   private final Object taskFactory;
   private final long containerShutdownMs;
-  private final String processorId;
   private final StreamProcessorLifeCycleAware lifeCycleAware;
 
   // Internal Member Variables
@@ -58,7 +57,6 @@ public class SamzaContainerController {
    * Creates an instance of a controller for instantiating, starting and/or stopping {@link SamzaContainer}
    * Requests to execute a container are submitted to the {@link ExecutorService}
    *
-   * @param processorId         {@link StreamProcessor} ID
    * @param taskFactory         Factory that be used create instances of {@link org.apache.samza.task.StreamTask} or
    *                            {@link org.apache.samza.task.AsyncStreamTask}
    * @param containerShutdownMs How long the Samza container should wait for an orderly shutdown of task instances
@@ -66,12 +64,10 @@ public class SamzaContainerController {
    * @param lifeCycleAware {@link StreamProcessorLifeCycleAware}
    */
   public SamzaContainerController(
-      String processorId,
       Object taskFactory,
       long containerShutdownMs,
       Map<String, MetricsReporter> metricsReporterMap,
       StreamProcessorLifeCycleAware lifeCycleAware) {
-    this.processorId = processorId;
     this.taskFactory = taskFactory;
     this.metricsReporterMap = metricsReporterMap;
     if (containerShutdownMs == -1) {
@@ -116,9 +112,9 @@ public class SamzaContainerController {
     containerFuture = executorService.submit(() -> {
         try {
           container.run();
-          lifeCycleAware.onShutdown(processorId);
+          lifeCycleAware.onShutdown();
         } catch (Throwable t) {
-          lifeCycleAware.onFailure(processorId, t);
+          lifeCycleAware.onFailure(t);
         }
       });
   }

--- a/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
+++ b/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
@@ -57,7 +57,7 @@ import java.util.Map;
 @InterfaceStability.Evolving
 public class StreamProcessor {
   private final JobCoordinator jobCoordinator;
-  private final StreamProcessorLifeCycleAware lifeCycleAware;
+  private final StreamProcessorLifecycleListener lifecycleListener;
   private final String processorId;
 
   /**
@@ -73,36 +73,36 @@ public class StreamProcessor {
    * @param config                 Instance of config object - contains all configuration required for processing
    * @param customMetricsReporters Map of custom MetricReporter instances that are to be injected in the Samza job
    * @param asyncStreamTaskFactory The {@link AsyncStreamTaskFactory} to be used for creating task instances.
-   * @param lifeCycleAware         listener to the StreamProcessor life cycle
+   * @param lifecycleListener         listener to the StreamProcessor life cycle
    */
   public StreamProcessor(String processorId, Config config, Map<String, MetricsReporter> customMetricsReporters,
-                         AsyncStreamTaskFactory asyncStreamTaskFactory, StreamProcessorLifeCycleAware lifeCycleAware) {
-    this(processorId, config, customMetricsReporters, (Object) asyncStreamTaskFactory, lifeCycleAware);
+                         AsyncStreamTaskFactory asyncStreamTaskFactory, StreamProcessorLifecycleListener lifecycleListener) {
+    this(processorId, config, customMetricsReporters, (Object) asyncStreamTaskFactory, lifecycleListener);
   }
 
 
   /**
-   *Same as {@link #StreamProcessor(String, Config, Map, AsyncStreamTaskFactory, StreamProcessorLifeCycleAware)}, except task
+   *Same as {@link #StreamProcessor(String, Config, Map, AsyncStreamTaskFactory, StreamProcessorLifecycleListener)}, except task
    * instances are created using the provided {@link StreamTaskFactory}.
    * @param config - config
    * @param customMetricsReporters metric Reporter
    * @param streamTaskFactory task factory to instantiate the Task
-   * @param lifeCycleAware  listener to the StreamProcessor life cycle
+   * @param lifecycleListener  listener to the StreamProcessor life cycle
    */
   public StreamProcessor(String processorId, Config config, Map<String, MetricsReporter> customMetricsReporters,
-                         StreamTaskFactory streamTaskFactory, StreamProcessorLifeCycleAware lifeCycleAware) {
-    this(processorId, config, customMetricsReporters, (Object) streamTaskFactory, lifeCycleAware);
+                         StreamTaskFactory streamTaskFactory, StreamProcessorLifecycleListener lifecycleListener) {
+    this(processorId, config, customMetricsReporters, (Object) streamTaskFactory, lifecycleListener);
   }
 
   private StreamProcessor(String processorId, Config config, Map<String, MetricsReporter> customMetricsReporters,
-                          Object taskFactory, StreamProcessorLifeCycleAware lifeCycleAware) {
+                          Object taskFactory, StreamProcessorLifecycleListener lifecycleListener) {
     this.processorId = processorId;
 
     SamzaContainerController containerController = new SamzaContainerController(
         taskFactory,
         new TaskConfigJava(config).getShutdownMs(),
         customMetricsReporters,
-        lifeCycleAware);
+        lifecycleListener);
 
     this.jobCoordinator = Util.
         <JobCoordinatorFactory>getObj(
@@ -110,7 +110,7 @@ public class StreamProcessor {
                 .getJobCoordinatorFactoryClassName())
         .getJobCoordinator(processorId, config, containerController);
 
-    this.lifeCycleAware = lifeCycleAware;
+    this.lifecycleListener = lifecycleListener;
   }
 
   /**
@@ -124,7 +124,7 @@ public class StreamProcessor {
    */
   public void start() {
     jobCoordinator.start();
-    lifeCycleAware.onStart();
+    lifecycleListener.onStart();
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/processor/StreamProcessorLifeCycleAware.java
+++ b/samza-core/src/main/java/org/apache/samza/processor/StreamProcessorLifeCycleAware.java
@@ -31,21 +31,18 @@ import org.apache.samza.annotation.InterfaceStability;
 public interface StreamProcessorLifeCycleAware {
   /**
    * Callback when the {@link StreamProcessor} is started
-   * @param processorId id of the StreamProcessor
    */
-  void onStart(String processorId);
+  void onStart();
 
   /**
    * Callback when the {@link StreamProcessor} is shut down.
-   * @param processorId id of the StreamProcessor
    */
-  void onShutdown(String processorId);
+  void onShutdown();
 
   /**
    * Callback when the {@link StreamProcessor} fails
-   * @param processorId id of the StreamProcessor
    * @param t exception of the failure
    */
-  void onFailure(String processorId, Throwable t);
+  void onFailure(Throwable t);
 
 }

--- a/samza-core/src/main/java/org/apache/samza/processor/StreamProcessorLifecycleListener.java
+++ b/samza-core/src/main/java/org/apache/samza/processor/StreamProcessorLifecycleListener.java
@@ -28,7 +28,7 @@ import org.apache.samza.annotation.InterfaceStability;
  */
 
 @InterfaceStability.Evolving
-public interface StreamProcessorLifeCycleAware {
+public interface StreamProcessorLifecycleListener {
   /**
    * Callback when the {@link StreamProcessor} is started
    */

--- a/samza-core/src/main/java/org/apache/samza/processor/StreamProcessorLifecycleListener.java
+++ b/samza-core/src/main/java/org/apache/samza/processor/StreamProcessorLifecycleListener.java
@@ -41,7 +41,7 @@ public interface StreamProcessorLifecycleListener {
 
   /**
    * Callback when the {@link StreamProcessor} fails
-   * @param t exception of the failure
+   * @param t Cause of the failure
    */
   void onFailure(Throwable t);
 

--- a/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
@@ -37,7 +37,7 @@ import org.apache.samza.coordinator.Latch;
 import org.apache.samza.execution.ExecutionPlan;
 import org.apache.samza.job.ApplicationStatus;
 import org.apache.samza.processor.StreamProcessor;
-import org.apache.samza.processor.StreamProcessorLifeCycleAware;
+import org.apache.samza.processor.StreamProcessorLifecycleListener;
 import org.apache.samza.system.StreamSpec;
 import org.apache.samza.task.AsyncStreamTaskFactory;
 import org.apache.samza.task.StreamTaskFactory;
@@ -66,7 +66,7 @@ public class LocalApplicationRunner extends AbstractApplicationRunner {
 
   private ApplicationStatus appStatus = ApplicationStatus.New;
 
-  final class LocalStreamProcessorListener implements StreamProcessorLifeCycleAware {
+  final class LocalStreamProcessorListener implements StreamProcessorLifecycleListener {
     public final String processorId;
 
     public LocalStreamProcessorListener(String processorId) {
@@ -223,7 +223,7 @@ public class LocalApplicationRunner extends AbstractApplicationRunner {
       String processorId,
       Config config,
       StreamApplication app,
-      StreamProcessorLifeCycleAware listener) {
+      StreamProcessorLifecycleListener listener) {
     Object taskFactory = TaskFactoryUtil.createTaskFactory(config, app, this);
     if (taskFactory instanceof StreamTaskFactory) {
       return new StreamProcessor(

--- a/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
@@ -26,6 +26,8 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.samza.SamzaException;
 import org.apache.samza.application.StreamApplication;
 import org.apache.samza.config.ApplicationConfig;
@@ -70,8 +72,8 @@ public class LocalApplicationRunner extends AbstractApplicationRunner {
     public final String processorId;
 
     public LocalStreamProcessorListener(String processorId) {
-      if (processorId == null) {
-        throw new NullPointerException("processorId cannot be null in LocalStreamProcessorListener!!");
+      if (StringUtils.isEmpty(processorId)) {
+        throw new NullPointerException("processorId has to be defined in LocalStreamProcessorListener.");
       }
       this.processorId = processorId;
     }

--- a/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
@@ -32,7 +32,7 @@ import org.apache.samza.execution.ExecutionPlanner;
 import org.apache.samza.execution.StreamManager;
 import org.apache.samza.job.ApplicationStatus;
 import org.apache.samza.processor.StreamProcessor;
-import org.apache.samza.processor.StreamProcessorLifeCycleAware;
+import org.apache.samza.processor.StreamProcessorLifecycleListener;
 import org.apache.samza.system.StreamSpec;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -229,12 +229,12 @@ public class TestLocalApplicationRunner {
     when(planner.plan(anyObject())).thenReturn(plan);
 
     StreamProcessor sp = mock(StreamProcessor.class);
-    ArgumentCaptor<StreamProcessorLifeCycleAware> captor =
-        ArgumentCaptor.forClass(StreamProcessorLifeCycleAware.class);
+    ArgumentCaptor<StreamProcessorLifecycleListener> captor =
+        ArgumentCaptor.forClass(StreamProcessorLifecycleListener.class);
 
     doAnswer(i ->
       {
-        StreamProcessorLifeCycleAware listener = captor.getValue();
+        StreamProcessorLifecycleListener listener = captor.getValue();
         listener.onShutdown();
         return null;
       }).when(sp).start();
@@ -282,11 +282,11 @@ public class TestLocalApplicationRunner {
 
     Throwable t = new Throwable("test failure");
     StreamProcessor sp = mock(StreamProcessor.class);
-    ArgumentCaptor<StreamProcessorLifeCycleAware> captor =
-        ArgumentCaptor.forClass(StreamProcessorLifeCycleAware.class);
+    ArgumentCaptor<StreamProcessorLifecycleListener> captor =
+        ArgumentCaptor.forClass(StreamProcessorLifecycleListener.class);
 
     doAnswer(i -> {
-        StreamProcessorLifeCycleAware listener = captor.getValue();
+        StreamProcessorLifecycleListener listener = captor.getValue();
         listener.onFailure(t);
         return null;
       }).when(sp).start();

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestStreamProcessor.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestStreamProcessor.java
@@ -40,7 +40,7 @@ import org.apache.samza.config.Config;
 import org.apache.samza.config.MapConfig;
 import org.apache.samza.config.ZkConfig;
 import org.apache.samza.processor.StreamProcessor;
-import org.apache.samza.processor.StreamProcessorLifeCycleAware;
+import org.apache.samza.processor.StreamProcessorLifecycleListener;
 import org.apache.samza.task.AsyncStreamTaskAdapter;
 import org.apache.samza.task.AsyncStreamTaskFactory;
 import org.apache.samza.task.StreamTaskFactory;
@@ -76,7 +76,7 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
         new MapConfig(configs),
         new HashMap<>(),
         IdentityStreamTask::new,
-        new StreamProcessorLifeCycleAware() {
+        new StreamProcessorLifecycleListener() {
           @Override
           public void onStart() {
 
@@ -112,7 +112,7 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
     createTopics(inputTopic, outputTopic);
     final StreamTaskFactory stf = IdentityStreamTask::new;
     final StreamProcessor processor =
-        new StreamProcessor("1", configs, new HashMap<>(), stf, new StreamProcessorLifeCycleAware() {
+        new StreamProcessor("1", configs, new HashMap<>(), stf, new StreamProcessorLifecycleListener() {
           /**
            * Callback when the {@link StreamProcessor} is started
            */
@@ -157,7 +157,7 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
         configs,
         new HashMap<>(),
         stf,
-        new StreamProcessorLifeCycleAware() {
+        new StreamProcessorLifecycleListener() {
           @Override
           public void onStart() {
 
@@ -199,7 +199,7 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
         configs,
         new HashMap<>(),
         (StreamTaskFactory) null,
-        new StreamProcessorLifeCycleAware() {
+        new StreamProcessorLifecycleListener() {
           @Override
           public void onStart() {
 

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestStreamProcessor.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestStreamProcessor.java
@@ -52,20 +52,6 @@ import org.junit.Test;
 import static org.apache.samza.test.processor.IdentityStreamTask.endLatch;
 
 public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
-  private final StreamProcessorLifeCycleAware listener = new StreamProcessorLifeCycleAware() {
-    @Override
-    public void onStart(String processorId) {
-    }
-
-    @Override
-    public void onShutdown(String processorId) {
-    }
-
-    @Override
-    public void onFailure(String processorId, Throwable t) {
-    }
-  };
-
   /**
    * Testing a basic identity stream task - reads data from a topic and writes it to another topic
    * (without any modifications)
@@ -85,7 +71,27 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
     // Note: createTopics needs to be called before creating a StreamProcessor. Otherwise it fails with a
     // TopicExistsException since StreamProcessor auto-creates them.
     createTopics(inputTopic, outputTopic);
-    final StreamProcessor processor = new StreamProcessor(new MapConfig(configs), new HashMap<>(), IdentityStreamTask::new, listener);
+    final StreamProcessor processor = new StreamProcessor(
+        "1",
+        new MapConfig(configs),
+        new HashMap<>(),
+        IdentityStreamTask::new,
+        new StreamProcessorLifeCycleAware() {
+          @Override
+          public void onStart() {
+
+          }
+
+          @Override
+          public void onShutdown() {
+
+          }
+
+          @Override
+          public void onFailure(Throwable t) {
+
+          }
+        });
 
     produceMessages(inputTopic, messageCount);
     run(processor, endLatch);
@@ -105,7 +111,27 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
     final Config configs = new MapConfig(createConfigs("1", testSystem, inputTopic, outputTopic, messageCount));
     createTopics(inputTopic, outputTopic);
     final StreamTaskFactory stf = IdentityStreamTask::new;
-    final StreamProcessor processor = new StreamProcessor(configs, new HashMap<>(), stf, listener);
+    final StreamProcessor processor =
+        new StreamProcessor("1", configs, new HashMap<>(), stf, new StreamProcessorLifeCycleAware() {
+          /**
+           * Callback when the {@link StreamProcessor} is started
+           */
+          @Override
+          public void onStart() { }
+          /**
+           * Callback when the {@link StreamProcessor} is shut down.
+           */
+          @Override
+          public void onShutdown() { }
+
+          /**
+           * Callback when the {@link StreamProcessor} fails
+           *
+           * @param t exception of the failure
+           */
+          @Override
+          public void onFailure(Throwable t) { }
+        });
 
     produceMessages(inputTopic, messageCount);
     run(processor, endLatch);
@@ -126,7 +152,27 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
     final ExecutorService executorService = Executors.newSingleThreadExecutor();
     createTopics(inputTopic, outputTopic);
     final AsyncStreamTaskFactory stf = () -> new AsyncStreamTaskAdapter(new IdentityStreamTask(), executorService);
-    final StreamProcessor processor = new StreamProcessor(configs, new HashMap<>(), stf, listener);
+    final StreamProcessor processor = new StreamProcessor(
+        "1",
+        configs,
+        new HashMap<>(),
+        stf,
+        new StreamProcessorLifeCycleAware() {
+          @Override
+          public void onStart() {
+
+          }
+
+          @Override
+          public void onShutdown() {
+
+          }
+
+          @Override
+          public void onFailure(Throwable t) {
+
+          }
+        });
 
     produceMessages(inputTopic, messageCount);
     run(processor, endLatch);
@@ -148,7 +194,27 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
     configMap.remove("task.class");
     final Config configs = new MapConfig(configMap);
 
-    StreamProcessor processor = new StreamProcessor(configs, new HashMap<>(), (StreamTaskFactory) null, listener);
+    StreamProcessor processor = new StreamProcessor(
+        "1",
+        configs,
+        new HashMap<>(),
+        (StreamTaskFactory) null,
+        new StreamProcessorLifeCycleAware() {
+          @Override
+          public void onStart() {
+
+          }
+
+          @Override
+          public void onShutdown() {
+
+          }
+
+          @Override
+          public void onFailure(Throwable t) {
+
+          }
+        });
     run(processor, endLatch);
   }
 


### PR DESCRIPTION
Refactoring LocalApplicationRunner s.t. each processor has its own listener instance, instead of a single listener keeping track of all processors.