### PR TITLE
SAMZA-1681: Samza-sql - Add support for handling older record schema versions in AvroRelConverter

### DIFF
--- a/samza-sql/src/test/java/org/apache/samza/sql/TestSamzaSqlRelMessageSerde.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/TestSamzaSqlRelMessageSerde.java
@@ -81,7 +81,7 @@ public class TestSamzaSqlRelMessageSerde {
 
     for (Schema.Field field : Profile.SCHEMA$.getFields()) {
       // equals() on GenericRecord does the nested record equality check as well.
-      Assert.assertEquals(recordPostConversion.get(field.name()), messageRecordPair.getValue().get(field.name()));
+      Assert.assertEquals(messageRecordPair.getValue().get(field.name()), recordPostConversion.get(field.name()));
     }
   }
 


### PR DESCRIPTION
In addition to handling older record schema versions in AvroRelConverter, this change also handles Avro enum and fixed types and also handles the proper conversion of samza message key to rel message.