### PR TITLE
SAMZA-1389: Fix ZkProcessorLatch await(timeout, TimeUnit) api.

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/zk/ZkProcessorLatch.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkProcessorLatch.java
@@ -53,8 +53,8 @@ public class ZkProcessorLatch implements Latch {
   }
 
   @Override
-  public void await(long timeout, TimeUnit tu) {
-    zkUtils.getZkClient().waitUntilExists(targetPath, TimeUnit.MILLISECONDS, timeout);
+  public void await(long timeout, TimeUnit timeUnit) {
+    zkUtils.getZkClient().waitUntilExists(targetPath, timeUnit, timeout);
   }
 
   @Override


### PR DESCRIPTION
Use passed in timeUnit value for zkClient.waitUnitExists method rather than hardcoding with  `TimeUnit.MILLISECONDS`.