### PR TITLE
SAMZA-1593: Upgrade gradle nexus plugin.

### DIFF
--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -27,5 +27,5 @@ repositories {
 
 dependencies {
   classpath 'de.obqo.gradle:gradle-lesscss-plugin:1.0-1.3.3'
-  classpath 'org.gradle.api.plugins:gradle-nexus-plugin:0.7.1'
+  classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
 }

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -55,15 +55,18 @@ task sourceRelease(type: Tar) {
 // Publishing to Apache's Maven repository (Nexus). To test this locally, set
 // repositoryUrl and snapshotRepositoryUrl below to 'file://localhost/tmp/myRepo'
 subprojects {
-  apply plugin: 'nexus'
+  apply plugin: 'com.bmuschko.nexus'
 
   nexus {
-    attachSources = true
-    attachTests = false
-    attachJavadoc = true
     sign = true
     repositoryUrl = 'https://repository.apache.org/service/local/staging/deploy/maven2'
     snapshotRepositoryUrl = 'https://repository.apache.org/content/repositories/snapshots'
+  }
+
+  extraArchive {
+    sources = true
+    tests = false
+    javadoc = true
   }
 
   modifyPom {


### PR DESCRIPTION
Current nexus plugin which samza repository is using is not compatible with the gradle versions greater than 3.0.

For doing the ligradle migration at linkedin, we need to update the nexus gradle plugin to the latest version. 