### PR TITLE
ScheduleAfterDebounceTime should catch all Throwable to avoid losing unhandled Errors

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/zk/ScheduleAfterDebounceTime.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ScheduleAfterDebounceTime.java
@@ -93,6 +93,8 @@ public class ScheduleAfterDebounceTime {
    * and all pending enqueued tasks will be cancelled.
    */
   public synchronized void stopScheduler() {
+    LOG.info("Stopping Scheduler");
+
     scheduledExecutorService.shutdownNow();
 
     // Clear the existing future handles.
@@ -142,9 +144,9 @@ public class ScheduleAfterDebounceTime {
         } else {
           LOG.debug("Action: {} completed successfully.", actionName);
         }
-      } catch (Exception exception) {
-        LOG.error("Execution of action: {} failed.", actionName, exception);
-        doCleanUpOnTaskException(exception);
+      } catch (Throwable t) {
+        LOG.error("Execution of action: {} failed.", actionName, t);
+        doCleanUpOnTaskException(t);
       }
     };
   }
@@ -159,7 +161,7 @@ public class ScheduleAfterDebounceTime {
    *
    * @param exception the exception happened during task execution.
    */
-  private void doCleanUpOnTaskException(Exception exception) {
+  private void doCleanUpOnTaskException(Throwable exception) {
     stopScheduler();
 
     scheduledTaskCallback.ifPresent(callback -> callback.onError(exception));

--- a/samza-core/src/main/java/org/apache/samza/zk/ScheduleAfterDebounceTime.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ScheduleAfterDebounceTime.java
@@ -152,19 +152,19 @@ public class ScheduleAfterDebounceTime {
   }
 
   /**
-   * Handler method to invoke on a exception during an scheduled task execution and which
+   * Handler method to invoke on a throwable during an scheduled task execution and which
    * the following operations in sequential order.
    * <ul>
    *   <li> Stop the scheduler. If the task execution fails or a task is interrupted, scheduler will not accept/execute any new tasks.</li>
    *   <li> Invokes the onError handler method if taskCallback is defined.</li>
    * </ul>
    *
-   * @param exception the exception happened during task execution.
+   * @param throwable the throwable that happened during task execution.
    */
-  private void doCleanUpOnTaskException(Throwable exception) {
+  private void doCleanUpOnTaskException(Throwable throwable) {
     stopScheduler();
 
-    scheduledTaskCallback.ifPresent(callback -> callback.onError(exception));
+    scheduledTaskCallback.ifPresent(callback -> callback.onError(throwable));
   }
 
   /**


### PR DESCRIPTION
If an Action executed in the scheduler throws an Error (or other Throwable?) besides Exception, it is silently lost since the Action/Runnable wrapper only catches Exception, not Throwable. This made my troubleshooting of an issue very difficult. Made it seem like the code was "hung" when really it had thrown a "NoSuchMethodError" (Error instead of Exception) due to a simple dependency issue on my side.

Catching Throwable instead ensures this is handled and propagated properly.