### PR TITLE
SAMZA-1514: Prevent changelog stream names with empty strings.

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/JavaStorageConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JavaStorageConfig.java
@@ -21,6 +21,7 @@ package org.apache.samza.config;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.samza.SamzaException;
 import org.apache.samza.execution.StreamManager;
 
@@ -58,11 +59,11 @@ public class JavaStorageConfig extends MapConfig {
     // If the config specifies 'stores.<storename>.changelog' as '<system>.<stream>' combination - it will take precedence.
     // If this config only specifies <astream> and there is a value in job.changelog.system=<asystem> -
     // these values will be combined into <asystem>.<astream>
-    String systemStream = get(String.format(CHANGELOG_STREAM, storeName), null);
-    String changelogSystem = getChangelogSystem();
+    String systemStream = StringUtils.trimToNull(get(String.format(CHANGELOG_STREAM, storeName), null));
 
     String systemStreamRes;
     if (systemStream != null  && !systemStream.contains(".")) {
+      String changelogSystem = getChangelogSystem();
       // contains only stream name
       if (changelogSystem != null) {
         systemStreamRes = changelogSystem + "." + systemStream;

--- a/samza-core/src/test/java/org/apache/samza/config/TestJavaStorageConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestJavaStorageConfig.java
@@ -68,4 +68,17 @@ public class TestJavaStorageConfig {
        // do nothing, it is expected
     }
   }
+
+  @Test
+  public void testEmptyStringOrNullChangelogStream() {
+    Map<String, String> configMap = new HashMap<>();
+    configMap.put("stores.store1.changelog", "");
+    configMap.put("stores.store2.changelog", " ");
+
+    JavaStorageConfig config = new JavaStorageConfig(new MapConfig(configMap));
+
+    assertNull(config.getChangelogStream("store1"));
+    assertNull(config.getChangelogStream("store2"));
+    assertNull(config.getChangelogStream("store-changelog-none"));
+  }
 }


### PR DESCRIPTION
This fix prevents changelog stream names with empty or whitespace-only strings. 