### PR TITLE
sql: initial insert support for table destination

### DIFF
--- a/samza-sql/src/main/java/org/apache/samza/sql/impl/ConfigBasedSourceResolverFactory.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/impl/ConfigBasedSourceResolverFactory.java
@@ -19,8 +19,10 @@
 
 package org.apache.samza.sql.impl;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.samza.SamzaException;
 import org.apache.samza.config.Config;
+import org.apache.samza.operators.TableDescriptor;
 import org.apache.samza.sql.interfaces.SourceResolver;
 import org.apache.samza.sql.interfaces.SourceResolverFactory;
 import org.apache.samza.sql.interfaces.SqlSystemSourceConfig;
@@ -100,6 +102,11 @@ public class ConfigBasedSourceResolverFactory implements SourceResolverFactory {
     public boolean isTable(String sourceName) {
       String[] sourceComponents = sourceName.split("\\.");
       return sourceComponents[sourceComponents.length - 1].equalsIgnoreCase(SAMZA_SQL_QUERY_TABLE_KEYWORD);
+    }
+
+    @Override
+    public TableDescriptor getTableDescriptor(String sourceName) {
+      throw new NotImplementedException("TableDescriptor is currently not supported by ConfigBasedSourceResolverFactory.");
     }
 
     private Config fetchSystemConfigs(String systemName) {

--- a/samza-sql/src/main/java/org/apache/samza/sql/interfaces/SourceResolver.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/interfaces/SourceResolver.java
@@ -19,8 +19,13 @@
 
 package org.apache.samza.sql.interfaces;
 
+import org.apache.samza.operators.TableDescriptor;
+
+
 /**
- * Source Resolvers are used by Samza Sql application to fetch the {@link SqlSystemSourceConfig} corresponding to the source.
+ * Source Resolvers are used by Samza Sql application to fetch the {@link SqlSystemSourceConfig} corresponding
+ * to the source. Additionally, it provides capability to resolve Samza table sources and creating the matching
+ * table descriptors.
  */
 public interface SourceResolver {
   /**
@@ -41,4 +46,12 @@ public interface SourceResolver {
    *  true if the source is a table, else false.
    */
   boolean isTable(String sourceName);
+
+  /**
+   * Return a Samza table descriptor corresponding to the {@code sourceName} if the underlying source is a table,
+   * ie. {@link SourceResolver#isTable(String)} should return true for the same {@code sourceName}.
+   * @param sourceName source for which the table descriptor is requested.
+   * @return table descriptor; null if the source is not a table.
+   */
+  TableDescriptor getTableDescriptor(String sourceName);
 }

--- a/samza-sql/src/test/java/org/apache/samza/sql/e2e/TestSamzaSqlTable.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/e2e/TestSamzaSqlTable.java
@@ -1,0 +1,50 @@
+package org.apache.samza.sql.e2e;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.samza.config.MapConfig;
+import org.apache.samza.sql.runner.SamzaSqlApplicationConfig;
+import org.apache.samza.sql.runner.SamzaSqlApplicationRunner;
+import org.apache.samza.sql.testutil.JsonUtil;
+import org.apache.samza.sql.testutil.SamzaSqlTestConfig;
+import org.apache.samza.sql.testutil.TestSourceResolverFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class TestSamzaSqlTable {
+  @Test
+  public void testEndToEnd() throws Exception {
+    int numMessages = 20;
+
+    TestSourceResolverFactory.TestTable.records.clear();
+
+    Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);
+
+    String sql1 = "Insert into testDb.testTable select id, name from testavro.SIMPLE1";
+    List<String> sqlStmts = Arrays.asList(sql1);
+    staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
+    SamzaSqlApplicationRunner runner = new SamzaSqlApplicationRunner(true, new MapConfig(staticConfigs));
+    runner.runAndWaitForFinish();
+
+    Assert.assertEquals(numMessages, TestSourceResolverFactory.TestTable.records.size());
+  }
+
+  @Test
+  public void testEndToEndWithKey() throws Exception {
+    int numMessages = 20;
+
+    TestSourceResolverFactory.TestTable.records.clear();
+    Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);
+
+    String sql1 = "Insert into testDb.testTable select id __key__, name from testavro.SIMPLE1";
+    List<String> sqlStmts = Arrays.asList(sql1);
+    staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
+    SamzaSqlApplicationRunner runner = new SamzaSqlApplicationRunner(true, new MapConfig(staticConfigs));
+    runner.runAndWaitForFinish();
+
+    Assert.assertEquals(numMessages, TestSourceResolverFactory.TestTable.records.size());
+  }
+}

--- a/samza-sql/src/test/java/org/apache/samza/sql/testutil/SamzaSqlTestConfig.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/testutil/SamzaSqlTestConfig.java
@@ -51,6 +51,7 @@ import org.apache.samza.standalone.PassthroughJobCoordinatorFactory;
 public class SamzaSqlTestConfig {
 
   public static final String SAMZA_SYSTEM_TEST_AVRO = "testavro";
+  public static final String SAMZA_SYSTEM_TEST_DB = "testDb";
 
   public static Map<String, String> fetchStaticConfigsWithFactories(int numberOfMessages) {
     return fetchStaticConfigsWithFactories(new HashMap<>(), numberOfMessages, false);
@@ -95,9 +96,18 @@ public class SamzaSqlTestConfig {
     staticConfigs.put(avroSamzaSqlConfigPrefix + SqlSystemSourceConfig.CFG_SAMZA_REL_CONVERTER, "avro");
     staticConfigs.put(avroSamzaSqlConfigPrefix + SqlSystemSourceConfig.CFG_REL_SCHEMA_PROVIDER, "config");
 
+    String testDbSamzaSqlConfigPrefix = configSourceResolverDomain + String.format("%s.", SAMZA_SYSTEM_TEST_DB);
+    staticConfigs.put(testDbSamzaSqlConfigPrefix + SqlSystemSourceConfig.CFG_SAMZA_REL_CONVERTER, "avro");
+    staticConfigs.put(testDbSamzaSqlConfigPrefix + SqlSystemSourceConfig.CFG_REL_SCHEMA_PROVIDER, "config");
+
     String avroSamzaToRelMsgConverterDomain =
         String.format(SamzaSqlApplicationConfig.CFG_FMT_SAMZA_REL_CONVERTER_DOMAIN, "avro");
     staticConfigs.put(avroSamzaToRelMsgConverterDomain + SamzaSqlApplicationConfig.CFG_FACTORY,
+        AvroRelConverterFactory.class.getName());
+
+    String testDbSamzaToRelMsgConverterDomain =
+        String.format(SamzaSqlApplicationConfig.CFG_FMT_SAMZA_REL_CONVERTER_DOMAIN, TestSourceResolverFactory.TEST_DB_SYSTEM);
+    staticConfigs.put(testDbSamzaToRelMsgConverterDomain + SamzaSqlApplicationConfig.CFG_FACTORY,
         AvroRelConverterFactory.class.getName());
 
     String configAvroRelSchemaProviderDomain =
@@ -128,6 +138,10 @@ public class SamzaSqlTestConfig {
 
     staticConfigs.put(configAvroRelSchemaProviderDomain + String.format(ConfigBasedAvroRelSchemaProviderFactory.CFG_SOURCE_SCHEMA,
         "testavro", "enrichedPageViewTopic"), EnrichedPageView.SCHEMA$.toString());
+
+    staticConfigs.put(
+        configAvroRelSchemaProviderDomain + String.format(ConfigBasedAvroRelSchemaProviderFactory.CFG_SOURCE_SCHEMA,
+            TestSourceResolverFactory.TEST_DB_SYSTEM, "testTable"), SimpleRecord.SCHEMA$.toString());
 
     staticConfigs.putAll(props);
 

--- a/samza-sql/src/test/java/org/apache/samza/sql/testutil/TestSourceResolverFactory.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/testutil/TestSourceResolverFactory.java
@@ -20,16 +20,123 @@
 package org.apache.samza.sql.testutil;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.samza.config.Config;
+import org.apache.samza.container.SamzaContainerContext;
+import org.apache.samza.operators.BaseTableDescriptor;
+import org.apache.samza.operators.TableDescriptor;
+import org.apache.samza.serializers.KVSerde;
+import org.apache.samza.serializers.NoOpSerde;
 import org.apache.samza.sql.interfaces.SourceResolver;
 import org.apache.samza.sql.interfaces.SourceResolverFactory;
 import org.apache.samza.sql.interfaces.SqlSystemSourceConfig;
+import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.Table;
+import org.apache.samza.table.TableProvider;
+import org.apache.samza.table.TableProviderFactory;
+import org.apache.samza.table.TableSpec;
+import org.apache.samza.task.TaskContext;
 
 
 public class TestSourceResolverFactory implements SourceResolverFactory {
+  public static final String TEST_DB_SYSTEM = "testDb";
+  public static final String TEST_TABLE_ID = "testDbId";
+
   @Override
   public SourceResolver create(Config config) {
     return new TestSourceResolver(config);
+  }
+
+  static class TestTableDescriptor extends BaseTableDescriptor {
+    protected TestTableDescriptor(String tableId) {
+      super(tableId);
+    }
+
+    @Override
+    public String getTableId() {
+      return tableId;
+    }
+
+    @Override
+    public TableSpec getTableSpec() {
+      return new TableSpec(tableId, KVSerde.of(new NoOpSerde(), new NoOpSerde()), TestTableProviderFactory.class.getName(), new HashMap<>());
+    }
+  }
+
+  public static class TestTable implements ReadWriteTable {
+    public static Map<Object, Object> records = new HashMap<>();
+    @Override
+    public Object get(Object key) {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public Map getAll(List keys) {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void put(Object key, Object value) {
+      if (key == null) {
+        records.put(System.nanoTime(), value);
+      } else {
+        records.put(key, value);
+      }
+    }
+
+    @Override
+    public void delete(Object key) {
+      records.remove(key);
+    }
+
+    @Override
+    public void deleteAll(List keys) {
+      records.clear();
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void putAll(List entries) {
+      throw new NotImplementedException();
+    }
+  }
+
+  public static class TestTableProviderFactory implements TableProviderFactory {
+    @Override
+    public TableProvider getTableProvider(TableSpec tableSpec) {
+      return new TestTableProvider();
+    }
+  }
+
+  static class TestTableProvider implements TableProvider {
+    @Override
+    public void init(SamzaContainerContext containerContext, TaskContext taskContext) {
+    }
+
+    @Override
+    public Table getTable() {
+      return new TestTable();
+    }
+
+    @Override
+    public Map<String, String> generateConfig(Map<String, String> config) {
+      return new HashMap<>();
+    }
+
+    @Override
+    public void close() {
+    }
   }
 
   private class TestSourceResolver implements SourceResolver {
@@ -52,15 +159,29 @@ public class TestSourceResolverFactory implements SourceResolverFactory {
         isTable = true;
         streamIdx = endIdx - 1;
       }
+
       Config systemConfigs = config.subset(sourceComponents[systemIdx] + ".");
       return new SqlSystemSourceConfig(sourceComponents[systemIdx], sourceComponents[streamIdx],
           Arrays.asList(sourceComponents), systemConfigs, isTable);
     }
 
     @Override
-    public boolean isTable(String sourceName) {
+    public boolean isTable(String sourceName){
       String[] sourceComponents = sourceName.split("\\.");
-      return sourceComponents[sourceComponents.length - 1].equalsIgnoreCase(SAMZA_SQL_QUERY_TABLE_KEYWORD);
+      return sourceComponents[sourceComponents.length - 1].equalsIgnoreCase(SAMZA_SQL_QUERY_TABLE_KEYWORD) ||
+          sourceName.equalsIgnoreCase("testDb.testTable");
+    }
+
+    @Override
+    public TableDescriptor getTableDescriptor(String sourceName) {
+      String[] sourceComponents = sourceName.split("\\.");
+
+      TableDescriptor tableDescriptor = null;
+      if (sourceComponents[0].equals(TEST_DB_SYSTEM)) {
+        tableDescriptor = new TestTableDescriptor(TEST_TABLE_ID);;
+      }
+
+      return tableDescriptor;
     }
   }
 }


### PR DESCRIPTION
Table is another main type of IO abstraction in Samza which supports
both read and write (optional). For the tables that do support writes, we
should be able to allow Samza SQL users to write a query to do that. One
example is to insert into a database. The current code only supports
inserting into a stream. This change adds the initial support for table
insert operation.