### PR TITLE
SAMZA-1246: ApplicatonRunner.stats() should include exception in case of failure

### DIFF
--- a/checkstyle/checkstyle-suppressions.xml
+++ b/checkstyle/checkstyle-suppressions.xml
@@ -27,5 +27,8 @@
            files="TestZkProcessorLatch.java"
            lines="91-275"/>
            -->
+  <suppress checks="ConstantName"
+            files="ApplicationStatus.java"
+            lines="26-29"/>
 </suppressions>
 

--- a/samza-api/src/main/java/org/apache/samza/job/ApplicationStatus.java
+++ b/samza-api/src/main/java/org/apache/samza/job/ApplicationStatus.java
@@ -22,16 +22,63 @@ package org.apache.samza.job;
 /**
  * Status of a {@link org.apache.samza.job.StreamJob} during and after its run.
  */
-public enum ApplicationStatus {
-  Running("Running"), SuccessfulFinish("SuccessfulFinish"), UnsuccessfulFinish("UnsuccessfulFinish"), New("New");
+public class ApplicationStatus {
+  public static final ApplicationStatus New = new ApplicationStatus(StatusCode.New, null);
+  public static final ApplicationStatus Running = new ApplicationStatus(StatusCode.Running, null);
+  public static final ApplicationStatus SuccessfulFinish = new ApplicationStatus(StatusCode.SuccessfulFinish, null);
+  public static final ApplicationStatus UnsuccessfulFinish = new ApplicationStatus(StatusCode.UnsuccessfulFinish, null);
 
-  private final String str;
-
-  private ApplicationStatus(String str) {
-    this.str = str;
+  public enum StatusCode {
+    New,
+    Running,
+    SuccessfulFinish,
+    UnsuccessfulFinish
   }
 
+  private final StatusCode statusCode;
+  private final Throwable throwable;
+
+  private ApplicationStatus(StatusCode code, Throwable t) {
+    this.statusCode = code;
+    this.throwable = t;
+  }
+
+  public StatusCode getStatusCode() {
+    return statusCode;
+  }
+
+  public Throwable getThrowable() {
+    return throwable;
+  }
+
+  @Override
   public String toString() {
-    return str;
+    return statusCode.name();
+  }
+
+
+  public static ApplicationStatus unsuccessfulFinish(Throwable t) {
+    return new ApplicationStatus(StatusCode.UnsuccessfulFinish, t);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null) {
+      return false;
+    }
+    if (obj == this) {
+      return true;
+    }
+    if (obj.getClass() != getClass()) {
+      return false;
+    }
+
+    ApplicationStatus rhs = (ApplicationStatus) obj;
+    return statusCode.equals(rhs.statusCode);
+  }
+
+  @Override
+  public int hashCode() {
+    return statusCode.hashCode();
   }
 }

--- a/samza-api/src/main/java/org/apache/samza/runtime/ApplicationRunner.java
+++ b/samza-api/src/main/java/org/apache/samza/runtime/ApplicationRunner.java
@@ -96,7 +96,7 @@ public abstract class ApplicationRunner {
 
   /**
    * Get the collective status of the Samza jobs represented by {@link StreamApplication}.
-   * Returns {@link ApplicationStatus#Running} if any of the jobs are running.
+   * Returns {@link ApplicationRunner} running if all jobs are running.
    *
    * @param streamApp  the user-defined {@link StreamApplication} object
    * @return the status of the application

--- a/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
@@ -133,7 +133,7 @@ public class LocalApplicationRunner extends AbstractApplicationRunner {
       awaitComplete();
 
     } catch (Throwable t) {
-      appStatus = ApplicationStatus.UnsuccessfulFinish;
+      appStatus = ApplicationStatus.unsuccessfulFinish(t);
       throw new SamzaException("Failed to run application", t);
     } finally {
       if (coordination != null) {
@@ -247,7 +247,6 @@ public class LocalApplicationRunner extends AbstractApplicationRunner {
     latch.await();
 
     if (throwable.get() != null) {
-      appStatus = ApplicationStatus.UnsuccessfulFinish;
       throw throwable.get();
     } else {
       appStatus = ApplicationStatus.SuccessfulFinish;

--- a/samza-core/src/main/java/org/apache/samza/runtime/RemoteApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/RemoteApplicationRunner.java
@@ -84,8 +84,9 @@ public class RemoteApplicationRunner extends AbstractApplicationRunner {
   @Override
   public ApplicationStatus status(StreamApplication app) {
     try {
-      boolean finished = false;
-      boolean unsuccessfulFinish = false;
+      boolean hasNewJobs = false;
+      boolean hasRunningJobs = false;
+      ApplicationStatus unsuccessfulFinishStatus = null;
 
       ExecutionPlan plan = getExecutionPlan(app);
       for (JobConfig jobConfig : plan.getJobConfigs()) {
@@ -93,25 +94,36 @@ public class RemoteApplicationRunner extends AbstractApplicationRunner {
         ApplicationStatus status = runner.status();
         log.debug("Status is {} for job {}", new Object[]{status, jobConfig.getName()});
 
-        switch (status) {
+        switch (status.getStatusCode()) {
+          case New:
+            hasNewJobs = true;
+            break;
           case Running:
-            return ApplicationStatus.Running;
+            hasRunningJobs = true;
+            break;
           case UnsuccessfulFinish:
-            unsuccessfulFinish = true;
+            unsuccessfulFinishStatus = status;
+            break;
           case SuccessfulFinish:
-            finished = true;
             break;
           default:
             // Do nothing
         }
       }
 
-      if (unsuccessfulFinish) {
-        return ApplicationStatus.UnsuccessfulFinish;
-      } else if (finished) {
+      if (hasNewJobs) {
+        // There are jobs not started, report as New
+        return ApplicationStatus.New;
+      } else if (hasRunningJobs) {
+        // All jobs are started, some are running
+        return ApplicationStatus.Running;
+      } else if (unsuccessfulFinishStatus != null) {
+        // All jobs are finished, some are not successful
+        return unsuccessfulFinishStatus;
+      } else {
+        // All jobs are finished successfully
         return ApplicationStatus.SuccessfulFinish;
       }
-      return ApplicationStatus.New;
     } catch (Throwable t) {
       throw new SamzaException("Failed to get status for application", t);
     }

--- a/samza-core/src/main/scala/org/apache/samza/job/local/ProcessJob.scala
+++ b/samza-core/src/main/scala/org/apache/samza/job/local/ProcessJob.scala
@@ -70,7 +70,7 @@ class ProcessJob(commandBuilder: CommandBuilder, jobCoordinator: JobModelManager
 
   def kill: StreamJob = {
     process.destroyForcibly
-    jobStatus = Some(UnsuccessfulFinish);
+    jobStatus = Some(UnsuccessfulFinish)
     ProcessJob.this
   }
 


### PR DESCRIPTION
Current when ApplicationRunner.stats() only returns the enum representing the status. It also need to include the exception if the status is failure.