### PR TITLE
SAMZA-1595: Fix scalacCompileOptions format to build with zinc scala compiler.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ allprojects {
   // For all scala compilation, add extra compiler options, taken from version-specific
   // dependency-versions-scala file applied above.
   tasks.withType(ScalaCompile) {
-    scalaCompileOptions.additionalParameters = [ scalaOptions ]
+    scalaCompileOptions.additionalParameters = scalaOptions
   }
 }
 

--- a/gradle/dependency-versions-scala-2.10.gradle
+++ b/gradle/dependency-versions-scala-2.10.gradle
@@ -23,7 +23,7 @@ ext {
   // -feature: Give detailed warnings about language feature use (rather than just 'there were 4 warnings')
   // -language:implicitConversions: Allow the use of implicit conversions without warning or library import
   // -language:reflectiveCalls: Allow the automatic use of reflection to access fields without warning or library import
-  scalaOptions = "-feature -language:implicitConversions -language:reflectiveCalls"
+  scalaOptions = ["-feature", "-language:implicitConversions", "-language:reflectiveCalls"]
   scalatraVersion = "2.2.1"
   jettyVersion = "9.2.7.v20150116"
 }

--- a/gradle/dependency-versions-scala-2.11.gradle
+++ b/gradle/dependency-versions-scala-2.11.gradle
@@ -23,7 +23,7 @@ ext {
   // -feature: Give detailed warnings about language feature use (rather than just 'there were 4 warnings')
   // -language:implicitConversions: Allow the use of implicit conversions without warning or library import
   // -language:reflectiveCalls: Allow the automatic use of reflection to access fields without warning or library import
-  scalaOptions = "-feature -language:implicitConversions -language:reflectiveCalls"
+  scalaOptions = ["-feature", "-language:implicitConversions", "-language:reflectiveCalls"]
   scalatraVersion = "2.5.0"
   jettyVersion = "9.2.7.v20150116"
 }

--- a/gradle/dependency-versions-scala-2.12.gradle
+++ b/gradle/dependency-versions-scala-2.12.gradle
@@ -23,7 +23,7 @@ ext {
   // -feature: Give detailed warnings about language feature use (rather than just 'there were 4 warnings')
   // -language:implicitConversions: Allow the use of implicit conversions without warning or library import
   // -language:reflectiveCalls: Allow the automatic use of reflection to access fields without warning or library import
-  scalaOptions = "-feature -language:implicitConversions -language:reflectiveCalls"
+  scalaOptions = ["-feature", "-language:implicitConversions", "-language:reflectiveCalls"]
   scalatraVersion = "2.5.0"
   jettyVersion = "9.2.7.v20150116"
 }


### PR DESCRIPTION
Zinc scala compiler(part of gradle version >= 3.0) expects the scala compilation arguments as a list(where each compilation argument is an element of the list).

In samza, the compilation arguments are concatenated into a single string and passed to the compiler.

This causes build failures when samza is built with Zinc scala compiler.

Existing ant scala compiler used to build samza in open source accepts the compilation arguments both as list and string.

