### PR TITLE
SAMZA-1289: Default id generator if not configured

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/operators/MessageStream.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/MessageStream.java
@@ -153,7 +153,7 @@ public interface MessageStream<M> {
    * The merged {@link MessageStream} contains messages from all {@code streams} in the order they arrive.
    *
    * @param streams {@link MessageStream}s to be merged
-   * @param <T> the common type of messages in the streams
+   * @param <T> the type of messages in each of the streams
    * @return the merged {@link MessageStream}
    * @throws IllegalArgumentException if {@code streams} is empty
    */

--- a/samza-api/src/main/java/org/apache/samza/operators/MessageStream.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/MessageStream.java
@@ -153,6 +153,7 @@ public interface MessageStream<M> {
    * The merged {@link MessageStream} contains messages from all {@code streams} in the order they arrive.
    *
    * @param streams {@link MessageStream}s to be merged
+   * @param <T> the common type of messages in the streams
    * @return the merged {@link MessageStream}
    * @throws IllegalArgumentException if {@code streams} is empty
    */

--- a/samza-core/src/main/java/org/apache/samza/config/ApplicationConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ApplicationConfig.java
@@ -18,6 +18,9 @@
  */
 package org.apache.samza.config;
 
+import org.apache.samza.runtime.UUIDGenerator;
+
+
 /**
  * Accessors for configs associated with Application scope
  */
@@ -52,7 +55,7 @@ public class ApplicationConfig extends MapConfig {
   }
 
   public String getAppProcessorIdGeneratorClass() {
-    return get(APP_PROCESSOR_ID_GENERATOR_CLASS, null);
+    return get(APP_PROCESSOR_ID_GENERATOR_CLASS, UUIDGenerator.class.getName());
   }
 
   public String getAppName() {

--- a/samza-core/src/main/java/org/apache/samza/container/ContainerHeartbeatClient.java
+++ b/samza-core/src/main/java/org/apache/samza/container/ContainerHeartbeatClient.java
@@ -60,7 +60,7 @@ public class ContainerHeartbeatClient {
   }
 
   /**
-   * Issues a heartbeat request to the coordinator and
+   * Issues a heartbeat request to the coordinator
    * @return the corresponding {@link ContainerHeartbeatResponse}.
    */
   public ContainerHeartbeatResponse requestHeartbeat() {

--- a/samza-core/src/main/java/org/apache/samza/container/ContainerHeartbeatClient.java
+++ b/samza-core/src/main/java/org/apache/samza/container/ContainerHeartbeatClient.java
@@ -61,7 +61,7 @@ public class ContainerHeartbeatClient {
 
   /**
    * Issues a heartbeat request to the coordinator and
-   * returns the corresponding {@link ContainerHeartbeatResponse}.
+   * @return the corresponding {@link ContainerHeartbeatResponse}.
    */
   public ContainerHeartbeatResponse requestHeartbeat() {
     ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
Right now in standalone deployment we require the user to provide an id generator. Since most of the time the users can simply use the UUID generator for id generation, we should default it using that.