### PR TITLE
SAMZA-1272 : ZkCoordinationUtils deletes the entire Zk tree on reset

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/zk/ZkControllerImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkControllerImpl.java
@@ -76,7 +76,6 @@ public class ZkControllerImpl implements ZkController {
     if (isLeader()) {
       zkLeaderElector.resignLeadership();
     }
-    zkUtils.close();
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkCoordinationUtils.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkCoordinationUtils.java
@@ -41,7 +41,7 @@ public class ZkCoordinationUtils implements CoordinationUtils {
 
   @Override
   public void reset() {
-    zkUtils.deleteRoot();
+    zkUtils.close();
   }
 
   @Override
@@ -59,7 +59,7 @@ public class ZkCoordinationUtils implements CoordinationUtils {
     return new ZkBarrierForVersionUpgrade(barrierId, zkUtils, debounceTimer, zkConfig.getZkBarrierTimeoutMs());
   }
 
-  // TODO - SAMZA-1128 CoordinationService should directly depende on ZkUtils and DebounceTimer
+  // TODO - SAMZA-1128 CoordinationService should directly depend on ZkUtils and DebounceTimer
   public ZkUtils getZkUtils() {
     return zkUtils;
   }

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
@@ -91,6 +91,7 @@ public class ZkJobCoordinator implements JobCoordinator, ZkControllerListener {
     }
     debounceTimer.stopScheduler();
     zkController.stop();
+
     if (coordinatorListener != null) {
       coordinatorListener.onCoordinatorStop();
     }

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkUtils.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkUtils.java
@@ -19,13 +19,6 @@
 
 package org.apache.samza.zk;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import com.google.common.annotations.VisibleForTesting;
 import org.I0Itec.zkclient.IZkChildListener;
 import org.I0Itec.zkclient.IZkDataListener;
 import org.I0Itec.zkclient.ZkClient;
@@ -38,6 +31,12 @@ import org.apache.zookeeper.data.Stat;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Util class to help manage Zk connection and ZkClient.
@@ -300,14 +299,5 @@ public class ZkUtils {
   public void subscribeToProcessorChange(IZkChildListener listener) {
     LOG.info("subscribing for child change at:" + keyBuilder.getProcessorsPath());
     zkClient.subscribeChildChanges(keyBuilder.getProcessorsPath(), listener);
-  }
-
-  @VisibleForTesting
-  public void deleteRoot() {
-    String rootPath = keyBuilder.getRootPath();
-    if (rootPath != null && !rootPath.isEmpty() && zkClient.exists(rootPath)) {
-      LOG.info("Deleteing root: " + rootPath);
-      zkClient.deleteRecursive(rootPath);
-    }
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkUtils.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkUtils.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import com.google.common.annotations.VisibleForTesting;
 import org.I0Itec.zkclient.IZkChildListener;
 import org.I0Itec.zkclient.IZkDataListener;
 import org.I0Itec.zkclient.ZkClient;
@@ -300,6 +302,7 @@ public class ZkUtils {
     zkClient.subscribeChildChanges(keyBuilder.getProcessorsPath(), listener);
   }
 
+  @VisibleForTesting
   public void deleteRoot() {
     String rootPath = keyBuilder.getRootPath();
     if (rootPath != null && !rootPath.isEmpty() && zkClient.exists(rootPath)) {

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkBarrierForVersionUpgrade.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkBarrierForVersionUpgrade.java
@@ -62,7 +62,6 @@ public class TestZkBarrierForVersionUpgrade {
 
     CoordinationServiceFactory serviceFactory = new ZkCoordinationServiceFactory();
     coordinationUtils = serviceFactory.getCoordinationService(groupId, processorId, config);
-    coordinationUtils.reset();
   }
 
   @After
@@ -94,27 +93,16 @@ public class TestZkBarrierForVersionUpgrade {
 
     barrier.start(ver, processors);
 
-    barrier.waitForBarrier(ver, "p1", new Runnable() {
-      @Override
-      public void run() {
-        s.p1 = true;
-      }
-    });
+    barrier.waitForBarrier(ver, "p1", () -> s.p1 = true);
 
-    barrier.waitForBarrier(ver, "p2", new Runnable() {
-      @Override
-      public void run() {
-        s.p2 = true;
-      }
-    });
+    barrier.waitForBarrier(ver, "p2", () -> s.p2 = true);
 
     Assert.assertTrue(TestZkUtils.testWithDelayBackOff(() -> s.p1 && s.p2, 2, 100));
   }
 
   @Test
   public void testNegativeZkBarrierForVersionUpgrade() {
-
-    String barrierId = "b1";
+    String barrierId = "negativeZkBarrierForVersionUpgrade";
     String ver = "1";
     List<String> processors = new ArrayList<String>();
     processors.add("p1");
@@ -151,7 +139,7 @@ public class TestZkBarrierForVersionUpgrade {
 
   @Test
   public void testZkBarrierForVersionUpgradeWithTimeOut() {
-    String barrierId = "b1";
+    String barrierId = "barrierTimeout";
     String ver = "1";
     List<String> processors = new ArrayList<String>();
     processors.add("p1");
@@ -169,27 +157,14 @@ public class TestZkBarrierForVersionUpgrade {
 
     barrier.start(ver, processors);
 
-    barrier.waitForBarrier(ver, "p1", new Runnable() {
-      @Override
-      public void run() {
-        s.p1 = true;
-      }
-    });
+    barrier.waitForBarrier(ver, "p1", () -> s.p1 = true);
 
-    barrier.waitForBarrier(ver, "p2", new Runnable() {
-      @Override
-      public void run() {
-        s.p2 = true;
-      }
-    });
+    barrier.waitForBarrier(ver, "p2", () -> s.p2 = true);
 
     // this node will join "too late"
-    barrier.waitForBarrier(ver, "p3", new Runnable() {
-      @Override
-      public void run() {
-        TestZkUtils.sleepMs(300);
-        s.p3 = true;
-      }
+    barrier.waitForBarrier(ver, "p3", () -> {
+      TestZkUtils.sleepMs(300);
+      s.p3 = true;
     });
     Assert.assertFalse(TestZkUtils.testWithDelayBackOff(() -> s.p1 && s.p2 && s.p3, 2, 400));
   }

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkBarrierForVersionUpgrade.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkBarrierForVersionUpgrade.java
@@ -79,7 +79,7 @@ public class TestZkBarrierForVersionUpgrade {
   public void testZkBarrierForVersionUpgrade() {
     String barrierId = "b1";
     String ver = "1";
-    List<String> processors = new ArrayList<String>();
+    List<String> processors = new ArrayList<>();
     processors.add("p1");
     processors.add("p2");
 
@@ -104,7 +104,7 @@ public class TestZkBarrierForVersionUpgrade {
   public void testNegativeZkBarrierForVersionUpgrade() {
     String barrierId = "negativeZkBarrierForVersionUpgrade";
     String ver = "1";
-    List<String> processors = new ArrayList<String>();
+    List<String> processors = new ArrayList<>();
     processors.add("p1");
     processors.add("p2");
     processors.add("p3");
@@ -120,19 +120,9 @@ public class TestZkBarrierForVersionUpgrade {
 
     barrier.start(ver, processors);
 
-    barrier.waitForBarrier(ver, "p1", new Runnable() {
-      @Override
-      public void run() {
-        s.p1 = true;
-      }
-    });
+    barrier.waitForBarrier(ver, "p1", () -> s.p1 = true);
 
-    barrier.waitForBarrier(ver, "p2", new Runnable() {
-      @Override
-      public void run() {
-        s.p2 = true;
-      }
-    });
+    barrier.waitForBarrier(ver, "p2", () -> s.p2 = true);
 
     Assert.assertFalse(TestZkUtils.testWithDelayBackOff(() -> s.p1 && s.p2 && s.p3, 2, 100));
   }
@@ -141,7 +131,7 @@ public class TestZkBarrierForVersionUpgrade {
   public void testZkBarrierForVersionUpgradeWithTimeOut() {
     String barrierId = "barrierTimeout";
     String ver = "1";
-    List<String> processors = new ArrayList<String>();
+    List<String> processors = new ArrayList<>();
     processors.add("p1");
     processors.add("p2");
     processors.add("p3");
@@ -163,9 +153,9 @@ public class TestZkBarrierForVersionUpgrade {
 
     // this node will join "too late"
     barrier.waitForBarrier(ver, "p3", () -> {
-      TestZkUtils.sleepMs(300);
-      s.p3 = true;
-    });
+        TestZkUtils.sleepMs(300);
+        s.p3 = true;
+      });
     Assert.assertFalse(TestZkUtils.testWithDelayBackOff(() -> s.p1 && s.p2 && s.p3, 2, 400));
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkLeaderElector.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkLeaderElector.java
@@ -79,7 +79,7 @@ public class TestZkLeaderElector {
 
   @After
   public void testTeardown() {
-    testZkUtils.deleteRoot();
+    testZkUtils.getZkClient().deleteRecursive(KEY_BUILDER.getRootPath());
     testZkUtils.close();
   }
 

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkProcessorLatch.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkProcessorLatch.java
@@ -67,7 +67,7 @@ public class TestZkProcessorLatch {
 
   @After
   public void testTeardown() {
-    testZkUtils.deleteRoot();
+    testZkUtils.getZkClient().deleteRecursive(KEY_BUILDER.getRootPath());
     testZkUtils.close();
   }
 


### PR DESCRIPTION
* ZkCoordinationUtils has a reset interface that deletes the entire Zk tree. This is not desirable.
* Also, fixed flakiness in unit test by unique barrier name in each of the unit tests. Otherwise, they share the same path on Zk and fail during concurrent test execution
