### PR TITLE
Remove latch sharing between task and tests to enable parallel execution

### DIFF
--- a/samza-test/src/test/java/org/apache/samza/test/processor/IdentityStreamTask.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/IdentityStreamTask.java
@@ -23,19 +23,14 @@ import org.apache.samza.config.Config;
 import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.system.OutgoingMessageEnvelope;
 import org.apache.samza.system.SystemStream;
-import org.apache.samza.task.ClosableTask;
 import org.apache.samza.task.InitableTask;
 import org.apache.samza.task.MessageCollector;
 import org.apache.samza.task.StreamTask;
 import org.apache.samza.task.TaskContext;
 import org.apache.samza.task.TaskCoordinator;
 
-import java.util.concurrent.CountDownLatch;
 
-public class IdentityStreamTask implements StreamTask , InitableTask , ClosableTask  {
-  // static field since there's no other way to share state b/w a task instance and
-  // stream processor when constructed from "task.class".
-  static CountDownLatch endLatch = new CountDownLatch(1);
+public class IdentityStreamTask implements StreamTask , InitableTask  {
   private int processedMessageCount = 0;
   private int expectedMessageCount;
   private String outputTopic;
@@ -59,14 +54,7 @@ public class IdentityStreamTask implements StreamTask , InitableTask , ClosableT
             incomingMessageEnvelope.getMessage()));
     processedMessageCount++;
     if (processedMessageCount == expectedMessageCount) {
-      endLatch.countDown();
+      taskCoordinator.shutdown(TaskCoordinator.RequestScope.ALL_TASKS_IN_CONTAINER);
     }
-  }
-
-  @Override
-  public void close() throws Exception {
-    // need to create a new latch after each test since it's a static field.
-    // tests are assumed to run sequentially.
-    endLatch = new CountDownLatch(1);
   }
 }

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestStreamProcessor.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestStreamProcessor.java
@@ -19,9 +19,9 @@
 
 package org.apache.samza.test.processor;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
@@ -35,6 +35,9 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.samza.SamzaException;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.MapConfig;
@@ -47,26 +50,14 @@ import org.apache.samza.task.StreamTaskFactory;
 import org.apache.samza.test.StandaloneIntegrationTestHarness;
 import org.apache.samza.test.StandaloneTestUtils;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
+import scala.Option$;
 
 import static org.mockito.Matchers.anyObject;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.apache.samza.test.processor.IdentityStreamTask.endLatch;
+import static org.mockito.Mockito.*;
+
 
 public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
-
-  private StreamProcessorLifecycleListener listener;
-
-  @Before
-  public void setup() {
-    listener = mock(StreamProcessorLifecycleListener.class);
-    doNothing().when(listener).onStart();
-    doNothing().when(listener).onShutdown();
-    doNothing().when(listener).onFailure(anyObject());
-  }
-
   /**
    * Testing a basic identity stream task - reads data from a topic and writes it to another topic
    * (without any modifications)
@@ -86,15 +77,11 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
     // Note: createTopics needs to be called before creating a StreamProcessor. Otherwise it fails with a
     // TopicExistsException since StreamProcessor auto-creates them.
     createTopics(inputTopic, outputTopic);
-    final StreamProcessor processor = new StreamProcessor(
-        new MapConfig(configs),
-        new HashMap<>(),
-        IdentityStreamTask::new,
-        listener);
+    final Mocks mocks = new Mocks(configs, IdentityStreamTask::new, bootstrapServers());
 
-    produceMessages(inputTopic, messageCount);
-    run(processor, endLatch);
-    verifyNumMessages(outputTopic, messageCount);
+    produceMessages(mocks.producer, inputTopic, messageCount);
+    run(mocks.processor, mocks.latch);
+    verifyNumMessages(mocks.consumer, outputTopic, messageCount);
   }
 
   /**
@@ -109,13 +96,11 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
 
     final Config configs = new MapConfig(createConfigs("1", testSystem, inputTopic, outputTopic, messageCount));
     createTopics(inputTopic, outputTopic);
-    final StreamTaskFactory stf = IdentityStreamTask::new;
-    final StreamProcessor processor =
-        new StreamProcessor(configs, new HashMap<>(), stf, listener);
+    final Mocks mocks = new Mocks(configs, IdentityStreamTask::new, bootstrapServers());
 
-    produceMessages(inputTopic, messageCount);
-    run(processor, endLatch);
-    verifyNumMessages(outputTopic, messageCount);
+    produceMessages(mocks.producer, inputTopic, messageCount);
+    run(mocks.processor, mocks.latch);
+    verifyNumMessages(mocks.consumer, outputTopic, messageCount);
   }
 
   /**
@@ -132,15 +117,11 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
     final ExecutorService executorService = Executors.newSingleThreadExecutor();
     createTopics(inputTopic, outputTopic);
     final AsyncStreamTaskFactory stf = () -> new AsyncStreamTaskAdapter(new IdentityStreamTask(), executorService);
-    final StreamProcessor processor = new StreamProcessor(
-        configs,
-        new HashMap<>(),
-        stf,
-        listener);
+    final Mocks mocks = new Mocks(configs, stf, bootstrapServers());
 
-    produceMessages(inputTopic, messageCount);
-    run(processor, endLatch);
-    verifyNumMessages(outputTopic, messageCount);
+    produceMessages(mocks.producer, inputTopic, messageCount);
+    run(mocks.processor, mocks.latch);
+    verifyNumMessages(mocks.consumer, outputTopic, messageCount);
     executorService.shutdownNow();
   }
 
@@ -157,13 +138,9 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
     final Map<String, String> configMap = createConfigs("1", testSystem, inputTopic, outputTopic, messageCount);
     configMap.remove("task.class");
     final Config configs = new MapConfig(configMap);
+    final Mocks mocks = new Mocks(configs, (StreamTaskFactory) null, bootstrapServers());
 
-    StreamProcessor processor = new StreamProcessor(
-        configs,
-        new HashMap<>(),
-        (StreamTaskFactory) null,
-        listener);
-    run(processor, endLatch);
+    run(mocks.processor, mocks.latch);
   }
 
   private void createTopics(String inputTopic, String outputTopic) {
@@ -189,8 +166,8 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
   /**
    * Produces the provided number of messages to the topic.
    */
-  private void produceMessages(String topic, int numMessages) {
-    KafkaProducer producer = getKafkaProducer();
+  @SuppressWarnings("unchecked")
+  private void produceMessages(KafkaProducer producer, String topic, int numMessages) {
     for (int i = 0; i < numMessages; i++) {
       try {
         producer.send(new ProducerRecord(topic, String.valueOf(i).getBytes())).get();
@@ -208,7 +185,6 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
     boolean latchResult = false;
     processor.start();
     try {
-      Thread.sleep(10000);
       latchResult = latch.await(10, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
       e.printStackTrace();
@@ -224,8 +200,8 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
    * Consumes data from the topic until there are no new messages for a while
    * and asserts that the number of consumed messages is as expected.
    */
-  private void verifyNumMessages(String topic, int expectedNumMessages) {
-    KafkaConsumer consumer = getKafkaConsumer();
+  @SuppressWarnings("unchecked")
+  private void verifyNumMessages(KafkaConsumer consumer, String topic, int expectedNumMessages) {
     consumer.subscribe(Collections.singletonList(topic));
 
     int count = 0;
@@ -234,9 +210,7 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
     while (count < expectedNumMessages && emptyPollCount < 5) {
       ConsumerRecords records = consumer.poll(5000);
       if (!records.isEmpty()) {
-        Iterator<ConsumerRecord> iterator = records.iterator();
-        while (iterator.hasNext()) {
-          ConsumerRecord record = iterator.next();
+        for (ConsumerRecord record : (Iterable<ConsumerRecord>) records) {
           Assert.assertEquals(new String((byte[]) record.value()), String.valueOf(count));
           count++;
         }
@@ -246,5 +220,71 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
     }
 
     Assert.assertEquals(count, expectedNumMessages);
+  }
+
+  private static class Mocks {
+    CountDownLatch latch;
+    KafkaConsumer consumer;
+    KafkaProducer producer;
+    StreamProcessor processor;
+    StreamProcessorLifecycleListener listener;
+
+    private Mocks(String bootstrapServer) {
+      latch = new CountDownLatch(1);
+      initProcessListener();
+      initConsumer(bootstrapServer);
+      initProducer(bootstrapServer);
+    }
+
+    Mocks(Config config, StreamTaskFactory taskFactory, String bootstrapServer) {
+      this(bootstrapServer);
+      processor = new StreamProcessor(config, new HashMap<>(), taskFactory, listener);
+    }
+
+    Mocks(Config config, AsyncStreamTaskFactory taskFactory, String bootstrapServer) {
+      this(bootstrapServer);
+      processor = new StreamProcessor(config, new HashMap<>(), taskFactory, listener);
+    }
+
+    private void initConsumer(String bootstrapServer) {
+      consumer = TestUtils.createNewConsumer(
+          bootstrapServer,
+          "group",
+          "earliest",
+          4096L,
+          "org.apache.kafka.clients.consumer.RangeAssignor",
+          30000,
+          SecurityProtocol.PLAINTEXT,
+          Option$.MODULE$.empty(),
+          Option$.MODULE$.empty(),
+          Option$.MODULE$.empty());
+    }
+
+    private void initProcessListener() {
+      listener = mock(StreamProcessorLifecycleListener.class);
+      doNothing().when(listener).onStart();
+      doNothing().when(listener).onFailure(anyObject());
+      doAnswer(invocation -> {
+        latch.countDown();
+        return null;
+      }).when(listener).onShutdown();
+    }
+
+    private void initProducer(String bootstrapServer) {
+      producer = TestUtils.createNewProducer(
+          bootstrapServer,
+          1,
+          60 * 1000L,
+          1024L * 1024L,
+          0,
+          0L,
+          5 * 1000L,
+          SecurityProtocol.PLAINTEXT,
+          null,
+          Option$.MODULE$.apply(new Properties()),
+          new StringSerializer(),
+          new ByteArraySerializer(),
+          Option$.MODULE$.apply(new Properties()));
+    }
   }
 }

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestStreamProcessor.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestStreamProcessor.java
@@ -19,7 +19,6 @@
 
 package org.apache.samza.test.processor;
 
-import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -265,9 +264,9 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
       doNothing().when(listener).onStart();
       doNothing().when(listener).onFailure(anyObject());
       doAnswer(invocation -> {
-        latch.countDown();
-        return null;
-      }).when(listener).onShutdown();
+          latch.countDown();
+          return null;
+        }).when(listener).onShutdown();
     }
 
     private void initProducer(String bootstrapServer) {


### PR DESCRIPTION
Refactoring the tests to enable parallel execution. Also, removed unnecessary sleeping during execution. This PR will serve as a prototype to get some feedback on this testing pattern which eliminates state sharing between the tests and opens up the avenue for parallel execution.

This change brings down the test time for these 4 tests to **14 sec** compared to **44 secs**.