### PR TITLE
SAMZA-1643: StreamPartitionCountMonitor should only restart/shut down the job if partition count increases

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/coordinator/StreamPartitionCountMonitor.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/StreamPartitionCountMonitor.java
@@ -184,11 +184,16 @@ public class StreamPartitionCountMonitor {
           int prevPartitionCount = metadata.getSystemStreamPartitionMetadata().size();
 
           Gauge gauge = gauges.get(systemStream);
-          gauge.set(currentPartitionCount - prevPartitionCount);
+          gauge.set(currentPartitionCount);
           if (currentPartitionCount != prevPartitionCount) {
             log.warn(String.format("Change of partition count detected in stream %s. old partition count: %d, current partition count: %d",
                 systemStream.toString(), prevPartitionCount, currentPartitionCount));
-            streamsChanged.add(systemStream);
+            if (currentPartitionCount  > prevPartitionCount) {
+              log.error(String.format("Shutting down (stateful) or restarting (stateless) the job since current " +
+                      "partition count %d is greater than the old partition count %d for stream %s.",
+                  currentPartitionCount, prevPartitionCount, systemStream.toString()));
+              streamsChanged.add(systemStream);
+            }
           }
         } catch (Exception e) {
           log.error(String.format("Error comparing partition count differences for stream: %s", metadataEntry.getKey().toString()));

--- a/samza-core/src/test/scala/org/apache/samza/coordinator/TestStreamPartitionCountMonitor.scala
+++ b/samza-core/src/test/scala/org/apache/samza/coordinator/TestStreamPartitionCountMonitor.scala
@@ -83,13 +83,13 @@ class TestStreamPartitionCountMonitor extends AssertionsForJUnit with MockitoSug
     partitionCountMonitor.updatePartitionCountMetric()
 
     assertNotNull(partitionCountMonitor.getGauges().get(inputSystemStream))
-    assertEquals(1, partitionCountMonitor.getGauges().get(inputSystemStream).getValue)
+    assertEquals(3, partitionCountMonitor.getGauges().get(inputSystemStream).getValue)
 
     assertNotNull(metrics.getGroup("job-coordinator"))
 
     val metricGroup = metrics.getGroup("job-coordinator")
     assertTrue(metricGroup.get("test-system-test-stream-partitionCount").isInstanceOf[Gauge[Int]])
-    assertEquals(1, metricGroup.get("test-system-test-stream-partitionCount").asInstanceOf[Gauge[Int]].getValue)
+    assertEquals(3, metricGroup.get("test-system-test-stream-partitionCount").asInstanceOf[Gauge[Int]].getValue)
 
     verify(mockCallback, times(1)).onSystemStreamPartitionChange(any())
 
@@ -148,13 +148,13 @@ class TestStreamPartitionCountMonitor extends AssertionsForJUnit with MockitoSug
     partitionCountMonitor.updatePartitionCountMetric()
 
     assertNotNull(partitionCountMonitor.getGauges().get(inputSystemStream))
-    assertEquals(1, partitionCountMonitor.getGauges().get(inputSystemStream).getValue)
+    assertEquals(3, partitionCountMonitor.getGauges().get(inputSystemStream).getValue)
 
     assertNotNull(metrics.getGroup("job-coordinator"))
 
     val metricGroup = metrics.getGroup("job-coordinator")
     assertTrue(metricGroup.get("test-system-test-stream-partitionCount").isInstanceOf[Gauge[Int]])
-    assertEquals(1, metricGroup.get("test-system-test-stream-partitionCount").asInstanceOf[Gauge[Int]].getValue)
+    assertEquals(3, metricGroup.get("test-system-test-stream-partitionCount").asInstanceOf[Gauge[Int]].getValue)
 
     // Make sure as long as one of the input stream topic partition change is detected, the callback is invoked
     verify(mockCallback, times(1)).onSystemStreamPartitionChange(any())


### PR DESCRIPTION
As an aside, also update the gauge to report current number of partitions instead of the change, since that's what its name indicates.