### PR TITLE
Move the changelog and checkpoint stream creation to the job coordinators.

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/checkpoint/CheckpointManager.java
+++ b/samza-api/src/main/java/org/apache/samza/checkpoint/CheckpointManager.java
@@ -26,6 +26,14 @@ import org.apache.samza.container.TaskName;
  * implementation-specific location.
  */
 public interface CheckpointManager {
+  /**
+   * Bootstrap any required resources needed prior to start.
+   */
+  default void init() { }
+
+  /**
+   * Perform startup operations.
+   */
   void start();
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/checkpoint/CheckpointManagerUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/checkpoint/CheckpointManagerUtil.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.checkpoint;
+
+import org.apache.samza.config.TaskConfig;
+import org.apache.samza.job.model.JobModel;
+import org.apache.samza.metrics.MetricsRegistry;
+import org.apache.samza.util.Util;
+import scala.Option;
+
+public class CheckpointManagerUtil {
+  public static CheckpointManager createAndInit(JobModel jobModel, MetricsRegistry metricsRegistry) {
+    // Initialize checkpoint streams during job coordination
+    Option<String> checkpointManagerFactoryName = new TaskConfig(jobModel.getConfig()).getCheckpointManagerFactory();
+    if (checkpointManagerFactoryName.isDefined()) {
+      CheckpointManager checkpointManager =
+          Util.<CheckpointManagerFactory>getObj(checkpointManagerFactoryName.get()).getCheckpointManager(jobModel.getConfig(), metricsRegistry);
+      checkpointManager.init();
+      return checkpointManager;
+    }
+    return null;
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/config/JavaStorageConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JavaStorageConfig.java
@@ -38,6 +38,10 @@ public class JavaStorageConfig extends MapConfig {
   private static final String MSG_SERDE = "stores.%s.msg.serde";
   private static final String CHANGELOG_STREAM = "stores.%s.changelog";
   private static final String CHANGELOG_SYSTEM = "job.changelog.system";
+  private static final String ACCESSLOG_STREAM_SUFFIX = "access-log";
+  private static final String ACCESSLOG_SAMPLING_RATIO = "stores.%s.accesslog.sampling.ratio";
+  private static final String ACCESSLOG_ENABLED = "stores.%s.accesslog.enabled";
+  private static final int DEFAULT_ACCESSLOG_SAMPLING_RATIO = 50;
 
   public JavaStorageConfig(Config config) {
     super(config);
@@ -80,6 +84,18 @@ public class JavaStorageConfig extends MapConfig {
     return systemStreamRes;
   }
 
+  public boolean getAccessLogEnabled(String storeName) {
+    return getBoolean(String.format(ACCESSLOG_ENABLED, storeName), false);
+  }
+
+  public String getAccessLogStream(String changeLogStream) {
+    return String.format("%s-%s", changeLogStream, ACCESSLOG_STREAM_SUFFIX);
+  }
+
+  public int getAccessLogSamplingRatio(String storeName) {
+    return getInt(String.format(ACCESSLOG_SAMPLING_RATIO, storeName), DEFAULT_ACCESSLOG_SAMPLING_RATIO);
+  }
+
   public String getStorageFactoryClassName(String storeName) {
     return get(String.format(FACTORY, storeName), null);
   }
@@ -105,7 +121,7 @@ public class JavaStorageConfig extends MapConfig {
    *
    * If the former syntax is used, that system name will still be honored. For the latter syntax, this method is used.
    *
-   * @return the name of the system to use by default for all changelogs, if defined. 
+   * @return the name of the system to use by default for all changelogs, if defined.
    */
   public String getChangelogSystem() {
     return get(CHANGELOG_SYSTEM,  get(JobConfig.JOB_DEFAULT_SYSTEM(), null));

--- a/samza-core/src/main/java/org/apache/samza/job/model/JobModel.java
+++ b/samza-core/src/main/java/org/apache/samza/job/model/JobModel.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.samza.config.Config;
 import org.apache.samza.container.LocalityManager;
+import org.apache.samza.container.TaskName;
 import org.apache.samza.coordinator.stream.messages.SetContainerHostMapping;
 
 /**
@@ -31,7 +32,7 @@ import org.apache.samza.coordinator.stream.messages.SetContainerHostMapping;
  * The data model used to represent a Samza job. The model is used in the job
  * coordinator and SamzaContainer to determine how to execute Samza jobs.
  * </p>
- * 
+ *
  * <p>
  * The hierarchy for a Samza's job data model is that jobs have containers, and
  * containers have tasks. Each data model contains relevant information, such as
@@ -45,6 +46,8 @@ public class JobModel {
 
   private final LocalityManager localityManager;
   private final Map<String, String> localityMappings;
+
+  private Map<TaskName, Integer> changelogTaskPartitionMappings;
 
   public int maxChangeLogStreamPartitions;
 
@@ -139,6 +142,14 @@ public class JobModel {
 
   public Map<String, ContainerModel> getContainers() {
     return containers;
+  }
+
+  public Map<TaskName, Integer> getChangelogTaskPartitionMappings() {
+    return changelogTaskPartitionMappings;
+  }
+
+  public void setChangelogTaskPartitionMappings(Map<TaskName, Integer> changelogTaskPartitionMappings) {
+    this.changelogTaskPartitionMappings = changelogTaskPartitionMappings;
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/standalone/PassthroughJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/standalone/PassthroughJobCoordinator.java
@@ -19,6 +19,7 @@
 package org.apache.samza.standalone;
 
 import org.apache.samza.SamzaException;
+import org.apache.samza.checkpoint.CheckpointManagerUtil;
 import org.apache.samza.config.ApplicationConfig;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.ConfigException;
@@ -80,6 +81,7 @@ public class PassthroughJobCoordinator implements JobCoordinator {
     JobModel jobModel = null;
     try {
       jobModel = getJobModel();
+      CheckpointManagerUtil.createAndInit(jobModel, null);
     } catch (Exception e) {
       LOGGER.error("Exception while trying to getJobModel.", e);
       if (coordinatorListener != null) {

--- a/samza-core/src/main/java/org/apache/samza/storage/ChangelogPartitionManager.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/ChangelogPartitionManager.java
@@ -21,15 +21,27 @@ package org.apache.samza.storage;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.samza.SamzaException;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.JavaStorageConfig;
+import org.apache.samza.config.JavaSystemConfig;
 import org.apache.samza.container.TaskName;
+import org.apache.samza.coordinator.stream.CoordinatorStreamSystemFactory;
 import org.apache.samza.coordinator.stream.messages.CoordinatorStreamMessage;
 import org.apache.samza.coordinator.stream.messages.SetChangelogMapping;
 import org.apache.samza.coordinator.stream.CoordinatorStreamSystemConsumer;
 import org.apache.samza.coordinator.stream.CoordinatorStreamSystemProducer;
 import org.apache.samza.coordinator.stream.AbstractCoordinatorStreamManager;
+import org.apache.samza.job.model.JobModel;
+import org.apache.samza.metrics.MetricsRegistryMap;
+import org.apache.samza.system.StreamSpec;
+import org.apache.samza.system.SystemAdmin;
+import org.apache.samza.system.SystemStream;
+import org.apache.samza.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 /**
  * The Changelog manager is used to persist and read the changelog information from the coordinator stream.
@@ -86,4 +98,72 @@ public class ChangelogPartitionManager extends AbstractCoordinatorStreamManager 
     }
   }
 
+  /**
+   * Create and validate changelog streams
+   * @param jobModel JobModel with changelog information
+   */
+  public void createChangeLogStreams(JobModel jobModel) {
+    createChangeLogStreams(getSource(), jobModel);
+  }
+
+  /**
+   * Create and validate changelog streams
+   * @param source Source name that creates the changelog stream
+   * @param jobModel JobModel with changelog information
+   */
+  public static void createChangeLogStreams(String source, JobModel jobModel) {
+    // Get changelog store config
+    JavaStorageConfig storageConfig = new JavaStorageConfig(jobModel.getConfig());
+    Map<String, SystemStream> storeNameSystemStreamMapping =
+        storageConfig.getStoreNames()
+            .stream()
+            .filter(name -> StringUtils.isNotBlank(storageConfig.getChangelogStream(name)))
+            .collect(Collectors.toMap(name -> name,
+                name -> Util.getSystemStreamFromNames(storageConfig.getChangelogStream(name))));
+
+    // Get SystemAdmin for changelog store's system and attempt to create the stream
+    JavaSystemConfig systemConfig = new JavaSystemConfig(jobModel.getConfig());
+    Map<String, SystemAdmin> systemAdminMapping = systemConfig.getSystemAdmins();
+    storeNameSystemStreamMapping.forEach((storeName, systemStream) -> {
+        SystemAdmin systemAdmin = systemAdminMapping.get(systemStream.getSystem());
+        if (systemAdmin == null) {
+          throw new SamzaException(String.format("Error creating changelog from %s. Changelog on store %s uses system %s, which is missing from the configuration.",
+              source, storeName, systemStream.getSystem()));
+        }
+
+        StreamSpec changelogSpec = StreamSpec.createChangeLogStreamSpec(systemStream.getStream(), systemStream.getSystem(),
+            jobModel.maxChangeLogStreamPartitions);
+        if (systemAdmin.createStream(changelogSpec)) {
+          log.info(String.format("%s created changelog stream %s.", source, systemStream.getStream()));
+        } else {
+          log.info(String.format("changelog stream %s already exists.", systemStream.getStream()));
+        }
+        systemAdmin.validateStream(changelogSpec);
+
+        if (storageConfig.getAccessLogEnabled(storeName)) {
+          String accesslogStream = storageConfig.getAccessLogStream(systemStream.getStream());
+          StreamSpec accesslogSpec = new StreamSpec(accesslogStream, accesslogStream, systemStream.getSystem(),
+              jobModel.maxChangeLogStreamPartitions);
+          systemAdmin.createStream(accesslogSpec);
+          systemAdmin.validateStream(accesslogSpec);
+        }
+      });
+  }
+
+  public static ChangelogPartitionManager fromConfig(Config config, String source, MetricsRegistryMap registryMap) {
+    CoordinatorStreamSystemFactory factory = new CoordinatorStreamSystemFactory();
+    CoordinatorStreamSystemConsumer consumer = factory.getCoordinatorStreamSystemConsumer(config, registryMap);
+    CoordinatorStreamSystemProducer producer = factory.getCoordinatorStreamSystemProducer(config, registryMap);
+    log.info("Registering coordinator system stream consumer.");
+    consumer.register();
+    log.debug("Starting coordinator system stream consumer.");
+    consumer.start();
+    log.debug("Bootstrapping coordinator system stream consumer.");
+    consumer.bootstrap();
+    log.info("Registering coordinator system stream producer.");
+    producer.register(source);
+    log.debug("Starting coordinator system stream producer");
+    producer.start();
+    return new ChangelogPartitionManager(producer, consumer, source);
+  }
 }

--- a/samza-core/src/main/scala/org/apache/samza/config/StorageConfig.scala
+++ b/samza-core/src/main/scala/org/apache/samza/config/StorageConfig.scala
@@ -21,7 +21,6 @@ package org.apache.samza.config
 
 
 import java.util.concurrent.TimeUnit
-import org.apache.samza.SamzaException
 import scala.collection.JavaConverters._
 import org.apache.samza.util.Logging
 import org.apache.samza.util.Util
@@ -51,7 +50,7 @@ class StorageConfig(config: Config) extends ScalaMapConfig(config) with Logging 
   def getStorageMsgSerde(name: String) = getOption(StorageConfig.MSG_SERDE format name)
 
   def getAccessLogEnabled(storeName: String) = {
-    getBoolean(ACCESSLOG_ENABLED format storeName, false)
+    new JavaStorageConfig(config).getAccessLogEnabled(storeName);
   }
 
   def getChangelogStream(name: String) = {
@@ -61,11 +60,11 @@ class StorageConfig(config: Config) extends ScalaMapConfig(config) with Logging 
 
   //Returns the accesslog stream name given a changelog stream name
   def getAccessLogStream(changeLogStream: String) = {
-    changeLogStream + "-" + ACCESSLOG_STREAM_SUFFIX
+    new JavaStorageConfig(config).getAccessLogStream(changeLogStream);
   }
 
   def getAccessLogSamplingRatio(storeName: String) = {
-    getInt(ACCESSLOG_SAMPLING_RATIO format storeName, DEFAULT_ACCESSLOG_SAMPLING_RATIO)
+    new JavaStorageConfig(config).getAccessLogSamplingRatio(storeName);
   }
 
   def getChangeLogDeleteRetentionInMs(storeName: String) = {

--- a/samza-core/src/main/scala/org/apache/samza/job/local/ProcessJobFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/job/local/ProcessJobFactory.scala
@@ -19,28 +19,38 @@
 
 package org.apache.samza.job.local
 
-
-import java.io.File
-
 import org.apache.samza.SamzaException
-import org.apache.samza.config.{JobConfig, Config}
+import org.apache.samza.checkpoint.CheckpointManagerUtil
+import org.apache.samza.clustermanager.ClusterBasedJobCoordinator
+import org.apache.samza.config.{Config, JobConfig}
 import org.apache.samza.config.TaskConfig._
 import org.apache.samza.coordinator.JobModelManager
 import org.apache.samza.job.{CommandBuilder, ShellCommandBuilder, StreamJob, StreamJobFactory}
+import org.apache.samza.metrics.MetricsRegistryMap
+import org.apache.samza.storage.ChangelogPartitionManager
 import org.apache.samza.util.{Logging, Util}
 
 /**
  * Creates a stand alone ProcessJob with the specified config.
  */
 class ProcessJobFactory extends StreamJobFactory with Logging {
-  def  getJob(config: Config): StreamJob = {
+  def getJob(config: Config): StreamJob = {
     val containerCount = JobConfig.Config2Job(config).getContainerCount
 
     if (containerCount > 1) {
       throw new SamzaException("Container count larger than 1 is not supported for ProcessJobFactory")
     }
-    
+
     val coordinator = JobModelManager(config)
+    val jobModel = coordinator.jobModel
+    val metricsRegistry = new MetricsRegistryMap()
+
+    //create necessary checkpoint and changelog streams, if not created
+    CheckpointManagerUtil.createAndInit(coordinator.jobModel, metricsRegistry)
+    val changelogPartitionManager = ChangelogPartitionManager.fromConfig(config, getClass.getSimpleName, metricsRegistry)
+    changelogPartitionManager.writeChangeLogPartitionMapping(coordinator.jobModel.getChangelogTaskPartitionMappings)
+    changelogPartitionManager.createChangeLogStreams(coordinator.jobModel)
+
     val containerModel = coordinator.jobModel.getContainers.get(0)
 
     val fwkPath = JobConfig.getFwkPath(config) // see if split deployment is configured

--- a/samza-kafka/src/test/java/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManagerJava.java
+++ b/samza-kafka/src/test/java/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManagerJava.java
@@ -75,6 +75,7 @@ public class TestKafkaCheckpointManagerJava {
         true, mock(Config.class), mock(MetricsRegistry.class), null, new KafkaCheckpointLogKeySerde());
 
     // expect an exception during startup
+    checkpointManager.init();
     checkpointManager.start();
   }
 
@@ -93,6 +94,7 @@ public class TestKafkaCheckpointManagerJava {
         true, mock(Config.class), mock(MetricsRegistry.class), null, new KafkaCheckpointLogKeySerde());
 
     // expect an exception during startup
+    checkpointManager.init();
     checkpointManager.start();
   }
 

--- a/samza-kafka/src/test/scala/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.scala
+++ b/samza-kafka/src/test/scala/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.scala
@@ -72,6 +72,7 @@ class TestKafkaCheckpointManager extends KafkaServerTestHarness {
     val checkpointTopic = "checkpoint-topic-1"
     val kcm1 = createKafkaCheckpointManager(checkpointTopic)
     kcm1.register(taskName)
+    kcm1.init
     kcm1.start
     kcm1.stop
     // check that start actually creates the topic with log compaction enabled
@@ -105,6 +106,7 @@ class TestKafkaCheckpointManager extends KafkaServerTestHarness {
     // create topic with the wrong number of partitions
     createTopic(checkpointTopic, 8, new KafkaConfig(config).getCheckpointTopicProperties())
     try {
+      kcm1.init
       kcm1.start
       fail("Expected an exception for invalid number of partitions in the checkpoint topic.")
     } catch {

--- a/samza-test/src/test/scala/org/apache/samza/test/integration/StreamTaskTestUtil.scala
+++ b/samza-test/src/test/scala/org/apache/samza/test/integration/StreamTaskTestUtil.scala
@@ -28,21 +28,24 @@ import kafka.admin.AdminUtils
 import kafka.consumer.{Consumer, ConsumerConfig}
 import kafka.message.MessageAndMetadata
 import kafka.server.{KafkaConfig, KafkaServer}
-import kafka.utils.{TestUtils, CoreUtils, ZkUtils}
+import kafka.utils.{CoreUtils, TestUtils, ZkUtils}
 import kafka.zk.EmbeddedZookeeper
 import org.apache.kafka.clients.producer.{KafkaProducer, Producer, ProducerConfig, ProducerRecord}
 import org.apache.samza.Partition
-import org.apache.samza.checkpoint.Checkpoint
+import org.apache.samza.checkpoint.{Checkpoint, CheckpointManagerFactory, CheckpointManagerUtil}
 import org.apache.kafka.common.protocol.SecurityProtocol
 import org.apache.kafka.common.security.JaasUtils
-import org.apache.samza.config.{ApplicationConfig, Config, KafkaProducerConfig, MapConfig}
+import org.apache.samza.config._
 import org.apache.samza.container.TaskName
 import org.apache.samza.job.local.ThreadJobFactory
+import org.apache.samza.job.model.{ContainerModel, JobModel}
 import org.apache.samza.job.{ApplicationStatus, JobRunner, StreamJob}
+import org.apache.samza.metrics.MetricsRegistryMap
+import org.apache.samza.storage.ChangelogPartitionManager
 import org.apache.samza.system.kafka.TopicMetadataCache
 import org.apache.samza.system.{IncomingMessageEnvelope, SystemStreamPartition}
 import org.apache.samza.task._
-import org.apache.samza.util.{ClientUtilTopicMetadataStore, KafkaUtil, TopicMetadataStore}
+import org.apache.samza.util.{ClientUtilTopicMetadataStore, KafkaUtil, TopicMetadataStore, Util}
 import org.junit.Assert._
 
 import scala.collection.JavaConverters._
@@ -182,7 +185,7 @@ object StreamTaskTestUtil {
     servers.foreach(server => CoreUtils.delete(server.config.logDirs))
 
     if (zkUtils != null)
-     CoreUtils.swallow(zkUtils.close())
+      CoreUtils.swallow(zkUtils.close())
     if (zookeeper != null)
       CoreUtils.swallow(zookeeper.shutdown())
     Configuration.setConfiguration(null)
@@ -202,7 +205,9 @@ class StreamTaskTestUtil {
    */
   def startJob = {
     // Start task.
-    val job = new JobRunner(new MapConfig(jobConfig.asJava)).run()
+    val jobRunner = new JobRunner(new MapConfig(jobConfig.asJava))
+    val job = jobRunner.run()
+    createStreams
     assertEquals(ApplicationStatus.Running, job.waitForStatus(ApplicationStatus.Running, 60000))
     TestTask.awaitTaskRegistered
     val tasks = TestTask.tasks
@@ -265,6 +270,16 @@ class StreamTaskTestUtil {
     messages.toList
   }
 
+  def createStreams {
+    val mapConfig = new MapConfig(jobConfig.asJava)
+    val containers = new util.HashMap[String, ContainerModel]()
+    val jobModel = new JobModel(mapConfig, containers)
+    jobModel.maxChangeLogStreamPartitions = 1
+
+    val checkpointManager = CheckpointManagerUtil.createAndInit(jobModel, new MetricsRegistryMap())
+    assert(checkpointManager != null, "No checkpoint manager factory configured")
+    ChangelogPartitionManager.createChangeLogStreams(this.getClass.toString, jobModel)
+  }
 }
 
 object TestTask {


### PR DESCRIPTION
**Overview**
The purpose of this PR is to consolidate the creation of the changelog and checkpoint streams into the JobCoordinators. In the current state, the changelog stream is created from the JobModelManager and the checkpoint stream is created within the OffsetManager. The issue with creating the checkpoint in the OffsetManager is that the first call happens from the first SamzaContainer that runs and each subsequent SamzaContainer run will attempt to create the checkpoint stream.

**Motivations**
There are three driving forces for this refactoring. The first motivation is to assign the creation of the changelog and checkpoint streams to the JobCoordinators where it is most appropriate. This was discussed in more detail with @nickpan47 . The second motivation is to have any potential failure to stream creation happen no later than during job coordination. The third motivation is to accommodate future security work to provide a robust way to set ACLs on streams. 

