### PR TITLE
SAMZA-1264: Make Operator Functions Closable

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/application/StreamApplication.java
+++ b/samza-api/src/main/java/org/apache/samza/application/StreamApplication.java
@@ -58,11 +58,18 @@ import org.apache.samza.task.TaskContext;
  *     runner.waitForFinish();
  *   }
  * }</pre>
+ *
  * <p>
  * Implementation Notes: Currently StreamApplications are wrapped in a {@link StreamTask} during execution.
  * A new StreamApplication instance will be created and initialized when planning the execution, as well as for each
- * {@link StreamTask} instance used for processing incoming messages. Execution is synchronous and thread-safe
- * within each {@link StreamTask}.
+ * {@link StreamTask} instance used for processing incoming messages. Execution is synchronous and thread-safe within
+ * each {@link StreamTask}.
+ *
+ * <p>
+ * Functions implemented for transforms in StreamApplications ({@link org.apache.samza.operators.functions.MapFunction},
+ * {@link org.apache.samza.operators.functions.FilterFunction} for e.g.) are initable and closable. They are initialized
+ * before messages are delivered to them and closed after their execution when the {@link StreamTask} instance is closed.
+ * See {@link InitableFunction} and {@link org.apache.samza.operators.functions.ClosableFunction}
  */
 @InterfaceStability.Unstable
 public interface StreamApplication {

--- a/samza-api/src/main/java/org/apache/samza/application/StreamApplication.java
+++ b/samza-api/src/main/java/org/apache/samza/application/StreamApplication.java
@@ -69,7 +69,7 @@ import org.apache.samza.task.TaskContext;
  * Functions implemented for transforms in StreamApplications ({@link org.apache.samza.operators.functions.MapFunction},
  * {@link org.apache.samza.operators.functions.FilterFunction} for e.g.) are initable and closable. They are initialized
  * before messages are delivered to them and closed after their execution when the {@link StreamTask} instance is closed.
- * See {@link InitableFunction} and {@link org.apache.samza.operators.functions.ClosableFunction}
+ * See {@link InitableFunction} and {@link org.apache.samza.operators.functions.ClosableFunction}.
  */
 @InterfaceStability.Unstable
 public interface StreamApplication {

--- a/samza-api/src/main/java/org/apache/samza/operators/functions/ClosableFunction.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/functions/ClosableFunction.java
@@ -22,7 +22,7 @@ package org.apache.samza.operators.functions;
 import org.apache.samza.annotation.InterfaceStability;
 
 /**
- * A function that can be closed after its execution
+ * A function that can be closed after its execution.
  *
  * <p> Implement {@link #close()} to free resources used during the execution of the function, clean up state etc.
  *

--- a/samza-api/src/main/java/org/apache/samza/operators/functions/ClosableFunction.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/functions/ClosableFunction.java
@@ -16,26 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.samza.operators.functions;
 
 import org.apache.samza.annotation.InterfaceStability;
 
-
 /**
- * Specifies whether a message should be retained for further processing.
+ * A function that can be closed
  *
- * @param <M>  type of the input message
+ * <p>
+ *   The {@link #close()} method is typically used to free resources used during the execution of the function,
+ *   clean up state etc.
+ * </p>
  */
 @InterfaceStability.Unstable
-@FunctionalInterface
-public interface FilterFunction<M> extends InitableFunction, ClosableFunction {
-
-  /**
-   * Returns a boolean indicating whether this message should be retained or filtered out.
-   *
-   * @param message  the input message to be checked
-   * @return  true if {@code message} should be retained
-   */
-  boolean apply(M message);
-
+public interface ClosableFunction {
+  default void close() {}
 }

--- a/samza-api/src/main/java/org/apache/samza/operators/functions/ClosableFunction.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/functions/ClosableFunction.java
@@ -22,12 +22,10 @@ package org.apache.samza.operators.functions;
 import org.apache.samza.annotation.InterfaceStability;
 
 /**
- * A function that can be closed
+ * A function that can be closed after its execution
  *
- * <p>
- *   The {@link #close()} method is typically used to free resources used during the execution of the function,
- *   clean up state etc.
- * </p>
+ * <p> Implement {@link #close()} to free resources used during the execution of the function, clean up state etc.
+ *
  */
 @InterfaceStability.Unstable
 public interface ClosableFunction {

--- a/samza-api/src/main/java/org/apache/samza/operators/functions/FlatMapFunction.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/functions/FlatMapFunction.java
@@ -31,7 +31,7 @@ import java.util.Collection;
  */
 @InterfaceStability.Unstable
 @FunctionalInterface
-public interface FlatMapFunction<M, OM>  extends InitableFunction {
+public interface FlatMapFunction<M, OM>  extends InitableFunction, ClosableFunction {
 
   /**
    * Transforms the provided message into a collection of 0 or more messages.

--- a/samza-api/src/main/java/org/apache/samza/operators/functions/FoldLeftFunction.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/functions/FoldLeftFunction.java
@@ -22,7 +22,7 @@ package org.apache.samza.operators.functions;
 /**
  * Incrementally updates the window value as messages are added to the window.
  */
-public interface FoldLeftFunction<M, WV> extends InitableFunction {
+public interface FoldLeftFunction<M, WV> extends InitableFunction, ClosableFunction {
 
   /**
    * Incrementally updates the window value as messages are added to the window.

--- a/samza-api/src/main/java/org/apache/samza/operators/functions/JoinFunction.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/functions/JoinFunction.java
@@ -30,7 +30,7 @@ import org.apache.samza.annotation.InterfaceStability;
  * @param <RM>  type of the joined message
  */
 @InterfaceStability.Unstable
-public interface JoinFunction<K, M, JM, RM>  extends InitableFunction {
+public interface JoinFunction<K, M, JM, RM>  extends InitableFunction, ClosableFunction {
 
   /**
    * Joins the provided messages and returns the joined message.

--- a/samza-api/src/main/java/org/apache/samza/operators/functions/MapFunction.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/functions/MapFunction.java
@@ -29,7 +29,7 @@ import org.apache.samza.annotation.InterfaceStability;
  */
 @InterfaceStability.Unstable
 @FunctionalInterface
-public interface MapFunction<M, OM>  extends InitableFunction {
+public interface MapFunction<M, OM>  extends InitableFunction, ClosableFunction {
 
   /**
    * Transforms the provided message into another message.

--- a/samza-api/src/main/java/org/apache/samza/operators/functions/SinkFunction.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/functions/SinkFunction.java
@@ -30,7 +30,7 @@ import org.apache.samza.task.TaskCoordinator;
  */
 @InterfaceStability.Unstable
 @FunctionalInterface
-public interface SinkFunction<M>  extends InitableFunction {
+public interface SinkFunction<M>  extends InitableFunction, ClosableFunction {
 
   /**
    * Allows sending the provided message to an output {@link org.apache.samza.system.SystemStream} using

--- a/samza-core/src/main/java/org/apache/samza/operators/MessageStreamImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/MessageStreamImpl.java
@@ -148,6 +148,12 @@ public class MessageStreamImpl<M> implements MessageStream<M> {
 
         thisStreamState = new InternalInMemoryStore<>();
       }
+
+      @Override
+      public void close() {
+        // joinFn#close() must only be called once, so we do it in this partial join function's #close.
+        joinFn.close();
+      }
     };
 
     PartialJoinFunction<K, OM, M, TM> otherPartialJoinFn = new PartialJoinFunction<K, OM, M, TM>() {

--- a/samza-core/src/main/java/org/apache/samza/operators/functions/PartialJoinFunction.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/functions/PartialJoinFunction.java
@@ -23,7 +23,7 @@ import org.apache.samza.storage.kv.KeyValueStore;
 /**
  * An internal function that maintains state and join logic for one side of a two-way join.
  */
-public interface PartialJoinFunction<K, M, JM, RM> extends InitableFunction {
+public interface PartialJoinFunction<K, M, JM, RM> extends InitableFunction, ClosableFunction {
 
   /**
    * Joins a message in this stream with a message from another stream.

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImpl.java
@@ -42,6 +42,7 @@ public abstract class OperatorImpl<M, RM> {
   private static final String METRICS_GROUP = OperatorImpl.class.getName();
 
   private boolean initialized;
+  private boolean closed;
   private Set<OperatorImpl<RM, ?>> registeredOperators;
   private HighResolutionClock highResClock;
   private Counter numMessage;
@@ -59,6 +60,10 @@ public abstract class OperatorImpl<M, RM> {
 
     if (initialized) {
       throw new IllegalStateException(String.format("Attempted to initialize Operator %s more than once.", opName));
+    }
+
+    if (closed) {
+      throw new IllegalStateException(String.format("Attempted to initialize Operator %s after it was closed.", opName));
     }
 
     this.highResClock = createHighResClock(config);
@@ -160,6 +165,19 @@ public abstract class OperatorImpl<M, RM> {
   protected Collection<RM> handleTimer(MessageCollector collector, TaskCoordinator coordinator) {
     return Collections.emptyList();
   }
+
+  public void close() {
+
+    String opName = getOperatorSpec().getOpName();
+
+    if (closed) {
+      throw new IllegalStateException(String.format("Attempted to close Operator %s more than once.", opName));
+    }
+    handleClose();
+    closed = true;
+  }
+
+  protected abstract void handleClose();
 
   /**
    * Get the {@link OperatorSpec} for this {@link OperatorImpl}.

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImpl.java
@@ -167,7 +167,6 @@ public abstract class OperatorImpl<M, RM> {
   }
 
   public void close() {
-
     String opName = getOperatorSpec().getOpName();
 
     if (closed) {

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImplGraph.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImplGraph.java
@@ -100,6 +100,15 @@ public class OperatorImplGraph {
   }
 
   /**
+   * Get all {@link OperatorImpl}s for the graph.
+   *
+   * @return  an unmodifiable view of all {@link OperatorImpl}s for the graph
+   */
+  public Collection<OperatorImpl> getAllOperators() {
+    return Collections.unmodifiableCollection(this.operatorImpls.values());
+  }
+
+  /**
    * Traverses the DAG of {@link OperatorSpec}s starting from the provided {@link MessageStreamImpl},
    * creates the corresponding DAG of {@link OperatorImpl}s, and returns its root {@link RootOperatorImpl} node.
    *

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/PartialJoinOperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/PartialJoinOperatorImpl.java
@@ -112,6 +112,11 @@ class PartialJoinOperatorImpl<K, M, JM, RM> extends OperatorImpl<M, RM> {
   }
 
   @Override
+  protected void handleClose() {
+    this.thisPartialJoinFn.close();
+  }
+
+  @Override
   protected OperatorSpec<RM> getOperatorSpec() {
     return partialJoinOpSpec;
   }

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/RootOperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/RootOperatorImpl.java
@@ -44,6 +44,10 @@ public final class RootOperatorImpl<M> extends OperatorImpl<M, M> {
     return Collections.singletonList(message);
   }
 
+  @Override
+  protected void handleClose() {
+  }
+
   // TODO: SAMZA-1221 - Change to InputOperatorSpec that also builds the message
   @Override
   protected OperatorSpec<M> getOperatorSpec() {

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/SinkOperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/SinkOperatorImpl.java
@@ -57,6 +57,11 @@ class SinkOperatorImpl<M> extends OperatorImpl<M, M> {
   }
 
   @Override
+  protected void handleClose() {
+    this.sinkFn.close();
+  }
+
+  @Override
   protected OperatorSpec<M> getOperatorSpec() {
     return sinkOpSpec;
   }

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/StreamOperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/StreamOperatorImpl.java
@@ -58,6 +58,11 @@ class StreamOperatorImpl<M, RM> extends OperatorImpl<M, RM> {
   }
 
   @Override
+  protected void handleClose() {
+    this.transformFn.close();
+  }
+
+  @Override
   protected OperatorSpec<RM> getOperatorSpec() {
     return streamOpSpec;
   }

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/WindowOperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/WindowOperatorImpl.java
@@ -158,6 +158,15 @@ public class WindowOperatorImpl<M, WK, WV> extends OperatorImpl<M, WindowPane<WK
     return windowOpSpec;
   }
 
+  @Override
+  protected void handleClose() {
+    WindowInternal<M, WK, WV> window = windowOpSpec.getWindow();
+
+    if (window.getFoldLeftFunction() != null) {
+      window.getFoldLeftFunction().close();
+    }
+  }
+
   /**
    * Get the key to be used for lookups in the store for this message.
    */

--- a/samza-core/src/main/java/org/apache/samza/task/StreamOperatorTask.java
+++ b/samza-core/src/main/java/org/apache/samza/task/StreamOperatorTask.java
@@ -22,6 +22,7 @@ import org.apache.samza.application.StreamApplication;
 import org.apache.samza.config.Config;
 import org.apache.samza.operators.ContextManager;
 import org.apache.samza.operators.StreamGraphImpl;
+import org.apache.samza.operators.impl.OperatorImpl;
 import org.apache.samza.operators.impl.OperatorImplGraph;
 import org.apache.samza.operators.impl.RootOperatorImpl;
 import org.apache.samza.operators.stream.InputStreamInternal;
@@ -31,6 +32,7 @@ import org.apache.samza.system.SystemStream;
 import org.apache.samza.util.Clock;
 import org.apache.samza.util.SystemClock;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -140,5 +142,8 @@ public final class StreamOperatorTask implements StreamTask, InitableTask, Windo
     if (this.contextManager != null) {
       this.contextManager.close();
     }
+
+    Collection<OperatorImpl> allOperators = operatorImplGraph.getAllOperators();
+    allOperators.forEach(OperatorImpl::close);
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/operators/TestJoinOperator.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/TestJoinOperator.java
@@ -57,7 +57,7 @@ public class TestJoinOperator {
 
   @Test
   public void join() throws Exception {
-    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication());
+    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication(new TestJoinFunction()));
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -74,8 +74,8 @@ public class TestJoinOperator {
   public void testJoinFnInitAndClose() throws Exception {
     TestJoinFunction joinFn = new TestJoinFunction();
     StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication(joinFn));
-    List<Integer> output = new ArrayList<>();
-    MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
+    assertEquals(joinFn.getNumInitCalls(), 1);
+    MessageCollector messageCollector = mock(MessageCollector.class);
 
     // push messages to first stream
     numbers.forEach(n -> sot.process(new FirstStreamIME(n, n), messageCollector, taskCoordinator));
@@ -85,13 +85,12 @@ public class TestJoinOperator {
     sot.close();
 
     // close should be called from sot.close()
-    assertEquals(joinFn.getNumInitCalls(), 1);
     assertEquals(joinFn.getNumCloseCalls(), 1);
   }
 
   @Test
   public void joinReverse() throws Exception {
-    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication());
+    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication(new TestJoinFunction()));
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -106,7 +105,7 @@ public class TestJoinOperator {
 
   @Test
   public void joinNoMatch() throws Exception {
-    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication());
+    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication(new TestJoinFunction()));
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -120,7 +119,7 @@ public class TestJoinOperator {
 
   @Test
   public void joinNoMatchReverse() throws Exception {
-    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication());
+    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication(new TestJoinFunction()));
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -134,7 +133,7 @@ public class TestJoinOperator {
 
   @Test
   public void joinRetainsLatestMessageForKey() throws Exception {
-    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication());
+    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication(new TestJoinFunction()));
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -151,7 +150,7 @@ public class TestJoinOperator {
 
   @Test
   public void joinRetainsLatestMessageForKeyReverse() throws Exception {
-    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication());
+    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication(new TestJoinFunction()));
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -168,7 +167,7 @@ public class TestJoinOperator {
 
   @Test
   public void joinRetainsMatchedMessages() throws Exception {
-    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication());
+    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication(new TestJoinFunction()));
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -190,7 +189,7 @@ public class TestJoinOperator {
 
   @Test
   public void joinRetainsMatchedMessagesReverse() throws Exception {
-    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication());
+    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication(new TestJoinFunction()));
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -213,7 +212,7 @@ public class TestJoinOperator {
   @Test
   public void joinRemovesExpiredMessages() throws Exception {
     TestClock testClock = new TestClock();
-    StreamOperatorTask sot = createStreamOperatorTask(testClock, new TestJoinStreamApplication());
+    StreamOperatorTask sot = createStreamOperatorTask(testClock, new TestJoinStreamApplication(new TestJoinFunction()));
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -233,7 +232,7 @@ public class TestJoinOperator {
   @Test
   public void joinRemovesExpiredMessagesReverse() throws Exception {
     TestClock testClock = new TestClock();
-    StreamOperatorTask sot = createStreamOperatorTask(testClock, new TestJoinStreamApplication());
+    StreamOperatorTask sot = createStreamOperatorTask(testClock, new TestJoinStreamApplication(new TestJoinFunction()));
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -273,10 +272,6 @@ public class TestJoinOperator {
 
     TestJoinStreamApplication(TestJoinFunction joinFn) {
       this.joinFn = joinFn;
-    }
-
-    TestJoinStreamApplication() {
-      this(new TestJoinFunction());
     }
 
     @Override

--- a/samza-core/src/test/java/org/apache/samza/operators/TestJoinOperator.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/TestJoinOperator.java
@@ -57,7 +57,7 @@ public class TestJoinOperator {
 
   @Test
   public void join() throws Exception {
-    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock());
+    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication());
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -71,8 +71,27 @@ public class TestJoinOperator {
   }
 
   @Test
+  public void testJoinFnInitAndClose() throws Exception {
+    TestJoinFunction joinFn = new TestJoinFunction();
+    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication(joinFn));
+    List<Integer> output = new ArrayList<>();
+    MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
+
+    // push messages to first stream
+    numbers.forEach(n -> sot.process(new FirstStreamIME(n, n), messageCollector, taskCoordinator));
+
+    // close should not be called till now
+    assertEquals(joinFn.getNumCloseCalls(), 0);
+    sot.close();
+
+    // close should be called from sot.close()
+    assertEquals(joinFn.getNumInitCalls(), 1);
+    assertEquals(joinFn.getNumCloseCalls(), 1);
+  }
+
+  @Test
   public void joinReverse() throws Exception {
-    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock());
+    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication());
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -87,7 +106,7 @@ public class TestJoinOperator {
 
   @Test
   public void joinNoMatch() throws Exception {
-    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock());
+    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication());
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -101,7 +120,7 @@ public class TestJoinOperator {
 
   @Test
   public void joinNoMatchReverse() throws Exception {
-    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock());
+    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication());
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -115,7 +134,7 @@ public class TestJoinOperator {
 
   @Test
   public void joinRetainsLatestMessageForKey() throws Exception {
-    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock());
+    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication());
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -132,7 +151,7 @@ public class TestJoinOperator {
 
   @Test
   public void joinRetainsLatestMessageForKeyReverse() throws Exception {
-    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock());
+    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication());
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -149,7 +168,7 @@ public class TestJoinOperator {
 
   @Test
   public void joinRetainsMatchedMessages() throws Exception {
-    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock());
+    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication());
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -171,7 +190,7 @@ public class TestJoinOperator {
 
   @Test
   public void joinRetainsMatchedMessagesReverse() throws Exception {
-    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock());
+    StreamOperatorTask sot = createStreamOperatorTask(new SystemClock(), new TestJoinStreamApplication());
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -194,7 +213,7 @@ public class TestJoinOperator {
   @Test
   public void joinRemovesExpiredMessages() throws Exception {
     TestClock testClock = new TestClock();
-    StreamOperatorTask sot = createStreamOperatorTask(testClock);
+    StreamOperatorTask sot = createStreamOperatorTask(testClock, new TestJoinStreamApplication());
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -214,7 +233,7 @@ public class TestJoinOperator {
   @Test
   public void joinRemovesExpiredMessagesReverse() throws Exception {
     TestClock testClock = new TestClock();
-    StreamOperatorTask sot = createStreamOperatorTask(testClock);
+    StreamOperatorTask sot = createStreamOperatorTask(testClock, new TestJoinStreamApplication());
     List<Integer> output = new ArrayList<>();
     MessageCollector messageCollector = envelope -> output.add((Integer) envelope.getMessage());
 
@@ -230,7 +249,7 @@ public class TestJoinOperator {
     assertTrue(output.isEmpty());
   }
 
-  private StreamOperatorTask createStreamOperatorTask(Clock clock) throws Exception {
+  private StreamOperatorTask createStreamOperatorTask(Clock clock, StreamApplication app) throws Exception {
     ApplicationRunner runner = mock(ApplicationRunner.class);
     when(runner.getStreamSpec("instream")).thenReturn(new StreamSpec("instream", "instream", "insystem"));
     when(runner.getStreamSpec("instream2")).thenReturn(new StreamSpec("instream2", "instream2", "insystem2"));
@@ -243,13 +262,23 @@ public class TestJoinOperator {
 
     Config config = mock(Config.class);
 
-    StreamApplication sgb = new TestStreamApplication();
-    StreamOperatorTask sot = new StreamOperatorTask(sgb, runner, clock);
+    StreamOperatorTask sot = new StreamOperatorTask(app, runner, clock);
     sot.init(config, taskContext);
     return sot;
   }
 
-  private static class TestStreamApplication implements StreamApplication {
+  private static class TestJoinStreamApplication implements StreamApplication {
+
+    private final TestJoinFunction joinFn;
+
+    TestJoinStreamApplication(TestJoinFunction joinFn) {
+      this.joinFn = joinFn;
+    }
+
+    TestJoinStreamApplication() {
+      this(new TestJoinFunction());
+    }
+
     @Override
     public void init(StreamGraph graph, Config config) {
       MessageStream<FirstStreamIME> inStream =
@@ -259,7 +288,7 @@ public class TestJoinOperator {
 
       SystemStream outputSystemStream = new SystemStream("outputSystem", "outputStream");
       inStream
-          .join(inStream2, new TestJoinFunction(), JOIN_TTL)
+          .join(inStream2, joinFn, JOIN_TTL)
           .sink((message, messageCollector, taskCoordinator) -> {
               messageCollector.send(new OutgoingMessageEnvelope(outputSystemStream, message));
             });
@@ -267,6 +296,15 @@ public class TestJoinOperator {
   }
 
   private static class TestJoinFunction implements JoinFunction<Integer, FirstStreamIME, SecondStreamIME, Integer> {
+
+    private int numInitCalls = 0;
+    private int numCloseCalls = 0;
+
+    @Override
+    public void init(Config config, TaskContext context) {
+      numInitCalls++;
+    }
+
     @Override
     public Integer apply(FirstStreamIME message, SecondStreamIME otherMessage) {
       return (Integer) message.getMessage() + (Integer) otherMessage.getMessage();
@@ -280,6 +318,19 @@ public class TestJoinOperator {
     @Override
     public Integer getSecondKey(SecondStreamIME message) {
       return (Integer) message.getKey();
+    }
+
+    @Override
+    public void close() {
+      numCloseCalls++;
+    }
+
+    public int getNumInitCalls() {
+      return numInitCalls;
+    }
+
+    public int getNumCloseCalls() {
+      return numCloseCalls;
     }
   }
 

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImpl.java
@@ -197,6 +197,9 @@ public class TestOperatorImpl {
     }
 
     @Override
+    protected void handleClose() {}
+
+    @Override
     protected OperatorSpec<Object> getOperatorSpec() {
       return new TestOpSpec();
     }

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestSinkOperatorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestSinkOperatorImpl.java
@@ -36,17 +36,25 @@ import static org.mockito.Mockito.when;
 public class TestSinkOperatorImpl {
 
   @Test
-  public void testSinkOperator() {
-    SinkOperatorSpec<TestOutputMessageEnvelope> sinkOp = mock(SinkOperatorSpec.class);
+  public void testSinkOperatorSinkFunction() {
     SinkFunction<TestOutputMessageEnvelope> sinkFn = mock(SinkFunction.class);
-    when(sinkOp.getSinkFn()).thenReturn(sinkFn);
-    Config mockConfig = mock(Config.class);
-    TaskContext mockContext = mock(TaskContext.class);
-    SinkOperatorImpl<TestOutputMessageEnvelope> sinkImpl = new SinkOperatorImpl<>(sinkOp, mockConfig, mockContext);
+    SinkOperatorImpl<TestOutputMessageEnvelope> sinkImpl = createSinkOperator(sinkFn);
     TestOutputMessageEnvelope mockMsg = mock(TestOutputMessageEnvelope.class);
     MessageCollector mockCollector = mock(MessageCollector.class);
     TaskCoordinator mockCoordinator = mock(TaskCoordinator.class);
 
+    sinkImpl.handleMessage(mockMsg, mockCollector, mockCoordinator);
+    verify(sinkFn, times(1)).apply(mockMsg, mockCollector, mockCoordinator);
+  }
+
+  @Test
+  public void testSinkOperatorClose() {
+    TestOutputMessageEnvelope mockMsg = mock(TestOutputMessageEnvelope.class);
+    MessageCollector mockCollector = mock(MessageCollector.class);
+    TaskCoordinator mockCoordinator = mock(TaskCoordinator.class);
+    SinkFunction<TestOutputMessageEnvelope> sinkFn = mock(SinkFunction.class);
+
+    SinkOperatorImpl<TestOutputMessageEnvelope> sinkImpl = createSinkOperator(sinkFn);
     sinkImpl.handleMessage(mockMsg, mockCollector, mockCoordinator);
     verify(sinkFn, times(1)).apply(mockMsg, mockCollector, mockCoordinator);
 
@@ -56,5 +64,14 @@ public class TestSinkOperatorImpl {
     sinkImpl.handleClose();
     // ensure that close is called once from handleClose()
     verify(sinkFn, times(1)).close();
+  }
+
+  private SinkOperatorImpl createSinkOperator(SinkFunction<TestOutputMessageEnvelope> sinkFn) {
+    SinkOperatorSpec<TestOutputMessageEnvelope> sinkOp = mock(SinkOperatorSpec.class);
+    when(sinkOp.getSinkFn()).thenReturn(sinkFn);
+
+    Config mockConfig = mock(Config.class);
+    TaskContext mockContext = mock(TaskContext.class);
+    return new SinkOperatorImpl<>(sinkOp, mockConfig, mockContext);
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestSinkOperatorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestSinkOperatorImpl.java
@@ -49,5 +49,12 @@ public class TestSinkOperatorImpl {
 
     sinkImpl.handleMessage(mockMsg, mockCollector, mockCoordinator);
     verify(sinkFn, times(1)).apply(mockMsg, mockCollector, mockCoordinator);
+
+    // ensure that close is not called yet
+    verify(sinkFn, times(0)).close();
+
+    sinkImpl.handleClose();
+    // ensure that close is called once from handleClose()
+    verify(sinkFn, times(1)).close();
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestStreamOperatorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestStreamOperatorImpl.java
@@ -63,5 +63,11 @@ public class TestStreamOperatorImpl {
         .handleMessage(inMsg, mockCollector, mockCoordinator);
     verify(txfmFn, times(1)).apply(inMsg);
     assertEquals(results, mockOutputs);
+
+    // ensure that close is not called yet
+    verify(txfmFn, times(0)).close();
+    opImpl.handleClose();
+    // ensure that close is called once inside handleClose()
+    verify(txfmFn, times(1)).close();
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestStreamOperatorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestStreamOperatorImpl.java
@@ -63,6 +63,18 @@ public class TestStreamOperatorImpl {
         .handleMessage(inMsg, mockCollector, mockCoordinator);
     verify(txfmFn, times(1)).apply(inMsg);
     assertEquals(results, mockOutputs);
+  }
+
+  @Test
+  public void testSimpleOperatorClose() {
+    StreamOperatorSpec<TestMessageEnvelope, TestOutputMessageEnvelope> mockOp = mock(StreamOperatorSpec.class);
+    FlatMapFunction<TestMessageEnvelope, TestOutputMessageEnvelope> txfmFn = mock(FlatMapFunction.class);
+    when(mockOp.getTransformFn()).thenReturn(txfmFn);
+    Config mockConfig = mock(Config.class);
+    TaskContext mockContext = mock(TaskContext.class);
+
+    StreamOperatorImpl<TestMessageEnvelope, TestOutputMessageEnvelope> opImpl =
+        spy(new StreamOperatorImpl<>(mockOp, mockConfig, mockContext));
 
     // ensure that close is not called yet
     verify(txfmFn, times(0)).close();


### PR DESCRIPTION
- Added `close()` to the lifecycle of `OperatorImpl`s, and all `Function`s.
- Added unit tests to verify calls to `close()`