### PR TITLE
Upgrade to latest event hub version (1.0.1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -202,7 +202,7 @@ project(':samza-azure') {
 
   dependencies {
     compile "com.microsoft.azure:azure-storage:5.3.1"
-    compile "com.microsoft.azure:azure-eventhubs:0.14.5"
+    compile "com.microsoft.azure:azure-eventhubs:1.0.1"
     compile "com.fasterxml.jackson.core:jackson-core:2.8.8"
     compile "io.dropwizard.metrics:metrics-core:3.1.2"
     compile project(':samza-api')

--- a/docs/learn/documentation/versioned/jobs/configuration-table.html
+++ b/docs/learn/documentation/versioned/jobs/configuration-table.html
@@ -2279,27 +2279,45 @@
                 </tr>
 
                 <tr>
-                    <td class="property" id="eventhub-stream-namespace">systems.<span class="system">system-name</span>.<br>streams.<span class="stream">stream-id</span>.<br>eventhubs.namespace</td>
+                    <td class="property" id="eventhub-stream-namespace">streams.<span class="stream">stream-id</span>.<br>eventhubs.namespace</td>
                     <td class="default"></td>
                     <td class="description">Namespace of the associated <span class="stream">stream-ids</span>. Required to access the Eventhubs entity per stream.</td>
                 </tr>
 
                 <tr>
-                    <td class="property" id="eventhub-stream-entity">systems.<span class="system">system-name</span>.<br>streams.<span class="stream">stream-id</span>.<br>eventhubs.entitypath</td>
+                    <td class="property" id="eventhub-stream-entity">streams.<span class="stream">stream-id</span>.<br>eventhubs.entitypath</td>
                     <td class="default"></td>
                     <td class="description">Entity of the associated <span class="stream">stream-ids</span>. Required to access the Eventhubs entity per stream.</td>
                 </tr>
 
                 <tr>
-                    <td class="property" id="eventhub-stream-sas-keyname">systems.<span class="system">system-name</span>.<br>streams.<span class="stream">stream-id</span>.<br>eventhubs.sas.keyname</td>
+                    <td class="property" id="eventhub-stream-sas-keyname">sensitive.streams.<span class="stream">stream-id</span>.<br>eventhubs.sas.keyname</td>
                     <td class="default"></td>
                     <td class="description">SAS Keyname of the associated <span class="stream">stream-ids</span>. Required to access the Eventhubs entity per stream.</td>
                 </tr>
 
                 <tr>
-                    <td class="property" id="eventhub-stream-sas-token">systems.<span class="system">system-name</span>.<br>streams.<span class="stream">stream-id</span>.<br>eventhubs.sas.token</td>
+                    <td class="property" id="eventhub-stream-sas-token">sensitive.streams.<span class="stream">stream-id</span>.<br>eventhubs.sas.token</td>
                     <td class="default"></td>
                     <td class="description">SAS Token the associated <span class="stream">stream-ids</span>. Required to access the Eventhubs entity per stream.</td>
+                </tr>
+
+                <tr>
+                    <td class="property" id="eventhub-client-threads">streams.<span class="system">stream-name</span>.<br>eventhubs.numClientThreads</td>
+                    <td class="default">10</td>
+                    <td class="description">Number of threads in thread pool that will be used by the EventHubClient. See <a href="https://docs.microsoft.com/en-us/java/api/com.microsoft.azure.eventhubs._event_hub_client.create">here </a> for more details.</td>
+                </tr>
+
+                <tr>
+                    <td class="property" id="eventhub-prefetch-count">systems.<span class="system">system-name</span>.<br>eventhubs.prefetchCount</td>
+                    <td class="default">999</td>
+                    <td class="description">Number of events that EventHub client should prefetch from the server. See <a href="https://docs.microsoft.com/en-us/java/api/com.microsoft.azure.eventhubs._partition_receiver.setprefetchcount">here </a> for more details.</td>
+                </tr>
+
+                <tr>
+                    <td class="property" id="eventhub-max-event-count">systems.<span class="system">system-name</span>.<br>eventhubs.maxEventCountPerPoll</td>
+                    <td class="default">50</td>
+                    <td class="description">Maximum number of events that EventHub client can return in a receive call. See <a href="https://docs.microsoft.com/en-us/java/api/com.microsoft.azure.eventhubs._partition_receive_handler.getmaxeventcount#com_microsoft_azure_eventhubs__partition_receive_handler_getMaxEventCount__">here </a> for more details.</td>
                 </tr>
 
                 <tr>
@@ -2333,7 +2351,7 @@
                 </tr>
 
                 <tr>
-                    <td class="property" id="eventhub-consumer-group">systems.<span class="system">system-name</span>.<br>streams.<span class="stream">stream-id</span>.<br>eventhubs.consumer.group</td>
+                    <td class="property" id="eventhub-consumer-group">streams.<span class="stream">stream-id</span>.<br>eventhubs.consumer.group</td>
                     <td class="default"><code>$Default</code></td>
                     <td class="description">
                         Consumer only config. Set the consumer group from the upstream Eventhub that the consumer is part of. Defaults to the <code>$Default</code> group that is initially present in all Eventhub entities (unless removed)

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/EventHubClientManagerFactory.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/EventHubClientManagerFactory.java
@@ -26,7 +26,8 @@ public class EventHubClientManagerFactory {
     String entityPath = config.getStreamEntityPath(systemName, streamName);
     String sasKeyName = config.getStreamSasKeyName(systemName, streamName);
     String sasToken = config.getStreamSasToken(systemName, streamName);
+    int numClientThreads = config.getNumClientThreads(systemName);
 
-    return new SamzaEventHubClientManager(eventHubNamespace, entityPath, sasKeyName, sasToken, config.getNumClientThreads(systemName));
+    return new SamzaEventHubClientManager(eventHubNamespace, entityPath, sasKeyName, sasToken, numClientThreads);
   }
 }

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/EventHubClientManagerFactory.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/EventHubClientManagerFactory.java
@@ -27,6 +27,6 @@ public class EventHubClientManagerFactory {
     String sasKeyName = config.getStreamSasKeyName(systemName, streamName);
     String sasToken = config.getStreamSasToken(systemName, streamName);
 
-    return new SamzaEventHubClientManager(eventHubNamespace, entityPath, sasKeyName, sasToken);
+    return new SamzaEventHubClientManager(eventHubNamespace, entityPath, sasKeyName, sasToken, config.getNumClientThreads(systemName));
   }
 }

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/EventHubConfig.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/EventHubConfig.java
@@ -154,7 +154,8 @@ public class EventHubConfig extends MapConfig {
   }
 
   /**
-   * Get the number of client threads
+   * Get the number of client threads, This is used to create the ThreadPool executor that is passed to the
+   * {@link EventHubClient#create}
    * @param systemName Name of the system.
    * @return Num of client threads to use.
    */

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/EventHubConfig.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/EventHubConfig.java
@@ -20,6 +20,7 @@
 package org.apache.samza.system.eventhub;
 
 import com.microsoft.azure.eventhubs.EventHubClient;
+import com.microsoft.azure.eventhubs.PartitionReceiver;
 import org.apache.samza.SamzaException;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.MapConfig;
@@ -48,6 +49,15 @@ public class EventHubConfig extends MapConfig {
 
   public static final String CONFIG_STREAM_CONSUMER_GROUP = "streams.%s.eventhubs.consumer.group";
   public static final String DEFAULT_CONFIG_STREAM_CONSUMER_GROUP = EventHubClient.DEFAULT_CONSUMER_GROUP_NAME;
+
+  public static final String CONFIG_SYSTEM_NUM_CLIENT_THREADS = "streams.%s.eventhubs.numClientThreads";
+  public static final int DEFAULT_CONFIG_SYSTEM_NUM_CLIENT_THREADS = 10;
+
+  public static final String CONFIG_PREFETCH_COUNT = "systems.%s.eventhubs.prefetchCount";
+  public static final int DEFAULT_CONFIG_PREFETCH_COUNT = PartitionReceiver.DEFAULT_PREFETCH_COUNT;
+
+  public static final String CONFIG_MAX_EVENT_COUNT_PER_POLL = "systems.%s.eventhubs.maxEventCountPerPoll";
+  public static final int DEFAULT_CONFIG_MAX_EVENT_COUNT_PER_POLL = 50;
 
   public static final String CONFIG_PRODUCER_PARTITION_METHOD = "systems.%s.eventhubs.partition.method";
   public static final String DEFAULT_CONFIG_PRODUCER_PARTITION_METHOD = EventHubSystemProducer
@@ -141,6 +151,33 @@ public class EventHubConfig extends MapConfig {
   public String getStreamEntityPath(String systemName, String streamName) {
     return validateRequiredConfig(getFromStreamIdOrName(CONFIG_STREAM_ENTITYPATH, streamName),
             "EntityPath", systemName, streamName);
+  }
+
+  /**
+   * Get the number of client threads
+   * @param systemName Name of the system.
+   * @return Num of client threads to use.
+   */
+  public Integer getNumClientThreads(String systemName) {
+    return getInt(String.format(CONFIG_SYSTEM_NUM_CLIENT_THREADS, systemName), DEFAULT_CONFIG_SYSTEM_NUM_CLIENT_THREADS);
+  }
+
+  /**
+   * Get the max event count returned per poll
+   * @param systemName Name of the system
+   * @return Max number of events returned per poll
+   */
+  public Integer getMaxEventCountPerPoll(String systemName) {
+    return getInt(String.format(CONFIG_MAX_EVENT_COUNT_PER_POLL, systemName), DEFAULT_CONFIG_MAX_EVENT_COUNT_PER_POLL);
+  }
+
+  /**
+   * Get the per partition prefetch count for the event hub client
+   * @param systemName Name of the system.
+   * @return Per partition Prefetch count for the event hub client.
+   */
+  public Integer getPrefetchCount(String systemName) {
+    return getInt(String.format(CONFIG_PREFETCH_COUNT, systemName), DEFAULT_CONFIG_PREFETCH_COUNT);
   }
 
   /**

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/admin/EventHubSystemAdmin.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/admin/EventHubSystemAdmin.java
@@ -19,8 +19,8 @@
 
 package org.apache.samza.system.eventhub.admin;
 
-import com.microsoft.azure.eventhubs.EventHubPartitionRuntimeInformation;
 import com.microsoft.azure.eventhubs.EventHubRuntimeInformation;
+import com.microsoft.azure.eventhubs.PartitionRuntimeInformation;
 import org.apache.samza.Partition;
 import org.apache.samza.SamzaException;
 import org.apache.samza.system.SystemAdmin;
@@ -144,10 +144,10 @@ public class EventHubSystemAdmin implements SystemAdmin {
   private Map<Partition, SystemStreamPartitionMetadata> getPartitionMetadata(String streamName, String[] partitionIds) {
     EventHubClientManager eventHubClientManager = getOrCreateStreamEventHubClient(streamName);
     Map<Partition, SystemStreamPartitionMetadata> sspMetadataMap = new HashMap<>();
-    Map<String, CompletableFuture<EventHubPartitionRuntimeInformation>> ehRuntimeInfos = new HashMap<>();
+    Map<String, CompletableFuture<PartitionRuntimeInformation>> ehRuntimeInfos = new HashMap<>();
 
     for (String partition : partitionIds) {
-      CompletableFuture<EventHubPartitionRuntimeInformation> partitionRuntimeInfo = eventHubClientManager
+      CompletableFuture<PartitionRuntimeInformation> partitionRuntimeInfo = eventHubClientManager
               .getEventHubClient()
               .getPartitionRuntimeInformation(partition);
 
@@ -157,7 +157,7 @@ public class EventHubSystemAdmin implements SystemAdmin {
     ehRuntimeInfos.forEach((partitionId, ehPartitionRuntimeInfo) -> {
         try {
           long timeoutMs = eventHubConfig.getRuntimeInfoWaitTimeMS(systemName);
-          EventHubPartitionRuntimeInformation ehPartitionInfo = ehPartitionRuntimeInfo.get(timeoutMs, TimeUnit.MILLISECONDS);
+          PartitionRuntimeInformation ehPartitionInfo = ehPartitionRuntimeInfo.get(timeoutMs, TimeUnit.MILLISECONDS);
 
           // Set offsets
           String startingOffset = EventHubSystemConsumer.START_OF_STREAM;

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
@@ -19,7 +19,6 @@
 
 package org.apache.samza.system.eventhub.consumer;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.microsoft.azure.eventhubs.EventData;
 import com.microsoft.azure.eventhubs.EventHubException;
 import com.microsoft.azure.eventhubs.EventPosition;
@@ -37,9 +36,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -133,7 +130,6 @@ public class EventHubSystemConsumer extends BlockingEnvelopeMap {
   private final ConcurrentHashMap<SystemStreamPartition, String> streamPartitionOffsets = new ConcurrentHashMap<>();
   private final Map<String, Interceptor> interceptors;
   private final Integer prefetchCount;
-  private final ScheduledExecutorService executorService;
   private boolean isStarted = false;
   private final EventHubConfig config;
   private final String systemName;
@@ -159,8 +155,6 @@ public class EventHubSystemConsumer extends BlockingEnvelopeMap {
     }
     prefetchCount = config.getPrefetchCount(systemName);
 
-    ThreadFactoryBuilder threadFactoryBuilder = new ThreadFactoryBuilder().setNameFormat("SamzaHistogram_%d");
-    executorService = Executors.newScheduledThreadPool(1, threadFactoryBuilder.build());
 
 
     // Initiate metrics
@@ -169,7 +163,7 @@ public class EventHubSystemConsumer extends BlockingEnvelopeMap {
     eventByteReadRates = streamIds.stream()
         .collect(Collectors.toMap(Function.identity(), x -> registry.newCounter(x, EVENT_BYTE_READ_RATE)));
     readLatencies = streamIds.stream()
-        .collect(Collectors.toMap(Function.identity(), x -> new SamzaHistogram(registry, x, READ_LATENCY, executorService)));
+        .collect(Collectors.toMap(Function.identity(), x -> new SamzaHistogram(registry, x, READ_LATENCY)));
     readErrors =
         streamIds.stream().collect(Collectors.toMap(Function.identity(), x -> registry.newCounter(x, READ_ERRORS)));
 
@@ -178,7 +172,7 @@ public class EventHubSystemConsumer extends BlockingEnvelopeMap {
       if (aggEventReadRate == null) {
         aggEventReadRate = registry.newCounter(AGGREGATE, EVENT_READ_RATE);
         aggEventByteReadRate = registry.newCounter(AGGREGATE, EVENT_BYTE_READ_RATE);
-        aggReadLatency = new SamzaHistogram(registry, AGGREGATE, READ_LATENCY, executorService);
+        aggReadLatency = new SamzaHistogram(registry, AGGREGATE, READ_LATENCY);
         aggReadErrors = registry.newCounter(AGGREGATE, READ_ERRORS);
       }
     }
@@ -350,7 +344,6 @@ public class EventHubSystemConsumer extends BlockingEnvelopeMap {
       LOG.warn("Failed to close receivers", e);
     }
     streamEventHubManagers.values().forEach(ehClientManager -> ehClientManager.close(DEFAULT_SHUTDOWN_TIMEOUT_MILLIS));
-    executorService.shutdown();
   }
 
   private boolean isErrorTransient(Throwable throwable) {

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
@@ -264,7 +264,8 @@ public class EventHubSystemConsumer extends BlockingEnvelopeMap {
 
         PartitionReceiveHandler handler =
             new PartitionReceiverHandlerImpl(ssp, eventReadRates.get(streamId), eventByteReadRates.get(streamId),
-                readLatencies.get(streamId), readErrors.get(streamId), interceptors.getOrDefault(streamId, null));
+                readLatencies.get(streamId), readErrors.get(streamId), interceptors.getOrDefault(streamId, null),
+                config.getMaxEventCountPerPoll(systemName));
 
         // Timeout for EventHubClient receive
         receiver.setReceiveTimeout(DEFAULT_EVENTHUB_RECEIVER_TIMEOUT);
@@ -376,14 +377,14 @@ public class EventHubSystemConsumer extends BlockingEnvelopeMap {
     SystemStreamPartition ssp;
 
     PartitionReceiverHandlerImpl(SystemStreamPartition ssp, Counter eventReadRate, Counter eventByteReadRate,
-        SamzaHistogram readLatency, Counter readErrors, Interceptor interceptor) {
+        SamzaHistogram readLatency, Counter readErrors, Interceptor interceptor, int maxEventCount) {
       this.ssp = ssp;
       this.eventReadRate = eventReadRate;
       this.eventByteReadRate = eventByteReadRate;
       this.readLatency = readLatency;
       this.errorRate = readErrors;
       this.interceptor = interceptor;
-      this.maxEventCount = config.getMaxEventCountPerPoll(systemName);
+      this.maxEventCount = maxEventCount;
     }
 
     @Override

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/metrics/SamzaHistogram.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/metrics/SamzaHistogram.java
@@ -62,7 +62,7 @@ public class SamzaHistogram implements Runnable {
         .filter(x -> x > 0 && x <= 100)
         .collect(
             Collectors.toMap(Function.identity(), x -> registry.newGauge(group, name + "_" + String.valueOf(0), 0D)));
-    executorService.schedule(this, UPDATE_FREQUENCY_MS, TimeUnit.MILLISECONDS);
+    executorService.scheduleAtFixedRate(this, 0, UPDATE_FREQUENCY_MS, TimeUnit.MILLISECONDS);
   }
 
   public void update(long value) {

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/metrics/SamzaHistogram.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/metrics/SamzaHistogram.java
@@ -1,62 +1,81 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.apache.samza.system.eventhub.metrics;
 
 import com.codahale.metrics.ExponentiallyDecayingReservoir;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Snapshot;
-import org.apache.samza.metrics.Gauge;
-import org.apache.samza.metrics.MetricsRegistry;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.apache.samza.metrics.Gauge;
+import org.apache.samza.metrics.MetricsRegistry;
+import org.apache.samza.system.eventhub.SamzaEventHubClientManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Creates a {@link Histogram} metric using {@link ExponentiallyDecayingReservoir}
  * Keeps a {@link Gauge} for each percentile
  */
-public class SamzaHistogram {
+public class SamzaHistogram implements Runnable {
+  private static final Logger LOG = LoggerFactory.getLogger(SamzaEventHubClientManager.class.getName());
   private static final List<Double> DEFAULT_HISTOGRAM_PERCENTILES = Arrays.asList(50D, 99D);
+  private static final int UPDATE_FREQUENCY_MS = 60000; // 1 minute
   private final Histogram histogram;
   private final List<Double> percentiles;
   private final Map<Double, Gauge<Double>> gauges;
+  private final String name;
 
-  public SamzaHistogram(MetricsRegistry registry, String group, String name) {
-    this(registry, group, name, DEFAULT_HISTOGRAM_PERCENTILES);
+  public SamzaHistogram(MetricsRegistry registry, String group, String name, ScheduledExecutorService executorService) {
+    this(registry, group, name, DEFAULT_HISTOGRAM_PERCENTILES, executorService);
   }
 
-  public SamzaHistogram(MetricsRegistry registry, String group, String name, List<Double> percentiles) {
+  public SamzaHistogram(MetricsRegistry registry, String group, String name, List<Double> percentiles,
+      ScheduledExecutorService executorService) {
+    this.name = name;
     this.histogram = new Histogram(new ExponentiallyDecayingReservoir());
     this.percentiles = percentiles;
     this.gauges = this.percentiles.stream()
-            .filter(x -> x > 0 && x <= 100)
-            .collect(
-                    Collectors.toMap(Function.identity(), x -> registry.newGauge(group, name + "_" + String.valueOf(0), 0D)));
+        .filter(x -> x > 0 && x <= 100)
+        .collect(
+            Collectors.toMap(Function.identity(), x -> registry.newGauge(group, name + "_" + String.valueOf(0), 0D)));
+    executorService.schedule(this, UPDATE_FREQUENCY_MS, TimeUnit.MILLISECONDS);
   }
 
   public void update(long value) {
     histogram.update(value);
-    Snapshot values = histogram.getSnapshot();
-    percentiles.forEach(x -> gauges.get(x).set(values.getValue(x / 100)));
+  }
+
+  @Override
+  public void run() {
+    try {
+      Snapshot values = histogram.getSnapshot();
+      percentiles.forEach(x -> gauges.get(x).set(values.getValue(x / 100)));
+    } catch (Exception e) {
+      LOG.warn("Error while computing the histogram percentiles for {}, Histogram metrics might be stale.", name, e);
+    }
   }
 }

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/metrics/SamzaHistogram.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/metrics/SamzaHistogram.java
@@ -30,9 +30,6 @@ import java.util.stream.Collectors;
 import org.apache.samza.metrics.Gauge;
 import org.apache.samza.metrics.MetricsRegistry;
 import org.apache.samza.metrics.MetricsVisitor;
-import org.apache.samza.system.eventhub.SamzaEventHubClientManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -40,7 +37,6 @@ import org.slf4j.LoggerFactory;
  * Keeps a {@link Gauge} for each percentile
  */
 public class SamzaHistogram {
-  private static final Logger LOG = LoggerFactory.getLogger(SamzaEventHubClientManager.class.getName());
   private static final List<Double> DEFAULT_HISTOGRAM_PERCENTILES = Arrays.asList(50D, 99D);
   private final Histogram histogram;
   private final List<Double> percentiles;

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/producer/AsyncSystemProducer.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/producer/AsyncSystemProducer.java
@@ -117,7 +117,7 @@ public abstract class AsyncSystemProducer implements SystemProducer {
     physicalToStreamIds =
         streamIds.stream().collect(Collectors.toMap(sconfig::getPhysicalName, Function.identity()));
     this.metricsRegistry = metricsRegistry;
-    ThreadFactoryBuilder threadFactoryBuilder = new ThreadFactoryBuilder().setNameFormat("SamzaHistogram_%d");
+    ThreadFactoryBuilder threadFactoryBuilder = new ThreadFactoryBuilder().setNameFormat("Samza Histogram Poll Thread-%d");
     executorService = Executors.newScheduledThreadPool(1, threadFactoryBuilder.build());
   }
 

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/producer/AsyncSystemProducer.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/producer/AsyncSystemProducer.java
@@ -139,7 +139,6 @@ public abstract class AsyncSystemProducer implements SystemProducer {
 
     // Auto update the metrics and possible throwable when futures are complete.
     sendResult.handle((aVoid, throwable) -> {
-        pendingFutures.remove(sendResult);
         long callbackLatencyMs = System.currentTimeMillis() - afterSendTimeMs;
         sendCallbackLatency.get(streamId).update(callbackLatencyMs);
         aggSendCallbackLatency.update(callbackLatencyMs);

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/producer/AsyncSystemProducer.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/producer/AsyncSystemProducer.java
@@ -19,7 +19,6 @@
 
 package org.apache.samza.system.eventhub.producer;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
@@ -28,8 +27,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -102,7 +99,6 @@ public abstract class AsyncSystemProducer implements SystemProducer {
   private final HashMap<String, SamzaHistogram> sendLatency = new HashMap<>();
   private final HashMap<String, SamzaHistogram> sendCallbackLatency = new HashMap<>();
   private final HashMap<String, Counter> sendErrors = new HashMap<>();
-  private final ScheduledExecutorService executorService;
 
   /**
    * Instantiates a new Async system producer.
@@ -117,8 +113,6 @@ public abstract class AsyncSystemProducer implements SystemProducer {
     physicalToStreamIds =
         streamIds.stream().collect(Collectors.toMap(sconfig::getPhysicalName, Function.identity()));
     this.metricsRegistry = metricsRegistry;
-    ThreadFactoryBuilder threadFactoryBuilder = new ThreadFactoryBuilder().setNameFormat("Samza Histogram Poll Thread-%d");
-    executorService = Executors.newScheduledThreadPool(1, threadFactoryBuilder.build());
   }
 
   /**
@@ -160,14 +154,14 @@ public abstract class AsyncSystemProducer implements SystemProducer {
 
   public void start() {
     streamIds.forEach(streamId -> {
-        sendCallbackLatency.put(streamId, new SamzaHistogram(metricsRegistry, streamId, SEND_CALLBACK_LATENCY, executorService));
-        sendLatency.put(streamId, new SamzaHistogram(metricsRegistry, streamId, SEND_LATENCY, executorService));
+        sendCallbackLatency.put(streamId, new SamzaHistogram(metricsRegistry, streamId, SEND_CALLBACK_LATENCY));
+        sendLatency.put(streamId, new SamzaHistogram(metricsRegistry, streamId, SEND_LATENCY));
         sendErrors.put(streamId, metricsRegistry.newCounter(streamId, SEND_ERRORS));
       });
 
     if (aggSendLatency == null) {
-      aggSendLatency = new SamzaHistogram(metricsRegistry, AGGREGATE, SEND_LATENCY, executorService);
-      aggSendCallbackLatency = new SamzaHistogram(metricsRegistry, AGGREGATE, SEND_CALLBACK_LATENCY, executorService);
+      aggSendLatency = new SamzaHistogram(metricsRegistry, AGGREGATE, SEND_LATENCY);
+      aggSendCallbackLatency = new SamzaHistogram(metricsRegistry, AGGREGATE, SEND_CALLBACK_LATENCY);
       aggSendErrors = metricsRegistry.newCounter(AGGREGATE, SEND_ERRORS);
     }
   }

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/producer/EventHubSystemProducer.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/producer/EventHubSystemProducer.java
@@ -21,8 +21,9 @@ package org.apache.samza.system.eventhub.producer;
 
 import com.microsoft.azure.eventhubs.EventData;
 import com.microsoft.azure.eventhubs.EventHubClient;
+import com.microsoft.azure.eventhubs.EventHubException;
 import com.microsoft.azure.eventhubs.PartitionSender;
-import com.microsoft.azure.servicebus.ServiceBusException;
+import com.microsoft.azure.eventhubs.impl.EventDataImpl;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -164,7 +165,7 @@ public class EventHubSystemProducer extends AsyncSystemProducer {
           } catch (InterruptedException | ExecutionException | TimeoutException e) {
             String msg = "Failed to fetch number of Event Hub partitions for partition sender creation";
             throw new SamzaException(msg, e);
-          } catch (ServiceBusException | IllegalArgumentException e) {
+          } catch (EventHubException | IllegalArgumentException e) {
             String msg = "Creation of partition sender failed with exception";
             throw new SamzaException(msg, e);
           }
@@ -282,7 +283,7 @@ public class EventHubSystemProducer extends AsyncSystemProducer {
       eventValue = interceptor.get().intercept(eventValue);
     }
 
-    EventData eventData = new EventData(eventValue);
+    EventData eventData = new EventDataImpl(eventValue);
 
     eventData.getProperties().put(PRODUCE_TIMESTAMP, Long.toString(System.currentTimeMillis()));
 

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/MockEventData.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/MockEventData.java
@@ -21,15 +21,17 @@ package org.apache.samza.system.eventhub;
 
 import com.microsoft.azure.eventhubs.EventData;
 
+import com.microsoft.azure.eventhubs.impl.EventDataImpl;
 import java.nio.charset.Charset;
 import java.util.*;
 
-public class MockEventData extends EventData {
+public class MockEventData implements EventData {
+  EventData eventData;
 
   private EventData.SystemProperties overridedSystemProperties;
 
   private MockEventData(byte[] data, String partitionKey, String offset) {
-    super(data);
+    eventData = new EventDataImpl(data);
     HashMap<String, Object> properties = new HashMap<>();
     properties.put("x-opt-offset", offset);
     properties.put("x-opt-partition-key", partitionKey);
@@ -48,6 +50,21 @@ public class MockEventData extends EventData {
       result.add(eventData);
     }
     return result;
+  }
+
+  @Override
+  public Object getObject() {
+    return eventData.getObject();
+  }
+
+  @Override
+  public byte[] getBytes() {
+    return eventData.getBytes();
+  }
+
+  @Override
+  public Map<String, Object> getProperties() {
+    return eventData.getProperties();
   }
 
   @Override

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/TestMetricsRegistry.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/TestMetricsRegistry.java
@@ -70,7 +70,12 @@ public class TestMetricsRegistry implements MetricsRegistry {
 
   @Override
   public <T> Gauge<T> newGauge(String group, Gauge<T> value) {
-    return null;
+    if (!gauges.containsKey(group)) {
+      gauges.put(group, new ArrayList<>());
+    }
+
+    gauges.get(group).add(value);
+    return value;
   }
 
   @Override

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/consumer/TestEventHubSystemConsumer.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/consumer/TestEventHubSystemConsumer.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
 import static org.apache.samza.system.eventhub.MockEventHubConfigFactory.*;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({EventHubRuntimeInformation.class, EventHubPartitionRuntimeInformation.class,
+@PrepareForTest({EventHubRuntimeInformation.class, PartitionRuntimeInformation.class,
         EventHubClient.class, PartitionReceiver.class, PartitionSender.class})
 public class TestEventHubSystemConsumer {
   private static final String MOCK_ENTITY_1 = "mocktopic1";
@@ -99,8 +99,8 @@ public class TestEventHubSystemConsumer {
     consumer.register(ssp, EventHubSystemConsumer.START_OF_STREAM);
     consumer.start();
 
-    Assert.assertEquals(EventHubSystemConsumer.START_OF_STREAM,
-            eventHubClientWrapperFactory.getPartitionOffset(String.valueOf(partitionId)));
+    Assert.assertEquals(EventPosition.fromOffset(EventHubSystemConsumer.START_OF_STREAM, false).toString(),
+            eventHubClientWrapperFactory.getPartitionOffset(String.valueOf(partitionId)).toString());
   }
 
   @Test

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/producer/ITestEventHubSystemProducer.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/producer/ITestEventHubSystemProducer.java
@@ -21,13 +21,13 @@ package org.apache.samza.system.eventhub.producer;
 
 import com.microsoft.azure.eventhubs.EventData;
 import com.microsoft.azure.eventhubs.EventHubClient;
+import com.microsoft.azure.eventhubs.EventHubException;
+import com.microsoft.azure.eventhubs.EventPosition;
 import com.microsoft.azure.eventhubs.PartitionReceiver;
-import com.microsoft.azure.servicebus.ServiceBusException;
 import org.apache.samza.SamzaException;
 import org.apache.samza.config.Config;
 import org.apache.samza.system.*;
 import org.apache.samza.system.eventhub.*;
-import org.apache.samza.system.eventhub.consumer.EventHubSystemConsumer;
 import org.apache.samza.util.NoOpMetricsRegistry;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -92,7 +92,7 @@ public class ITestEventHubSystemProducer {
   }
 
   @Test
-  public void testReceive() throws ServiceBusException {
+  public void testReceive() throws EventHubException {
     EventHubClientManagerFactory clientFactory = new EventHubClientManagerFactory();
     EventHubClientManager wrapper = clientFactory
             .getEventHubClientManager(SYSTEM_NAME, STREAM_NAME1, new EventHubConfig(createEventHubConfig()));
@@ -100,11 +100,11 @@ public class ITestEventHubSystemProducer {
     EventHubClient client = wrapper.getEventHubClient();
     PartitionReceiver receiver =
             client.createReceiverSync(EventHubClient.DEFAULT_CONSUMER_GROUP_NAME, "0",
-                    EventHubSystemConsumer.START_OF_STREAM, true);
+                    EventPosition.fromStartOfStream());
     receiveMessages(receiver, 300);
   }
 
-  private void receiveMessages(PartitionReceiver receiver, int numMessages) throws ServiceBusException {
+  private void receiveMessages(PartitionReceiver receiver, int numMessages) throws EventHubException {
     int count = 0;
     while (count < numMessages) {
 

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/producer/TestEventHubSystemProducer.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/producer/TestEventHubSystemProducer.java
@@ -20,9 +20,9 @@
 package org.apache.samza.system.eventhub.producer;
 
 import com.microsoft.azure.eventhubs.EventHubClient;
-import com.microsoft.azure.eventhubs.EventHubPartitionRuntimeInformation;
 import com.microsoft.azure.eventhubs.EventHubRuntimeInformation;
 import com.microsoft.azure.eventhubs.PartitionReceiver;
+import com.microsoft.azure.eventhubs.PartitionRuntimeInformation;
 import com.microsoft.azure.eventhubs.PartitionSender;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -49,7 +49,7 @@ import static org.apache.samza.system.eventhub.MockEventHubConfigFactory.*;
 
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({EventHubRuntimeInformation.class, EventHubPartitionRuntimeInformation.class, EventHubClient.class, PartitionReceiver.class, PartitionSender.class})
+@PrepareForTest({EventHubRuntimeInformation.class, PartitionRuntimeInformation.class, EventHubClient.class, PartitionReceiver.class, PartitionSender.class})
 public class TestEventHubSystemProducer {
 
   private static final String SOURCE = "TestEventHubSystemProducer";

--- a/samza-tools/src/main/java/org/apache/samza/tools/EventHubConsoleConsumer.java
+++ b/samza-tools/src/main/java/org/apache/samza/tools/EventHubConsoleConsumer.java
@@ -1,37 +1,40 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.apache.samza.tools;
 
+import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
 import com.microsoft.azure.eventhubs.EventData;
 import com.microsoft.azure.eventhubs.EventHubClient;
+import com.microsoft.azure.eventhubs.EventHubException;
 import com.microsoft.azure.eventhubs.EventHubRuntimeInformation;
+import com.microsoft.azure.eventhubs.EventPosition;
 import com.microsoft.azure.eventhubs.PartitionReceiver;
-import com.microsoft.azure.servicebus.ConnectionStringBuilder;
-import com.microsoft.azure.servicebus.ServiceBusException;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import org.apache.commons.cli.BasicParser;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
+
 
 /**
  * Tool to read events from Microsoft Azure event hubs.
@@ -59,17 +62,17 @@ public class EventHubConsoleConsumer {
   private static final String OPT_DESC_TOKEN = "Token corresponding to the key.";
 
   public static void main(String[] args)
-      throws ServiceBusException, IOException, ExecutionException, InterruptedException {
+      throws EventHubException, IOException, ExecutionException, InterruptedException {
     Options options = new Options();
     options.addOption(
         CommandLineHelper.createOption(OPT_SHORT_EVENTHUB_NAME, OPT_LONG_EVENTHUB_NAME, OPT_ARG_EVENTHUB_NAME, true,
-        OPT_DESC_EVENTHUB_NAME));
+            OPT_DESC_EVENTHUB_NAME));
 
-    options.addOption(
-        CommandLineHelper.createOption(OPT_SHORT_NAMESPACE, OPT_LONG_NAMESPACE, OPT_ARG_NAMESPACE, true, OPT_DESC_NAMESPACE));
+    options.addOption(CommandLineHelper.createOption(OPT_SHORT_NAMESPACE, OPT_LONG_NAMESPACE, OPT_ARG_NAMESPACE, true,
+        OPT_DESC_NAMESPACE));
 
-    options.addOption(
-        CommandLineHelper.createOption(OPT_SHORT_KEY_NAME, OPT_LONG_KEY_NAME, OPT_ARG_KEY_NAME, true, OPT_DESC_KEY_NAME));
+    options.addOption(CommandLineHelper.createOption(OPT_SHORT_KEY_NAME, OPT_LONG_KEY_NAME, OPT_ARG_KEY_NAME, true,
+        OPT_DESC_KEY_NAME));
 
     options.addOption(
         CommandLineHelper.createOption(OPT_SHORT_TOKEN, OPT_LONG_TOKEN, OPT_ARG_TOKEN, true, OPT_DESC_TOKEN));
@@ -93,17 +96,20 @@ public class EventHubConsoleConsumer {
   }
 
   private static void consumeEvents(String ehName, String namespace, String keyName, String token)
-      throws ServiceBusException, IOException, ExecutionException, InterruptedException {
-    ConnectionStringBuilder connStr = new ConnectionStringBuilder(namespace, ehName, keyName, token);
+      throws EventHubException, IOException, ExecutionException, InterruptedException {
+    ConnectionStringBuilder connStr = new ConnectionStringBuilder().setNamespaceName(namespace)
+        .setEventHubName(ehName)
+        .setSasKeyName(keyName)
+        .setSasKey(token);
 
-    EventHubClient client = EventHubClient.createFromConnectionStringSync(connStr.toString());
+    EventHubClient client = EventHubClient.createSync(connStr.toString(), Executors.newFixedThreadPool(10));
 
     EventHubRuntimeInformation runTimeInfo = client.getRuntimeInformation().get();
     int numPartitions = runTimeInfo.getPartitionCount();
     for (int partition = 0; partition < numPartitions; partition++) {
       PartitionReceiver receiver =
           client.createReceiverSync(EventHubClient.DEFAULT_CONSUMER_GROUP_NAME, String.valueOf(partition),
-              PartitionReceiver.START_OF_STREAM);
+              EventPosition.fromStartOfStream());
       receiver.receive(10).handle((records, throwable) -> handleComplete(receiver, records, throwable));
     }
   }


### PR DESCRIPTION
* Upgrade to the latest event hub version 1.0.1
* Adding configs for prefetchCount and maxEventPerPoll
* Fix the high cpu usage issue in SamzaHistogram
* Fixing a race condition in event hub system producer where the future was getting removed while it was being checked for completion resulting in NPE.