### PR TITLE
SAMZA-1542 refactor config classes in samza-core java to hide non-necessary interfaces

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/ApplicationConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ApplicationConfig.java
@@ -24,7 +24,7 @@ import org.apache.samza.runtime.UUIDGenerator;
 /**
  * Accessors for configs associated with Application scope
  */
-public class ApplicationConfig extends MapConfig {
+public class ApplicationConfig {
   /**
    * <p>processor.id is similar to the logical containerId generated in Samza. However, in addition to identifying the JVM
    * of the processor, it also contains a segment to identify the instance of the
@@ -57,24 +57,29 @@ public class ApplicationConfig extends MapConfig {
   public static final String APP_MODE = "app.mode";
   public static final String APP_RUN_ID = "app.run.id";
 
-  public ApplicationConfig(Config config) {
-    super(config);
+  private final Config config;
+
+  public ApplicationConfig(final Config config) {
+    if (null == config) {
+      throw new IllegalArgumentException("config cannot be null");
+    }
+    this.config = config;
   }
 
   public String getAppProcessorIdGeneratorClass() {
-    return get(APP_PROCESSOR_ID_GENERATOR_CLASS, UUIDGenerator.class.getName());
+    return config.get(APP_PROCESSOR_ID_GENERATOR_CLASS, UUIDGenerator.class.getName());
   }
 
   public String getAppName() {
-    return get(APP_NAME, get(JobConfig.JOB_NAME()));
+    return config.get(APP_NAME, config.get(JobConfig.JOB_NAME()));
   }
 
   public String getAppId() {
-    return get(APP_ID, get(JobConfig.JOB_ID(), "1"));
+    return config.get(APP_ID, config.get(JobConfig.JOB_ID(), "1"));
   }
 
   public String getAppClass() {
-    return get(APP_CLASS, null);
+    return config.get(APP_CLASS, null);
   }
 
   /**
@@ -87,15 +92,15 @@ public class ApplicationConfig extends MapConfig {
 
   @Deprecated
   public String getProcessorId() {
-    return get(PROCESSOR_ID, null);
+    return config.get(PROCESSOR_ID, null);
   }
 
   public String getRunId() {
-    return get(APP_RUN_ID, null);
+    return config.get(APP_RUN_ID, null);
   }
 
   public ApplicationMode getAppMode() {
-    return ApplicationMode.valueOf(get(APP_MODE, ApplicationMode.STREAM.name()).toUpperCase());
+    return ApplicationMode.valueOf(config.get(APP_MODE, ApplicationMode.STREAM.name()).toUpperCase());
   }
 
 }

--- a/samza-core/src/main/java/org/apache/samza/config/ClusterManagerConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ClusterManagerConfig.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * with the cluster-manager.* configs taking precedence. There will be a deprecated config warning when old configs are used.
  * Later, we'll enforce the new configs.
  */
-public class ClusterManagerConfig extends MapConfig {
+public class ClusterManagerConfig {
 
   private static final Logger log = LoggerFactory.getLogger(ClusterManagerConfig.class);
 
@@ -100,82 +100,87 @@ public class ClusterManagerConfig extends MapConfig {
   public static final String CLUSTER_MANAGER_SLEEP_MS = "cluster-manager.jobcoordinator.sleep.interval.ms";
   private static final int DEFAULT_CLUSTER_MANAGER_SLEEP_MS = 1000;
 
-  public ClusterManagerConfig(Config config) {
-      super(config);
+  private final Config config;
+
+  public ClusterManagerConfig(final Config config) {
+    if (null == config) {
+      throw new IllegalArgumentException("config cannot be null");
+    }
+    this.config = config;
   }
 
   public int getAllocatorSleepTime() {
-    if (containsKey(ALLOCATOR_SLEEP_MS)) {
-      return getInt(ALLOCATOR_SLEEP_MS);
-    } else if (containsKey(YARN_ALLOCATOR_SLEEP_MS)) {
+    if (config.containsKey(ALLOCATOR_SLEEP_MS)) {
+      return config.getInt(ALLOCATOR_SLEEP_MS);
+    } else if (config.containsKey(YARN_ALLOCATOR_SLEEP_MS)) {
       log.info("Configuration {} is deprecated. Please use {}", YARN_ALLOCATOR_SLEEP_MS, ALLOCATOR_SLEEP_MS);
-      return getInt(YARN_ALLOCATOR_SLEEP_MS);
+      return config.getInt(YARN_ALLOCATOR_SLEEP_MS);
     } else {
       return DEFAULT_ALLOCATOR_SLEEP_MS;
     }
   }
 
   public int getNumCores() {
-    if (containsKey(CLUSTER_MANAGER_MAX_CORES)) {
-      return getInt(CLUSTER_MANAGER_MAX_CORES);
-    } else if (containsKey(CONTAINER_MAX_CPU_CORES)) {
+    if (config.containsKey(CLUSTER_MANAGER_MAX_CORES)) {
+      return config.getInt(CLUSTER_MANAGER_MAX_CORES);
+    } else if (config.containsKey(CONTAINER_MAX_CPU_CORES)) {
       log.info("Configuration {} is deprecated. Please use {}", CONTAINER_MAX_CPU_CORES, CLUSTER_MANAGER_MAX_CORES);
-      return getInt(CONTAINER_MAX_CPU_CORES);
+      return config.getInt(CONTAINER_MAX_CPU_CORES);
     } else {
       return DEFAULT_CPU_CORES;
     }
   }
 
   public int getContainerMemoryMb() {
-    if (containsKey(CLUSTER_MANAGER_MEMORY_MB)) {
-      return getInt(CLUSTER_MANAGER_MEMORY_MB);
-    } else if (containsKey(CONTAINER_MAX_MEMORY_MB)) {
+    if (config.containsKey(CLUSTER_MANAGER_MEMORY_MB)) {
+      return config.getInt(CLUSTER_MANAGER_MEMORY_MB);
+    } else if (config.containsKey(CONTAINER_MAX_MEMORY_MB)) {
       log.info("Configuration {} is deprecated. Please use {}", CONTAINER_MAX_MEMORY_MB, CLUSTER_MANAGER_MEMORY_MB);
-      return getInt(CONTAINER_MAX_MEMORY_MB);
+      return config.getInt(CONTAINER_MAX_MEMORY_MB);
     } else {
       return DEFAULT_CONTAINER_MEM;
     }
   }
 
   public boolean getHostAffinityEnabled() {
-    if (containsKey(CLUSTER_MANAGER_HOST_AFFINITY_ENABLED)) {
-      return getBoolean(CLUSTER_MANAGER_HOST_AFFINITY_ENABLED);
-    } else if (containsKey(HOST_AFFINITY_ENABLED)) {
+    if (config.containsKey(CLUSTER_MANAGER_HOST_AFFINITY_ENABLED)) {
+      return config.getBoolean(CLUSTER_MANAGER_HOST_AFFINITY_ENABLED);
+    } else if (config.containsKey(HOST_AFFINITY_ENABLED)) {
       log.info("Configuration {} is deprecated. Please use {}", HOST_AFFINITY_ENABLED, CLUSTER_MANAGER_HOST_AFFINITY_ENABLED);
-      return getBoolean(HOST_AFFINITY_ENABLED);
+      return config.getBoolean(HOST_AFFINITY_ENABLED);
     } else {
       return false;
     }
   }
 
   public int getContainerRequestTimeout() {
-    if (containsKey(CLUSTER_MANAGER_REQUEST_TIMEOUT_MS)) {
-      return getInt(CLUSTER_MANAGER_REQUEST_TIMEOUT_MS);
-    } else if (containsKey(CONTAINER_REQUEST_TIMEOUT_MS)) {
+    if (config.containsKey(CLUSTER_MANAGER_REQUEST_TIMEOUT_MS)) {
+      return config.getInt(CLUSTER_MANAGER_REQUEST_TIMEOUT_MS);
+    } else if (config.containsKey(CONTAINER_REQUEST_TIMEOUT_MS)) {
       log.info("Configuration {} is deprecated. Please use {}", CONTAINER_REQUEST_TIMEOUT_MS, CLUSTER_MANAGER_REQUEST_TIMEOUT_MS);
-      return getInt(CONTAINER_REQUEST_TIMEOUT_MS);
+      return config.getInt(CONTAINER_REQUEST_TIMEOUT_MS);
     } else {
       return DEFAULT_CONTAINER_REQUEST_TIMEOUT_MS;
     }
   }
 
   public int getContainerRetryCount() {
-    if (containsKey(CLUSTER_MANAGER_CONTAINER_RETRY_COUNT))
-      return getInt(CLUSTER_MANAGER_CONTAINER_RETRY_COUNT);
-    else if (containsKey(CONTAINER_RETRY_COUNT)) {
+    if (config.containsKey(CLUSTER_MANAGER_CONTAINER_RETRY_COUNT))
+      return config.getInt(CLUSTER_MANAGER_CONTAINER_RETRY_COUNT);
+    else if (config.containsKey(CONTAINER_RETRY_COUNT)) {
       log.info("Configuration {} is deprecated. Please use {}", CONTAINER_RETRY_COUNT, CLUSTER_MANAGER_CONTAINER_RETRY_COUNT);
-      return getInt(CONTAINER_RETRY_COUNT);
+      return config.getInt(CONTAINER_RETRY_COUNT);
     } else {
       return DEFAULT_CONTAINER_RETRY_COUNT;
     }
   }
 
   public int getContainerRetryWindowMs() {
-    if (containsKey(CLUSTER_MANAGER_RETRY_WINDOW_MS)) {
-      return getInt(CLUSTER_MANAGER_RETRY_WINDOW_MS);
-    } else if (containsKey(CONTAINER_RETRY_WINDOW_MS)) {
+    if (config.containsKey(CLUSTER_MANAGER_RETRY_WINDOW_MS)) {
+      return config.getInt(CLUSTER_MANAGER_RETRY_WINDOW_MS);
+    } else if (config.containsKey(CONTAINER_RETRY_WINDOW_MS)) {
       log.info("Configuration {} is deprecated. Please use {}", CONTAINER_RETRY_WINDOW_MS, CLUSTER_MANAGER_RETRY_WINDOW_MS);
-      return getInt(CONTAINER_RETRY_WINDOW_MS);
+      return config.getInt(CONTAINER_RETRY_WINDOW_MS);
     } else {
       return DEFAULT_CONTAINER_RETRY_WINDOW_MS;
     }
@@ -183,19 +188,19 @@ public class ClusterManagerConfig extends MapConfig {
 
 
   public int getJobCoordinatorSleepInterval() {
-    return getInt(CLUSTER_MANAGER_SLEEP_MS, DEFAULT_CLUSTER_MANAGER_SLEEP_MS);
+    return config.getInt(CLUSTER_MANAGER_SLEEP_MS, DEFAULT_CLUSTER_MANAGER_SLEEP_MS);
   }
 
   public String getContainerManagerClass() {
-    return get(CLUSTER_MANAGER_FACTORY, CLUSTER_MANAGER_FACTORY_DEFAULT);
+    return config.get(CLUSTER_MANAGER_FACTORY, CLUSTER_MANAGER_FACTORY_DEFAULT);
   }
 
   public boolean getJmxEnabled() {
-    if (containsKey(CLUSTER_MANAGER_JMX_ENABLED)) {
-      return getBoolean(CLUSTER_MANAGER_JMX_ENABLED);
-    } else if (containsKey(AM_JMX_ENABLED)) {
+    if (config.containsKey(CLUSTER_MANAGER_JMX_ENABLED)) {
+      return config.getBoolean(CLUSTER_MANAGER_JMX_ENABLED);
+    } else if (config.containsKey(AM_JMX_ENABLED)) {
       log.info("Configuration {} is deprecated. Please use {}", AM_JMX_ENABLED, CLUSTER_MANAGER_JMX_ENABLED);
-      return getBoolean(AM_JMX_ENABLED);
+      return config.getBoolean(AM_JMX_ENABLED);
     } else {
       return true;
     }

--- a/samza-core/src/main/java/org/apache/samza/config/DefaultChooserConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/DefaultChooserConfig.java
@@ -29,14 +29,19 @@ import org.apache.samza.system.SystemStream;
 /**
  * A convenience class for fetching configs related to the {@link org.apache.samza.system.chooser.DefaultChooser}
  */
-public class DefaultChooserConfig extends MapConfig {
+public class DefaultChooserConfig {
   private static final String BATCH_SIZE = "task.consumer.batch.size";
 
   private final TaskConfigJava taskConfigJava;
   private final StreamConfig streamConfig;
 
-  public DefaultChooserConfig(Config config) {
-    super(config);
+  private final Config config;
+
+  public DefaultChooserConfig(final Config config) {
+    if (null == config) {
+      throw new IllegalArgumentException("config cannot be null");
+    }
+    this.config = config;
     taskConfigJava = new TaskConfigJava(config);
     streamConfig = new StreamConfig(config);
   }
@@ -45,7 +50,7 @@ public class DefaultChooserConfig extends MapConfig {
    * @return  the configured batch size, or 0 if it was not configured.
    */
   public int getChooserBatchSize() {
-    return getInt(BATCH_SIZE, 0);
+    return config.getInt(BATCH_SIZE, 0);
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/config/JavaSerializerConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JavaSerializerConfig.java
@@ -25,16 +25,21 @@ import java.util.List;
 /**
  * java version of the SerializerConfig
  */
-public class JavaSerializerConfig extends MapConfig {
+public class JavaSerializerConfig {
   private final static String SERIALIZER_PREFIX = "serializers.registry.%s";
   private final static String SERDE = "serializers.registry.%s.class";
 
-  public JavaSerializerConfig(Config config) {
-    super(config);
+  private final Config config;
+
+  public JavaSerializerConfig(final Config config) {
+    if (null == config) {
+      throw new IllegalArgumentException("config cannot be null");
+    }
+    this.config = config;
   }
 
   public String getSerdeClass(String name) {
-    return get(String.format(SERDE, name), null);
+    return config.get(String.format(SERDE, name), null);
   }
 
   /**
@@ -43,12 +48,16 @@ public class JavaSerializerConfig extends MapConfig {
    */
   public List<String> getSerdeNames() {
     List<String> results = new ArrayList<String>();
-    Config subConfig = subset(String.format(SERIALIZER_PREFIX, ""), true);
+    Config subConfig = config.subset(String.format(SERIALIZER_PREFIX, ""), true);
     for (String key : subConfig.keySet()) {
       if (key.endsWith(".class")) {
         results.add(key.replace(".class", ""));
       }
     }
     return results;
+  }
+
+  public Config getFilteredConfig() {
+    return config.subset(String.format(SERIALIZER_PREFIX, ""), false);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/config/JavaSystemConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JavaSystemConfig.java
@@ -33,15 +33,20 @@ import org.apache.samza.util.Util;
 /**
  * a java version of the system config
  */
-public class JavaSystemConfig extends MapConfig {
+public class JavaSystemConfig {
   public static final String SYSTEM_PREFIX = "systems.";
   public static final String SYSTEM_FACTORY_SUFFIX = ".samza.factory";
   public static final String SYSTEM_FACTORY_FORMAT = SYSTEM_PREFIX + "%s" + SYSTEM_FACTORY_SUFFIX;
   private static final String SYSTEM_DEFAULT_STREAMS_PREFIX_FORMAT = SYSTEM_PREFIX + "%s" + ".default.stream.";
   private static final String EMPTY = "";
 
-  public JavaSystemConfig(Config config) {
-    super(config);
+  protected final Config config;
+
+  public JavaSystemConfig(final Config config) {
+    if (null == config) {
+      throw new IllegalArgumentException("config cannot be null");
+    }
+    this.config = config;
   }
 
   public String getSystemFactory(String name) {
@@ -49,7 +54,7 @@ public class JavaSystemConfig extends MapConfig {
       return null;
     }
     String systemFactory = String.format(SYSTEM_FACTORY_FORMAT, name);
-    String value = get(systemFactory, null);
+    String value = config.get(systemFactory, null);
     return (StringUtils.isBlank(value)) ? null : value;
   }
 
@@ -59,7 +64,7 @@ public class JavaSystemConfig extends MapConfig {
    * @return A list system names
    */
   public List<String> getSystemNames() {
-    Config subConf = subset(SYSTEM_PREFIX, true);
+    Config subConf = config.subset(SYSTEM_PREFIX, true);
     ArrayList<String> systemNames = new ArrayList<String>();
     for (Map.Entry<String, String> entry : subConf.entrySet()) {
       String key = entry.getKey();
@@ -80,7 +85,7 @@ public class JavaSystemConfig extends MapConfig {
         .stream()
         .collect(Collectors.toMap(systemNameToFactoryEntry -> systemNameToFactoryEntry.getKey(),
             systemNameToFactoryEntry -> systemNameToFactoryEntry.getValue()
-                .getAdmin(systemNameToFactoryEntry.getKey(), this)));
+                .getAdmin(systemNameToFactoryEntry.getKey(), config)));
   }
 
   /**
@@ -110,6 +115,6 @@ public class JavaSystemConfig extends MapConfig {
    * @return a subset of the config with the system prefix removed.
    */
   public Config getDefaultStreamProperties(String systemName) {
-    return subset(String.format(SYSTEM_DEFAULT_STREAMS_PREFIX_FORMAT, systemName), true);
+    return config.subset(String.format(SYSTEM_DEFAULT_STREAMS_PREFIX_FORMAT, systemName), true);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/config/JavaTableConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JavaTableConfig.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 /**
  * A helper class for handling table configuration
  */
-public class JavaTableConfig extends MapConfig {
+public class JavaTableConfig {
 
   // Prefix
   public static final String TABLES_PREFIX = "tables.";
@@ -40,9 +40,13 @@ public class JavaTableConfig extends MapConfig {
   public static final String TABLE_KEY_SERDE = String.format("%s.key.serde", TABLE_ID_PREFIX);
   public static final String TABLE_VALUE_SERDE = String.format("%s.value.serde", TABLE_ID_PREFIX);
 
+  private final Config config;
 
-  public JavaTableConfig(Config config) {
-    super(config);
+  public JavaTableConfig(final Config config) {
+    if (null == config) {
+      throw new IllegalArgumentException("config cannot be null");
+    }
+    this.config = config;
   }
 
   /**
@@ -50,7 +54,7 @@ public class JavaTableConfig extends MapConfig {
    * @return list of table Id's
    */
   public List<String> getTableIds() {
-    Config subConfig = subset(TABLES_PREFIX, true);
+    Config subConfig = config.subset(TABLES_PREFIX, true);
     Set<String> tableNames = subConfig.keySet().stream()
         .filter(k -> k.endsWith(TABLE_PROVIDER_FACTORY_SUFFIX))
         .map(k -> k.substring(0, k.indexOf(".")))
@@ -64,7 +68,7 @@ public class JavaTableConfig extends MapConfig {
    * @return the {@link org.apache.samza.table.TableProviderFactory} class name
    */
   public String getTableProviderFactory(String tableId) {
-    return get(String.format(TABLE_PROVIDER_FACTORY, tableId), null);
+    return config.get(String.format(TABLE_PROVIDER_FACTORY, tableId), null);
   }
 
   /**
@@ -73,7 +77,7 @@ public class JavaTableConfig extends MapConfig {
    * @return serde retistry key
    */
   public String getKeySerde(String tableId) {
-    return get(String.format(TABLE_KEY_SERDE, tableId), null);
+    return config.get(String.format(TABLE_KEY_SERDE, tableId), null);
   }
 
   /**
@@ -82,6 +86,6 @@ public class JavaTableConfig extends MapConfig {
    * @return serde retistry key
    */
   public String getValueSerde(String tableId) {
-    return get(String.format(TABLE_VALUE_SERDE, tableId), null);
+    return config.get(String.format(TABLE_VALUE_SERDE, tableId), null);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/config/JobCoordinatorConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobCoordinatorConfig.java
@@ -25,17 +25,22 @@ import org.apache.samza.coordinator.CoordinationUtilsFactory;
 import org.apache.samza.util.ClassLoaderHelper;
 import org.apache.samza.zk.ZkCoordinationUtilsFactory;
 
-public class JobCoordinatorConfig extends MapConfig {
+public class JobCoordinatorConfig {
   public static final String JOB_COORDINATOR_FACTORY = "job.coordinator.factory";
   public static final String JOB_COORDINATION_UTILS_FACTORY = "job.coordination.utils.factory";
   public final static String DEFAULT_COORDINATION_UTILS_FACTORY = ZkCoordinationUtilsFactory.class.getName();
 
-  public JobCoordinatorConfig(Config config) {
-    super(config);
+  private final Config config;
+
+  public JobCoordinatorConfig(final Config config) {
+    if (null == config) {
+      throw new IllegalArgumentException("config cannot be null");
+    }
+    this.config = config;
   }
 
   public String getJobCoordinationUtilsFactoryClassName() {
-    String className = get(JOB_COORDINATION_UTILS_FACTORY, DEFAULT_COORDINATION_UTILS_FACTORY);
+    String className = config.get(JOB_COORDINATION_UTILS_FACTORY, DEFAULT_COORDINATION_UTILS_FACTORY);
 
     if (Strings.isNullOrEmpty(className)) {
       throw new SamzaException("Empty config for " + JOB_COORDINATION_UTILS_FACTORY + " = " + className);
@@ -59,7 +64,7 @@ public class JobCoordinatorConfig extends MapConfig {
   }
 
   public String getJobCoordinatorFactoryClassName() {
-    String jobCoordinatorFactoryClassName = get(JOB_COORDINATOR_FACTORY);
+    String jobCoordinatorFactoryClassName = config.get(JOB_COORDINATOR_FACTORY);
     if (Strings.isNullOrEmpty(jobCoordinatorFactoryClassName)) {
       throw new ConfigException(
           String.format("Missing config - %s. Cannot start StreamProcessor!", JOB_COORDINATOR_FACTORY));

--- a/samza-core/src/main/java/org/apache/samza/config/TaskConfigJava.java
+++ b/samza-core/src/main/java/org/apache/samza/config/TaskConfigJava.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 import scala.collection.JavaConverters;
 
 
-public class TaskConfigJava extends MapConfig {
+public class TaskConfigJava {
   // Task Configs
   public static final String TASK_SHUTDOWN_MS = "task.shutdown.ms";
   public static final long DEFAULT_TASK_SHUTDOWN_MS = 30000L;
@@ -45,9 +45,13 @@ public class TaskConfigJava extends MapConfig {
   private static final String BROADCAST_STREAM_RANGE_PATTERN = "^\\[[\\d]+\\-[\\d]+\\]$";
   public static final Logger LOGGER = LoggerFactory.getLogger(TaskConfigJava.class);
 
+  private final Config config;
 
-  public TaskConfigJava(Config config) {
-    super(config);
+  public TaskConfigJava(final Config config) {
+    if (null == config) {
+      throw new IllegalArgumentException("config cannot be null");
+    }
+    this.config = config;
   }
 
   /**
@@ -59,7 +63,7 @@ public class TaskConfigJava extends MapConfig {
    */
   public Set<SystemStreamPartition> getBroadcastSystemStreamPartitions() {
     HashSet<SystemStreamPartition> systemStreamPartitionSet = new HashSet<SystemStreamPartition>();
-    List<String> systemStreamPartitions = getList(BROADCAST_INPUT_STREAMS, Collections.<String>emptyList());
+    List<String> systemStreamPartitions = config.getList(BROADCAST_INPUT_STREAMS, Collections.<String>emptyList());
 
     for (String systemStreamPartition : systemStreamPartitions) {
       int hashPosition = systemStreamPartition.indexOf("#");
@@ -115,7 +119,7 @@ public class TaskConfigJava extends MapConfig {
   public Set<SystemStream> getAllInputStreams() {
     Set<SystemStream> allInputSS = new HashSet<>();
 
-    TaskConfig taskConfig = TaskConfig.Config2Task(this);
+    TaskConfig taskConfig = TaskConfig.Config2Task(config);
     allInputSS.addAll((Set<? extends SystemStream>) JavaConverters.setAsJavaSetConverter(taskConfig.getInputStreams()).asJava());
     allInputSS.addAll(getBroadcastSystemStreams());
 
@@ -130,7 +134,7 @@ public class TaskConfigJava extends MapConfig {
    * @return Long value indicating how long to wait for all the tasks to shutdown
    */
   public long getShutdownMs() {
-    String shutdownMs = get(TASK_SHUTDOWN_MS);
+    String shutdownMs = config.get(TASK_SHUTDOWN_MS);
     try {
       return Long.parseLong(shutdownMs);
     } catch (NumberFormatException nfe) {

--- a/samza-core/src/main/java/org/apache/samza/config/ZkConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ZkConfig.java
@@ -19,7 +19,7 @@
 
 package org.apache.samza.config;
 
-public class ZkConfig extends MapConfig {
+public class ZkConfig {
   // Connection string for ZK, format: :<hostname>:<port>,..."
   public static final String ZK_CONNECT = "job.coordinator.zk.connect";
   public static final String ZK_SESSION_TIMEOUT_MS = "job.coordinator.zk.session.timeout.ms";
@@ -30,26 +30,31 @@ public class ZkConfig extends MapConfig {
   public static final int DEFAULT_SESSION_TIMEOUT_MS = 30000;
   public static final int DEFAULT_CONSENSUS_TIMEOUT_MS = 40000;
 
-  public ZkConfig(Config config) {
-    super(config);
+  private final Config config;
+
+  public ZkConfig(final Config config) {
+    if (null == config) {
+      throw new IllegalArgumentException("config cannot be null");
+    }
+    this.config = config;
   }
 
   public String getZkConnect() {
-    if (!containsKey(ZK_CONNECT)) {
+    if (!config.containsKey(ZK_CONNECT)) {
       throw new ConfigException("Missing " + ZK_CONNECT + " config!");
     }
-    return get(ZK_CONNECT);
+    return config.get(ZK_CONNECT);
   }
 
   public int getZkSessionTimeoutMs() {
-    return getInt(ZK_SESSION_TIMEOUT_MS, DEFAULT_SESSION_TIMEOUT_MS);
+    return config.getInt(ZK_SESSION_TIMEOUT_MS, DEFAULT_SESSION_TIMEOUT_MS);
   }
 
   public int getZkConnectionTimeoutMs() {
-    return getInt(ZK_CONNECTION_TIMEOUT_MS, DEFAULT_CONNECTION_TIMEOUT_MS);
+    return config.getInt(ZK_CONNECTION_TIMEOUT_MS, DEFAULT_CONNECTION_TIMEOUT_MS);
   }
 
   public int getZkBarrierTimeoutMs() {
-    return getInt(ZK_CONSENSUS_TIMEOUT_MS, DEFAULT_CONSENSUS_TIMEOUT_MS);
+    return config.getInt(ZK_CONSENSUS_TIMEOUT_MS, DEFAULT_CONSENSUS_TIMEOUT_MS);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/execution/JobNode.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/JobNode.java
@@ -146,7 +146,7 @@ public class JobNode {
     streamGraph.getAllOperatorSpecs().forEach(opSpec -> {
         if (opSpec instanceof StatefulOperatorSpec) {
           ((StatefulOperatorSpec) opSpec).getStoreDescriptors()
-              .forEach(sd -> configs.putAll(sd.getStorageConfigs()));
+              .forEach(sd -> configs.putAll(sd.getStorageConfigs().getFilteredConfig()));
           // store key and message serdes are configured separately in #addSerdeConfigs
         }
       });

--- a/samza-kv-rocksdb/src/main/java/org/apache/samza/storage/kv/RocksDbKeyValueReader.java
+++ b/samza-kv-rocksdb/src/main/java/org/apache/samza/storage/kv/RocksDbKeyValueReader.java
@@ -127,6 +127,6 @@ public class RocksDbKeyValueReader {
     if (serdeClassName == null) {
       serdeClassName = Util.defaultSerdeFactoryFromSerdeName(name);
     }
-    return Util.<SerdeFactory<Object>> getObj(serdeClassName).getSerde(name, serializerConfig);
+    return Util.<SerdeFactory<Object>> getObj(serdeClassName).getSerde(name, serializerConfig.getFilteredConfig());
   }
 }

--- a/samza-log4j/src/main/java/org/apache/samza/config/Log4jSystemConfig.java
+++ b/samza-log4j/src/main/java/org/apache/samza/config/Log4jSystemConfig.java
@@ -44,7 +44,7 @@ public class Log4jSystemConfig extends JavaSystemConfig {
    *         information in Log4J appender messages.
    */
   public boolean getLocationEnabled() {
-    return "true".equals(get(Log4jSystemConfig.LOCATION_ENABLED, "false"));
+    return "true".equals(config.get(Log4jSystemConfig.LOCATION_ENABLED, "false"));
   }
 
   /**
@@ -54,7 +54,7 @@ public class Log4jSystemConfig extends JavaSystemConfig {
    * @return log4j system name
    */
   public String getSystemName() {
-    String log4jSystem = get(TASK_LOG4J_SYSTEM, null);
+    String log4jSystem = config.get(TASK_LOG4J_SYSTEM, null);
     if (log4jSystem == null) {
       throw new ConfigException("Missing " + TASK_LOG4J_SYSTEM + " configuration. Can't figure out the system name to use.");
     }
@@ -62,11 +62,11 @@ public class Log4jSystemConfig extends JavaSystemConfig {
   }
 
   public String getJobName() {
-    return get(JobConfig.JOB_NAME(), null);
+    return config.get(JobConfig.JOB_NAME(), null);
   }
 
   public String getJobId() {
-    return get(JobConfig.JOB_ID(), null);
+    return config.get(JobConfig.JOB_ID(), null);
   }
 
   /**
@@ -77,11 +77,11 @@ public class Log4jSystemConfig extends JavaSystemConfig {
    *         supplied serde name.
    */
   public String getSerdeClass(String name) {
-    return get(String.format(SerializerConfig.SERDE_FACTORY_CLASS(), name), null);
+    return config.get(String.format(SerializerConfig.SERDE_FACTORY_CLASS(), name), null);
   }
 
   public String getStreamSerdeName(String systemName, String streamName) {
-    StreamConfig streamConfig =  new StreamConfig(this);
+    StreamConfig streamConfig =  new StreamConfig(config);
     scala.Option<String> option = streamConfig.getStreamMsgSerde(new SystemStream(systemName, streamName));
     return option.isEmpty() ? null : option.get();
   }

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
@@ -102,9 +102,9 @@ public class TestZkLocalApplicationRunner extends StandaloneIntegrationTestHarne
   private String inputSinglePartitionKafkaTopic;
   private String outputSinglePartitionKafkaTopic;
   private ZkUtils zkUtils;
-  private ApplicationConfig applicationConfig1;
-  private ApplicationConfig applicationConfig2;
-  private ApplicationConfig applicationConfig3;
+  private Config applicationConfig1;
+  private Config applicationConfig2;
+  private Config applicationConfig3;
   private LocalApplicationRunner applicationRunner1;
   private LocalApplicationRunner applicationRunner2;
   private LocalApplicationRunner applicationRunner3;
@@ -133,11 +133,11 @@ public class TestZkLocalApplicationRunner extends StandaloneIntegrationTestHarne
     Map<String, String> configMap =
         buildStreamApplicationConfigMap(TEST_SYSTEM, inputKafkaTopic, testStreamAppName, testStreamAppId);
     configMap.put(JobConfig.PROCESSOR_ID(), PROCESSOR_IDS[0]);
-    applicationConfig1 = new ApplicationConfig(new MapConfig(configMap));
+    applicationConfig1 = new MapConfig(configMap);
     configMap.put(JobConfig.PROCESSOR_ID(), PROCESSOR_IDS[1]);
-    applicationConfig2 = new ApplicationConfig(new MapConfig(configMap));
+    applicationConfig2 = new MapConfig(configMap);
     configMap.put(JobConfig.PROCESSOR_ID(), PROCESSOR_IDS[2]);
-    applicationConfig3 = new ApplicationConfig(new MapConfig(configMap));
+    applicationConfig3 = new MapConfig(configMap);
 
     ZkClient zkClient = new ZkClient(zkConnect());
     ZkKeyBuilder zkKeyBuilder = new ZkKeyBuilder(ZkJobCoordinatorFactory.getJobCoordinationZkPath(applicationConfig1));


### PR DESCRIPTION
With previous inheritance, it exposed everything from Config class, which is a bad practice and is error prone. We are refactoring it to use composition over inheritance make it more robust. 