### PR TITLE
SAMZA-1688 use per partition eventhubs client

### DIFF
--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
@@ -361,6 +361,7 @@ public class EventHubSystemConsumer extends BlockingEnvelopeMap {
       LOG.warn("Failed to close receivers", e);
     }
     perPartitionEventHubManagers.values()
+        .parallelStream()
         .forEach(ehClientManager -> ehClientManager.close(DEFAULT_SHUTDOWN_TIMEOUT_MILLIS));
     perPartitionEventHubManagers.clear();
     perStreamEventHubManagers.clear();

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/producer/EventHubSystemProducer.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/producer/EventHubSystemProducer.java
@@ -360,7 +360,9 @@ public class EventHubSystemProducer extends AsyncSystemProducer {
           LOG.error("Closing the partition sender failed ", e);
         }
       });
-    perStreamEventHubClientManagers.values().forEach(ehClient -> ehClient.close(DEFAULT_SHUTDOWN_TIMEOUT_MILLIS));
+    perStreamEventHubClientManagers.values()
+        .parallelStream()
+        .forEach(ehClient -> ehClient.close(DEFAULT_SHUTDOWN_TIMEOUT_MILLIS));
     perStreamEventHubClientManagers.clear();
     if (config.getPerPartitionConnection(systemName)) {
       perPartitionEventHubClients.values()

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/consumer/TestEventHubSystemConsumer.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/consumer/TestEventHubSystemConsumer.java
@@ -203,7 +203,16 @@ public class TestEventHubSystemConsumer {
   }
 
   @Test
-  public void testMultiPartitionConsumptionHappyPath() throws Exception {
+  public void testMultiPartitionConsumptionPerPartitionConnection() throws Exception {
+    testMultiPartitionConsumptionHappyPath(true);
+  }
+
+  @Test
+  public void testMultiPartitionConsumptionShareConnection() throws Exception {
+    testMultiPartitionConsumptionHappyPath(false);
+  }
+
+  private void testMultiPartitionConsumptionHappyPath(boolean perPartitionConnection) throws Exception {
     String systemName = "eventhubs";
     String streamName = "testStream";
     int numEvents = 10; // needs to be less than BLOCKING_QUEUE_SIZE
@@ -229,6 +238,8 @@ public class TestEventHubSystemConsumer {
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_NAMESPACE, streamName), EVENTHUB_NAMESPACE);
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_SAS_KEY_NAME, streamName), EVENTHUB_KEY_NAME);
     configMap.put(String.format(EventHubConfig.CONFIG_STREAM_SAS_TOKEN, streamName), EVENTHUB_KEY);
+    configMap.put(String.format(EventHubConfig.CONFIG_PER_PARTITION_CONNECTION, systemName),
+        String.valueOf(perPartitionConnection));
     MapConfig config = new MapConfig(configMap);
 
     MockEventHubClientManagerFactory eventHubClientWrapperFactory = new MockEventHubClientManagerFactory(eventData);
@@ -257,6 +268,14 @@ public class TestEventHubSystemConsumer {
 
     Assert.assertEquals(counters.get(EventHubSystemConsumer.EVENT_READ_RATE).getCount(), numEvents * 2);
     Assert.assertEquals(counters.get(EventHubSystemConsumer.READ_ERRORS).getCount(), 0);
+    if (perPartitionConnection) {
+      Assert.assertNotEquals("perPartitionConnection=true; SSPs should not share the same client",
+          consumer.perPartitionEventHubManagers.get(ssp1), consumer.perPartitionEventHubManagers.get(ssp2));
+    } else {
+
+      Assert.assertEquals("perPartitionConnection=false; SSPs should share the same client",
+          consumer.perPartitionEventHubManagers.get(ssp1), consumer.perPartitionEventHubManagers.get(ssp2));
+    }
   }
 
   @Test


### PR DESCRIPTION
Use per partition eventhubs client to improve throughput. As each eventhub client maintains only one single TCP connection.
Also reduce the time spent on getPartitionRuntimeInfo on starting up, by making the calls run in parallels in system admin and also completely removing it from system consumer.

Benchmark:
See 8x improvement on consumption throughput from ~3Mb/s (or 1.5k QPS) to ~21Mb/s (or 10.5k QPS). Memory footprint doesn't seem to get affected. CPU usage also increases by 8x. Essentially, with per partition client, we are able to saturate the CPU usages. The benchmark I did was on a machine with 8 cores. If the machine has say 16 CPU cores, I expect the the throughput to improve by around 16x. 