### PR TITLE
SAMZA-1594: Remove ScalaCompileOptions to make samza codebase build with gradle version > 3.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,8 +118,6 @@ subprojects {
   tasks.withType(ScalaCompile) {
     // show compile errors in console output
     logging.setLevel LogLevel.WARN
-    scalaCompileOptions.fork = false
-    scalaCompileOptions.useAnt = true
   }
 
   tasks.withType(Test) {


### PR DESCRIPTION
When samza repository is built with the gradle version greater than 3.0, we notice the following build failure.

No such property: useAnt for class: org.gradle.api.tasks.scala.ScalaCompileOptions  

This needs to be fixed to build samza with  gradle version >= 3.0.

