### PR TITLE
fix HdfsSystemAdmin when staging directory is empty

### DIFF
--- a/samza-hdfs/src/main/java/org/apache/samza/system/hdfs/HdfsSystemConsumer.java
+++ b/samza-hdfs/src/main/java/org/apache/samza/system/hdfs/HdfsSystemConsumer.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
 import org.apache.samza.Partition;
 import org.apache.samza.SamzaException;
@@ -132,6 +133,12 @@ public class HdfsSystemConsumer extends BlockingEnvelopeMap {
         public Map<Partition, List<String>> load(String streamName)
           throws Exception {
           Validate.notEmpty(streamName);
+          if (StringUtils.isBlank(stagingDirectory)) {
+            throw new SamzaException("Staging directory can't be empty. "
+                + "Is this not a yarn job (currently hdfs system consumer only works in "
+                + "the same yarn environment on which hdfs is running)? " + "Is STAGING_DIRECTORY ("
+                + HdfsConfig.STAGING_DIRECTORY() + ") not set (see HdfsConfig.scala)?");
+          }
           return HdfsSystemAdmin.obtainPartitionDescriptorMap(stagingDirectory, streamName);
         }
       });

--- a/samza-hdfs/src/main/java/org/apache/samza/system/hdfs/partitioner/DirectoryPartitioner.java
+++ b/samza-hdfs/src/main/java/org/apache/samza/system/hdfs/partitioner/DirectoryPartitioner.java
@@ -20,6 +20,7 @@
 package org.apache.samza.system.hdfs.partitioner;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -32,6 +33,8 @@ import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.samza.Partition;
 import org.apache.samza.SamzaException;
@@ -192,12 +195,12 @@ public class DirectoryPartitioner {
   public Map<Partition, SystemStreamPartitionMetadata> getPartitionMetadataMap(String streamName,
     @Nullable Map<Partition, List<String>> existingPartitionDescriptorMap) {
     LOG.info("Trying to obtain metadata for " + streamName);
-    LOG.info("Existing partition descriptor: " + (existingPartitionDescriptorMap == null ? "empty"
+    LOG.info("Existing partition descriptor: " + (MapUtils.isEmpty(existingPartitionDescriptorMap) ? "empty"
       : existingPartitionDescriptorMap));
     Map<Partition, SystemStreamPartitionMetadata> partitionMetadataMap = new HashMap<>();
     partitionDescriptorMap.putIfAbsent(streamName, new HashMap<>());
     List<FileMetadata> filteredFiles = getFilteredFiles(streamName);
-    if (existingPartitionDescriptorMap != null) {
+    if (!MapUtils.isEmpty(existingPartitionDescriptorMap)) {
       filteredFiles = validateAndGetOriginalFilteredFiles(filteredFiles, existingPartitionDescriptorMap);
     }
     List<List<FileMetadata>> groupedPartitions = generatePartitionGroups(filteredFiles);


### PR DESCRIPTION
getSystemStreamMetadata has the potential side effect to persist metadata to a staging directory on hdfs. This could fail if staging directory is empty. This patch addresses the issue with test to cover the scenario.