### PR TITLE
SAMZA-1340 - StreamProcessor does not propagate container failures from StreamTask

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/coordinator/JobCoordinatorListener.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/JobCoordinatorListener.java
@@ -47,6 +47,7 @@ public interface JobCoordinatorListener {
 
   /**
    * Method invoked by a {@link org.apache.samza.coordinator.JobCoordinator} when it is shutting without any errors
+   * Typically, this happens when the StreamProcessor invokes {@link JobCoordinator#stop()}.
    */
   void onCoordinatorStop();
 

--- a/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
+++ b/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
@@ -67,7 +67,8 @@ public class StreamProcessor {
   private ExecutorService executorService;
 
   private volatile SamzaContainer container = null;
-
+  private volatile Throwable containerException = null;
+  
   // Latch used to synchronize between the JobCoordinator thread and the container thread, when the container is
   // stopped due to re-balancing
   private volatile CountDownLatch jcContainerShutdownLatch = new CountDownLatch(1);
@@ -75,7 +76,6 @@ public class StreamProcessor {
 
   @VisibleForTesting
   JobCoordinatorListener jobCoordinatorListener = null;
-  volatile Throwable containerException = null;
 
   /**
    * Create an instance of StreamProcessor that encapsulates a JobCoordinator and Samza Container

--- a/samza-core/src/test/java/org/apache/samza/processor/TestStreamProcessor.java
+++ b/samza-core/src/test/java/org/apache/samza/processor/TestStreamProcessor.java
@@ -35,7 +35,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -51,18 +50,18 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TestStreamProcessor {
-  private ConcurrentMap<Listener_Callback, Boolean> processorListenerState;
-  private enum Listener_Callback {
+  private ConcurrentMap<ListenerCallback, Boolean> processorListenerState;
+  private enum ListenerCallback {
     ON_START, ON_SHUTDOWN, ON_FAILURE
   }
 
   @Before
   public void before() {
-    processorListenerState = new ConcurrentHashMap<Listener_Callback, Boolean>() {
+    processorListenerState = new ConcurrentHashMap<ListenerCallback, Boolean>() {
       {
-        put(Listener_Callback.ON_START, false);
-        put(Listener_Callback.ON_FAILURE, false);
-        put(Listener_Callback.ON_SHUTDOWN, false);
+        put(ListenerCallback.ON_START, false);
+        put(ListenerCallback.ON_FAILURE, false);
+        put(ListenerCallback.ON_SHUTDOWN, false);
       }
     };
   }
@@ -147,19 +146,19 @@ public class TestStreamProcessor {
         new StreamProcessorLifecycleListener() {
           @Override
           public void onStart() {
-            processorListenerState.put(Listener_Callback.ON_START, true);
+            processorListenerState.put(ListenerCallback.ON_START, true);
             processorListenerStart.countDown();
           }
 
           @Override
           public void onShutdown() {
-            processorListenerState.put(Listener_Callback.ON_SHUTDOWN, true);
+            processorListenerState.put(ListenerCallback.ON_SHUTDOWN, true);
             processorListenerStop.countDown();
           }
 
           @Override
           public void onFailure(Throwable t) {
-            processorListenerState.put(Listener_Callback.ON_FAILURE, true);
+            processorListenerState.put(ListenerCallback.ON_FAILURE, true);
           }
         },
         mockJobCoordinator,
@@ -203,9 +202,9 @@ public class TestStreamProcessor {
     processorListenerStop.await();
 
     // Assertions on which callbacks are expected to be invoked
-    Assert.assertTrue(processorListenerState.get(Listener_Callback.ON_START));
-    Assert.assertTrue(processorListenerState.get(Listener_Callback.ON_SHUTDOWN));
-    Assert.assertFalse(processorListenerState.get(Listener_Callback.ON_FAILURE));
+    Assert.assertTrue(processorListenerState.get(ListenerCallback.ON_START));
+    Assert.assertTrue(processorListenerState.get(ListenerCallback.ON_SHUTDOWN));
+    Assert.assertFalse(processorListenerState.get(ListenerCallback.ON_FAILURE));
   }
 
   /**
@@ -244,17 +243,17 @@ public class TestStreamProcessor {
         new StreamProcessorLifecycleListener() {
           @Override
           public void onStart() {
-            processorListenerState.put(Listener_Callback.ON_START, true);
+            processorListenerState.put(ListenerCallback.ON_START, true);
           }
 
           @Override
           public void onShutdown() {
-            processorListenerState.put(Listener_Callback.ON_SHUTDOWN, true);
+            processorListenerState.put(ListenerCallback.ON_SHUTDOWN, true);
           }
 
           @Override
           public void onFailure(Throwable t) {
-            processorListenerState.put(Listener_Callback.ON_FAILURE, true);
+            processorListenerState.put(ListenerCallback.ON_FAILURE, true);
             actualThrowable.getAndSet(t);
             processorListenerFailed.countDown();
           }
@@ -294,9 +293,9 @@ public class TestStreamProcessor {
         processorListenerFailed.await(30, TimeUnit.SECONDS));
     Assert.assertEquals(expectedThrowable, actualThrowable.get());
 
-    Assert.assertFalse(processorListenerState.get(Listener_Callback.ON_SHUTDOWN));
-    Assert.assertTrue(processorListenerState.get(Listener_Callback.ON_START));
-    Assert.assertTrue(processorListenerState.get(Listener_Callback.ON_FAILURE));
+    Assert.assertFalse(processorListenerState.get(ListenerCallback.ON_SHUTDOWN));
+    Assert.assertTrue(processorListenerState.get(ListenerCallback.ON_START));
+    Assert.assertTrue(processorListenerState.get(ListenerCallback.ON_FAILURE));
   }
 
   // TODO:

--- a/samza-core/src/test/scala/org/apache/samza/processor/StreamProcessorTestUtils.scala
+++ b/samza-core/src/test/scala/org/apache/samza/processor/StreamProcessorTestUtils.scala
@@ -29,7 +29,7 @@ import org.apache.samza.task.{StreamTask, TaskInstanceCollector}
 
 
 object StreamProcessorTestUtils {
-  def getDummyContainer(mockRunloop: RunLoop, containerListener: SamzaContainerListener, streamTask: StreamTask) = {
+  def getDummyContainer(mockRunloop: RunLoop, streamTask: StreamTask) = {
     val config = new MapConfig
     val taskName = new TaskName("taskName")
     val consumerMultiplexer = new SystemConsumers(
@@ -58,9 +58,6 @@ object StreamProcessorTestUtils {
       consumerMultiplexer = consumerMultiplexer,
       producerMultiplexer = producerMultiplexer,
       metrics = new SamzaContainerMetrics)
-    if (containerListener != null) {
-      container.setContainerListener(containerListener)
-    }
     container
   }
 }


### PR DESCRIPTION
Storing the exception seen from the container in the `SamzaContainerListener#onFailure(Throwable)` in the StreamProcessor.
`JobCoordinator#stop` callback inspects this stored exception and invokes the correct callback for StreamProcessorLifecycleListener.
It is pretty difficult to add all test cases. Suggestion welcome for improving code/testing.