### PR TITLE
SAMZA-1523 Cleanup table entries before shutting down the processor

### DIFF
--- a/samza-azure/src/main/java/org/apache/samza/coordinator/AzureJobCoordinator.java
+++ b/samza-azure/src/main/java/org/apache/samza/coordinator/AzureJobCoordinator.java
@@ -19,22 +19,10 @@
 
 package org.apache.samza.coordinator;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.samza.AzureClient;
-import org.apache.samza.config.AzureConfig;
-import org.apache.samza.coordinator.data.BarrierState;
 import org.apache.samza.config.ApplicationConfig;
+import org.apache.samza.config.AzureConfig;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.ConfigException;
 import org.apache.samza.config.JobConfig;
@@ -42,8 +30,8 @@ import org.apache.samza.config.TaskConfig;
 import org.apache.samza.container.TaskName;
 import org.apache.samza.container.grouper.stream.SystemStreamPartitionGrouper;
 import org.apache.samza.container.grouper.stream.SystemStreamPartitionGrouperFactory;
-import org.apache.samza.job.model.JobModel;
-import org.apache.samza.runtime.ProcessorIdGenerator;
+import org.apache.samza.coordinator.data.BarrierState;
+import org.apache.samza.coordinator.data.ProcessorEntity;
 import org.apache.samza.coordinator.scheduler.HeartbeatScheduler;
 import org.apache.samza.coordinator.scheduler.JMVersionUpgradeScheduler;
 import org.apache.samza.coordinator.scheduler.LeaderBarrierCompleteScheduler;
@@ -51,6 +39,8 @@ import org.apache.samza.coordinator.scheduler.LeaderLivenessCheckScheduler;
 import org.apache.samza.coordinator.scheduler.LivenessCheckScheduler;
 import org.apache.samza.coordinator.scheduler.RenewLeaseScheduler;
 import org.apache.samza.coordinator.scheduler.SchedulerStateChangeListener;
+import org.apache.samza.job.model.JobModel;
+import org.apache.samza.runtime.ProcessorIdGenerator;
 import org.apache.samza.system.StreamMetadataCache;
 import org.apache.samza.system.SystemStream;
 import org.apache.samza.system.SystemStreamMetadata;
@@ -63,6 +53,18 @@ import org.apache.samza.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.collection.JavaConverters;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 /**
@@ -80,7 +82,6 @@ public class AzureJobCoordinator implements JobCoordinator {
   private final TableUtils table;
   private final Config config;
   private final String processorId;
-  private final AzureClient client;
   private final AtomicReference<String> currentJMVersion;
   private final AtomicBoolean versionUpgradeDetected;
   private final HeartbeatScheduler heartbeat;
@@ -103,7 +104,7 @@ public class AzureJobCoordinator implements JobCoordinator {
     processorId = createProcessorId(config);
     currentJMVersion = new AtomicReference<>(INITIAL_STATE);
     AzureConfig azureConfig = new AzureConfig(config);
-    client = new AzureClient(azureConfig.getAzureConnectionString());
+    AzureClient client = new AzureClient(azureConfig.getAzureConnectionString());
     leaderBlob = new BlobUtils(client, azureConfig.getAzureContainerName(), azureConfig.getAzureBlobName(), azureConfig.getAzureBlobLength());
     errorHandler = (errorMsg) -> {
       LOG.error(errorMsg);
@@ -149,17 +150,16 @@ public class AzureJobCoordinator implements JobCoordinator {
   public void stop() {
     LOG.info("Shutting down Azure job coordinator.");
 
-    if (coordinatorListener != null) {
-      coordinatorListener.onJobModelExpired();
-    }
-
-    // Resign leadership
-    if (azureLeaderElector.amILeader()) {
-      azureLeaderElector.resignLeadership();
-    }
+    // Clean up resources & Resign leadership (if you are leader)
+    azureLeaderElector.resignLeadership();
+    table.deleteProcessorEntity(currentJMVersion.get(), processorId, true);
 
     // Shutdown all schedulers
     shutdownSchedulers();
+
+    if (coordinatorListener != null) {
+      coordinatorListener.onJobModelExpired();
+    }
 
     if (coordinatorListener != null) {
       coordinatorListener.onCoordinatorStop();
@@ -217,7 +217,6 @@ public class AzureJobCoordinator implements JobCoordinator {
       if (!leaderBlob.publishBarrierState(state, azureLeaderElector.getLeaseId().get())) {
         LOG.info("Leader failed to publish the job model {}. Stopping the processor with PID: .", jobModel, processorId);
         stop();
-        table.deleteProcessorEntity(currentJMVersion.get(), processorId);
       }
       leaderBarrierScheduler.shutdown();
     };
@@ -374,7 +373,6 @@ public class AzureJobCoordinator implements JobCoordinator {
     if (!jmWrite || !barrierWrite || !processorWrite) {
       LOG.info("Leader failed to publish the job model {}. Stopping the processor with PID: .", jobModel, processorId);
       stop();
-      table.deleteProcessorEntity(currentJMVersion.get(), processorId);
     }
 
     LOG.info("pid=" + processorId + "Published new Job Model. Version = " + nextJMVersion);
@@ -400,7 +398,6 @@ public class AzureJobCoordinator implements JobCoordinator {
     if (!jobModel.getContainers().containsKey(processorId)) {
       LOG.info("JobModel: {} does not contain the processorId: {}. Stopping the processor.", jobModel, processorId);
       stop();
-      table.deleteProcessorEntity(currentJMVersion.get(), processorId);
     } else {
       //Stop current work
       if (coordinatorListener != null) {
@@ -443,17 +440,23 @@ public class AzureJobCoordinator implements JobCoordinator {
   private void onNewJobModelConfirmed(final String nextJMVersion) {
     LOG.info("pid=" + processorId + "new version " + nextJMVersion + " of the job model got confirmed");
 
-    // Delete previous value
-    if (table.getEntity(currentJMVersion.get(), processorId) != null) {
-      table.deleteProcessorEntity(currentJMVersion.get(), processorId);
-    }
-    if (table.getEntity(INITIAL_STATE, processorId) != null) {
-      table.deleteProcessorEntity(INITIAL_STATE, processorId);
-    }
+    String prevVersion = currentJMVersion.get();
 
-    //Start heartbeating to new entry only when barrier reached.
+    //Start heart-beating to new entry only when barrier reached.
     //Changing the current job model version enables that since we are heartbeating to a row identified by the current job model version.
     currentJMVersion.getAndSet(nextJMVersion);
+
+    // Delete previous value
+    ProcessorEntity entity = table.getEntity(prevVersion, processorId);
+    if (entity != null) {
+      entity.setEtag("*");
+      table.deleteProcessorEntity(entity);
+    }
+    entity = table.getEntity(INITIAL_STATE, processorId);
+    if (entity != null) {
+      entity.setEtag("*");
+      table.deleteProcessorEntity(entity);
+    }
 
     //Start the container with the new model
     if (coordinatorListener != null) {

--- a/samza-azure/src/main/java/org/apache/samza/coordinator/data/ProcessorEntity.java
+++ b/samza-azure/src/main/java/org/apache/samza/coordinator/data/ProcessorEntity.java
@@ -59,4 +59,12 @@ public class ProcessorEntity extends TableServiceEntity {
   public boolean getIsLeader() {
     return isLeader;
   }
+
+  public String getJobModelVersion() {
+    return partitionKey;
+  }
+
+  public String getProcessorId() {
+    return rowKey;
+  }
 }

--- a/samza-azure/src/main/java/org/apache/samza/coordinator/scheduler/JMVersionUpgradeScheduler.java
+++ b/samza-azure/src/main/java/org/apache/samza/coordinator/scheduler/JMVersionUpgradeScheduler.java
@@ -20,6 +20,11 @@
 package org.apache.samza.coordinator.scheduler;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.samza.coordinator.data.BarrierState;
+import org.apache.samza.util.BlobUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -29,10 +34,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import org.apache.samza.coordinator.data.BarrierState;
-import org.apache.samza.util.BlobUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**


### PR DESCRIPTION
Modified the `TableUtils#deleteProcessorEntity` to provide an option to disable optimistic locking during a call to Azure Table Storage service. 

@sborya @PawasChhokra @nickpan47   Review please? 