### PR TITLE
SAMZA-1431: Enable SonarCloud integration with Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jdk:
 
 script:
   - ./gradlew clean build
-  - sonar-scanner
+  - type sonar-scanner &>/dev/null; if [ $? -eq 0 ]; then sonar-scanner; else echo "Not running sonar"; fi
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -45,4 +45,4 @@ cache:
 
 env:
   global:
-    - secure: liks8uabmOxZq/vnA7J0vh3qjScsze3FiCu0cRrTGYIAT9rA5/AhdMTD3ebfF87E05FV7tP8TlZ710bNIrTkRE57IktLNl06m95OAqaj7+usRvblI/w8nFTvRdGwVsHpmnyXzydl8xdaWpCwFlLEIXjweJOKF4Oes58AGzVK2B8=
+    - secure: S8MhhgBq1SVgthw3jDBmsKtUu1so4t+uVMSEpGSVENpxJc55APQKMJNfZAtxLlObjJSClTvtZj0tjNTTrfyKebrunJ1xGriJRTCvhiKeywDE3iRHBIV4ZIUS8Yc4i8CqVTF8gqbshf2gvwc+kvOj2r2BvMPPM3MkjcTI3f9q56I=

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ addons:
 jdk:
   - oraclejdk8
 
-script: "./gradlew clean test && sonar-scanner"
+script: "./gradlew clean build && sonar-scanner"
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,9 @@ addons:
 jdk:
   - oraclejdk8
 
-script: "./gradlew clean build && sonar-scanner"
+script:
+  - ./gradlew clean build
+  - sonar-scanner
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,18 @@
 language: java
 
 dist: trusty
-
 sudo: false
 
+addons:
+  sonarcloud:
+    organization: samza
+    branches:
+      - master
+      - travis-sonarcloud
 jdk:
   - oraclejdk8
+
+script: "./gradlew clean test && sonar-scanner"
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -30,5 +37,10 @@ before_cache:
 
 cache:
   directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
+    - "$HOME/.gradle/caches/"
+    - "$HOME/.gradle/wrapper/"
+    - "$HOME/.sonar/cache/"
+
+env:
+  global:
+    - secure: liks8uabmOxZq/vnA7J0vh3qjScsze3FiCu0cRrTGYIAT9rA5/AhdMTD3ebfF87E05FV7tP8TlZ710bNIrTkRE57IktLNl06m95OAqaj7+usRvblI/w8nFTvRdGwVsHpmnyXzydl8xdaWpCwFlLEIXjweJOKF4Oes58AGzVK2B8=

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,6 @@ allprojects {
 subprojects {
   apply plugin: 'eclipse'
   apply plugin: 'project-report'
-  apply plugin: 'java'
   apply plugin: 'jacoco'
 
   tasks.withType(Test) {

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,8 @@ allprojects {
 subprojects {
   apply plugin: 'eclipse'
   apply plugin: 'project-report'
+  apply plugin: 'java'
+  apply plugin: 'jacoco'
 
   tasks.withType(Test) {
     test {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
 sonar.projectKey=org.apache.samza
 sonar.projectName=Apache Samza
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,18 @@
+sonar.projectKey=org.apache.samza
+sonar.projectName=Apache Samza
+
+# Metadata
+sonar.links.homepage=https://samza.apache.org
+sonar.links.ci=https://travis-ci.org/apache/samza
+sonar.links.issue=https://issues.apache.org/jira/projects/SAMZA/issues
+
+# Standard properties
+sonar.sources=src/main
+sonar.java.binaries=build/classes
+sonar.tests=src/test
+
+# Code coverage reporting
+sonar.jacoco.reportPaths=build/jacoco/test.exec
+
+# List of subprojects here
+sonar.modules=samza-api,samza-autoscaling,samza-azure,samza-core,samza-elasticsearch,samza-hdfs,samza-kafka,samza-kv-inmemory,samza-kv-rocksdb,samza-kv,samza-log4j,samza-rest,samza-shell,samza-test,samza-yarn


### PR DESCRIPTION
These are modifications needed to integrate Travis-CI with SonarCloud. Also, the JaCoCo plugin is enabled in gradle for code coverage reporting to SonarCloud.

For reference, here is the request to Apache Infra to enable Travis-CI: https://issues.apache.org/jira/browse/INFRA-15132

@nickpan47 @isolis 