### PR TITLE
SAMZA-1588: Add random jitter to monitor’s scheduling interval.

### DIFF
--- a/docs/learn/documentation/versioned/rest/monitors.md
+++ b/docs/learn/documentation/versioned/rest/monitors.md
@@ -47,6 +47,14 @@ The following configurations are required for each of the monitors.
             not defined, it is defaulted to 60 seconds.</td>
           </tr>
           <tr>
+            <td>monitor.monitorName.scheduling.jitter.percent</td>
+            <td></td>
+            <td>
+            Defines the random jitter percentage that should be added to the monitor
+            scheduling interval for a monitor named monitorName. If undefined,
+            it is defaulted to zero.</td>
+          </tr>
+          <tr>
             <td>monitor.monitorName.factory.class</td>
             <td></td>
             <td>

--- a/samza-rest/src/main/java/org/apache/samza/monitor/MonitorConfig.java
+++ b/samza-rest/src/main/java/org/apache/samza/monitor/MonitorConfig.java
@@ -42,6 +42,10 @@ public class MonitorConfig extends MapConfig {
 
   private static final String MONITOR_PREFIX = String.format("monitor%s", MONITOR_CONFIG_KEY_SEPARATOR);
 
+  private static final String CONFIG_SCHEDULING_JITTER_PERCENT = "scheduling.jitter.percent";
+
+  private static final int DEFAULT_SCHEDULING_JITTER_PERCENT = 0;
+
   public MonitorConfig(Config config) {
     super(config);
   }
@@ -95,5 +99,9 @@ public class MonitorConfig extends MapConfig {
    */
   public int getSchedulingIntervalInMs() {
     return getInt(CONFIG_SCHEDULING_INTERVAL, DEFAULT_SCHEDULING_INTERVAL_IN_MS);
+  }
+
+  public double getSchedulingJitterPercent() {
+    return getDouble(CONFIG_SCHEDULING_JITTER_PERCENT, DEFAULT_SCHEDULING_JITTER_PERCENT);
   }
 }


### PR DESCRIPTION
We’ve observed in LinkedIn execution environments that, all the monitors running on the YARN node-manager machines hitting an external service at the same time based upon the configured monitor scheduling interval.

To eliminate unnecessary monitor execution spike and congestion caused to an external service at the same time, it’s essential to add a random jitter to the monitor scheduling interval.

Random jitter will be added to monitor scheduling interval based upon a boolean configuration.