### PR TITLE
Disabled flaky test for TestExponentialSleepStrategy testThreadInterruptInOperationSleep

### DIFF
--- a/samza-core/src/test/scala/org/apache/samza/util/TestExponentialSleepStrategy.scala
+++ b/samza-core/src/test/scala/org/apache/samza/util/TestExponentialSleepStrategy.scala
@@ -145,7 +145,9 @@ class TestExponentialSleepStrategy {
     assertEquals(classOf[InterruptedException], exception.get.getClass)
   }
 
-  @Test def testThreadInterruptInOperationSleep {
+  // TODO fix in SAMZA-1269
+  // @Test
+  def testThreadInterruptInOperationSleep {
     val strategy = new ExponentialSleepStrategy
     var iterations = 0
     var loopObject: RetryLoop = null


### PR DESCRIPTION
To be fixed in SAMZA-1269