### PR TITLE
SAMZA-1224 : Revert job coordinator factory config to the old format

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/JobCoordinatorConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobCoordinatorConfig.java
@@ -22,8 +22,8 @@ package org.apache.samza.config;
 import com.google.common.base.Strings;
 
 public class JobCoordinatorConfig extends MapConfig {
-  public static final String JOB_COORDINATOR_FACTORY = "job-coordinator.factory";
-  public static final String JOB_COORDINATIOIN_SERVICE_FACTORY = "job-coordinationService.factory";
+  public static final String JOB_COORDINATOR_FACTORY = "job.coordinator.factory";
+  public static final String JOB_COORDINATIOIN_SERVICE_FACTORY = "job.coordinationService.factory";
 
   public JobCoordinatorConfig(Config config) {
     super(config);


### PR DESCRIPTION
We didn't release since adding this config. So, it is ok to change the format now.