### PR TITLE
SAMZA-1532: Eventhub connector fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -213,11 +213,6 @@ project(':samza-azure') {
     configFile = new File(rootDir, "checkstyle/checkstyle.xml")
     toolVersion = "$checkstyleVersion"
   }
-  test {
-    // Exclude integration tests that require connection to EventHub
-    exclude 'org/apache/samza/system/eventhub/producer/*ITest*'
-    exclude 'org/apache/samza/system/eventhub/consumer/*ITest*'
-  }
 }
 
 project(":samza-autoscaling_$scalaVersion") {

--- a/samza-azure/src/main/java/org/apache/samza/checkpoint/azure/AzureCheckpointManagerFactory.java
+++ b/samza-azure/src/main/java/org/apache/samza/checkpoint/azure/AzureCheckpointManagerFactory.java
@@ -23,11 +23,13 @@ import org.apache.samza.checkpoint.CheckpointManager;
 import org.apache.samza.checkpoint.CheckpointManagerFactory;
 import org.apache.samza.config.AzureConfig;
 import org.apache.samza.config.Config;
+import org.apache.samza.config.JobConfig;
 import org.apache.samza.metrics.MetricsRegistry;
 
 public class AzureCheckpointManagerFactory implements CheckpointManagerFactory {
   @Override
   public CheckpointManager getCheckpointManager(Config config, MetricsRegistry registry) {
-    return new AzureCheckpointManager(new AzureConfig(config));
+    JobConfig jobConfig = new JobConfig(config);
+    return new AzureCheckpointManager(new AzureConfig(config), jobConfig.getName());
   }
 }

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/EventHubConfig.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/EventHubConfig.java
@@ -52,7 +52,7 @@ public class EventHubConfig extends MapConfig {
           .PartitioningMethod.EVENT_HUB_HASHING.name();
 
   public static final String CONFIG_SEND_KEY_IN_EVENT_PROPERTIES = "systems.%s.eventhubs.send.key";
-  public static final Boolean DEFAULT_CONFIG_SEND_KEY_IN_EVENT_PROPERTIES = false;
+  public static final Boolean DEFAULT_CONFIG_SEND_KEY_IN_EVENT_PROPERTIES = true;
 
   public static final String CONFIG_FETCH_RUNTIME_INFO_TIMEOUT_MILLIS = "systems.%s.eventhubs.runtime.info.timeout";
   public static final long DEFAULT_CONFIG_FETCH_RUNTIME_INFO_TIMEOUT_MILLIS = Duration.ofMinutes(1L).toMillis();

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/EventHubConfig.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/EventHubConfig.java
@@ -20,10 +20,15 @@
 package org.apache.samza.system.eventhub;
 
 import com.microsoft.azure.eventhubs.EventHubClient;
+import org.apache.samza.SamzaException;
+import org.apache.samza.config.Config;
 import org.apache.samza.config.MapConfig;
+import org.apache.samza.config.StreamConfig;
 import org.apache.samza.system.eventhub.producer.EventHubSystemProducer;
+import scala.collection.JavaConversions;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -55,9 +60,47 @@ public class EventHubConfig extends MapConfig {
   public static final String CONFIG_CONSUMER_BUFFER_CAPACITY = "systems.%s.eventhubs.receive.queue.size";
   public static final int DEFAULT_CONFIG_CONSUMER_BUFFER_CAPACITY = 100;
 
+  private final Map<String, String> physcialToId = new HashMap<>();
 
-  public EventHubConfig(Map<String, String> config) {
+  public EventHubConfig(Config config) {
     super(config);
+
+    // Build reverse index for streamName -> streamId
+    StreamConfig streamConfig = new StreamConfig(config);
+    JavaConversions.asJavaCollection(streamConfig.getStreamIds())
+            .forEach((streamId) -> physcialToId.put(streamConfig.getPhysicalName(streamId), streamId));
+  }
+
+  private String getFromStreamIdOrName(String configName, String systemName, String streamName, String defaultString) {
+    String result = getFromStreamIdOrName(configName, systemName, streamName);
+    if (result == null) {
+      return defaultString;
+    }
+    return result;
+  }
+
+  private String getFromStreamIdOrName(String configName, String systemName, String streamName) {
+    String streamId = getStreamId(streamName);
+    return get(String.format(configName, systemName, streamId),
+            streamId.equals(streamName) ? null : get(String.format(configName, systemName, streamName)));
+  }
+
+  private String validateRequiredConfig(String value, String fieldName, String systemName, String streamName) {
+    if (value == null) {
+      throw new SamzaException(String.format("Missing %s configuration for system: %s, stream: %s",
+              fieldName, systemName, streamName));
+    }
+    return value;
+  }
+
+  /**
+   * Get the streamId for the specified streamName
+   *
+   * @param streamName the physical identifier of a stream
+   * @return the streamId identifier for the stream or the queried streamName if it is not found.
+   */
+  public String getStreamId(String streamName) {
+    return physcialToId.getOrDefault(streamName, streamName);
   }
 
   /**
@@ -75,55 +118,59 @@ public class EventHubConfig extends MapConfig {
    * Get the EventHubs namespace for the stream
    *
    * @param systemName name of the system
-   * @param streamName name of stream
+   * @param streamName name of stream (physical or streamId)
    * @return EventHubs namespace
    */
   public String getStreamNamespace(String systemName, String streamName) {
-    return get(String.format(CONFIG_STREAM_NAMESPACE, systemName, streamName));
+    return validateRequiredConfig(getFromStreamIdOrName(CONFIG_STREAM_NAMESPACE, systemName, streamName),
+            "Namespace", systemName, streamName);
   }
 
   /**
    * Get the EventHubs entity path (topic name) for the stream
    *
    * @param systemName name of the system
-   * @param streamName name of stream
+   * @param streamName name of stream (physical or streamId)
    * @return EventHubs entity path
    */
   public String getStreamEntityPath(String systemName, String streamName) {
-    return get(String.format(CONFIG_STREAM_ENTITYPATH, systemName, streamName));
+    return validateRequiredConfig(getFromStreamIdOrName(CONFIG_STREAM_ENTITYPATH, systemName, streamName),
+            "EntityPath", systemName, streamName);
   }
 
   /**
    * Get the EventHubs SAS (Shared Access Signature) key name for the stream
    *
    * @param systemName name of the system
-   * @param streamName name of stream
+   * @param streamName name of stream (physical or streamId)
    * @return EventHubs SAS key name
    */
   public String getStreamSasKeyName(String systemName, String streamName) {
-    return get(String.format(CONFIG_STREAM_SAS_KEY_NAME, systemName, streamName));
+    return validateRequiredConfig(getFromStreamIdOrName(CONFIG_STREAM_SAS_KEY_NAME, systemName, streamName),
+            "SASKeyName", systemName, streamName);
   }
 
   /**
    * Get the EventHubs SAS (Shared Access Signature) token for the stream
    *
    * @param systemName name of the system
-   * @param streamName name of stream
+   * @param streamName name of stream (physical or streamId)
    * @return EventHubs SAS token
    */
   public String getStreamSasToken(String systemName, String streamName) {
-    return get(String.format(CONFIG_STREAM_SAS_TOKEN, systemName, streamName));
+    return validateRequiredConfig(getFromStreamIdOrName(CONFIG_STREAM_SAS_TOKEN, systemName, streamName),
+            "SASToken", systemName, streamName);
   }
 
   /**
    * Get the EventHubs consumer group used for consumption for the stream
    *
    * @param systemName name of the system
-   * @param streamName name of stream
+   * @param streamName name of stream (physical or streamId)
    * @return EventHubs consumer group
    */
   public String getStreamConsumerGroup(String systemName, String streamName) {
-    return get(String.format(CONFIG_STREAM_CONSUMER_GROUP, systemName, streamName), DEFAULT_CONFIG_STREAM_CONSUMER_GROUP);
+    return getFromStreamIdOrName(CONFIG_STREAM_CONSUMER_GROUP, systemName, streamName, DEFAULT_CONFIG_STREAM_CONSUMER_GROUP);
   }
 
   /**

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/SamzaEventHubClientManager.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/SamzaEventHubClientManager.java
@@ -75,8 +75,8 @@ public class SamzaEventHubClientManager implements EventHubClientManager {
 
       eventHubClient = EventHubClient.createFromConnectionStringSync(connectionStringBuilder.toString(), retryPolicy);
     } catch (IOException | ServiceBusException e) {
-      String msg = String.format("Creation of EventHub client failed for eventHub %s %s %s %s on remote host %s:%d",
-              entityPath, eventHubNamespace, sasKeyName, sasKey, remoteHost, ClientConstants.AMQPS_PORT);
+      String msg = String.format("Creation of EventHub client failed for eventHub EntityPath: %s on remote host %s:%d",
+              entityPath, remoteHost, ClientConstants.AMQPS_PORT);
       LOG.error(msg, e);
       throw new SamzaException(msg, e);
     }

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/admin/EventHubSystemAdmin.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/admin/EventHubSystemAdmin.java
@@ -160,7 +160,7 @@ public class EventHubSystemAdmin implements SystemAdmin {
 
           String startingOffset = EventHubSystemConsumer.START_OF_STREAM;
           String newestOffset = ehPartitionInfo.getLastEnqueuedOffset();
-          String upcomingOffset = getNextOffset(newestOffset);
+          String upcomingOffset = EventHubSystemConsumer.END_OF_STREAM;
           SystemStreamPartitionMetadata sspMetadata = new SystemStreamPartitionMetadata(startingOffset, newestOffset,
                   upcomingOffset);
 

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
@@ -174,6 +174,7 @@ public class EventHubSystemConsumer extends BlockingEnvelopeMap {
   public void register(SystemStreamPartition systemStreamPartition, String offset) {
     super.register(systemStreamPartition, offset);
 
+    LOG.debug(String.format("Eventhub consumer trying to register ssp %s, offset %s", systemStreamPartition, offset));
     if (isStarted) {
       throw new SamzaException("Trying to add partition when the connection has already started.");
     }

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/producer/EventHubSystemProducer.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/producer/EventHubSystemProducer.java
@@ -58,6 +58,7 @@ public class EventHubSystemProducer implements SystemProducer {
   private static final long DEFAULT_FLUSH_TIMEOUT_MILLIS = Duration.ofMinutes(1L).toMillis();
 
   public static final String PRODUCE_TIMESTAMP = "produce-timestamp";
+  public static final String KEY = "key";
 
   // Metrics recording
   private static final String EVENT_WRITE_RATE = "eventWriteRate";
@@ -184,7 +185,7 @@ public class EventHubSystemProducer implements SystemProducer {
 
   @Override
   public synchronized void send(String source, OutgoingMessageEnvelope envelope) {
-    LOG.info(String.format("Trying to send %s", envelope));
+    LOG.debug(String.format("Trying to send %s", envelope));
     if (!isStarted) {
       throw new SamzaException("Trying to call send before the producer is started.");
     }
@@ -290,7 +291,7 @@ public class EventHubSystemProducer implements SystemProducer {
         keyValue = (envelope.getKey() instanceof byte[]) ? new String((byte[]) envelope.getKey())
                 : envelope.getKey().toString();
       }
-      eventData.getProperties().put("key", keyValue);
+      eventData.getProperties().put(KEY, keyValue);
     }
     return eventData;
   }

--- a/samza-azure/src/test/java/org/apache/samza/checkpoint/azure/ITestAzureCheckpointManager.java
+++ b/samza-azure/src/test/java/org/apache/samza/checkpoint/azure/ITestAzureCheckpointManager.java
@@ -34,7 +34,7 @@ import org.junit.*;
 import java.util.HashMap;
 import java.util.Map;
 
-@Ignore("Intergration Test")
+@Ignore("Requires Azure account credentials")
 public class ITestAzureCheckpointManager {
 
   private static String storageConnectionString = "";

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/MockEventHubClientManagerFactory.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/MockEventHubClientManagerFactory.java
@@ -101,6 +101,10 @@ public class MockEventHubClientManagerFactory extends EventHubClientManagerFacto
           }
           return null;
         });
+      EventHubPartitionRuntimeInformation mockPartitionRuntimeInfo = PowerMockito.mock(EventHubPartitionRuntimeInformation.class);
+      PowerMockito.when(mockPartitionRuntimeInfo.getLastEnqueuedOffset())
+              .thenReturn(EventHubSystemConsumer.START_OF_STREAM);
+      CompletableFuture<EventHubPartitionRuntimeInformation> partitionFuture =  new MockPartitionFuture(mockPartitionRuntimeInfo);
 
       // Producer mocks
       PartitionSender mockPartitionSender0 = PowerMockito.mock(PartitionSender.class);
@@ -137,6 +141,7 @@ public class MockEventHubClientManagerFactory extends EventHubClientManagerFacto
                     startingOffsets.put(partitionId, offset);
                     return mockPartitionReceiver;
                   });
+        PowerMockito.when(mockEventHubClient.getPartitionRuntimeInformation(anyString())).thenReturn(partitionFuture);
 
         // Producer calls
         PowerMockito.when(mockEventHubClient.createPartitionSenderSync("0")).thenReturn(mockPartitionSender0);
@@ -187,6 +192,19 @@ public class MockEventHubClientManagerFactory extends EventHubClientManagerFacto
 
       @Override
       public EventHubRuntimeInformation get(long timeout, TimeUnit unit) {
+        return runtimeInformation;
+      }
+    }
+
+    private class MockPartitionFuture extends CompletableFuture<EventHubPartitionRuntimeInformation> {
+      EventHubPartitionRuntimeInformation runtimeInformation;
+
+      MockPartitionFuture(EventHubPartitionRuntimeInformation runtimeInformation) {
+        this.runtimeInformation = runtimeInformation;
+      }
+
+      @Override
+      public EventHubPartitionRuntimeInformation get(long timeout, TimeUnit unit) {
         return runtimeInformation;
       }
     }

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/admin/TestEventHubSystemAdmin.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/admin/TestEventHubSystemAdmin.java
@@ -49,14 +49,8 @@ public class TestEventHubSystemAdmin {
     Assert.assertEquals(0, eventHubSystemAdmin.offsetComparator("150", "150").intValue());
     Assert.assertEquals(1, eventHubSystemAdmin.offsetComparator("200", "100").intValue());
     Assert.assertNull(eventHubSystemAdmin.offsetComparator("1", "a"));
-    Assert.assertEquals(-1, eventHubSystemAdmin
-            .offsetComparator("100", EventHubSystemConsumer.END_OF_STREAM).intValue());
-    Assert.assertEquals(0, eventHubSystemAdmin.offsetComparator(EventHubSystemConsumer.END_OF_STREAM,
-            EventHubSystemConsumer.END_OF_STREAM).intValue());
-    Assert.assertEquals(1, eventHubSystemAdmin
-            .offsetComparator(EventHubSystemConsumer.END_OF_STREAM, "100").intValue());
-    Assert.assertEquals(-1, eventHubSystemAdmin
-            .offsetComparator(EventHubSystemConsumer.START_OF_STREAM, "10").intValue());
+    Assert.assertNull(eventHubSystemAdmin.offsetComparator("100", EventHubSystemConsumer.END_OF_STREAM));
+    Assert.assertNull(eventHubSystemAdmin.offsetComparator(EventHubSystemConsumer.END_OF_STREAM, EventHubSystemConsumer.END_OF_STREAM));
   }
 
   @Test
@@ -66,16 +60,13 @@ public class TestEventHubSystemAdmin {
             MockEventHubConfigFactory.getEventHubConfig(EventHubSystemProducer.PartitioningMethod.EVENT_HUB_HASHING));
     Map<SystemStreamPartition, String> offsets = new HashMap<>();
     SystemStreamPartition ssp0 = new SystemStreamPartition(SYSTEM_NAME, STREAM_NAME1, new Partition(0));
-    SystemStreamPartition ssp1 = new SystemStreamPartition(SYSTEM_NAME, STREAM_NAME1, new Partition(1));
     SystemStreamPartition ssp2 = new SystemStreamPartition(SYSTEM_NAME, STREAM_NAME1, new Partition(2));
     offsets.put(ssp0, Integer.toString(0));
-    offsets.put(ssp1, EventHubSystemConsumer.END_OF_STREAM);
     offsets.put(ssp2, EventHubSystemConsumer.START_OF_STREAM);
 
     Map<SystemStreamPartition, String> updatedOffsets = eventHubSystemAdmin.getOffsetsAfter(offsets);
     Assert.assertEquals(offsets.size(), updatedOffsets.size());
     Assert.assertEquals("1", updatedOffsets.get(ssp0));
-    Assert.assertEquals("-2", updatedOffsets.get(ssp1));
     Assert.assertEquals("0", updatedOffsets.get(ssp2));
   }
 
@@ -102,8 +93,6 @@ public class TestEventHubSystemAdmin {
       partitionMetadataMap.forEach((partition, metadata) -> {
           Assert.assertEquals(EventHubSystemConsumer.START_OF_STREAM, metadata.getOldestOffset());
           Assert.assertNotSame(EventHubSystemConsumer.END_OF_STREAM, metadata.getNewestOffset());
-          Assert.assertTrue(Long.parseLong(EventHubSystemConsumer.END_OF_STREAM)
-                  <= Long.parseLong(metadata.getNewestOffset()));
           String expectedUpcomingOffset = String.valueOf(Long.parseLong(metadata.getNewestOffset()) + 1);
           Assert.assertEquals(expectedUpcomingOffset, metadata.getUpcomingOffset());
         });

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/consumer/ITestEventHubSystemConsumer.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/consumer/ITestEventHubSystemConsumer.java
@@ -29,6 +29,7 @@ import org.apache.samza.system.eventhub.MockEventHubConfigFactory;
 import org.apache.samza.system.eventhub.TestMetricsRegistry;
 import org.apache.samza.system.eventhub.producer.EventHubSystemProducer;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -37,6 +38,7 @@ import java.util.List;
 import static org.apache.samza.system.eventhub.MockEventHubConfigFactory.STREAM_NAME1;
 import static org.apache.samza.system.eventhub.MockEventHubConfigFactory.SYSTEM_NAME;
 
+@Ignore("Requires Azure account credentials")
 public class ITestEventHubSystemConsumer {
 
   private Config createEventHubConfig() {

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/consumer/ITestEventHubSystemConsumer.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/consumer/ITestEventHubSystemConsumer.java
@@ -32,8 +32,7 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static org.apache.samza.system.eventhub.MockEventHubConfigFactory.STREAM_NAME1;
 import static org.apache.samza.system.eventhub.MockEventHubConfigFactory.SYSTEM_NAME;

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/consumer/TestEventHubSystemConsumer.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/consumer/TestEventHubSystemConsumer.java
@@ -22,6 +22,7 @@ package org.apache.samza.system.eventhub.consumer;
 
 import com.microsoft.azure.eventhubs.*;
 import org.apache.samza.Partition;
+import org.apache.samza.config.MapConfig;
 import org.apache.samza.metrics.Counter;
 import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.system.SystemStreamPartition;
@@ -86,11 +87,12 @@ public class TestEventHubSystemConsumer {
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_SAS_KEY_NAME, systemName, streamName), EVENTHUB_KEY_NAME);
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_SAS_TOKEN, systemName, streamName), EVENTHUB_KEY);
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_ENTITYPATH, systemName, streamName), MOCK_ENTITY_1);
+    MapConfig config = new MapConfig(configMap);
 
     MockEventHubClientManagerFactory eventHubClientWrapperFactory = new MockEventHubClientManagerFactory(eventData);
 
     EventHubSystemConsumer consumer =
-            new EventHubSystemConsumer(new EventHubConfig(configMap), systemName, eventHubClientWrapperFactory, interceptors,
+            new EventHubSystemConsumer(new EventHubConfig(config), systemName, eventHubClientWrapperFactory, interceptors,
                     testMetrics);
     consumer.register(ssp, "1");
     consumer.register(ssp, EventHubSystemConsumer.END_OF_STREAM);
@@ -125,11 +127,12 @@ public class TestEventHubSystemConsumer {
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_SAS_KEY_NAME, systemName, streamName), EVENTHUB_KEY_NAME);
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_SAS_TOKEN, systemName, streamName), EVENTHUB_KEY);
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_ENTITYPATH, systemName, streamName), MOCK_ENTITY_1);
+    MapConfig config = new MapConfig(configMap);
 
     MockEventHubClientManagerFactory eventHubClientWrapperFactory = new MockEventHubClientManagerFactory(eventData);
 
     EventHubSystemConsumer consumer =
-            new EventHubSystemConsumer(new EventHubConfig(configMap), systemName, eventHubClientWrapperFactory, interceptors,
+            new EventHubSystemConsumer(new EventHubConfig(config), systemName, eventHubClientWrapperFactory, interceptors,
                     testMetrics);
     consumer.register(ssp, EventHubSystemConsumer.END_OF_STREAM);
     consumer.start();
@@ -174,11 +177,12 @@ public class TestEventHubSystemConsumer {
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_SAS_KEY_NAME, systemName, streamName), EVENTHUB_KEY_NAME);
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_SAS_TOKEN, systemName, streamName), EVENTHUB_KEY);
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_ENTITYPATH, systemName, streamName), MOCK_ENTITY_1);
+    MapConfig config = new MapConfig(configMap);
 
     MockEventHubClientManagerFactory eventHubClientWrapperFactory = new MockEventHubClientManagerFactory(eventData);
 
     EventHubSystemConsumer consumer =
-            new EventHubSystemConsumer(new EventHubConfig(configMap), systemName, eventHubClientWrapperFactory, interceptors,
+            new EventHubSystemConsumer(new EventHubConfig(config), systemName, eventHubClientWrapperFactory, interceptors,
                     testMetrics);
     consumer.register(ssp, EventHubSystemConsumer.END_OF_STREAM);
     consumer.start();
@@ -225,11 +229,12 @@ public class TestEventHubSystemConsumer {
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_NAMESPACE, systemName, streamName), EVENTHUB_NAMESPACE);
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_SAS_KEY_NAME, systemName, streamName), EVENTHUB_KEY_NAME);
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_SAS_TOKEN, systemName, streamName), EVENTHUB_KEY);
+    MapConfig config = new MapConfig(configMap);
 
     MockEventHubClientManagerFactory eventHubClientWrapperFactory = new MockEventHubClientManagerFactory(eventData);
 
     EventHubSystemConsumer consumer =
-            new EventHubSystemConsumer(new EventHubConfig(configMap), systemName, eventHubClientWrapperFactory, interceptor,
+            new EventHubSystemConsumer(new EventHubConfig(config), systemName, eventHubClientWrapperFactory, interceptor,
                     testMetrics);
     consumer.register(ssp1, EventHubSystemConsumer.START_OF_STREAM);
     consumer.register(ssp2, EventHubSystemConsumer.START_OF_STREAM);
@@ -285,11 +290,12 @@ public class TestEventHubSystemConsumer {
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_NAMESPACE, systemName, streamName2), EVENTHUB_NAMESPACE);
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_SAS_KEY_NAME, systemName, streamName2), EVENTHUB_KEY_NAME);
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_SAS_TOKEN, systemName, streamName2), EVENTHUB_KEY);
+    MapConfig config = new MapConfig(configMap);
 
     MockEventHubClientManagerFactory eventHubClientWrapperFactory = new MockEventHubClientManagerFactory(eventData);
 
     EventHubSystemConsumer consumer =
-            new EventHubSystemConsumer(new EventHubConfig(configMap), systemName, eventHubClientWrapperFactory, interceptor,
+            new EventHubSystemConsumer(new EventHubConfig(config), systemName, eventHubClientWrapperFactory, interceptor,
                     testMetrics);
 
     consumer.register(ssp1, EventHubSystemConsumer.START_OF_STREAM);

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/consumer/TestEventHubSystemConsumer.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/consumer/TestEventHubSystemConsumer.java
@@ -41,7 +41,8 @@ import java.util.stream.Collectors;
 import static org.apache.samza.system.eventhub.MockEventHubConfigFactory.*;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({EventHubRuntimeInformation.class, EventHubClient.class, PartitionReceiver.class, PartitionSender.class})
+@PrepareForTest({EventHubRuntimeInformation.class, EventHubPartitionRuntimeInformation.class,
+        EventHubClient.class, PartitionReceiver.class, PartitionSender.class})
 public class TestEventHubSystemConsumer {
   private static final String MOCK_ENTITY_1 = "mocktopic1";
   private static final String MOCK_ENTITY_2 = "mocktopic2";

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/producer/ITestEventHubSystemProducer.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/producer/ITestEventHubSystemProducer.java
@@ -30,12 +30,14 @@ import org.apache.samza.system.eventhub.*;
 import org.apache.samza.system.eventhub.consumer.EventHubSystemConsumer;
 import org.apache.samza.util.NoOpMetricsRegistry;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.samza.system.eventhub.MockEventHubConfigFactory.*;
 
+@Ignore("Requires Azure account credentials")
 public class ITestEventHubSystemProducer {
   private static final Logger LOG = LoggerFactory.getLogger(ITestEventHubSystemProducer.class.getName());
 

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/producer/TestEventHubSystemProducer.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/producer/TestEventHubSystemProducer.java
@@ -20,6 +20,7 @@
 package org.apache.samza.system.eventhub.producer;
 
 import com.microsoft.azure.eventhubs.*;
+import org.apache.samza.config.MapConfig;
 import org.apache.samza.system.OutgoingMessageEnvelope;
 import org.apache.samza.system.SystemStream;
 import org.apache.samza.system.eventhub.EventHubConfig;
@@ -79,11 +80,12 @@ public class TestEventHubSystemProducer {
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_ENTITYPATH, systemName, streamName), EVENTHUB_ENTITY1);
     configMap.put(String.format(EventHubConfig.CONFIG_PRODUCER_PARTITION_METHOD, systemName),
             PartitioningMethod.PARTITION_KEY_AS_PARTITION.toString());
+    MapConfig config = new MapConfig(configMap);
 
     MockEventHubClientManagerFactory factory = new MockEventHubClientManagerFactory();
 
     EventHubSystemProducer producer =
-            new EventHubSystemProducer(new EventHubConfig(configMap), systemName, factory, interceptor, testMetrics);
+            new EventHubSystemProducer(new EventHubConfig(config), systemName, factory, interceptor, testMetrics);
 
     SystemStream systemStream = new SystemStream(systemName, streamName);
     producer.register(SOURCE);
@@ -129,11 +131,12 @@ public class TestEventHubSystemProducer {
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_ENTITYPATH, systemName, streamName), EVENTHUB_ENTITY1);
     configMap.put(String.format(EventHubConfig.CONFIG_PRODUCER_PARTITION_METHOD, systemName),
             PartitioningMethod.PARTITION_KEY_AS_PARTITION.toString());
+    MapConfig config = new MapConfig(configMap);
 
     MockEventHubClientManagerFactory factory = new MockEventHubClientManagerFactory();
 
     EventHubSystemProducer producer =
-            new EventHubSystemProducer(new EventHubConfig(configMap), systemName, factory, interceptors, testMetrics);
+            new EventHubSystemProducer(new EventHubConfig(config), systemName, factory, interceptors, testMetrics);
 
     SystemStream systemStream = new SystemStream(systemName, streamName);
     producer.register(SOURCE);
@@ -187,11 +190,12 @@ public class TestEventHubSystemProducer {
     // mod 2 on the partitionid to simulate consistent hashing
     configMap.put(String.format(EventHubConfig.CONFIG_PRODUCER_PARTITION_METHOD, systemName),
             PartitioningMethod.EVENT_HUB_HASHING.toString());
+    MapConfig config = new MapConfig(configMap);
 
     MockEventHubClientManagerFactory factory = new MockEventHubClientManagerFactory();
 
     EventHubSystemProducer producer =
-            new EventHubSystemProducer(new EventHubConfig(configMap), systemName, factory, interceptor, testMetrics);
+            new EventHubSystemProducer(new EventHubConfig(config), systemName, factory, interceptor, testMetrics);
 
     SystemStream systemStream = new SystemStream(systemName, streamName);
     producer.register(SOURCE);

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/producer/TestEventHubSystemProducer.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/producer/TestEventHubSystemProducer.java
@@ -40,7 +40,8 @@ import java.util.stream.Collectors;
 import static org.apache.samza.system.eventhub.MockEventHubConfigFactory.*;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({EventHubRuntimeInformation.class, EventHubClient.class, PartitionReceiver.class, PartitionSender.class})
+@PrepareForTest({EventHubRuntimeInformation.class, EventHubPartitionRuntimeInformation.class,
+        EventHubClient.class, PartitionReceiver.class, PartitionSender.class})
 public class TestEventHubSystemProducer {
 
   private static final String SOURCE = "TestEventHubSystemProducer";

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/producer/TestEventHubSystemProducer.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/producer/TestEventHubSystemProducer.java
@@ -43,6 +43,8 @@ import static org.apache.samza.system.eventhub.MockEventHubConfigFactory.*;
 @PrepareForTest({EventHubRuntimeInformation.class, EventHubClient.class, PartitionReceiver.class, PartitionSender.class})
 public class TestEventHubSystemProducer {
 
+  private static final String SOURCE = "TestEventHubSystemProducer";
+
   private static List<String> generateMessages(int numMsg) {
     Random rand = new Random(System.currentTimeMillis());
     List<String> messages = new ArrayList<>();
@@ -83,13 +85,13 @@ public class TestEventHubSystemProducer {
             new EventHubSystemProducer(new EventHubConfig(configMap), systemName, factory, interceptor, testMetrics);
 
     SystemStream systemStream = new SystemStream(systemName, streamName);
-    producer.register(streamName);
+    producer.register(SOURCE);
     producer.start();
 
     outgoingMessagesP0.forEach(message ->
-            producer.send(streamName, new OutgoingMessageEnvelope(systemStream, partitionId0, null, message.getBytes())));
+            producer.send(SOURCE, new OutgoingMessageEnvelope(systemStream, partitionId0, null, message.getBytes())));
     outgoingMessagesP1.forEach(message ->
-            producer.send(streamName, new OutgoingMessageEnvelope(systemStream, partitionId1, null, message.getBytes())));
+            producer.send(SOURCE, new OutgoingMessageEnvelope(systemStream, partitionId1, null, message.getBytes())));
 
     // Retrieve sent data
     List<String> receivedData0 = factory.getSentData(systemName, streamName, partitionId0)
@@ -133,13 +135,13 @@ public class TestEventHubSystemProducer {
             new EventHubSystemProducer(new EventHubConfig(configMap), systemName, factory, interceptors, testMetrics);
 
     SystemStream systemStream = new SystemStream(systemName, streamName);
-    producer.register(streamName);
+    producer.register(SOURCE);
     producer.start();
 
     outgoingMessagesP0.forEach(message ->
-            producer.send(streamName, new OutgoingMessageEnvelope(systemStream, partitionId0, null, message.getBytes())));
+            producer.send(SOURCE, new OutgoingMessageEnvelope(systemStream, partitionId0, null, message.getBytes())));
     outgoingMessagesP1.forEach(message ->
-            producer.send(streamName, new OutgoingMessageEnvelope(systemStream, partitionId1, null, message.getBytes())));
+            producer.send(SOURCE, new OutgoingMessageEnvelope(systemStream, partitionId1, null, message.getBytes())));
 
     // Retrieve sent data
     List<String> receivedData0 = factory.getSentData(systemName, streamName, partitionId0)
@@ -180,6 +182,7 @@ public class TestEventHubSystemProducer {
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_SAS_KEY_NAME, systemName, streamName), EVENTHUB_KEY_NAME);
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_SAS_TOKEN, systemName, streamName), EVENTHUB_KEY);
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_ENTITYPATH, systemName, streamName), EVENTHUB_ENTITY1);
+
     // mod 2 on the partitionid to simulate consistent hashing
     configMap.put(String.format(EventHubConfig.CONFIG_PRODUCER_PARTITION_METHOD, systemName),
             PartitioningMethod.EVENT_HUB_HASHING.toString());
@@ -190,13 +193,13 @@ public class TestEventHubSystemProducer {
             new EventHubSystemProducer(new EventHubConfig(configMap), systemName, factory, interceptor, testMetrics);
 
     SystemStream systemStream = new SystemStream(systemName, streamName);
-    producer.register(streamName);
+    producer.register(SOURCE);
     producer.start();
 
     outgoingMessagesP0.forEach(message ->
-            producer.send(streamName, new OutgoingMessageEnvelope(systemStream, partitionId0, null, message.getBytes())));
+            producer.send(SOURCE, new OutgoingMessageEnvelope(systemStream, partitionId0, null, message.getBytes())));
     outgoingMessagesP1.forEach(message ->
-            producer.send(streamName, new OutgoingMessageEnvelope(systemStream, partitionId1, null, message.getBytes())));
+            producer.send(SOURCE, new OutgoingMessageEnvelope(systemStream, partitionId1, null, message.getBytes())));
 
     // Retrieve sent data
     List<String> receivedData0 = factory.getSentData(systemName, streamName, 0)


### PR DESCRIPTION
Key fixes @vjagadish1989 @lhaiesp @srinipunuru 
- Switched Producer source vs destination assumptions in `send`, `register`
- Check `OME.key` if `OME.partitionId` is null for to get partitionId
- Upcoming offset changed the `END_OF_STREAM` rather than `newestOffset` + 1, eventHub returns an error if the offset does not exist in the system
- Made the NewestOffset+1 as upcoming offset, consumer checks if the offset is valid on startup
- Differentiated between streamNames and streamIds in configs, consumer, producer
- Checkpoint table named after job name
- Checkpoint prints better message for invalid key on write

QOL 
- How to ignore integration tests
- Improved logging

EDIT:
- Also added Round Robin producer partitioning