### PR TITLE
SAMZA-1656: EventHubSystemAdmin does not fetch metadata for valid streams.

### DIFF
--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/admin/EventHubSystemAdmin.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/admin/EventHubSystemAdmin.java
@@ -21,6 +21,7 @@ package org.apache.samza.system.eventhub.admin;
 
 import com.microsoft.azure.eventhubs.EventHubRuntimeInformation;
 import com.microsoft.azure.eventhubs.PartitionRuntimeInformation;
+import java.util.Arrays;
 import org.apache.samza.Partition;
 import org.apache.samza.SamzaException;
 import org.apache.samza.system.SystemAdmin;
@@ -89,7 +90,7 @@ public class EventHubSystemAdmin implements SystemAdmin {
 
           long timeoutMs = eventHubConfig.getRuntimeInfoWaitTimeMS(systemName);
           EventHubRuntimeInformation ehInfo = runtimeInfo.get(timeoutMs, TimeUnit.MILLISECONDS);
-          LOG.debug(String.format("Adding partition ids for Stream=%s", streamName));
+          LOG.info(String.format("Adding partition ids=%s for stream=%s", Arrays.toString(ehInfo.getPartitionIds()), streamName));
           streamPartitions.put(streamName, ehInfo.getPartitionIds());
         }
         String[] partitionIds = streamPartitions.get(streamName);


### PR DESCRIPTION
Currently successive invocation of EventHubSystemAdmin.getSystemStreamMetadata with the same stream collection returns empty results.

This is an implementation bug, where the streams requested as a part of prior invocations of EventHubSystemAdmin.getSystemStreamMetadata are ignored(due to stale caching). 

This bug causes the JobModel generation phase to fail and kills the StreamProcessor. 