### PR TITLE
sql: initial insert support for table destination

### DIFF
--- a/samza-sql/src/main/java/org/apache/samza/sql/impl/ConfigBasedSourceResolverFactory.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/impl/ConfigBasedSourceResolverFactory.java
@@ -56,7 +56,7 @@ public class ConfigBasedSourceResolverFactory implements SourceResolverFactory {
 
       // This source resolver expects sources of format {systemName}.{streamName}
       if (sourceComponents.length != 2) {
-        String msg = String.format("Source %s is not of the format {systemName}.{streamName{", source);
+        String msg = String.format("Source %s is not of the format {systemName}.{streamName}", source);
         LOG.error(msg);
         throw new SamzaException(msg);
       }

--- a/samza-sql/src/main/java/org/apache/samza/sql/interfaces/SqlSystemStreamConfig.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/interfaces/SqlSystemStreamConfig.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.apache.commons.lang.Validate;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.MapConfig;
+import org.apache.samza.operators.TableDescriptor;
 import org.apache.samza.system.SystemStream;
 
 
@@ -51,12 +52,14 @@ public class SqlSystemStreamConfig {
 
   private List<String> sourceParts;
 
+  private TableDescriptor tableDescriptor;
+
   public SqlSystemStreamConfig(String systemName, String streamName, Config systemConfig) {
-    this(systemName, streamName, Arrays.asList(systemName, streamName), systemConfig);
+    this(systemName, streamName, Arrays.asList(systemName, streamName), systemConfig, null);
   }
 
   public SqlSystemStreamConfig(String systemName, String streamName, List<String> sourceParts,
-      Config systemConfig) {
+      Config systemConfig, TableDescriptor tableDescriptor) {
 
 
     HashMap<String, String> streamConfigs = new HashMap<>(systemConfig);
@@ -65,6 +68,7 @@ public class SqlSystemStreamConfig {
     this.source = getSourceFromSourceParts(sourceParts);
     this.sourceParts = sourceParts;
     this.systemStream = new SystemStream(systemName, streamName);
+    this.tableDescriptor = tableDescriptor;
 
     samzaRelConverterName = streamConfigs.get(CFG_SAMZA_REL_CONVERTER);
     Validate.notEmpty(samzaRelConverterName,
@@ -113,5 +117,13 @@ public class SqlSystemStreamConfig {
 
   public String getSource() {
     return source;
+  }
+
+  public boolean isTable() {
+    return tableDescriptor != null;
+  }
+
+  public TableDescriptor getTableDescriptor() {
+    return tableDescriptor;
   }
 }

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/QueryTranslator.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/QueryTranslator.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.RelShuttleImpl;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.samza.SamzaException;
 import org.apache.samza.operators.KV;
 import org.apache.samza.operators.MessageStream;
 import org.apache.samza.operators.MessageStreamImpl;
@@ -36,6 +37,9 @@ import org.apache.samza.sql.interfaces.SqlSystemStreamConfig;
 import org.apache.samza.sql.planner.QueryPlanner;
 import org.apache.samza.sql.runner.SamzaSqlApplicationConfig;
 import org.apache.samza.sql.testutil.SamzaSqlQueryParser;
+import org.apache.samza.table.Table;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -44,6 +48,7 @@ import org.apache.samza.sql.testutil.SamzaSqlQueryParser;
  * It then walks the relational graph and then populates the Samza's {@link StreamGraph} accordingly.
  */
 public class QueryTranslator {
+  private static final Logger LOG = LoggerFactory.getLogger(QueryTranslator.class);
 
   private final ScanTranslator scanTranslator;
   private final SamzaSqlApplicationConfig sqlConfig;
@@ -89,9 +94,19 @@ public class QueryTranslator {
     SqlSystemStreamConfig outputSystemConfig =
         sqlConfig.getOutputSystemStreamConfigsBySource().get(queryInfo.getOutputSource());
     SamzaRelConverter samzaMsgConverter = sqlConfig.getSamzaRelConverters().get(queryInfo.getOutputSource());
-    MessageStreamImpl<SamzaSqlRelMessage> stream =
-        (MessageStreamImpl<SamzaSqlRelMessage>) context.getMessageStream(node.getId());
+    MessageStreamImpl<SamzaSqlRelMessage> stream = (MessageStreamImpl<SamzaSqlRelMessage>) context.getMessageStream(node.getId());
     MessageStream<KV<Object, Object>> outputStream = stream.map(samzaMsgConverter::convertToSamzaMessage);
-    outputStream.sendTo(streamGraph.getOutputStream(outputSystemConfig.getStreamName()));
+
+    if (!outputSystemConfig.isTable()) {
+      outputStream.sendTo(streamGraph.getOutputStream(outputSystemConfig.getStreamName()));
+    } else {
+      Table outputTable = streamGraph.getTable(outputSystemConfig.getTableDescriptor());
+      if (outputTable == null) {
+        String msg = "Failed to obtain table with " + outputSystemConfig.getSource();
+        LOG.error(msg);
+        throw new SamzaException(msg);
+      }
+      outputStream.sendTo(outputTable);
+    }
   }
 }

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/TranslatorContext.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/TranslatorContext.java
@@ -35,6 +35,7 @@ import org.apache.samza.operators.MessageStream;
 import org.apache.samza.operators.StreamGraph;
 import org.apache.samza.sql.data.RexToJavaCompiler;
 import org.apache.samza.sql.data.SamzaSqlExecutionContext;
+import org.apache.samza.table.Table;
 
 
 /**
@@ -43,6 +44,7 @@ import org.apache.samza.sql.data.SamzaSqlExecutionContext;
 public class TranslatorContext {
   private final StreamGraph streamGraph;
   private final Map<Integer, MessageStream> messsageStreams = new HashMap<>();
+  private final Map<String, Table> tables = new HashMap<>();
   private final RexToJavaCompiler compiler;
 
   private final SamzaSqlExecutionContext executionContext;

--- a/samza-sql/src/test/java/org/apache/samza/sql/e2e/TestSamzaSqlEndToEnd.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/e2e/TestSamzaSqlEndToEnd.java
@@ -150,4 +150,5 @@ public class TestSamzaSqlEndToEnd {
     // There should be two messages that contain "4"
     Assert.assertEquals(TestAvroSystemFactory.messages.size(), 2);
   }
+
 }

--- a/samza-sql/src/test/java/org/apache/samza/sql/e2e/TestSamzaSqlTable.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/e2e/TestSamzaSqlTable.java
@@ -1,0 +1,54 @@
+package org.apache.samza.sql.e2e;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.samza.config.MapConfig;
+import org.apache.samza.sql.runner.SamzaSqlApplicationConfig;
+import org.apache.samza.sql.runner.SamzaSqlApplicationRunner;
+import org.apache.samza.sql.testutil.JsonUtil;
+import org.apache.samza.sql.testutil.SamzaSqlTestConfig;
+import org.apache.samza.sql.testutil.TestSourceResolverFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class TestSamzaSqlTable {
+  private static final Logger LOG = LoggerFactory.getLogger(TestSamzaSqlEndToEnd.class);
+
+  @Test
+  public void testEndToEnd() throws Exception {
+    int numMessages = 20;
+
+    TestSourceResolverFactory.TestTable.records.clear();
+
+    Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);
+
+    String sql1 = "Insert into testDb.testTable select id, name from testavro.SIMPLE1";
+    List<String> sqlStmts = Arrays.asList(sql1);
+    staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
+    SamzaSqlApplicationRunner runner = new SamzaSqlApplicationRunner(true, new MapConfig(staticConfigs));
+    runner.runAndWaitForFinish();
+
+    Assert.assertEquals(numMessages, TestSourceResolverFactory.TestTable.records.size());
+  }
+
+  @Test
+  public void testEndToEndWithKey() throws Exception {
+    int numMessages = 20;
+
+    TestSourceResolverFactory.TestTable.records.clear();
+    Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);
+
+    String sql1 = "Insert into testDb.testTable select id __key__, name from testavro.SIMPLE1";
+    List<String> sqlStmts = Arrays.asList(sql1);
+    staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
+    SamzaSqlApplicationRunner runner = new SamzaSqlApplicationRunner(true, new MapConfig(staticConfigs));
+    runner.runAndWaitForFinish();
+
+    Assert.assertEquals(numMessages, TestSourceResolverFactory.TestTable.records.size());
+  }
+}

--- a/samza-sql/src/test/java/org/apache/samza/sql/testutil/SamzaSqlTestConfig.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/testutil/SamzaSqlTestConfig.java
@@ -46,6 +46,7 @@ import org.apache.samza.standalone.PassthroughJobCoordinatorFactory;
 public class SamzaSqlTestConfig {
 
   public static final String SAMZA_SYSTEM_TEST_AVRO = "testavro";
+  public static final String SAMZA_SYSTEM_TEST_DB = "testDb";
 
   public static Map<String, String> fetchStaticConfigsWithFactories(int numberOfMessages) {
     HashMap<String, String> staticConfigs = new HashMap<>();
@@ -78,9 +79,18 @@ public class SamzaSqlTestConfig {
     staticConfigs.put(avroSamzaSqlConfigPrefix + SqlSystemStreamConfig.CFG_SAMZA_REL_CONVERTER, "avro");
     staticConfigs.put(avroSamzaSqlConfigPrefix + SqlSystemStreamConfig.CFG_REL_SCHEMA_PROVIDER, "config");
 
+    String testDbSamzaSqlConfigPrefix = configSourceResolverDomain + String.format("%s.", SAMZA_SYSTEM_TEST_DB);
+    staticConfigs.put(testDbSamzaSqlConfigPrefix + SqlSystemStreamConfig.CFG_SAMZA_REL_CONVERTER, "avro");
+    staticConfigs.put(testDbSamzaSqlConfigPrefix + SqlSystemStreamConfig.CFG_REL_SCHEMA_PROVIDER, "config");
+
     String avroSamzaToRelMsgConverterDomain =
         String.format(SamzaSqlApplicationConfig.CFG_FMT_SAMZA_REL_CONVERTER_DOMAIN, "avro");
     staticConfigs.put(avroSamzaToRelMsgConverterDomain + SamzaSqlApplicationConfig.CFG_FACTORY,
+        AvroRelConverterFactory.class.getName());
+
+    String testDbSamzaToRelMsgConverterDomain =
+        String.format(SamzaSqlApplicationConfig.CFG_FMT_SAMZA_REL_CONVERTER_DOMAIN, TestSourceResolverFactory.TEST_DB_SYSTEM);
+    staticConfigs.put(testDbSamzaToRelMsgConverterDomain + SamzaSqlApplicationConfig.CFG_FACTORY,
         AvroRelConverterFactory.class.getName());
 
     String configAvroRelSchemaProviderDomain =
@@ -99,6 +109,10 @@ public class SamzaSqlTestConfig {
     staticConfigs.put(
         configAvroRelSchemaProviderDomain + String.format(ConfigBasedAvroRelSchemaProviderFactory.CFG_SOURCE_SCHEMA,
             "testavro", "COMPLEX1"), ComplexRecord.SCHEMA$.toString());
+
+    staticConfigs.put(
+        configAvroRelSchemaProviderDomain + String.format(ConfigBasedAvroRelSchemaProviderFactory.CFG_SOURCE_SCHEMA,
+            TestSourceResolverFactory.TEST_DB_SYSTEM, "testTable"), SimpleRecord.SCHEMA$.toString());
 
     return staticConfigs;
   }

--- a/samza-sql/src/test/java/org/apache/samza/sql/testutil/TestSourceResolverFactory.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/testutil/TestSourceResolverFactory.java
@@ -20,16 +20,126 @@
 package org.apache.samza.sql.testutil;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.samza.config.Config;
+import org.apache.samza.container.SamzaContainerContext;
+import org.apache.samza.operators.BaseTableDescriptor;
+import org.apache.samza.operators.TableDescriptor;
+import org.apache.samza.serializers.KVSerde;
+import org.apache.samza.serializers.NoOpSerde;
 import org.apache.samza.sql.interfaces.SourceResolver;
 import org.apache.samza.sql.interfaces.SourceResolverFactory;
 import org.apache.samza.sql.interfaces.SqlSystemStreamConfig;
+import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.Table;
+import org.apache.samza.table.TableProvider;
+import org.apache.samza.table.TableProviderFactory;
+import org.apache.samza.table.TableSpec;
+import org.apache.samza.task.TaskContext;
+
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 
 public class TestSourceResolverFactory implements SourceResolverFactory {
+  public static final String TEST_DB_SYSTEM = "testDb";
+  public static final String TEST_TABLE_ID = "testDbId";
+
   @Override
   public SourceResolver create(Config config) {
     return new TestSourceResolver(config);
+  }
+
+  static class TestTableDescriptor extends BaseTableDescriptor {
+    protected TestTableDescriptor(String tableId) {
+      super(tableId);
+    }
+
+    @Override
+    public String getTableId() {
+      return tableId;
+    }
+
+    @Override
+    public TableSpec getTableSpec() {
+      return new TableSpec(tableId, KVSerde.of(new NoOpSerde(), new NoOpSerde()), TestTableProviderFactory.class.getName(), new HashMap<>());
+    }
+  }
+
+  public static class TestTable implements ReadWriteTable {
+    public static Map<Object, Object> records = new HashMap<>();
+    @Override
+    public Object get(Object key) {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public Map getAll(List keys) {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void put(Object key, Object value) {
+      if (key == null) {
+        records.put(System.nanoTime(), value);
+      } else {
+        records.put(key, value);
+      }
+    }
+
+    @Override
+    public void delete(Object key) {
+      records.remove(key);
+    }
+
+    @Override
+    public void deleteAll(List keys) {
+      records.clear();
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void putAll(List entries) {
+      throw new NotImplementedException();
+    }
+  }
+
+  public static class TestTableProviderFactory implements TableProviderFactory {
+    @Override
+    public TableProvider getTableProvider(TableSpec tableSpec) {
+      return new TestTableProvider();
+    }
+  }
+
+  static class TestTableProvider implements TableProvider {
+    @Override
+    public void init(SamzaContainerContext containerContext, TaskContext taskContext) {
+
+    }
+
+    @Override
+    public Table getTable() {
+      return new TestTable();
+    }
+
+    @Override
+    public Map<String, String> generateConfig(Map<String, String> config) {
+      return new HashMap<>();
+    }
+
+    @Override
+    public void close() {
+
+    }
   }
 
   private class TestSourceResolver implements SourceResolver {
@@ -43,8 +153,19 @@ public class TestSourceResolverFactory implements SourceResolverFactory {
     public SqlSystemStreamConfig fetchSourceInfo(String sourceName) {
       String[] sourceComponents = sourceName.split("\\.");
       Config systemConfigs = config.subset(sourceComponents[0] + ".");
+
+      TableDescriptor tableDescriptor = null;
+      if (sourceComponents[0].equals(TEST_DB_SYSTEM)) {
+        // Table
+        tableDescriptor = getTestDbDescriptor(config);
+      }
+
       return new SqlSystemStreamConfig(sourceComponents[0], sourceComponents[sourceComponents.length - 1],
-          Arrays.asList(sourceComponents), systemConfigs);
+          Arrays.asList(sourceComponents), systemConfigs, tableDescriptor);
+    }
+
+    private TableDescriptor getTestDbDescriptor(Config config) {
+      return new TestTableDescriptor(TEST_TABLE_ID);
     }
   }
 }


### PR DESCRIPTION
Table is another main type of IO abstraction in Samza which supports
both read and write (optional). For the table that do support writes, we
should be able to allow SamzaSQL users to write a query to do that. One
example is to insert into a database. The current code only supports
inserting into a stream. This change adds the initial support for table
insert operation.