### PR TITLE
Samza versioned Release Notes

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,7 +20,7 @@ highlighter: pygments
 markdown: redcarpet
 exclude: ['_notes']
 redcarpet:
-  extensions: ['with_toc_data', 'smart']
+  extensions: ['with_toc_data', 'smart', 'strikethrough']
 exclude: [_docs]
 baseurl: http://samza.apache.org
 version: latest

--- a/docs/_docs/replace-versioned.sh
+++ b/docs/_docs/replace-versioned.sh
@@ -37,5 +37,8 @@ mv -f $DIR/_site/learn/documentation/versioned $DIR/_site/learn/documentation/$v
 echo "replaced learn/tutorials/versioned to learn/tutorials/"$version
 mv -f $DIR/_site/learn/tutorials/versioned $DIR/_site/learn/tutorials/$version
 
+echo "replaced learn/releases/versioned to learn/releases/"$version
+mv -f $DIR/_site/startup/releases/versioned $DIR/_site/startup/releases/$version
+
 echo "replaced startup/hello-samza/versioned to startup/hello-samza/"$version
 mv -f $DIR/_site/startup/hello-samza/versioned $DIR/_site/startup/hello-samza/$version

--- a/docs/startup/releases/versioned/release-notes.md
+++ b/docs/startup/releases/versioned/release-notes.md
@@ -1,0 +1,75 @@
+---
+layout: page
+title: Release Notes
+---
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+{% if site.version != "latest" %}
+1. [Download](#download)
+2. [Release Notes for Samza-{{site.version}} version](#release-notes-for-{{site.version}})
+3. [Upgrade Notes](#upgrade-notes)
+
+{% else %}
+1. [Release Notes for Samza-{{site.version}} version](#release-notes)
+2. [Upgrade Notes](#upgrade-notes)
+{% endif %}
+
+{% if site.version != "latest" %}
+## Download
+
+## Source Release
+[samza-sources-{{site.version}}.tgz](http://www.apache.org/dyn/closer.lua/samza/{{site.version}}.*)
+
+
+{% endif %}
+
+
+
+## Release Notes
+<!-- Add notes on new features, modified behavior of existing features, operational/performance improvements, new tools etc -->
+
+<TBD>
+
+## Upgrade Notes
+<!-- Add detailed notes on how someone using an older version of samza (typically, currentVersion - 1) can upgrade to the latest -->
+<!-- Notes typically include config changes, public-api changes, new user guides/tutorials etc -->
+
+### Configuration Changes
+
+<!-- PR 290 -->
+* Introduced a new **mandatory** configuration - `job.coordination.utils.factory`. Read more about it
+[here](../../learn/{{site.version}}/configuration.html). <br />This config is applicable to all Samza
+applications deployed using the `LocalApplicationRunner` (that is, non-yarn deployments).
+
+### API Changes
+
+<!-- PR 292 -->
+* The following APIs in `SystemAdmin` have been deprecated in the previous versions and hence, replaced with newer APIs.
+If you have a custom **System** implementation, then you have to update to the newer APIs.
+  * ~~void createChangelogStream(String streamName, int numOfPartitions);~~ -> ``` boolean createStream(StreamSpec streamSpec); ```
+  * ~~void createCoordinatorStream(String streamName);~~ -> ``` boolean createStream(StreamSpec streamSpec); ```
+  * ~~void validateChangelogStream(String streamName, int numOfPartitions);~~ -> ``` void validateStream(StreamSpec streamSpec) throws StreamValidationException; ```
+
+<!-- PR 292 -->
+* New API has been added to `SystemAdmin` that clear a stream. <br />
+```
+boolean clearStream(StreamSpec streamSpec);
+```
+<br />
+Read more about it in the [API docs]().
+


### PR DESCRIPTION
Adding a versioned page for release/upgrade notes. We can start this process from the next major version release, aka 0.14.0. 

Please update this page as and when you add new features/configs/API or deprecate features/configs/API. Basically, anything that can be useful for Samza users trying to upgrade. 

Note: `site.version` is not necessarily same as samza release version. For now, I am using it as a placeholder. Hopefully, with the next generation of our website, it will be better defined. 