### PR TITLE
SAMZA-1228 : StreamProcessor should stop JmxServer

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
+++ b/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
@@ -33,7 +33,6 @@ import org.apache.samza.coordinator.JobCoordinatorFactory;
 import org.apache.samza.coordinator.JobCoordinatorListener;
 import org.apache.samza.job.model.ContainerModel;
 import org.apache.samza.job.model.JobModel;
-import org.apache.samza.metrics.JmxServer;
 import org.apache.samza.metrics.MetricsReporter;
 import org.apache.samza.task.AsyncStreamTaskFactory;
 import org.apache.samza.task.StreamTaskFactory;
@@ -200,12 +199,11 @@ public class StreamProcessor {
 
   }
 
-  SamzaContainer createSamzaContainer(ContainerModel containerModel, int maxChangelogStreamPartitions, JmxServer jmxServer) {
+  SamzaContainer createSamzaContainer(ContainerModel containerModel, int maxChangelogStreamPartitions) {
     return SamzaContainer.apply(
         containerModel,
         config,
         maxChangelogStreamPartitions,
-        jmxServer,
         Util.<String, MetricsReporter>javaMapAsScalaMap(customMetricsReporter),
         taskFactory);
   }
@@ -298,8 +296,7 @@ public class StreamProcessor {
 
           container = createSamzaContainer(
               jobModel.getContainers().get(processorId),
-              jobModel.maxChangeLogStreamPartitions,
-              new JmxServer());
+              jobModel.maxChangeLogStreamPartitions);
           container.setContainerListener(containerListener);
           LOGGER.info("Starting container " + container.toString());
           executorService = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -678,6 +678,8 @@ class SamzaContainer(
       info("Shutting down.")
       removeShutdownHook
 
+      jmxServer.stop
+
       shutdownConsumers
       shutdownTask
       shutdownStores
@@ -702,8 +704,6 @@ class SamzaContainer(
         }
         status = SamzaContainerStatus.FAILED
     }
-
-    jmxServer.stop
 
     status match {
       case SamzaContainerStatus.STOPPED =>

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -110,7 +110,6 @@ object SamzaContainer extends Logging {
     containerModel: ContainerModel,
     config: Config,
     maxChangeLogStreamPartitions: Int,
-    jmxServer: JmxServer,
     customReporters: Map[String, MetricsReporter] = Map[String, MetricsReporter](),
     taskFactory: Object) = {
     val containerId = containerModel.getProcessorId()
@@ -601,7 +600,6 @@ object SamzaContainer extends Logging {
       metrics = samzaContainerMetrics,
       reporters = reporters,
       jvm = jvm,
-      jmxServer = jmxServer,
       diskSpaceMonitor = diskSpaceMonitor,
       hostStatisticsMonitor = memoryStatisticsMonitor,
       taskThreadPool = taskThreadPool)
@@ -615,7 +613,6 @@ class SamzaContainer(
   consumerMultiplexer: SystemConsumers,
   producerMultiplexer: SystemProducers,
   metrics: SamzaContainerMetrics,
-  jmxServer: JmxServer,
   diskSpaceMonitor: DiskSpaceMonitor = null,
   hostStatisticsMonitor: SystemStatisticsMonitor = null,
   offsetManager: OffsetManager = new OffsetManager,
@@ -627,6 +624,7 @@ class SamzaContainer(
 
   val shutdownMs = containerContext.config.getShutdownMs.getOrElse(5000L)
   var shutdownHookThread: Thread = null
+  var jmxServer: JmxServer = null
 
   @volatile private var status = SamzaContainerStatus.NOT_STARTED
   private var exceptionSeen: Throwable = null
@@ -644,6 +642,8 @@ class SamzaContainer(
       info("Starting container.")
 
       status = SamzaContainerStatus.STARTING
+
+      jmxServer = new JmxServer()
 
       startMetrics
       startOffsetManager
@@ -673,6 +673,7 @@ class SamzaContainer(
         status = SamzaContainerStatus.FAILED
         exceptionSeen = e
     }
+
     try {
       info("Shutting down.")
       removeShutdownHook
@@ -701,6 +702,8 @@ class SamzaContainer(
         }
         status = SamzaContainerStatus.FAILED
     }
+
+    jmxServer.stop
 
     status match {
       case SamzaContainerStatus.STOPPED =>

--- a/samza-core/src/main/scala/org/apache/samza/job/local/ThreadJobFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/job/local/ThreadJobFactory.scala
@@ -70,7 +70,6 @@ class ThreadJobFactory extends StreamJobFactory with Logging {
         containerModel,
         config,
         jobModel.maxChangeLogStreamPartitions,
-        jmxServer,
         Map[String, MetricsReporter](),
         taskFactory)
       container.setContainerListener(containerListener)

--- a/samza-core/src/test/java/org/apache/samza/processor/TestStreamProcessor.java
+++ b/samza-core/src/test/java/org/apache/samza/processor/TestStreamProcessor.java
@@ -26,7 +26,6 @@ import org.apache.samza.container.SamzaContainer;
 import org.apache.samza.coordinator.JobCoordinator;
 import org.apache.samza.job.model.ContainerModel;
 import org.apache.samza.job.model.JobModel;
-import org.apache.samza.metrics.JmxServer;
 import org.apache.samza.metrics.MetricsReporter;
 import org.apache.samza.task.StreamTask;
 import org.apache.samza.task.StreamTaskFactory;
@@ -62,8 +61,7 @@ public class TestStreamProcessor {
     @Override
     SamzaContainer createSamzaContainer(
         ContainerModel containerModel,
-        int maxChangelogStreamPartitions,
-        JmxServer jmxServer) {
+        int maxChangelogStreamPartitions) {
       RunLoop mockRunLoop = mock(RunLoop.class);
       doAnswer(invocation ->
         {

--- a/samza-core/src/test/scala/org/apache/samza/container/TestSamzaContainer.scala
+++ b/samza-core/src/test/scala/org/apache/samza/container/TestSamzaContainer.scala
@@ -191,8 +191,7 @@ class TestSamzaContainer extends AssertionsForJUnit with MockitoSugar {
       runLoop = runLoop,
       consumerMultiplexer = consumerMultiplexer,
       producerMultiplexer = producerMultiplexer,
-      metrics = new SamzaContainerMetrics,
-      jmxServer = null)
+      metrics = new SamzaContainerMetrics)
 
     val containerListener = new SamzaContainerListener {
       override def onContainerFailed(t: Throwable): Unit = {
@@ -272,8 +271,7 @@ class TestSamzaContainer extends AssertionsForJUnit with MockitoSugar {
       runLoop = mockRunLoop,
       consumerMultiplexer = consumerMultiplexer,
       producerMultiplexer = producerMultiplexer,
-      metrics = new SamzaContainerMetrics,
-      jmxServer = null)
+      metrics = new SamzaContainerMetrics)
     val containerListener = new SamzaContainerListener {
       override def onContainerFailed(t: Throwable): Unit = {
         onContainerFailedCalled = true
@@ -354,8 +352,7 @@ class TestSamzaContainer extends AssertionsForJUnit with MockitoSugar {
       runLoop = runLoop,
       consumerMultiplexer = consumerMultiplexer,
       producerMultiplexer = producerMultiplexer,
-      metrics = new SamzaContainerMetrics,
-      jmxServer = null)
+      metrics = new SamzaContainerMetrics)
     val containerListener = new SamzaContainerListener {
       override def onContainerFailed(t: Throwable): Unit = {
         onContainerFailedCalled = true
@@ -437,8 +434,7 @@ class TestSamzaContainer extends AssertionsForJUnit with MockitoSugar {
       runLoop = mockRunLoop,
       consumerMultiplexer = consumerMultiplexer,
       producerMultiplexer = producerMultiplexer,
-      metrics = new SamzaContainerMetrics,
-      jmxServer = null)
+      metrics = new SamzaContainerMetrics)
       val containerListener = new SamzaContainerListener {
         override def onContainerFailed(t: Throwable): Unit = {
           onContainerFailedCalled = true
@@ -514,8 +510,7 @@ class TestSamzaContainer extends AssertionsForJUnit with MockitoSugar {
       runLoop = mockRunLoop,
       consumerMultiplexer = consumerMultiplexer,
       producerMultiplexer = producerMultiplexer,
-      metrics = new SamzaContainerMetrics,
-      jmxServer = null)
+      metrics = new SamzaContainerMetrics)
 
     val containerListener = new SamzaContainerListener {
         override def onContainerFailed(t: Throwable): Unit = {
@@ -582,8 +577,7 @@ class TestSamzaContainer extends AssertionsForJUnit with MockitoSugar {
       runLoop = null,
       consumerMultiplexer = consumerMultiplexer,
       producerMultiplexer = producerMultiplexer,
-      metrics = containerMetrics,
-      jmxServer = null)
+      metrics = containerMetrics)
 
     container.startStores
     assertNotNull(containerMetrics.taskStoreRestorationMetrics)

--- a/samza-core/src/test/scala/org/apache/samza/processor/StreamProcessorTestUtils.scala
+++ b/samza-core/src/test/scala/org/apache/samza/processor/StreamProcessorTestUtils.scala
@@ -57,8 +57,7 @@ object StreamProcessorTestUtils {
       runLoop = mockRunloop,
       consumerMultiplexer = consumerMultiplexer,
       producerMultiplexer = producerMultiplexer,
-      metrics = new SamzaContainerMetrics,
-      jmxServer = null)
+      metrics = new SamzaContainerMetrics)
     if (containerListener != null) {
       container.setContainerListener(containerListener)
     }


### PR DESCRIPTION
This is not the solution posted in SAMZA-1228. For now, we are moving jmxserver lifecycle to be within the container. Ideally, it should be within the Streamprocessor so that the job coordinator can also be associated with the same instance. 