### PR TITLE
Updated test build and README versions to next version

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,7 +26,8 @@ And before you proceed, do the following steps:
    * checkout the $VERSION branch
    * update the gradle.properties s.t. the following property is $VERSION w/o the suffix '-SNAPSHOT':
       version=$VERSION
-   * change the samza_executable variable in samza-test/src/main/python/configs/tests.json to point to a Samza version w/o the suffix '-SNAPSHOT'
+   * change the samza_executable variable in samza-test/src/main/python/configs/tests.json to $VERSION w/o the suffix '-SNAPSHOT'. 
+   * change the samza-test versions in samza-test/src/main/config/join/README to $VERSION w/o the suffix '-SNAPSHOT'.
    * push the changes to the $VERSION branch
 
 Validate that all Samza source files have proper license information in their header.

--- a/docs/startup/hello-samza/versioned/index.md
+++ b/docs/startup/hello-samza/versioned/index.md
@@ -61,7 +61,7 @@ Then, you can continue w/ the following command in hello-samza project:
 {% highlight bash %}
 mvn clean package
 mkdir -p deploy/samza
-tar -xvf ./target/hello-samza-0.13.1-SNAPSHOT-dist.tar.gz -C deploy/samza
+tar -xvf ./target/hello-samza-0.13.1-dist.tar.gz -C deploy/samza
 {% endhighlight %}
 
 ### Run a Samza Job

--- a/docs/startup/hello-samza/versioned/index.md
+++ b/docs/startup/hello-samza/versioned/index.md
@@ -61,7 +61,7 @@ Then, you can continue w/ the following command in hello-samza project:
 {% highlight bash %}
 mvn clean package
 mkdir -p deploy/samza
-tar -xvf ./target/hello-samza-0.13.1-dist.tar.gz -C deploy/samza
+tar -xvf ./target/hello-samza-0.13.1-SNAPSHOT-dist.tar.gz -C deploy/samza
 {% endhighlight %}
 
 ### Run a Samza Job

--- a/samza-test/src/main/config/join/README
+++ b/samza-test/src/main/config/join/README
@@ -44,17 +44,17 @@ Deploy Zookeeper, YARN and Kafka:
 > cd $HELLO_SAMZA_SRC
 > for i in zookeeper kafka yarn; do ./bin/grid install $i; ./bin/grid start $i; done
 
-Update the "yarn.package.path" to $DEPLOY_DIR/samza-test_2.11-0.13.1.tgz
+Update the "yarn.package.path" to $DEPLOY_DIR/samza-test_2.11-0.13.1-SNAPSHOT.tgz
 > cd $SAMZA_SRC
 > vi samza-test/src/main/config/join/common.properties
-yarn.package.path=file:///path/to/samza-hello-samza/deploy/samza-test_2.11-0.13.1.tgz
+yarn.package.path=file:///path/to/samza-hello-samza/deploy/samza-test_2.11-0.13.1-SNAPSHOT.tgz
 
 Then release and extract the test tarball:
 > cd $SAMZA_SRC
 > ./gradlew releaseTestJobs
-> cp samza-test/build/distributions/samza-test_2.11-0.13.1.tgz $DEPLOY_DIR
+> cp samza-test/build/distributions/samza-test_2.11-0.13.1-SNAPSHOT.tgz $DEPLOY_DIR
 > mkdir $DEPLOY_DIR/samza
-> tar -xvf $DEPLOY_DIR/samza-test_2.11-0.13.1.tgz -C $DEPLOY_DIR/samza
+> tar -xvf $DEPLOY_DIR/samza-test_2.11-0.13.1-SNAPSHOT.tgz -C $DEPLOY_DIR/samza
 
 Finally, create the kafka topics and start the samza jobs:
 > ./bin/setup-int-test.sh $DEPLOY_DIR

--- a/samza-test/src/main/config/join/README
+++ b/samza-test/src/main/config/join/README
@@ -44,17 +44,17 @@ Deploy Zookeeper, YARN and Kafka:
 > cd $HELLO_SAMZA_SRC
 > for i in zookeeper kafka yarn; do ./bin/grid install $i; ./bin/grid start $i; done
 
-Update the "yarn.package.path" to $DEPLOY_DIR/samza-test_2.11-0.13.0.tgz
+Update the "yarn.package.path" to $DEPLOY_DIR/samza-test_2.11-0.13.1.tgz
 > cd $SAMZA_SRC
 > vi samza-test/src/main/config/join/common.properties
-yarn.package.path=file:///path/to/samza-hello-samza/deploy/samza-test_2.11-0.13.0.tgz
+yarn.package.path=file:///path/to/samza-hello-samza/deploy/samza-test_2.11-0.13.1.tgz
 
 Then release and extract the test tarball:
 > cd $SAMZA_SRC
 > ./gradlew releaseTestJobs
-> cp samza-test/build/distributions/samza-test_2.11-0.13.0.tgz $DEPLOY_DIR
+> cp samza-test/build/distributions/samza-test_2.11-0.13.1.tgz $DEPLOY_DIR
 > mkdir $DEPLOY_DIR/samza
-> tar -xvf $DEPLOY_DIR/samza-test_2.11-0.13.0.tgz -C $DEPLOY_DIR/samza
+> tar -xvf $DEPLOY_DIR/samza-test_2.11-0.13.1.tgz -C $DEPLOY_DIR/samza
 
 Finally, create the kafka topics and start the samza jobs:
 > ./bin/setup-int-test.sh $DEPLOY_DIR

--- a/samza-test/src/main/python/configs/tests.json
+++ b/samza-test/src/main/python/configs/tests.json
@@ -1,5 +1,5 @@
 {
-  "samza_executable": "samza-test_2.11-0.13.1.tgz",
+  "samza_executable": "samza-test_2.11-0.13.1-SNAPSHOT.tgz",
   "samza_install_path": "deploy/smoke_tests",
   "samza_config_factory": "org.apache.samza.config.factories.PropertiesConfigFactory"
 }

--- a/samza-test/src/main/python/configs/tests.json
+++ b/samza-test/src/main/python/configs/tests.json
@@ -1,5 +1,5 @@
 {
-  "samza_executable": "samza-test_2.11-0.13.0-SNAPSHOT.tgz",
+  "samza_executable": "samza-test_2.11-0.13.1-SNAPSHOT.tgz",
   "samza_install_path": "deploy/smoke_tests",
   "samza_config_factory": "org.apache.samza.config.factories.PropertiesConfigFactory"
 }

--- a/samza-test/src/main/python/configs/tests.json
+++ b/samza-test/src/main/python/configs/tests.json
@@ -1,5 +1,5 @@
 {
-  "samza_executable": "samza-test_2.11-0.13.1-SNAPSHOT.tgz",
+  "samza_executable": "samza-test_2.11-0.13.1.tgz",
   "samza_install_path": "deploy/smoke_tests",
   "samza_config_factory": "org.apache.samza.config.factories.PropertiesConfigFactory"
 }


### PR DESCRIPTION
Updated the versions used in smoke tests and the README for overnight tests to point to the next release. Using 0.13.1 instead of 0.13.1-SNAPSHOT here since these tests are usually run against the release branch when release testing, where the version doesn't have -SNAPSHOT in it.