### PR TITLE
SAMZA-1615: Fix a couple of issues in ControlMessageSender

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/operators/impl/ControlMessageSender.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/ControlMessageSender.java
@@ -43,9 +43,9 @@ class ControlMessageSender {
   }
 
   void send(ControlMessage message, SystemStream systemStream, MessageCollector collector) {
-    SystemStreamMetadata metadata = metadataCache.getSystemStreamMetadata(systemStream, true);
+    SystemStreamMetadata metadata = metadataCache.getSystemStreamMetadata(systemStream, false);
     int partitionCount = metadata.getSystemStreamPartitionMetadata().size();
-    LOG.info(String.format("Broadcast %s message from task %s to %s with %s partition",
+    LOG.debug(String.format("Broadcast %s message from task %s to %s with %s partition",
         MessageType.of(message).name(), message.getTaskName(), systemStream, partitionCount));
 
     for (int i = 0; i < partitionCount; i++) {

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/ControlMessageSender.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/ControlMessageSender.java
@@ -19,6 +19,7 @@
 
 package org.apache.samza.operators.impl;
 
+import org.apache.samza.SamzaException;
 import org.apache.samza.system.ControlMessage;
 import org.apache.samza.system.MessageType;
 import org.apache.samza.system.OutgoingMessageEnvelope;
@@ -49,6 +50,9 @@ class ControlMessageSender {
   void send(ControlMessage message, SystemStream systemStream, MessageCollector collector) {
     Integer partitionCount = PARTITION_COUNT_CACHE.computeIfAbsent(systemStream, ss -> {
         SystemStreamMetadata metadata = metadataCache.getSystemStreamMetadata(ss, true);
+        if (metadata == null) {
+          throw new SamzaException("Unable to find metadata for stream " + systemStream);
+        }
         return metadata.getSystemStreamPartitionMetadata().size();
       });
 


### PR DESCRIPTION
Two issues I found during testing: 1) medaDataCache.getSystemStreamMetadata(): if we pass in partitionOnly to be true, it will actually not store the metadata into the cache, resulting every call being another query to kafka. I turned off the partitionOnly in order to make it in the cache. 2) change the log for info to debug.