### PR TITLE
SAMZA-1541 migrate config classes in samza-yarn to use composition over inherence

### DIFF
--- a/samza-yarn/src/main/java/org/apache/samza/config/FileSystemImplConfig.java
+++ b/samza-yarn/src/main/java/org/apache/samza/config/FileSystemImplConfig.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.samza.job.yarn;
+package org.apache.samza.config;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/samza-yarn/src/main/java/org/apache/samza/config/LocalizerResourceConfig.java
+++ b/samza-yarn/src/main/java/org/apache/samza/config/LocalizerResourceConfig.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.samza.job.yarn;
+package org.apache.samza.config;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +25,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.LocalResourceType;
 import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
 import org.apache.samza.config.Config;
+import org.apache.samza.job.yarn.LocalizerResourceException;
+
 
 /**
  * LocalizerResourceConfig is intended to manage/fetch the config values

--- a/samza-yarn/src/main/java/org/apache/samza/config/YarnConfig.java
+++ b/samza-yarn/src/main/java/org/apache/samza/config/YarnConfig.java
@@ -21,7 +21,7 @@ package org.apache.samza.config;
 
 import org.apache.samza.SamzaException;
 
-public class YarnConfig extends MapConfig {
+public class YarnConfig {
   /**
    * (Required) URL from which the job package can be downloaded
    */
@@ -121,24 +121,29 @@ public class YarnConfig extends MapConfig {
    */
   public static final String YARN_JOB_STAGING_DIRECTORY = "yarn.job.staging.directory";
 
+  private final Config config;
+
   public YarnConfig(Config config) {
-    super(config);
+    if (null == config) {
+      throw new IllegalArgumentException("config cannot be null");
+    }
+    this.config = config;
   }
 
   public int getAMPollIntervalMs() {
-    return getInt(AM_POLL_INTERVAL_MS, DEFAULT_POLL_INTERVAL_MS);
+    return config.getInt(AM_POLL_INTERVAL_MS, DEFAULT_POLL_INTERVAL_MS);
   }
 
   public String getContainerLabel() {
-    return get(CONTAINER_LABEL, null);
+    return config.get(CONTAINER_LABEL, null);
   }
 
   public boolean getJmxServerEnabled() {
-    return getBoolean(AM_JMX_ENABLED, true);
+    return config.getBoolean(AM_JMX_ENABLED, true);
   }
 
   public String getPackagePath() {
-    String packagePath = get(PACKAGE_PATH);
+    String packagePath = config.get(PACKAGE_PATH);
     if (packagePath == null) {
       throw new SamzaException("No YARN package path defined in config.");
     }
@@ -146,58 +151,58 @@ public class YarnConfig extends MapConfig {
   }
 
   public int getAMContainerMaxMemoryMb() {
-    return getInt(AM_CONTAINER_MAX_MEMORY_MB, DEFAULT_AM_CONTAINER_MAX_MEMORY_MB);
+    return config.getInt(AM_CONTAINER_MAX_MEMORY_MB, DEFAULT_AM_CONTAINER_MAX_MEMORY_MB);
   }
 
   public String getAMContainerLabel() {
-    return get(AM_CONTAINER_LABEL, null);
+    return config.get(AM_CONTAINER_LABEL, null);
   }
 
   public int getAMContainerMaxCpuCores() {
-    return getInt(AM_CONTAINER_MAX_CPU_CORES, DEFAULT_AM_CPU_CORES);
+    return config.getInt(AM_CONTAINER_MAX_CPU_CORES, DEFAULT_AM_CPU_CORES);
   }
 
   public String getAmOpts() {
-    return get(AM_JVM_OPTIONS, "");
+    return config.get(AM_JVM_OPTIONS, "");
   }
 
   public String getQueueName() {
-    return get(QUEUE_NAME, null);
+    return config.get(QUEUE_NAME, null);
   }
 
   public String getAMJavaHome() {
-    return get(AM_JAVA_HOME, null);
+    return config.get(AM_JAVA_HOME, null);
   }
 
   public int getAllocatorSleepTime() {
-    return getInt(ALLOCATOR_SLEEP_MS, DEFAULT_ALLOCATOR_SLEEP_MS);
+    return config.getInt(ALLOCATOR_SLEEP_MS, DEFAULT_ALLOCATOR_SLEEP_MS);
   }
 
   public int getContainerRequestTimeout() {
-    return getInt(CONTAINER_REQUEST_TIMEOUT_MS, DEFAULT_CONTAINER_REQUEST_TIMEOUT_MS);
+    return config.getInt(CONTAINER_REQUEST_TIMEOUT_MS, DEFAULT_CONTAINER_REQUEST_TIMEOUT_MS);
   }
 
   public boolean getHostAffinityEnabled() {
-    return getBoolean(HOST_AFFINITY_ENABLED, DEFAULT_HOST_AFFINITY_ENABLED);
+    return config.getBoolean(HOST_AFFINITY_ENABLED, DEFAULT_HOST_AFFINITY_ENABLED);
   }
 
   public String getYarnKerberosPrincipal() {
-    return get(YARN_KERBEROS_PRINCIPAL, null);
+    return config.get(YARN_KERBEROS_PRINCIPAL, null);
   }
 
   public String getYarnKerberosKeytab() {
-    return get(YARN_KERBEROS_KEYTAB, null);
+    return config.get(YARN_KERBEROS_KEYTAB, null);
   }
 
   public long getYarnTokenRenewalIntervalSeconds() {
-    return getLong(YARN_TOKEN_RENEWAL_INTERVAL_SECONDS, DEFAULT_YARN_TOKEN_RENEWAL_INTERVAL_SECONDS);
+    return config.getLong(YARN_TOKEN_RENEWAL_INTERVAL_SECONDS, DEFAULT_YARN_TOKEN_RENEWAL_INTERVAL_SECONDS);
   }
 
   public String getYarnCredentialsFile() {
-    return get(YARN_CREDENTIALS_FILE, null);
+    return config.get(YARN_CREDENTIALS_FILE, null);
   }
 
   public String getYarnJobStagingDirectory() {
-    return get(YARN_JOB_STAGING_DIRECTORY, null);
+    return config.get(YARN_JOB_STAGING_DIRECTORY, null);
   }
 }

--- a/samza-yarn/src/main/java/org/apache/samza/job/yarn/LocalizerResourceMapper.java
+++ b/samza-yarn/src/main/java/org/apache/samza/job/yarn/LocalizerResourceMapper.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.yarn.api.records.URL;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.hadoop.yarn.util.Records;
+import org.apache.samza.config.LocalizerResourceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnClusterResourceManager.java
+++ b/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnClusterResourceManager.java
@@ -33,6 +33,7 @@ import org.apache.samza.clustermanager.SamzaApplicationState;
 import org.apache.samza.clustermanager.SamzaContainerLaunchException;
 import org.apache.samza.config.ClusterManagerConfig;
 import org.apache.samza.config.Config;
+import org.apache.samza.config.FileSystemImplConfig;
 import org.apache.samza.config.ShellCommandConfig;
 import org.apache.samza.config.YarnConfig;
 import org.apache.samza.coordinator.JobModelManager;

--- a/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnContainerRunner.java
+++ b/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnContainerRunner.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.yarn.util.Records;
 import org.apache.samza.clustermanager.SamzaContainerLaunchException;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.JobConfig;
+import org.apache.samza.config.LocalizerResourceConfig;
 import org.apache.samza.config.ShellCommandConfig;
 import org.apache.samza.config.YarnConfig;
 import org.apache.samza.job.CommandBuilder;

--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/ClientHelper.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/ClientHelper.scala
@@ -22,7 +22,7 @@ package org.apache.samza.job.yarn
 
 import org.apache.commons.lang.StringUtils
 import org.apache.hadoop.fs.permission.FsPermission
-import org.apache.samza.config.{Config, JobConfig, YarnConfig}
+import org.apache.samza.config.{Config, JobConfig, LocalizerResourceConfig, YarnConfig}
 import org.apache.samza.coordinator.stream.CoordinatorStreamWriter
 import org.apache.samza.coordinator.stream.messages.SetConfig
 

--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/YarnJobFactory.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/YarnJobFactory.scala
@@ -23,9 +23,10 @@ package org.apache.samza.job.yarn
 import org.apache.hadoop.hdfs.DistributedFileSystem
 import org.apache.samza.job.StreamJobFactory
 import org.apache.hadoop.yarn.conf.YarnConfiguration
-import org.apache.samza.config.Config
+import org.apache.samza.config.{Config, FileSystemImplConfig}
 import org.apache.samza.util.hadoop.HttpFileSystem
 import org.apache.samza.util.Logging
+
 import scala.collection.JavaConverters._
 
 class YarnJobFactory extends StreamJobFactory with Logging {

--- a/samza-yarn/src/test/java/org/apache/samza/job/yarn/TestFileSystemImplConfig.java
+++ b/samza-yarn/src/test/java/org/apache/samza/job/yarn/TestFileSystemImplConfig.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.samza.config.Config;
+import org.apache.samza.config.FileSystemImplConfig;
 import org.apache.samza.config.MapConfig;
 import org.junit.Rule;
 import org.junit.Test;

--- a/samza-yarn/src/test/java/org/apache/samza/job/yarn/TestLocalizerResourceConfig.java
+++ b/samza-yarn/src/test/java/org/apache/samza/job/yarn/TestLocalizerResourceConfig.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.hadoop.yarn.api.records.LocalResourceType;
 import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
 import org.apache.samza.config.Config;
+import org.apache.samza.config.LocalizerResourceConfig;
 import org.apache.samza.config.MapConfig;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;

--- a/samza-yarn/src/test/java/org/apache/samza/job/yarn/TestLocalizerResourceMapper.java
+++ b/samza-yarn/src/test/java/org/apache/samza/job/yarn/TestLocalizerResourceMapper.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.yarn.api.records.LocalResourceType;
 import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.samza.config.Config;
+import org.apache.samza.config.LocalizerResourceConfig;
 import org.apache.samza.config.MapConfig;
 import org.apache.samza.util.hadoop.HttpFileSystem;
 import org.junit.Rule;


### PR DESCRIPTION
./gradlew clean check successfully.
The reason for doing this is described in https://issues.apache.org/jira/browse/SAMZA-1160. 
I am going to migrate for each directory and this PR is for samza-yarn. 
Besides the refactoring, two config class files (LocalizerResourceConfig.java and FileSystemImplConfig.java) are also moved from org.apache.samza.job.yarn to org.apache.samza.config. 
