### PR TITLE
SAMZA-1261: Fix TestProcessJob flaky test

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/job/local/ProcessJob.scala
+++ b/samza-core/src/main/scala/org/apache/samza/job/local/ProcessJob.scala
@@ -103,8 +103,14 @@ class ProcessJob(commandBuilder: CommandBuilder, val jobModelManager: JobModelMa
     require(timeoutMs >= 0, "Timeout values must be non-negative.")
 
     timeoutMs match {
-      case 0 => while (getStatus != status) lock.wait(0)
+      case 0 => {
+        info("Waiting for application status %s indefinitely".format(status))
+
+        while (getStatus != status) lock.wait(0)
+      }
       case _ => {
+        info("Waiting for application status %s for %d ms".format(status, timeoutMs))
+
         val startTimeMs = System.currentTimeMillis
         var remainingTimeoutMs = timeoutMs
 

--- a/samza-core/src/test/scala/org/apache/samza/job/local/TestProcessJob.scala
+++ b/samza-core/src/test/scala/org/apache/samza/job/local/TestProcessJob.scala
@@ -20,7 +20,7 @@
 package org.apache.samza.job.local
 
 import org.apache.samza.coordinator.JobModelManager
-import org.apache.samza.job.ApplicationStatus.{SuccessfulFinish, UnsuccessfulFinish}
+import org.apache.samza.job.ApplicationStatus.{Running, SuccessfulFinish, UnsuccessfulFinish}
 import org.apache.samza.job.CommandBuilder
 import org.junit.Assert._
 import org.junit.Test
@@ -77,10 +77,10 @@ class TestProcessJob {
   def testProcessJobWaitForFinishShouldTimeOut: Unit = {
     val processJob = createProcessJob(OneSecondCommand)
 
-    val status = processJob.waitForFinish(10)
+    // Wait for a shorter duration than that necessary for the specified command to complete.
+    val status = processJob.submit.waitForFinish(10)
 
-    assertNotEquals(SuccessfulFinish, status)
-    assertNotEquals(UnsuccessfulFinish, status)
+    assertEquals(Running, status)
   }
 
   @Test
@@ -117,10 +117,10 @@ class TestProcessJob {
   def testProcessJobWaitForStatusShouldTimeOut: Unit = {
     val processJob = createProcessJob(OneSecondCommand)
 
-    val status = processJob.submit.waitForFinish(10)
+    // Wait for a shorter duration than that necessary for the specified command to complete.
+    val status = processJob.submit.waitForStatus(SuccessfulFinish, 10)
 
-    assertNotEquals(SuccessfulFinish, status)
-    assertNotEquals(UnsuccessfulFinish, status)
+    assertEquals(Running, status)
   }
 
   @Test(expected = classOf[IllegalArgumentException])


### PR DESCRIPTION
- Fix flaky test, `TestProcessJob` `testProcessJobKillShouldWork`, which was failing intermittently due to a race condition. In particular, the thread running the test could assert `jobModelManager.stopped` before another thread, enclosed within `ProcessJob.submit`, could actually invoke `jobModelManager.stop`.

+ Refactor `ProcessJob` to improve its overall robustness
  + Handle corner cases, e.g.
     + Fail gracefully if starting process within `ProcessJob.submit` throws
     + Ignore attempts to kill a job before it is submitted
     + Ensure job status is always set appropriately
  + Remove unnecessary stdout/stderr piping code
  + Employ `wait`/`notify` instead of `Thread.sleep`
  + Eliminate all artificial wait method invocations intended to influence inter-thread execution order in unit tests
  + Add more unit tests
