### PR TITLE
SAMZA-1282: Spinning up more containers than number of tasks.

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/container/grouper/task/GroupByContainerIds.java
+++ b/samza-core/src/main/java/org/apache/samza/container/grouper/task/GroupByContainerIds.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * IDs as an argument. Please note - this first implementation ignores locality information.
  */
 public class GroupByContainerIds implements TaskNameGrouper {
-  private static final Logger LOGGER = LoggerFactory.getLogger(GroupByContainerIds.class);
+  private static final Logger LOG = LoggerFactory.getLogger(GroupByContainerIds.class);
 
   private final int startContainerCount;
   public GroupByContainerIds(int count) {
@@ -70,7 +70,7 @@ public class GroupByContainerIds implements TaskNameGrouper {
           .toString(containersIds.toArray()));
 
     if (containersIds.size() > tasks.size()) {
-      LOGGER.info("Number of containers: {} is greater than number of tasks: {}.",  containersIds.size(), tasks.size());
+      LOG.info("Number of containers: {} is greater than number of tasks: {}.",  containersIds.size(), tasks.size());
       /**
        * Choose lexicographically least `x` containerIds(where x = tasks.size()).
        */
@@ -78,7 +78,7 @@ public class GroupByContainerIds implements TaskNameGrouper {
                                    .sorted()
                                    .limit(tasks.size())
                                    .collect(Collectors.toList());
-      LOGGER.info("Generating containerModel with containers: {}.", containersIds);
+      LOG.info("Generating containerModel with containers: {}.", containersIds);
     }
 
     int containerCount = containersIds.size();

--- a/samza-core/src/main/java/org/apache/samza/container/grouper/task/GroupByContainerIds.java
+++ b/samza-core/src/main/java/org/apache/samza/container/grouper/task/GroupByContainerIds.java
@@ -70,7 +70,7 @@ public class GroupByContainerIds implements TaskNameGrouper {
           .toString(containersIds.toArray()));
 
     if (containersIds.size() > tasks.size()) {
-      LOG.info("Number of containers: {} is greater than number of tasks: {}.",  containersIds.size(), tasks.size());
+      LOG.warn("Number of containers: {} is greater than number of tasks: {}.",  containersIds.size(), tasks.size());
       /**
        * Choose lexicographically least `x` containerIds(where x = tasks.size()).
        */

--- a/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
+++ b/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
@@ -250,10 +250,6 @@ public class StreamProcessor {
 
       @Override
       public void onNewJobModel(String processorId, JobModel jobModel) {
-        if (!jobModel.getContainers().containsKey(processorId)) {
-          LOGGER.warn("JobModel does not contain the processorId: " + processorId + ". Stopping the processor.");
-          stop();
-        } else {
           jcContainerShutdownLatch = new CountDownLatch(1);
 
           SamzaContainerListener containerListener = new SamzaContainerListener() {
@@ -307,7 +303,6 @@ public class StreamProcessor {
           executorService = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
               .setNameFormat("p-" + processorId + "-container-thread-%d").build());
           executorService.submit(container::run);
-        }
       }
 
       @Override

--- a/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
+++ b/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
@@ -250,59 +250,59 @@ public class StreamProcessor {
 
       @Override
       public void onNewJobModel(String processorId, JobModel jobModel) {
-          jcContainerShutdownLatch = new CountDownLatch(1);
+        jcContainerShutdownLatch = new CountDownLatch(1);
 
-          SamzaContainerListener containerListener = new SamzaContainerListener() {
-            @Override
-            public void onContainerStart() {
-              if (!processorOnStartCalled) {
-                // processorListener is called on start only the first time the container starts.
-                // It is not called after every re-balance of partitions among the processors
-                processorOnStartCalled = true;
-                if (processorListener != null) {
-                  processorListener.onStart();
-                }
-              } else {
-                LOGGER.debug("StreamProcessorListener was notified of container start previously. Hence, skipping this time.");
+        SamzaContainerListener containerListener = new SamzaContainerListener() {
+          @Override
+          public void onContainerStart() {
+            if (!processorOnStartCalled) {
+              // processorListener is called on start only the first time the container starts.
+              // It is not called after every re-balance of partitions among the processors
+              processorOnStartCalled = true;
+              if (processorListener != null) {
+                processorListener.onStart();
               }
+            } else {
+              LOGGER.debug("StreamProcessorListener was notified of container start previously. Hence, skipping this time.");
             }
+          }
 
-            @Override
-            public void onContainerStop(boolean pauseByJm) {
-              if (pauseByJm) {
-                LOGGER.info("Container " + container.toString() + " stopped due to a request from JobCoordinator.");
-                if (jcContainerShutdownLatch != null) {
-                  jcContainerShutdownLatch.countDown();
-                }
-              } else {  // sp.stop was called or container stopped by itself
-                LOGGER.info("Container " + container.toString() + " stopped.");
-                container = null; // this guarantees that stop() doesn't try to stop container again
-                stop();
-              }
-            }
-
-            @Override
-            public void onContainerFailed(Throwable t) {
+          @Override
+          public void onContainerStop(boolean pauseByJm) {
+            if (pauseByJm) {
+              LOGGER.info("Container " + container.toString() + " stopped due to a request from JobCoordinator.");
               if (jcContainerShutdownLatch != null) {
                 jcContainerShutdownLatch.countDown();
-              } else {
-                LOGGER.warn("JobCoordinatorLatch was null. It is possible for some component to be waiting.");
               }
-              containerException = t;
-              LOGGER.error("Container failed. Stopping the processor.", containerException);
-              container = null;
+            } else {  // sp.stop was called or container stopped by itself
+              LOGGER.info("Container " + container.toString() + " stopped.");
+              container = null; // this guarantees that stop() doesn't try to stop container again
               stop();
             }
-          };
+          }
 
-          container = createSamzaContainer(
-              jobModel.getContainers().get(processorId),
-              jobModel.maxChangeLogStreamPartitions);
-          container.setContainerListener(containerListener);
-          LOGGER.info("Starting container " + container.toString());
-          executorService = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
-              .setNameFormat("p-" + processorId + "-container-thread-%d").build());
-          executorService.submit(container::run);
+          @Override
+          public void onContainerFailed(Throwable t) {
+            if (jcContainerShutdownLatch != null) {
+              jcContainerShutdownLatch.countDown();
+            } else {
+              LOGGER.warn("JobCoordinatorLatch was null. It is possible for some component to be waiting.");
+            }
+            containerException = t;
+            LOGGER.error("Container failed. Stopping the processor.", containerException);
+            container = null;
+            stop();
+          }
+        };
+
+        container = createSamzaContainer(
+            jobModel.getContainers().get(processorId),
+            jobModel.maxChangeLogStreamPartitions);
+        container.setContainerListener(containerListener);
+        LOGGER.info("Starting container " + container.toString());
+        executorService = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
+            .setNameFormat("p-" + processorId + "-container-thread-%d").build());
+        executorService.submit(container::run);
       }
 
       @Override

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
@@ -85,7 +85,7 @@ public class ZkJobCoordinator implements JobCoordinator, ZkControllerListener {
     this.zkUtils = zkUtils;
     // setup a listener for a session state change
     // we are mostly interested in "session closed" and "new session created" events
-     zkUtils.getZkClient().subscribeStateChanges(new ZkSessionStateChangedListener());
+    zkUtils.getZkClient().subscribeStateChanges(new ZkSessionStateChangedListener());
     LeaderElector leaderElector = new ZkLeaderElector(processorId, zkUtils);
     leaderElector.setLeaderElectorListener(new LeaderElectorListenerImpl());
     this.zkController = new ZkControllerImpl(processorId, zkUtils, this, leaderElector);

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
@@ -83,6 +83,9 @@ public class ZkJobCoordinator implements JobCoordinator, ZkControllerListener {
 
     this.processorId = createProcessorId(config);
     this.zkUtils = zkUtils;
+    // setup a listener for a session state change
+    // we are mostly interested in "session closed" and "new session created" events
+     zkUtils.getZkClient().subscribeStateChanges(new ZkSessionStateChangedListener());
     LeaderElector leaderElector = new ZkLeaderElector(processorId, zkUtils);
     leaderElector.setLeaderElectorListener(new LeaderElectorListenerImpl());
     this.zkController = new ZkControllerImpl(processorId, zkUtils, this, leaderElector);

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinatorFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinatorFactory.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 public class ZkJobCoordinatorFactory implements JobCoordinatorFactory {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ZkJobCoordinatorFactory.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ZkJobCoordinatorFactory.class);
 
   /**
    * Method to instantiate an implementation of JobCoordinator
@@ -44,7 +44,7 @@ public class ZkJobCoordinatorFactory implements JobCoordinatorFactory {
   public JobCoordinator getJobCoordinator(Config config) {
     MetricsRegistry metricsRegistry = new MetricsRegistryMap();
     ZkUtils zkUtils = getZkUtils(config, metricsRegistry);
-    LOGGER.debug("Creating ZkJobCoordinator instance with config: {}.", config);
+    LOG.debug("Creating ZkJobCoordinator instance with config: {}.", config);
     return new ZkJobCoordinator(config, metricsRegistry, zkUtils);
   }
 

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinatorFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinatorFactory.java
@@ -19,13 +19,21 @@
 
 package org.apache.samza.zk;
 
+import org.I0Itec.zkclient.ZkClient;
+import org.apache.samza.config.ApplicationConfig;
 import org.apache.samza.config.Config;
+import org.apache.samza.config.ZkConfig;
 import org.apache.samza.coordinator.JobCoordinator;
 import org.apache.samza.coordinator.JobCoordinatorFactory;
+import org.apache.samza.metrics.MetricsRegistry;
 import org.apache.samza.metrics.MetricsRegistryMap;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ZkJobCoordinatorFactory implements JobCoordinatorFactory {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZkJobCoordinatorFactory.class);
+
   /**
    * Method to instantiate an implementation of JobCoordinator
    *
@@ -34,6 +42,16 @@ public class ZkJobCoordinatorFactory implements JobCoordinatorFactory {
    */
   @Override
   public JobCoordinator getJobCoordinator(Config config) {
-    return new ZkJobCoordinator(config, new MetricsRegistryMap());
+    MetricsRegistry metricsRegistry = new MetricsRegistryMap();
+    ZkUtils zkUtils = getZkUtils(config, metricsRegistry);
+    LOGGER.debug("Creating ZkJobCoordinator instance with config: {}.", config);
+    return new ZkJobCoordinator(config, metricsRegistry, zkUtils);
+  }
+
+  private ZkUtils getZkUtils(Config config, MetricsRegistry metricsRegistry) {
+    ZkConfig zkConfig = new ZkConfig(config);
+    ZkKeyBuilder keyBuilder = new ZkKeyBuilder(new ApplicationConfig(config).getGlobalAppId());
+    ZkClient zkClient = ZkCoordinationServiceFactory.createZkClient(zkConfig.getZkConnect(), zkConfig.getZkSessionTimeoutMs(), zkConfig.getZkConnectionTimeoutMs());
+    return new ZkUtils(keyBuilder, zkClient, zkConfig.getZkConnectionTimeoutMs(), metricsRegistry);
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkJobCoordinator.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkJobCoordinator.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.zk;
+
+import java.util.HashMap;
+import org.apache.samza.config.MapConfig;
+import org.apache.samza.job.model.JobModel;
+import org.apache.samza.util.NoOpMetricsRegistry;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class TestZkJobCoordinator {
+  private static final String TEST_BARRIER_ROOT = "/testBarrierRoot";
+  private static final String TEST_JOB_MODEL_VERSION = "1";
+
+  @Test
+  public void testFollowerShouldStopWhenNotPartOfGeneratedJobModel() {
+    ZkKeyBuilder keyBuilder = Mockito.mock(ZkKeyBuilder.class);
+    Mockito.when(keyBuilder.getJobModelVersionBarrierPrefix()).thenReturn(TEST_BARRIER_ROOT);
+
+    ZkUtils zkUtils = Mockito.mock(ZkUtils.class);
+    Mockito.when(zkUtils.getKeyBuilder()).thenReturn(keyBuilder);
+    Mockito.when(zkUtils.getJobModel(TEST_JOB_MODEL_VERSION)).thenReturn(new JobModel(new MapConfig(), new HashMap<>()));
+
+    ZkJobCoordinator zkJobCoordinator = Mockito.spy(new ZkJobCoordinator(new MapConfig(), new NoOpMetricsRegistry(), zkUtils));
+    zkJobCoordinator.onNewJobModelAvailable(TEST_JOB_MODEL_VERSION);
+
+    Mockito.doNothing().when(zkJobCoordinator).stop();
+    Mockito.verify(zkJobCoordinator, Mockito.atMost(1)).stop();
+  }
+}

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
@@ -35,7 +35,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import kafka.admin.AdminUtils;
 import kafka.utils.TestUtils;
-import org.I0Itec.zkclient.IZkChildListener;
 import org.I0Itec.zkclient.ZkClient;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -207,10 +206,10 @@ public class TestZkLocalApplicationRunner extends StandaloneIntegrationTestHarne
     final CountDownLatch secondProcessorRegistered = new CountDownLatch(1);
 
     zkUtils.subscribeToProcessorChange((parentPath, currentChilds) -> {
-      // When streamApp2 with id: PROCESSOR_IDS[1] is registered, start processing message in streamApp1.
-      if (currentChilds.contains(PROCESSOR_IDS[1])) {
-        secondProcessorRegistered.countDown();
-      }
+        // When streamApp2 with id: PROCESSOR_IDS[1] is registered, start processing message in streamApp1.
+        if (currentChilds.contains(PROCESSOR_IDS[1])) {
+          secondProcessorRegistered.countDown();
+        }
     });
 
     // Set up stream app 2.

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
@@ -207,10 +207,10 @@ public class TestZkLocalApplicationRunner extends StandaloneIntegrationTestHarne
 
     zkUtils.subscribeToProcessorChange((parentPath, currentChilds) -> {
         // When streamApp2 with id: PROCESSOR_IDS[1] is registered, start processing message in streamApp1.
-          if (currentChilds.contains(PROCESSOR_IDS[1])) {
-            secondProcessorRegistered.countDown();
-          }
-    });
+        if (currentChilds.contains(PROCESSOR_IDS[1])) {
+          secondProcessorRegistered.countDown();
+        }
+      });
 
     // Set up stream app 2.
     CountDownLatch processedMessagesLatch = new CountDownLatch(NUM_KAFKA_EVENTS);


### PR DESCRIPTION
Changes

* Stop streamProcessor in onNewJobModelAvailable eventHandler(instead of onNewJobModelConfirmed
  eventHandler) when it's not part of the group and prevent it from joining the barrier.
* When numContainerIds > numTaskModels, generate JobModel by choosing lexicographically
  least `x` containerIds(where x = numTaskModels).
* Added unit and integration tests in appropriate classes to verify the expected behavior.