### PR TITLE
SAMZA-1406: Fix potential orphaned containers problem in stand alone.

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/zk/ScheduleAfterDebounceTime.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ScheduleAfterDebounceTime.java
@@ -153,17 +153,15 @@ public class ScheduleAfterDebounceTime {
    * Handler method to invoke on a exception during an scheduled task execution and which
    * the following operations in sequential order.
    * <ul>
-   *   <li> Stops the scheduler.</li>
+   *   <li> Stop the scheduler. If the task execution fails or a task is interrupted, scheduler will not accept/execute any new tasks.</li>
    *   <li> Invokes the onError handler method if taskCallback is defined.</li>
    * </ul>
    *
    * @param exception the exception happened during task execution.
    */
   private void doCleanUpOnTaskException(Exception exception) {
-    // 1. Stop the scheduler. If the task execution fails or a task is interrupted, scheduler will not accept/execute any new tasks.
     stopScheduler();
 
-    // 2. Invoke the callback if its defined.
     scheduledTaskCallback.ifPresent(callback -> callback.onError(exception));
   }
 

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
@@ -61,6 +61,19 @@ public class ZkJobCoordinator implements JobCoordinator, ZkControllerListener {
   private static final int METADATA_CACHE_TTL_MS = 5000;
   private static final int NUM_VERSIONS_TO_LEAVE = 10;
 
+  // Action name when the JobModel version changes
+  private static final String JOB_MODEL_VERSION_CHANGE = "JobModelVersionChange";
+
+  // Action name when the Processor membership changes
+  private static final String ON_PROCESSOR_CHANGE = "OnProcessorChange";
+
+  /**
+   * Cleanup process is started after every new job model generation is complete.
+   * It deletes old versions of job model and the barrier.
+   * How many to delete (or to leave) is controlled by @see org.apache.samza.zk.ZkJobCoordinator#NUM_VERSIONS_TO_LEAVE.
+   **/
+  private static final String ON_ZK_CLEANUP = "OnCleanUp";
+
   private final ZkUtils zkUtils;
   private final String processorId;
   private final ZkController zkController;
@@ -95,7 +108,8 @@ public class ZkJobCoordinator implements JobCoordinator, ZkControllerListener {
         new ZkBarrierListenerImpl());
     this.debounceTimeMs = new JobConfig(config).getDebounceTimeMs();
     this.reporters = MetricsReporterLoader.getMetricsReporters(new MetricsConfig(config), processorId);
-    debounceTimer = new ScheduleAfterDebounceTime(throwable -> {
+    debounceTimer = new ScheduleAfterDebounceTime();
+    debounceTimer.setScheduledTaskCallback(throwable -> {
         LOG.error("Received exception from in JobCoordinator Processing!", throwable);
         stop();
       });
@@ -157,7 +171,7 @@ public class ZkJobCoordinator implements JobCoordinator, ZkControllerListener {
   @Override
   public void onProcessorChange(List<String> processors) {
     LOG.info("ZkJobCoordinator::onProcessorChange - list of processors changed! List size=" + processors.size());
-    debounceTimer.scheduleAfterDebounceTime(ScheduleAfterDebounceTime.ON_PROCESSOR_CHANGE, debounceTimeMs,
+    debounceTimer.scheduleAfterDebounceTime(ON_PROCESSOR_CHANGE, debounceTimeMs,
         () -> doOnProcessorChange(processors));
   }
 
@@ -195,12 +209,12 @@ public class ZkJobCoordinator implements JobCoordinator, ZkControllerListener {
 
     LOG.info("pid=" + processorId + "Published new Job Model. Version = " + nextJMVersion);
 
-    debounceTimer.scheduleAfterDebounceTime(ScheduleAfterDebounceTime.ON_ZK_CLEANUP, 0, () -> zkUtils.cleanupZK(NUM_VERSIONS_TO_LEAVE));
+    debounceTimer.scheduleAfterDebounceTime(ON_ZK_CLEANUP, 0, () -> zkUtils.cleanupZK(NUM_VERSIONS_TO_LEAVE));
   }
 
   @Override
   public void onNewJobModelAvailable(final String version) {
-    debounceTimer.scheduleAfterDebounceTime(ScheduleAfterDebounceTime.JOB_MODEL_VERSION_CHANGE, 0, () ->
+    debounceTimer.scheduleAfterDebounceTime(JOB_MODEL_VERSION_CHANGE, 0, () ->
       {
         LOG.info("pid=" + processorId + "new JobModel available");
         // get the new job model from ZK
@@ -273,7 +287,7 @@ public class ZkJobCoordinator implements JobCoordinator, ZkControllerListener {
       LOG.info("ZkJobCoordinator::onBecomeLeader - I became the leader!");
       metrics.isLeader.set(true);
       zkController.subscribeToProcessorChange();
-      debounceTimer.scheduleAfterDebounceTime(ScheduleAfterDebounceTime.ON_PROCESSOR_CHANGE, debounceTimeMs, () ->
+      debounceTimer.scheduleAfterDebounceTime(ON_PROCESSOR_CHANGE, debounceTimeMs, () ->
         {
           // actual actions to do are the same as onProcessorChange
           doOnProcessorChange(new ArrayList<>());
@@ -312,7 +326,7 @@ public class ZkJobCoordinator implements JobCoordinator, ZkControllerListener {
           LOG.warn("Barrier for version " + version + " timed out.");
           if (zkController.isLeader()) {
             LOG.info("Leader will schedule a new job model generation");
-            debounceTimer.scheduleAfterDebounceTime(ScheduleAfterDebounceTime.ON_PROCESSOR_CHANGE, debounceTimeMs, () ->
+            debounceTimer.scheduleAfterDebounceTime(ON_PROCESSOR_CHANGE, debounceTimeMs, () ->
               {
                 // actual actions to do are the same as onProcessorChange
                 doOnProcessorChange(new ArrayList<>());

--- a/samza-core/src/test/java/org/apache/samza/zk/TestScheduleAfterDebounceTime.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestScheduleAfterDebounceTime.java
@@ -19,14 +19,22 @@
 
 package org.apache.samza.zk;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.rules.Timeout;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestScheduleAfterDebounceTime {
+  private static final Logger LOG = LoggerFactory.getLogger(TestScheduleAfterDebounceTime.class);
+
   private static final long WAIT_TIME = 500;
+
+  @Rule
+  public Timeout testTimeOutInSeconds = new Timeout(10, TimeUnit.SECONDS);
 
   class TestObj {
     private volatile int i = 0;
@@ -91,8 +99,10 @@ public class TestScheduleAfterDebounceTime {
   @Test
   public void testRunnableWithExceptionInvokesCallback() throws InterruptedException {
     final CountDownLatch latch = new CountDownLatch(1);
-    ScheduleAfterDebounceTime scheduledQueue = new ScheduleAfterDebounceTime(e -> {
-        Assert.assertEquals(RuntimeException.class, e.getClass());
+    final Throwable[] taskCallbackException = new Exception[1];
+    ScheduleAfterDebounceTime scheduledQueue = new ScheduleAfterDebounceTime();
+    scheduledQueue.setScheduledTaskCallback(throwable -> {
+        taskCallbackException[0] = throwable;
         latch.countDown();
       });
 
@@ -107,6 +117,60 @@ public class TestScheduleAfterDebounceTime {
     boolean result = latch.await(5 * WAIT_TIME, TimeUnit.MILLISECONDS);
     Assert.assertTrue("Latch timed-out.", result);
     Assert.assertEquals(0, testObj.get());
+    Assert.assertEquals(RuntimeException.class, taskCallbackException[0].getClass());
     scheduledQueue.stopScheduler();
+  }
+
+  /**
+   * Validates if the interrupted exception triggered by ExecutorService is handled by ScheduleAfterDebounceTime.
+   */
+  @Test
+  public void testStopSchedulerInvokesRegisteredCallback() throws InterruptedException {
+    final CountDownLatch hasTaskCallbackCompleted = new CountDownLatch(1);
+    final CountDownLatch hasThreadStarted = new CountDownLatch(1);
+    final CountDownLatch isSchedulerShutdownTriggered = new CountDownLatch(1);
+
+    /**
+     * Declaring this as an array to record the value inside the lambda.
+     */
+    final Throwable[] taskCallbackException = new Exception[1];
+
+    ScheduleAfterDebounceTime scheduledQueue = new ScheduleAfterDebounceTime();
+    scheduledQueue.setScheduledTaskCallback(throwable -> {
+      /**
+       * Assertion failures in callback doesn't fail the test.
+       * Record the received exception here and assert outside
+       * the callback.
+       */
+        taskCallbackException[0] = throwable;
+        hasTaskCallbackCompleted.countDown();
+      });
+
+    scheduledQueue.scheduleAfterDebounceTime("TEST1", WAIT_TIME , () -> {
+        hasThreadStarted.countDown();
+        try {
+          LOG.debug("Waiting for the scheduler shutdown trigger.");
+          isSchedulerShutdownTriggered.await();
+        } catch (InterruptedException e) {
+          /**
+           * Don't swallow the exception and restore the interrupt status.
+           * Expect the ScheduleDebounceTime to handle this interrupt
+           * and invoke ScheduledTaskCallback.
+           */
+          Thread.currentThread().interrupt();
+        }
+      });
+
+    // Wait for the task to run.
+    hasThreadStarted.await();
+
+    // Shutdown the scheduler and update relevant state.
+    scheduledQueue.stopScheduler();
+    isSchedulerShutdownTriggered.countDown();
+
+    hasTaskCallbackCompleted.await();
+
+    // Assert on exception thrown.
+    Assert.assertEquals(InterruptedException.class, taskCallbackException[0].getClass());
   }
 }


### PR DESCRIPTION
Changes:

* Switch from `executorService.shutdown()` to `executorService.shutdownNow()` in `stopScheduler()` implementation. Along with cancelling all the pending tasks, this switch will also interrupt the current running thread.

* Check for the interrupted flag in `ScheduleAfterDebounceTime` scheduled task and trigger the stop sequence.  

* Update stop sequence of `ScheduleAfterDebounceTime` on task exception.

* Move zookeeper specific constants outside of `ScheduleAfterDebounceTime` into `ZkJobCoordinator`(The overall purpose of this `ScheduleAfterDebounceTime` class is to become the common scheduler for both AzureTasks, ZkTasks. This cleanup takes few steps in that general direction).

* Unit test to verify the callback triggering on exception.

* General code cleanup and java doc added to fields and methods. 

NOTE:  Scenario that triggers orphaned containers is the last run of `ScheduleAfterDebounceTime` which brings up the container. Though we handle the interrupt and kill container, during the small window between interrupt occurrence and killing container, there’ll be orphaned containers.