### PR TITLE
Support source types where the last part of the source is not the streamName

### DIFF
--- a/samza-sql/src/main/java/org/apache/samza/sql/avro/AvroRelConverter.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/avro/AvroRelConverter.java
@@ -134,7 +134,6 @@ public class AvroRelConverter implements SamzaRelConverter {
   private final Schema mapSchema = Schema.parse(
       "{\"type\":\"map\",\"values\":{\"type\":\"record\",\"name\":\"Object\",\"namespace\":\"java.lang\",\"fields\":[]}}");
 
-
   public AvroRelConverter(SystemStream systemStream, AvroRelSchemaProvider schemaProvider, Config config) {
     this.config = config;
     this.relationalSchema = schemaProvider.getRelationalSchema();
@@ -175,7 +174,9 @@ public class AvroRelConverter implements SamzaRelConverter {
     List<String> fieldNames = relMessage.getFieldNames();
     List<Object> values = relMessage.getFieldValues();
     for (int index = 0; index < fieldNames.size(); index++) {
-      record.put(fieldNames.get(index), values.get(index));
+      if (!fieldNames.get(index).equalsIgnoreCase(SamzaSqlRelMessage.KEY_NAME)) {
+        record.put(fieldNames.get(index), values.get(index));
+      }
     }
 
     return new KV<>(relMessage.getKey(), record);

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/FilterTranslator.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/FilterTranslator.java
@@ -45,7 +45,7 @@ public class FilterTranslator {
 
     MessageStream<SamzaSqlRelMessage> outputStream = inputStream.filter(message -> {
       Object[] result = new Object[1];
-      expr.execute(context.getExecutionContext(), context.getDataContext(), message.getRelFieldValues().toArray(), result);
+      expr.execute(context.getExecutionContext(), context.getDataContext(), message.getFieldValues().toArray(), result);
       if (result.length > 0 && result[0] instanceof Boolean) {
         boolean retVal = (Boolean) result[0];
         log.debug(

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/ProjectTranslator.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/ProjectTranslator.java
@@ -66,13 +66,13 @@ public class ProjectTranslator {
     MessageStream<SamzaSqlRelMessage> outputStream = messageStream.map(m -> {
       RelDataType type = project.getRowType();
       Object[] output = new Object[type.getFieldCount()];
-      expr.execute(context.getExecutionContext(), context.getDataContext(), m.getRelFieldValues().toArray(), output);
+      expr.execute(context.getExecutionContext(), context.getDataContext(), m.getFieldValues().toArray(), output);
       List<String> names = new ArrayList<>();
       for (int index = 0; index < output.length; index++) {
         names.add(index, project.getNamedProjects().get(index).getValue());
       }
 
-      return SamzaSqlRelMessage.createRelMessage(Arrays.asList(output), names);
+      return new SamzaSqlRelMessage(names, Arrays.asList(output));
     });
 
     context.registerMessageStream(project.getId(), outputStream);
@@ -81,14 +81,14 @@ public class ProjectTranslator {
   private MessageStream<SamzaSqlRelMessage> translateFlatten(Integer flattenIndex,
       MessageStream<SamzaSqlRelMessage> inputStream) {
     return inputStream.flatMap(message -> {
-      Object field = message.getRelFieldValues().get(flattenIndex);
+      Object field = message.getFieldValues().get(flattenIndex);
 
       if (field != null && field instanceof List) {
         List<SamzaSqlRelMessage> outMessages = new ArrayList<>();
         for (Object fieldValue : (List) field) {
           List<Object> newValues = new ArrayList<>(message.getFieldValues());
           newValues.set(flattenIndex, Collections.singletonList(fieldValue));
-          outMessages.add(new SamzaSqlRelMessage(message.getKey(), message.getFieldNames(), newValues));
+          outMessages.add(new SamzaSqlRelMessage(message.getFieldNames(), newValues));
         }
         return outMessages;
       } else {

--- a/samza-sql/src/test/java/org/apache/samza/sql/TestSamzaSqlRelMessage.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/TestSamzaSqlRelMessage.java
@@ -33,14 +33,14 @@ public class TestSamzaSqlRelMessage {
 
   @Test
   public void testGetField() {
-    SamzaSqlRelMessage message = SamzaSqlRelMessage.createRelMessage(values, names);
+    SamzaSqlRelMessage message = new SamzaSqlRelMessage(names, values);
     Assert.assertEquals(values.get(0), message.getField(names.get(0)).get());
     Assert.assertEquals(values.get(1), message.getField(names.get(1)).get());
   }
 
   @Test
   public void testGetNonExistentField() {
-    SamzaSqlRelMessage message = SamzaSqlRelMessage.createRelMessage(values, names);
+    SamzaSqlRelMessage message = new SamzaSqlRelMessage(names, values);
     Assert.assertFalse(message.getField("field3").isPresent());
   }
 }

--- a/samza-sql/src/test/java/org/apache/samza/sql/avro/TestAvroRelConversion.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/avro/TestAvroRelConversion.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -144,7 +143,6 @@ public class TestAvroRelConversion {
     Assert.assertEquals(message.getFieldNames().size(), message.getFieldValues().size());
   }
 
-
   @Test
   public void testNullRecordConversion() {
     SamzaSqlRelMessage message = simpleRecordAvroRelConverter.convertToRelMessage(new KV<>("key", null));
@@ -218,8 +216,7 @@ public class TestAvroRelConversion {
     RelDataType dataType = complexRecordSchemProvider.getRelationalSchema();
 
     SamzaSqlRelMessage message = complexRecordAvroRelConverter.convertToRelMessage(new KV<>("key", complexRecordValue));
-    Assert.assertEquals(message.getFieldNames().size(),
-        ComplexRecord.SCHEMA$.getFields().size());
+    Assert.assertEquals(message.getFieldNames().size(), ComplexRecord.SCHEMA$.getFields().size() + 1);
 
     Assert.assertEquals(message.getField("id").get(), id);
     Assert.assertEquals(message.getField("bool_value").get(), boolValue);


### PR DESCRIPTION
Contains following fixes

1. Right now Samza SQL framework assumes that the last part of the source is the stream Name, removed the assumption
2. Made consoleLoggingSystemFactory to log formatted json so that it's easily readable.
3. Added support in SamzaSqlRelMessage where the key may not be present.