### PR TITLE
SAMZA-1687: Prioritize preferred host requests over ANY-HOST requests

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ResourceRequestState.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ResourceRequestState.java
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * this state is shared across both the Allocator Thread, and the Callback handler thread.
  *
  */
-public class ResourceRequestState {
+public class  ResourceRequestState {
   private static final Logger log = LoggerFactory.getLogger(ResourceRequestState.class);
   public static final String ANY_HOST = "ANY_HOST";
 
@@ -190,8 +190,12 @@ public class ResourceRequestState {
     synchronized (lock) {
       requestsQueue.remove(request);
       // A reference for the resource could either be held in the preferred host buffer or in the ANY_HOST buffer.
-      allocatedResources.get(assignedHost).remove(samzaResource);
-      allocatedResources.get(ANY_HOST).remove(samzaResource);
+      if (allocatedResources.get(assignedHost) != null) {
+        allocatedResources.get(assignedHost).remove(samzaResource);
+      }
+      if (allocatedResources.get(ANY_HOST) != null) {
+        allocatedResources.get(ANY_HOST).remove(samzaResource);
+      }
       if (hostAffinityEnabled) {
         // assignedHost may not always be the preferred host.
         // Hence, we should safely decrement the counter for the preferredHost


### PR DESCRIPTION
Working on a documentation that describes this better, but a TL;DR summary is that we should prioritize preferred-host requests over ANY_HOST requests.

Yarn enforces these two checks:
1. ANY_HOST requests should always be made with relax-locality = true
2. A request with relax-locality = false should not be in the same priority as another with relax-locality = true

Since the Samza AM makes preferred-host requests with relax-locality = false, it follows that ANY_HOST requests should specify a different priority-level. We can safely set priority of preferred-host requests to be higher than any-host requests since data-locality is critical.