### PR TITLE
SAMZA-1505: Fix CheckpointTool writing only one ssp per task

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/checkpoint/CheckpointTool.scala
+++ b/samza-core/src/main/scala/org/apache/samza/checkpoint/CheckpointTool.scala
@@ -24,7 +24,7 @@ import java.util.regex.Pattern
 import joptsimple.OptionSet
 import org.apache.samza.checkpoint.CheckpointTool.TaskNameToCheckpointMap
 import org.apache.samza.config.TaskConfig.Config2Task
-import org.apache.samza.config.{JobConfig, ConfigRewriter, Config, StreamConfig}
+import org.apache.samza.config.{JobConfig, ConfigRewriter, Config}
 import org.apache.samza.container.TaskName
 import org.apache.samza.job.JobRunner._
 import org.apache.samza.metrics.MetricsRegistryMap

--- a/samza-core/src/main/scala/org/apache/samza/checkpoint/CheckpointTool.scala
+++ b/samza-core/src/main/scala/org/apache/samza/checkpoint/CheckpointTool.scala
@@ -34,6 +34,8 @@ import org.apache.samza.{Partition, SamzaException}
 import scala.collection.JavaConverters._
 import org.apache.samza.coordinator.JobModelManager
 
+import scala.collection.mutable.ListBuffer
+
 
 /**
  * Command-line tool for inspecting and manipulating the checkpoints for a job.
@@ -80,19 +82,20 @@ object CheckpointTool {
     var newOffsets: TaskNameToCheckpointMap = null
 
     def parseOffsets(propertiesFile: Config): TaskNameToCheckpointMap = {
-      val taskNameSSPPairs = propertiesFile.asScala.flatMap { case (key, value) => {
+      var checkpoints : ListBuffer[(TaskName, Map[SystemStreamPartition, String])] = ListBuffer()
+      propertiesFile.asScala.foreach { case (key, value) => {
         val matcher = SSP_REGEX.matcher(key)
         if (matcher.matches) {
           val taskname = new TaskName(matcher.group(1))
           val partition = new Partition(Integer.parseInt(matcher.group(4)))
           val ssp = new SystemStreamPartition(matcher.group(2), matcher.group(3), partition)
-          Some(taskname -> Map(ssp -> value))
+          val tuple = (taskname -> Map(ssp -> value))
+          checkpoints += tuple
         } else {
           warn("Warning: ignoring unrecognised property: %s = %s" format (key, value))
-          None
         }
-      }}.toList
-
+      }}
+      val taskNameSSPPairs = checkpoints.toList
       if(taskNameSSPPairs.isEmpty) {
         return null
       }

--- a/samza-core/src/test/scala/org/apache/samza/checkpoint/TestCheckpointTool.scala
+++ b/samza-core/src/test/scala/org/apache/samza/checkpoint/TestCheckpointTool.scala
@@ -21,7 +21,6 @@ package org.apache.samza.checkpoint
 
 import java.util
 
-import com.sun.scenario.effect.Offset
 import org.apache.samza.Partition
 import org.apache.samza.checkpoint.CheckpointTool.CheckpointToolCommandLine
 import org.apache.samza.container.TaskName
@@ -29,7 +28,7 @@ import org.apache.samza.checkpoint.TestCheckpointTool.{MockCheckpointManagerFact
 import org.apache.samza.config.{Config, MapConfig, SystemConfig, TaskConfig}
 import org.apache.samza.metrics.MetricsRegistry
 import org.apache.samza.system.SystemStreamMetadata.SystemStreamPartitionMetadata
-import org.apache.samza.system.{SystemAdmin, SystemConsumer, SystemFactory, SystemProducer, SystemStream, SystemStreamMetadata, SystemStreamPartition}
+import org.apache.samza.system.{SystemAdmin, SystemConsumer, SystemFactory, SystemProducer, SystemStreamMetadata, SystemStreamPartition}
 import org.junit.{Before, Test}
 import org.mockito.Matchers._
 import org.mockito.Mockito._

--- a/samza-core/src/test/scala/org/apache/samza/checkpoint/TestCheckpointTool.scala
+++ b/samza-core/src/test/scala/org/apache/samza/checkpoint/TestCheckpointTool.scala
@@ -19,7 +19,11 @@
 
 package org.apache.samza.checkpoint
 
+import java.util
+
+import com.sun.scenario.effect.Offset
 import org.apache.samza.Partition
+import org.apache.samza.checkpoint.CheckpointTool.CheckpointToolCommandLine
 import org.apache.samza.container.TaskName
 import org.apache.samza.checkpoint.TestCheckpointTool.{MockCheckpointManagerFactory, MockSystemFactory}
 import org.apache.samza.config.{Config, MapConfig, SystemConfig, TaskConfig}
@@ -34,6 +38,8 @@ import org.scalatest.mockito.MockitoSugar
 import scala.collection.JavaConverters._
 import org.apache.samza.config.JobConfig
 import org.apache.samza.coordinator.stream.MockCoordinatorStreamSystemFactory
+
+import scala.collection.immutable.HashMap
 
 object TestCheckpointTool {
   var checkpointManager: CheckpointManager = null
@@ -105,5 +111,21 @@ class TestCheckpointTool extends AssertionsForJUnit with MockitoSugar {
       .writeCheckpoint(tn0, new Checkpoint(Map(new SystemStreamPartition("test", "foo", p0) -> "42").asJava))
     verify(TestCheckpointTool.checkpointManager)
       .writeCheckpoint(tn1, new Checkpoint(Map(new SystemStreamPartition("test", "foo", p1) -> "43").asJava))
+  }
+
+  @Test
+  def testGrouping(): Unit = {
+    val config : java.util.Map[String, String] = new util.HashMap()
+    config.put("tasknames.Partition 0.systems.kafka-atc-repartitioned-requests.streams.ArticleRead.partitions.0", "0000")
+    config.put("tasknames.Partition 0.systems.kafka-atc-repartitioned-requests.streams.CommunicationRequest.partitions.0", "1111")
+    config.put("tasknames.Partition 1.systems.kafka-atc-repartitioned-requests.streams.ArticleRead.partitions.1", "2222")
+    config.put("tasknames.Partition 1.systems.kafka-atc-repartitioned-requests.streams.CommunicationRequest.partitions.1", "44444")
+    config.put("tasknames.Partition 1.systems.kafka-atc-repartitioned-requests.streams.StateChange.partitions.1", "5555")
+
+    val ccl = new CheckpointToolCommandLine
+    val result = ccl.parseOffsets(new MapConfig(config))
+
+    assert(result(new TaskName("Partition 0")).size == 2)
+    assert(result(new TaskName("Partition 1")).size == 3)
   }
 }


### PR DESCRIPTION
Currently when using CheckpointTool to write checkpoints, it only writes a checkpoint of a single ssp per task. By debugging the code, looks like the flatMap() on the checkpoint of Optional tuple(taskname -> Map(ssp -> offset)) merges the results by key taskname. This patch stores the results explicitly in a list and then groupBy() on it, which fixes the problem.