### PR TITLE
SAMZA-1492: Add exception counter to LocalStoreMonitor.

### DIFF
--- a/samza-rest/src/main/java/org/apache/samza/monitor/LocalStoreMonitor.java
+++ b/samza-rest/src/main/java/org/apache/samza/monitor/LocalStoreMonitor.java
@@ -104,6 +104,7 @@ public class LocalStoreMonitor implements Monitor {
           }
         }
       } catch (Exception ex) {
+        localStoreMonitorMetrics.failedStoreDeletionAttempts.inc();
         if (!config.getIgnoreFailures()) {
           throw ex;
         }

--- a/samza-rest/src/main/java/org/apache/samza/monitor/LocalStoreMonitorMetrics.java
+++ b/samza-rest/src/main/java/org/apache/samza/monitor/LocalStoreMonitorMetrics.java
@@ -33,9 +33,13 @@ public class LocalStoreMonitorMetrics extends MetricsBase {
   /** Total disk space cleared by the LocalStoreMonitor. */
   public final Counter diskSpaceFreedInBytes;
 
+  /** Total number of times task store deletions have been attempted and failed. */
+  public final Counter failedStoreDeletionAttempts;
+
   public LocalStoreMonitorMetrics(String prefix, MetricsRegistry registry) {
     super(prefix, registry);
     diskSpaceFreedInBytes = newCounter("diskSpaceFreedInBytes");
     noOfDeletedTaskPartitionStores = newCounter("noOfDeletedTaskPartitionStores");
+    failedStoreDeletionAttempts = newCounter("failedStoreDeletionAttempts");
   }
 }


### PR DESCRIPTION
Add storeGCExceptionCounter to LocalStoreMonitor(as a part of LocalStoreMonitorMetrics) to enable alerts setup in an production environment.