### PR TITLE
SAMZA-1568: Handle ZkInterruptedException in zkclient.close.

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/zk/ZkControllerImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkControllerImpl.java
@@ -89,7 +89,7 @@ public class ZkControllerImpl implements ZkController {
 
     // close zk connection
     if (zkUtils != null) {
-      zkUtils.getZkClient().close();
+      zkUtils.close();
     }
   }
 

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkUtils.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkUtils.java
@@ -94,8 +94,6 @@ public class ZkUtils {
     return currentGeneration.get();
   }
 
-
-
   public ZkUtils(ZkKeyBuilder zkKeyBuilder, ZkClient zkClient, int connectionTimeoutMs, MetricsRegistry metricsRegistry) {
     this.keyBuilder = zkKeyBuilder;
     this.connectionTimeoutMs = connectionTimeoutMs;
@@ -298,7 +296,13 @@ public class ZkUtils {
   }
 
   public void close() throws ZkInterruptedException {
-    zkClient.close();
+    try {
+      zkClient.close();
+    } catch (ZkInterruptedException e) {
+      // Swallowing due to occurrence in the last stage of lifecycle (Not actionable) and clear the interrupted status.
+      Thread.interrupted();
+      LOG.warn("Ignoring the exception when closing the zookeeper client.", e);
+    }
   }
 
   /**


### PR DESCRIPTION
When zookeeper session failures occur in a stream processor,   leaves the group(zkClient is closed) and joins the group again.

The last step in that shutdown sequence is zkClient.close(). In some scenarios, it throws the following exception, 

    org.I0Itec.zkclient.exception.ZkInterruptedException: java.lang.InterruptedException
    at org.I0Itec.zkclient.ZkClient.close(ZkClient.java:1278)
    at org.apache.samza.zk.ZkControllerImpl.stop(ZkControllerImpl.java:92)

    at org.apache.samza.zk.ZkJobCoordinator.stop(ZkJobCoordinator.java:141)
In existing implementation this is not handled, there by killing the stream processor.  The following codepath triggers this exception:

`StreamProcessor.stop -> ZkJobCoordinator.stop() ->  zkController.stop() -> zkUtils.close`

This exception causes the integration test to fail occasionally  and can cause LocalApplicationRunner.waitForFinish method call to block indefinitely(since this callback event success, updates the latch state required for waitForFinish to end).

