### PR TITLE
SAMZA-1451: Disable integration tests conditionally in build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Samza builds with [Scala](http://www.scala-lang.org/) 2.10 or 2.11 and [YARN](ht
 
 ### Testing Samza
 
-To run all unit tests:
+To run all tests:
 
     ./gradlew clean test
 

--- a/bin/check-all.sh
+++ b/bin/check-all.sh
@@ -81,7 +81,7 @@ do
     for yarn_version in "${YARNs[@]}"
     do
       echo "------------- Running check task against JDK${jdk_number}/Scala ${scala_version}/YARN ${yarn_version}"
-      ${gradle_file} -PscalaVersion=${scala_version} -PyarnVersion=${yarn_version} -Dorg.gradle.java.home=${!i} -PrunIntegrationTests clean check $@
+      ${gradle_file} -PscalaVersion=${scala_version} -PyarnVersion=${yarn_version} -Dorg.gradle.java.home=${!i} clean check $@
       echo "------------- Finished running check task against JDK${jdk_number}/Scala ${scala_version}/YARN ${yarn_version}"
     done
   done

--- a/docs/contribute/tests.md
+++ b/docs/contribute/tests.md
@@ -25,7 +25,7 @@ Samza's unit tests are written on top of [JUnit](http://junit.org/), and license
 
 To run all tests, and license checks:
 
-    ./gradlew clean check -PrunIntegrationTests
+    ./gradlew clean check
 
 To run a single test:
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,18 +48,17 @@ rootProject.children.each {
 }
 
 /**
- * Skips execution of all integration tests in project 'samza-test'.
- * To run integration tests in samza-test: './gradlew clean build -PrunIntegrationTests'
+ * To skip integration tests in samza-test: './gradlew clean build -PskipIntegrationTests'
  */
 gradle.taskGraph.whenReady { taskGraph ->
   taskGraph.getAllTasks().each { task ->
     def project = task.getProject()
     task.onlyIf {
       /**
-       * Behaves as pass through filter for all tasks when `runIntegrationTests` property is turned on.
+       * Behaves as pass through filter for all tasks when `skipIntegrationTests` property is turned off.
        * Filters 'test' task of 'samza-test' project otherwise.
        */
-      project.hasProperty("runIntegrationTests") || !(project.getName().contains("samza-test") && task.getName() == "test")
+      !project.hasProperty("skipIntegrationTests") || !(project.getName().contains("samza-test") && task.getName() == "test")
     }
   }
 }


### PR DESCRIPTION
Remove runIntegrationTests gradle property added as a part of SAMZA-1355 and introduce skipIntegrationTests property(which inverts it).
If skipIntegrationTests gradle project property is enabled, execution of all tests in samza-test project will be skipped from the build.
