### PR TITLE
SAMZA-1247: MessageStreamImpl#merge shouldn't mutate input collection

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/operators/MessageStream.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/MessageStream.java
@@ -127,13 +127,11 @@ public interface MessageStream<M> {
 
   /**
    * Merge all {@code otherStreams} with this {@link MessageStream}.
-   * <p>
-   * The merging streams must have the same messages of type {@code M}.
    *
    * @param otherStreams other {@link MessageStream}s to be merged with this {@link MessageStream}
    * @return the merged {@link MessageStream}
    */
-  MessageStream<M> merge(Collection<MessageStream<? extends M>> otherStreams);
+  MessageStream<M> merge(Collection<? extends MessageStream<? extends M>> otherStreams);
 
   /**
    * Sends the messages of type {@code M}in this {@link MessageStream} to a repartitioned output stream and consumes

--- a/samza-core/src/main/java/org/apache/samza/operators/MessageStreamImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/MessageStreamImpl.java
@@ -187,9 +187,8 @@ public class MessageStreamImpl<M> implements MessageStream<M> {
   @Override
   public MessageStream<M> merge(Collection<? extends MessageStream<? extends M>> otherStreams) {
     MessageStreamImpl<M> nextStream = new MessageStreamImpl<>(this.graph);
-    List<MessageStream<M>> streamsToMerge = new ArrayList<>();
+    List<MessageStream<M>> streamsToMerge = new ArrayList<>((Collection<MessageStream<M>>) otherStreams);
     streamsToMerge.add(this);
-    streamsToMerge.addAll((Collection<MessageStream<M>>) otherStreams);
     streamsToMerge.forEach(stream -> {
         OperatorSpec mergeOperatorSpec =
             OperatorSpecs.createMergeOperatorSpec(nextStream, this.graph.getNextOpId());

--- a/samza-core/src/main/java/org/apache/samza/operators/MessageStreamImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/MessageStreamImpl.java
@@ -190,10 +190,10 @@ public class MessageStreamImpl<M> implements MessageStream<M> {
     List<MessageStream<M>> streamsToMerge = new ArrayList<>();
     streamsToMerge.add(this);
     streamsToMerge.addAll((Collection<MessageStream<M>>) otherStreams);
-    streamsToMerge.forEach(ms -> {
+    streamsToMerge.forEach(other -> {
         OperatorSpec mergeOperatorSpec =
             OperatorSpecs.createMergeOperatorSpec(nextStream, this.graph.getNextOpId());
-        ((MessageStreamImpl<M>) ms).registeredOperatorSpecs.add(mergeOperatorSpec);
+        ((MessageStreamImpl<M>) other).registeredOperatorSpecs.add(mergeOperatorSpec);
       });
     return nextStream;
   }

--- a/samza-core/src/main/java/org/apache/samza/operators/MessageStreamImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/MessageStreamImpl.java
@@ -190,10 +190,10 @@ public class MessageStreamImpl<M> implements MessageStream<M> {
     List<MessageStream<M>> streamsToMerge = new ArrayList<>();
     streamsToMerge.add(this);
     streamsToMerge.addAll((Collection<MessageStream<M>>) otherStreams);
-    streamsToMerge.forEach(other -> {
+    streamsToMerge.forEach(stream -> {
         OperatorSpec mergeOperatorSpec =
             OperatorSpecs.createMergeOperatorSpec(nextStream, this.graph.getNextOpId());
-        ((MessageStreamImpl<M>) other).registeredOperatorSpecs.add(mergeOperatorSpec);
+        ((MessageStreamImpl<M>) stream).registeredOperatorSpecs.add(mergeOperatorSpec);
       });
     return nextStream;
   }

--- a/samza-core/src/main/java/org/apache/samza/operators/MessageStreamImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/MessageStreamImpl.java
@@ -189,6 +189,7 @@ public class MessageStreamImpl<M> implements MessageStream<M> {
     MessageStreamImpl<M> nextStream = new MessageStreamImpl<>(this.graph);
     List<MessageStream<M>> streamsToMerge = new ArrayList<>((Collection<MessageStream<M>>) otherStreams);
     streamsToMerge.add(this);
+    
     streamsToMerge.forEach(stream -> {
         OperatorSpec mergeOperatorSpec =
             OperatorSpecs.createMergeOperatorSpec(nextStream, this.graph.getNextOpId());

--- a/samza-core/src/main/java/org/apache/samza/operators/MessageStreamImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/MessageStreamImpl.java
@@ -38,9 +38,11 @@ import org.apache.samza.storage.kv.KeyValueStore;
 import org.apache.samza.task.TaskContext;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -183,14 +185,15 @@ public class MessageStreamImpl<M> implements MessageStream<M> {
   }
 
   @Override
-  public MessageStream<M> merge(Collection<MessageStream<? extends M>> otherStreams) {
+  public MessageStream<M> merge(Collection<? extends MessageStream<? extends M>> otherStreams) {
     MessageStreamImpl<M> nextStream = new MessageStreamImpl<>(this.graph);
-
-    otherStreams.add(this);
-    otherStreams.forEach(other -> {
-        OperatorSpec mergeOperatorSepc =
+    List<MessageStream<M>> streamsToMerge = new ArrayList<>();
+    streamsToMerge.add(this);
+    streamsToMerge.addAll((Collection<MessageStream<M>>) otherStreams);
+    streamsToMerge.forEach(ms -> {
+        OperatorSpec mergeOperatorSpec =
             OperatorSpecs.createMergeOperatorSpec(nextStream, this.graph.getNextOpId());
-        ((MessageStreamImpl<M>) other).registeredOperatorSpecs.add(mergeOperatorSepc);
+        ((MessageStreamImpl<M>) ms).registeredOperatorSpecs.add(mergeOperatorSpec);
       });
     return nextStream;
   }


### PR DESCRIPTION
Also fixes
SAMZA-1253: MessageStream.merge operator broken for nested types