### PR TITLE
SAMZA-1276 : Adding customReporters passed by StreamProcessor into SamzaContainer

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -309,7 +309,7 @@ object SamzaContainer extends Logging {
 
     info("Setting up metrics reporters.")
 
-    val reporters = MetricsReporterLoader.getMetricsReporters(config, containerName).asScala.toMap
+    val reporters = MetricsReporterLoader.getMetricsReporters(config, containerName).asScala.toMap ++ customReporters
 
     info("Got metrics reporters: %s" format reporters.keys)
 


### PR DESCRIPTION
SamzaContainer is not adding custom reporters along side class-loaded reporters from config. This was missed in [SAMZA-1080](https://issues.apache.org/jira/browse/SAMZA-1080). 