### PR TITLE
SAMZA-1410 make tests pass in different Junit versions for testPlanIdWithShuffledStreamSpecs and testGeneratePlanIdWithDifferentStreamSpec

### DIFF
--- a/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
@@ -371,7 +371,8 @@ public class TestLocalApplicationRunner {
         new StreamSpec("test-stream-1", "stream-1", "testStream"),
         new StreamSpec("test-stream-3", "stream-3", "testStream"));
 
-    assertFalse("Expected both of the latch ids to be different", planIdBeforeShuffle.equals(getExecutionPlanId(shuffledStreamSpecs)));
+    assertFalse("Expected both of the latch ids to be different",
+        planIdBeforeShuffle.equals(getExecutionPlanId(shuffledStreamSpecs)));
   }
 
   /**
@@ -408,7 +409,8 @@ public class TestLocalApplicationRunner {
         new StreamSpec("test-stream-4", "stream-4", "testStream"),
         new StreamSpec("test-stream-3", "stream-3", "testStream"));
 
-    assertFalse("Expected both of the latch ids to be different", planIdBeforeShuffle.equals(getExecutionPlanId(updatedStreamSpecs)));
+    assertFalse("Expected both of the latch ids to be different",
+        planIdBeforeShuffle.equals(getExecutionPlanId(updatedStreamSpecs)));
   }
 
   private String getExecutionPlanId(List<StreamSpec> updatedStreamSpecs) {

--- a/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
@@ -371,8 +371,7 @@ public class TestLocalApplicationRunner {
         new StreamSpec("test-stream-1", "stream-1", "testStream"),
         new StreamSpec("test-stream-3", "stream-3", "testStream"));
 
-    assertNotEquals("Expected both of the latch ids to be different", planIdBeforeShuffle,
-        getExecutionPlanId(shuffledStreamSpecs));
+    assertFalse("Expected both of the latch ids to be different", planIdBeforeShuffle.equals(getExecutionPlanId(shuffledStreamSpecs)));
   }
 
   /**
@@ -409,8 +408,7 @@ public class TestLocalApplicationRunner {
         new StreamSpec("test-stream-4", "stream-4", "testStream"),
         new StreamSpec("test-stream-3", "stream-3", "testStream"));
 
-    assertNotEquals("Expected both of the latch ids to be different", planIdBeforeShuffle,
-        getExecutionPlanId(updatedStreamSpecs));
+    assertFalse("Expected both of the latch ids to be different", planIdBeforeShuffle.equals(getExecutionPlanId(updatedStreamSpecs)));
   }
 
   private String getExecutionPlanId(List<StreamSpec> updatedStreamSpecs) {


### PR DESCRIPTION
More details are in https://issues.apache.org/jira/browse/SAMZA-1410.

gradlew build and test passed.