### PR TITLE
Support for UDFs in where clauses

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/sql/udfs/ScalarUdf.java
+++ b/samza-api/src/main/java/org/apache/samza/sql/udfs/ScalarUdf.java
@@ -30,7 +30,7 @@ import org.apache.samza.config.Config;
  *     select myudf(id, name) from profile
  * In the above query, Profile should contain fields named 'id' of INTEGER/NUMBER type and 'name' of type VARCHAR/CHARACTER
  */
-public interface ScalarUdf {
+public interface ScalarUdf<T> {
   /**
    * Udfs can implement this method to perform any initialization that they may need.
    * @param udfConfig Config specific to the udf.
@@ -44,5 +44,5 @@ public interface ScalarUdf {
    * @return
    *   Return value from the scalar udf.
    */
-  Object execute(Object... args);
+  T execute(Object... args);
 }

--- a/samza-sql/src/main/java/org/apache/samza/sql/avro/AvroRelConverter.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/avro/AvroRelConverter.java
@@ -155,7 +155,7 @@ public class AvroRelConverter implements SamzaRelConverter {
           .collect(Collectors.toList()));
     } else if (value == null) {
       fieldNames.addAll(relationalSchema.getFieldNames());
-      IntStream.range(0, fieldNames.size() - 1).forEach(x -> values.add(null));
+      IntStream.range(0, fieldNames.size()).forEach(x -> values.add(null));
     } else {
       String msg = "Avro message converter doesn't support messages of type " + value.getClass();
       LOG.error(msg);

--- a/samza-sql/src/main/java/org/apache/samza/sql/data/SamzaSqlRelMessage.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/data/SamzaSqlRelMessage.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import org.apache.commons.lang.Validate;
 
 
 /**
@@ -51,6 +52,7 @@ public class SamzaSqlRelMessage {
    *               all the fields in the row can be null.
    */
   public SamzaSqlRelMessage(Object key, List<String> names, List<Object> values) {
+    Validate.isTrue(names.size() == values.size(), "Field Names and values are not of same length.");
     this.key = key;
     this.value.addAll(values);
     this.names.addAll(names);

--- a/samza-sql/src/main/java/org/apache/samza/sql/fn/FlattenUdf.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/fn/FlattenUdf.java
@@ -24,7 +24,7 @@ import org.apache.samza.config.Config;
 import org.apache.samza.sql.udfs.ScalarUdf;
 
 
-public class FlattenUdf implements ScalarUdf {
+public class FlattenUdf implements ScalarUdf<Object> {
   @Override
   public void init(Config udfConfig) {
   }

--- a/samza-sql/src/main/java/org/apache/samza/sql/fn/RegexMatchUdf.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/fn/RegexMatchUdf.java
@@ -17,7 +17,7 @@
 * under the License.
 */
 
-package org.apache.samza.tools.udf;
+package org.apache.samza.sql.fn;
 
 import java.util.regex.Pattern;
 import org.apache.samza.config.Config;
@@ -27,14 +27,13 @@ import org.apache.samza.sql.udfs.ScalarUdf;
 /**
  * Simple RegexMatch Udf.
  */
-public class RegexMatchUdf implements ScalarUdf {
+public class RegexMatchUdf implements ScalarUdf<Boolean> {
   @Override
   public void init(Config config) {
 
   }
 
-  @Override
-  public Object execute(Object... args) {
+  public Boolean execute(Object... args) {
     return Pattern.matches((String) args[0], (String) args[1]);
   }
 }

--- a/samza-sql/src/main/java/org/apache/samza/sql/planner/SamzaSqlScalarFunctionImpl.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/planner/SamzaSqlScalarFunctionImpl.java
@@ -67,8 +67,11 @@ public class SamzaSqlScalarFunctionImpl implements ScalarFunction, Implementable
       final Expression context = Expressions.parameter(SamzaSqlExecutionContext.class, "context");
       final Expression getUdfInstance = Expressions.call(ScalarUdf.class, context, getUdfMethod,
           Expressions.constant(udfMethod.getDeclaringClass().getName()), Expressions.constant(udfName));
-      return Expressions.call(Expressions.convert_(getUdfInstance, udfMethod.getDeclaringClass()), udfMethod,
-          translatedOperands);
+      final Expression callExpression = Expressions.convert_(Expressions.call(Expressions.convert_(getUdfInstance, udfMethod.getDeclaringClass()), udfMethod,
+          translatedOperands), Object.class);
+      // The Janino compiler which is used to compile the expressions doesn't seem to understand the Type of the ScalarUdf.execute
+      // because it is a generic. To work around that we are explicitly casting it to the return type.
+      return Expressions.convert_(callExpression, udfMethod.getReturnType());
     }, NullPolicy.NONE, false);
   }
 

--- a/samza-sql/src/test/java/org/apache/samza/sql/avro/TestAvroRelConversion.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/avro/TestAvroRelConversion.java
@@ -137,6 +137,20 @@ public class TestAvroRelConversion {
     LOG.info(Joiner.on(",").join(message.getFieldNames()));
   }
 
+  @Test
+  public void testEmptyRecordConversion() {
+    GenericData.Record record = new GenericData.Record(SimpleRecord.SCHEMA$);
+    SamzaSqlRelMessage message = simpleRecordAvroRelConverter.convertToRelMessage(new KV<>("key", record));
+    Assert.assertEquals(message.getFieldNames().size(), message.getFieldValues().size());
+  }
+
+
+  @Test
+  public void testNullRecordConversion() {
+    SamzaSqlRelMessage message = simpleRecordAvroRelConverter.convertToRelMessage(new KV<>("key", null));
+    Assert.assertEquals(message.getFieldNames().size(), message.getFieldValues().size());
+  }
+
   public static <T> byte[] encodeAvroSpecificRecord(Class<T> clazz, T record) throws IOException {
     DatumWriter<T> msgDatumWriter = new SpecificDatumWriter<>(clazz);
     ByteArrayOutputStream os = new ByteArrayOutputStream();

--- a/samza-sql/src/test/java/org/apache/samza/sql/testutil/MyTestArrayUdf.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/testutil/MyTestArrayUdf.java
@@ -19,18 +19,19 @@
 
 package org.apache.samza.sql.testutil;
 
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.samza.config.Config;
 import org.apache.samza.sql.udfs.ScalarUdf;
 
 
-public class MyTestArrayUdf implements ScalarUdf {
+public class MyTestArrayUdf implements ScalarUdf<List<String>> {
   @Override
   public void init(Config udfConfig) {
   }
 
-  public Object execute(Object... args) {
+  public List<String> execute(Object... args) {
     Integer value = (Integer) args[0];
     return IntStream.range(0, value).mapToObj(String::valueOf).collect(Collectors.toList());
   }

--- a/samza-sql/src/test/java/org/apache/samza/sql/testutil/MyTestUdf.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/testutil/MyTestUdf.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Test UDF used by unit and integration tests.
  */
-public class MyTestUdf implements ScalarUdf {
+public class MyTestUdf implements ScalarUdf<Integer> {
 
   private static final Logger LOG = LoggerFactory.getLogger(MyTestUdf.class);
 

--- a/samza-sql/src/test/java/org/apache/samza/sql/testutil/SamzaSqlTestConfig.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/testutil/SamzaSqlTestConfig.java
@@ -31,6 +31,7 @@ import org.apache.samza.sql.avro.ConfigBasedAvroRelSchemaProviderFactory;
 import org.apache.samza.sql.avro.schemas.ComplexRecord;
 import org.apache.samza.sql.avro.schemas.SimpleRecord;
 import org.apache.samza.sql.fn.FlattenUdf;
+import org.apache.samza.sql.fn.RegexMatchUdf;
 import org.apache.samza.sql.impl.ConfigBasedSourceResolverFactory;
 import org.apache.samza.sql.impl.ConfigBasedUdfResolver;
 import org.apache.samza.sql.interfaces.SqlSystemStreamConfig;
@@ -64,8 +65,9 @@ public class SamzaSqlTestConfig {
     String configUdfResolverDomain = String.format(SamzaSqlApplicationConfig.CFG_FMT_UDF_RESOLVER_DOMAIN, "config");
     staticConfigs.put(configUdfResolverDomain + SamzaSqlApplicationConfig.CFG_FACTORY,
         ConfigBasedUdfResolver.class.getName());
-    staticConfigs.put(configUdfResolverDomain + ConfigBasedUdfResolver.CFG_UDF_CLASSES,
-        Joiner.on(",").join(MyTestUdf.class.getName(), FlattenUdf.class.getName(), MyTestArrayUdf.class.getName()));
+    staticConfigs.put(configUdfResolverDomain + ConfigBasedUdfResolver.CFG_UDF_CLASSES, Joiner.on(",")
+        .join(MyTestUdf.class.getName(), RegexMatchUdf.class.getName(), FlattenUdf.class.getName(),
+            MyTestArrayUdf.class.getName()));
 
     String avroSystemConfigPrefix =
         String.format(ConfigBasedSourceResolverFactory.CFG_FMT_SAMZA_PREFIX, SAMZA_SYSTEM_TEST_AVRO);

--- a/samza-tools/src/main/java/org/apache/samza/tools/SamzaSqlConsole.java
+++ b/samza-tools/src/main/java/org/apache/samza/tools/SamzaSqlConsole.java
@@ -20,12 +20,6 @@
 package org.apache.samza.tools;
 
 import com.google.common.base.Joiner;
-import org.apache.samza.tools.avro.AvroSchemaGenRelConverterFactory;
-import org.apache.samza.tools.avro.AvroSerDeFactory;
-import org.apache.samza.tools.json.JsonRelConverterFactory;
-import org.apache.samza.tools.schemas.PageViewEvent;
-import org.apache.samza.tools.schemas.ProfileChangeEvent;
-import org.apache.samza.tools.udf.RegexMatchUdf;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -43,6 +37,7 @@ import org.apache.samza.container.grouper.task.SingleContainerGrouperFactory;
 import org.apache.samza.serializers.StringSerdeFactory;
 import org.apache.samza.sql.avro.ConfigBasedAvroRelSchemaProviderFactory;
 import org.apache.samza.sql.fn.FlattenUdf;
+import org.apache.samza.sql.fn.RegexMatchUdf;
 import org.apache.samza.sql.impl.ConfigBasedSourceResolverFactory;
 import org.apache.samza.sql.impl.ConfigBasedUdfResolver;
 import org.apache.samza.sql.interfaces.SqlSystemStreamConfig;
@@ -52,6 +47,11 @@ import org.apache.samza.sql.testutil.JsonUtil;
 import org.apache.samza.sql.testutil.SqlFileParser;
 import org.apache.samza.standalone.PassthroughJobCoordinatorFactory;
 import org.apache.samza.system.kafka.KafkaSystemFactory;
+import org.apache.samza.tools.avro.AvroSchemaGenRelConverterFactory;
+import org.apache.samza.tools.avro.AvroSerDeFactory;
+import org.apache.samza.tools.json.JsonRelConverterFactory;
+import org.apache.samza.tools.schemas.PageViewEvent;
+import org.apache.samza.tools.schemas.ProfileChangeEvent;
 
 
 public class SamzaSqlConsole {


### PR DESCRIPTION
The existing version of the udf implementation doesn't seem to support udfs in the where clauses because the Type of the object returned is "ANY" and when you do a 
`select * from kafka.topic where regexMatch('.*foo', Name)` it fails in the query validation, because calcite doesn't know the type of regexMatch. 

To solve the problem, We made the scalarUdf generic with a strongly typed return type.

https://issues.apache.org/jira/browse/SAMZA-1535

This PR can be merged into trunk not the 0.14. 