### PR TITLE
SAMZA-1534: Fix the visualization in job graph with the new PartitionBy Op

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/execution/JobGraphJsonGenerator.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/JobGraphJsonGenerator.java
@@ -28,18 +28,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import org.apache.samza.config.ApplicationConfig;
 import org.apache.samza.operators.spec.JoinOperatorSpec;
 import org.apache.samza.operators.spec.OperatorSpec;
 import org.apache.samza.operators.spec.OperatorSpec.OpCode;
 import org.apache.samza.operators.spec.OutputOperatorSpec;
 import org.apache.samza.operators.spec.OutputStreamImpl;
+import org.apache.samza.operators.spec.PartitionByOperatorSpec;
 import org.apache.samza.operators.spec.StreamTableJoinOperatorSpec;
 import org.apache.samza.table.TableSpec;
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.ObjectMapper;
-
 
 /**
  * This class generates the JSON representation of the {@link JobGraph}.
@@ -219,6 +218,9 @@ import org.codehaus.jackson.map.ObjectMapper;
 
     if (spec instanceof OutputOperatorSpec) {
       OutputStreamImpl outputStream = ((OutputOperatorSpec) spec).getOutputStream();
+      map.put("outputStreamId", outputStream.getStreamSpec().getId());
+    } else if (spec instanceof PartitionByOperatorSpec) {
+      OutputStreamImpl outputStream = ((PartitionByOperatorSpec) spec).getOutputStream();
       map.put("outputStreamId", outputStream.getStreamSpec().getId());
     }
 

--- a/samza-core/src/main/java/org/apache/samza/runtime/RemoteApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/RemoteApplicationRunner.java
@@ -33,6 +33,8 @@ import org.apache.samza.metrics.MetricsRegistryMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.UUID;
+
 
 /**
  * This class implements the {@link ApplicationRunner} that runs the applications in a remote cluster
@@ -57,8 +59,9 @@ public class RemoteApplicationRunner extends AbstractApplicationRunner {
   @Override
   public void run(StreamApplication app) {
     try {
-      // TODO: this is a tmp solution and the run.id generation will be addressed in another JIRA
-      String runId = String.valueOf(System.currentTimeMillis());
+      // TODO: run.id needs to be set for standalone: SAMZA-1531
+      // run.id is based on current system time with the most significant bits in UUID (8 digits) to avoid collision
+      String runId = String.valueOf(System.currentTimeMillis()) + "-" + UUID.randomUUID().toString().substring(0, 8);
       LOG.info("The run id for this run is {}", runId);
 
       // 1. initialize and plan

--- a/samza-shell/src/main/visualizer/js/planToDagre.js
+++ b/samza-shell/src/main/visualizer/js/planToDagre.js
@@ -36,7 +36,7 @@ function planToDagre(data) {
       labelVal += "<li>PhysicalName: " + stream.streamSpec.physicalName + "</li>"
       labelVal += "<li>PartitionCount: " + stream.streamSpec.partitionCount + "</li>"
       labelVal += "</ul></div>"
-      g.setNode(streamId,  { label: labelVal, labelType: "html", shape: "ellipse", class: streamClasses[i] });
+      g.setNode(streamId + "-stream",  { label: labelVal, labelType: "html", shape: "ellipse", class: streamClasses[i] });
     }
   }
 
@@ -67,7 +67,7 @@ function planToDagre(data) {
     for (var k = 0; k < inputs.length; k++) {
       var input = inputs[k];
       for (var m = 0; m < input.nextOperatorIds.length; m++) {
-        g.setEdge(input.streamId, input.nextOperatorIds[m]);
+        g.setEdge(input.streamId + "-stream", input.nextOperatorIds[m]);
       }
     }
 
@@ -78,7 +78,7 @@ function planToDagre(data) {
         g.setEdge(opId, operator.nextOperatorIds[j]);
       }
       if (typeof(operator.outputStreamId) !== 'undefined') {
-        g.setEdge(opId, operator.outputStreamId);
+        g.setEdge(opId, operator.outputStreamId + "-stream");
       }
     }
   }


### PR DESCRIPTION
Seems the stream and the partitionBy op has the same id. So in rendering I added the stream as the id for the node. Also resolved the run.id collision issue.
