### PR TITLE
SAMZA-1474: Bump up rocksdb version to 5.7.3 to include licensing changes

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -3,5 +3,3 @@ Copyright 2014 The Apache Software Foundation
 
 This product includes software developed at The Apache Software
 Foundation (http://www.apache.org/).
-
-This product uses RocksDB which carries Facebook BSD+patents license.

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -35,7 +35,7 @@
   metricsVersion = "2.2.0"
   mockitoVersion = "1.10.19"
   powerMockVersion = "1.6.6"
-  rocksdbVersion = "5.0.1"
+  rocksdbVersion = "5.7.3"
   scalaTestVersion = "3.0.1"
   slf4jVersion = "1.6.2"
   yarnVersion = "2.6.1"


### PR DESCRIPTION
You can find more details on the bug fixes and API changes [here](https://github.com/facebook/rocksdb/releases). I upgraded to 5.7.3 since 5.8.0 has a regression [KAFKA-6100](https://issues.apache.org/jira/browse/KAFKA-6100)

All of our tests passed locally. I will monitor travis for failures.