### PR TITLE
SAMZA-1685 : Need to resolve redirects for virtualenv download location for running integration tests

### DIFF
--- a/bin/integration-tests.sh
+++ b/bin/integration-tests.sh
@@ -53,7 +53,8 @@ cd $ABS_TEST_DIR
 # setup virtualenv locally if it's not already there
 VIRTUAL_ENV=virtualenv-15.0.1
 if [[ ! -d "${ABS_TEST_DIR}/${VIRTUAL_ENV}" ]] ; then
-  curl -O https://pypi.python.org/packages/source/v/virtualenv/$VIRTUAL_ENV.tar.gz
+  # using --location to follow any redirects
+  curl -O --location https://pypi.python.org/packages/source/v/virtualenv/$VIRTUAL_ENV.tar.gz
   tar xvfz $VIRTUAL_ENV.tar.gz
 fi
 


### PR DESCRIPTION
Testing Done: ran bin/integration-tests.sh locally from mac/linux which did not run the integration tests before