### PR TITLE
SAMZA-1623: include avro as the file suffix for hdfs producer

### DIFF
--- a/samza-hdfs/src/main/scala/org/apache/samza/system/hdfs/writer/AvroDataFileHdfsWriter.scala
+++ b/samza-hdfs/src/main/scala/org/apache/samza/system/hdfs/writer/AvroDataFileHdfsWriter.scala
@@ -66,7 +66,7 @@ class AvroDataFileHdfsWriter (dfs: FileSystem, systemName: String, config: HdfsC
   }
 
   protected def getNextWriter(record: Object): Option[DataFileWriter[Object]] = {
-    val path = bucketer.get.getNextWritePath(dfs)
+    val path = bucketer.get.getNextWritePath(dfs).suffix(".avro")
     val isGenericRecord = record.isInstanceOf[GenericRecord]
     val schema = record match {
       case genericRecord: GenericRecord => genericRecord.getSchema


### PR DESCRIPTION
AvroDataFileHdfsWriter should include avro as the file suffix as some pig jobs couldn't read the avro files if they don't come with the proper suffix