### PR TITLE
SAMZA-1506: Fix for robust ContainerHeartbeatMonitor exception handling.

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/container/ContainerHeartbeatMonitor.java
+++ b/samza-core/src/main/java/org/apache/samza/container/ContainerHeartbeatMonitor.java
@@ -54,7 +54,7 @@ public class ContainerHeartbeatMonitor {
         if (!response.isAlive()) {
           scheduler.schedule(() -> {
               // On timeout of container shutting down, force exit.
-              LOG.error("Gracefully shutdown timeout expired. Force exiting.");
+              LOG.error("Graceful shutdown timeout expired. Force exiting.");
               System.exit(1);
             }, SHUTDOWN_TIMOUT_MS, TimeUnit.MILLISECONDS);
           onContainerExpired.run();

--- a/samza-core/src/main/java/org/apache/samza/runtime/LocalContainerRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/LocalContainerRunner.java
@@ -153,8 +153,13 @@ public class LocalContainerRunner extends AbstractApplicationRunner {
     if (executionEnvContainerId != null) {
       log.info("Got execution environment container id: {}", executionEnvContainerId);
       containerHeartbeatMonitor = new ContainerHeartbeatMonitor(() -> {
-          container.shutdown();
-          containerRunnerException = new SamzaException("Container shutdown due to expired heartbeat");
+          try {
+            container.shutdown();
+            containerRunnerException = new SamzaException("Container shutdown due to expired heartbeat");
+          } catch (Exception e) {
+            log.error("Heartbeat monitor failed to shutdown the container gracefully. Exiting process.", e);
+            System.exit(1);
+          }
         }, new ContainerHeartbeatClient(coordinatorUrl, executionEnvContainerId));
       containerHeartbeatMonitor.start();
     } else {


### PR DESCRIPTION
The Fix includes the following changes:
- Catch all exceptions inside the heartbeat thread and not just
  IOException.
- A time based force kill when the heartbeat is invalid,
  this makes the monitor immune to threads that may keep the
  container stuck in the shutdown sequence. When the timeout
  occurs, a System.exit(1) is called.
- Increasing number of retries for failed heartbeats from 3 to 6.
  This prevents short intermittent network failurs from causing the
  containers to be invalidated.