### PR TITLE
SAMZA-1461 : Expose RocksDB properties as metrics

### DIFF
--- a/docs/learn/documentation/versioned/jobs/configuration-table.html
+++ b/docs/learn/documentation/versioned/jobs/configuration-table.html
@@ -1781,6 +1781,14 @@
                 </tr>
 
                 <tr>
+                    <td class="property" id="stores-rocksdb-metrics">stores.<span class="store">store-name</span>.<br>rocksdb.metrics.list</td>
+                    <td class="default"></td>
+                    <td class="description">
+                        A list of RocksDB <a href="https://github.com/facebook/rocksdb/blob/master/include/rocksdb/db.h#L409">properties</a> to expose as metrics (gauges).
+                    </td>
+                </tr>
+
+                <tr>
                     <th colspan="3" class="section" id="cluster-manager">
                         Running Samza with a cluster manager<br>
                     </th>


### PR DESCRIPTION
Automatically build gauges for RocksDB properties via configuration:
`stores.<storename>.rocksdb.telemetry.list=<rocksDbProperty1>, <rocksDbProperty1>`