### PR TITLE
SAMZA-1358: fix the bug in validating task.class empty string when ap…

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/task/TaskFactoryUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/task/TaskFactoryUtil.java
@@ -32,6 +32,8 @@ import java.util.concurrent.ExecutorService;
 
 import scala.runtime.AbstractFunction0;
 
+import static org.apache.samza.util.ScalaToJavaUtils.defaultValue;
+
 /**
  * This class provides utility functions to load task factory classes based on config, and to wrap {@link StreamTaskFactory} in {@link AsyncStreamTaskFactory}
  * when running {@link StreamTask}s in multi-thread mode
@@ -162,7 +164,8 @@ public class TaskFactoryUtil {
     ApplicationConfig appConfig = new ApplicationConfig(config);
     if (appConfig.getAppClass() != null && !appConfig.getAppClass().isEmpty()) {
       TaskConfig taskConfig = new TaskConfig(config);
-      if (taskConfig.getTaskClass() != null && !taskConfig.getTaskClass().isEmpty()) {
+      String taskClassName = taskConfig.getTaskClass().getOrElse(defaultValue(null));
+      if (taskClassName != null && !taskClassName.isEmpty()) {
         throw new ConfigException("High level StreamApplication API cannot be used together with low-level API using task.class.");
       }
 

--- a/samza-core/src/test/java/org/apache/samza/task/TestTaskFactoryUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestTaskFactoryUtil.java
@@ -156,6 +156,17 @@ public class TestTaskFactoryUtil {
     } catch (ConfigException ce) {
       // expected
     }
+
+
+    config = new MapConfig(new HashMap<String, String>() {
+      {
+        this.put("task.class", "");
+        this.put(ApplicationConfig.APP_CLASS, "org.apache.samza.testUtils.TestStreamApplication");
+      }
+    });
+    streamApp = TaskFactoryUtil.createStreamApplication(config);
+    assertNotNull(streamApp);
+
   }
 
   @Test


### PR DESCRIPTION
…p.class is configured

Another bug due to scala/java differences.