### PR TITLE
SAMZA-1691: Support get iterable from KeyValueStore

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/storage/kv/KeyValueIterable.java
+++ b/samza-api/src/main/java/org/apache/samza/storage/kv/KeyValueIterable.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.storage.kv;
+
+public interface KeyValueIterable<K, V> extends Iterable<Entry<K, V>> {
+  KeyValueIterator<K, V> iterator();
+}

--- a/samza-api/src/main/java/org/apache/samza/storage/kv/KeyValueStore.java
+++ b/samza-api/src/main/java/org/apache/samza/storage/kv/KeyValueStore.java
@@ -112,6 +112,8 @@ public interface KeyValueStore<K, V> {
 
   /**
    * Returns an iterable for a sorted range of entries specified by [{@code from}, {@code to}).
+   * Note that we snapshot the iterator when the iterable is created from this function, and
+   * the iteration results is guaranteed to reflect the snapshot if only one iterator is in use at a time.
    *
    * @param from the key specifying the low endpoint (inclusive) of the keys in the returned range.
    * @param to the key specifying the high endpoint (exclusive) of the keys in the returned range.

--- a/samza-api/src/main/java/org/apache/samza/storage/kv/KeyValueStore.java
+++ b/samza-api/src/main/java/org/apache/samza/storage/kv/KeyValueStore.java
@@ -111,6 +111,18 @@ public interface KeyValueStore<K, V> {
   KeyValueIterator<K, V> range(K from, K to);
 
   /**
+   * Returns an iterable for a sorted range of entries specified by [{@code from}, {@code to}).
+   *
+   * @param from the key specifying the low endpoint (inclusive) of the keys in the returned range.
+   * @param to the key specifying the high endpoint (exclusive) of the keys in the returned range.
+   * @return an iterable for the specified key range.
+   * @throws NullPointerException if null is used for {@code from} or {@code to}.
+   */
+  default KeyValueIterable<K, V> iterate(K from, K to) {
+    return () -> range(from, to);
+  }
+
+  /**
    * Returns an iterator for all entries in this key-value store.
    *
    * <p><b>API Note:</b> The returned iterator MUST be closed after use.</p>

--- a/samza-core/src/main/java/org/apache/samza/operators/util/InternalInMemoryStore.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/util/InternalInMemoryStore.java
@@ -20,6 +20,7 @@
 package org.apache.samza.operators.util;
 
 import org.apache.samza.storage.kv.Entry;
+import org.apache.samza.storage.kv.KeyValueIterable;
 import org.apache.samza.storage.kv.KeyValueIterator;
 import org.apache.samza.storage.kv.KeyValueStore;
 
@@ -91,6 +92,11 @@ public class InternalInMemoryStore<K, V> implements KeyValueStore<K, V> {
   @Override
   public KeyValueIterator<K, V> range(K from, K to) {
     throw new RuntimeException("not implemented.");
+  }
+
+  @Override
+  public KeyValueIterable<K, V> iterate(K from, K to) {
+    throw new UnsupportedOperationException("iterate() is not supported in " + InternalInMemoryStore.class.getName());
   }
 
   @Override

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/store/TestInMemoryStore.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/store/TestInMemoryStore.java
@@ -21,6 +21,7 @@ package org.apache.samza.operators.impl.store;
 import com.google.common.primitives.UnsignedBytes;
 import org.apache.samza.serializers.Serde;
 import org.apache.samza.storage.kv.Entry;
+import org.apache.samza.storage.kv.KeyValueIterable;
 import org.apache.samza.storage.kv.KeyValueIterator;
 import org.apache.samza.storage.kv.KeyValueStore;
 
@@ -96,6 +97,17 @@ public class TestInMemoryStore<K, V> implements KeyValueStore<K, V> {
   public KeyValueIterator<K, V> range(K from, K to) {
     ConcurrentNavigableMap<byte[], byte[]> values = map.subMap(keySerde.toBytes(from), keySerde.toBytes(to));
     return new InMemoryIterator(values.entrySet().iterator(), keySerde, valSerde);
+  }
+
+  @Override
+  public KeyValueIterable<K, V> iterate(K from, K to) {
+    final ConcurrentNavigableMap<byte[], byte[]> values = map.subMap(keySerde.toBytes(from), keySerde.toBytes(to));
+    return new KeyValueIterable<K, V>() {
+      @Override
+      public KeyValueIterator<K, V> iterator() {
+        return new InMemoryIterator<>(values.entrySet().iterator(), keySerde, valSerde);
+      }
+    };
   }
 
   @Override

--- a/samza-kv-inmemory/src/main/scala/org/apache/samza/storage/kv/inmemory/InMemoryKeyValueStore.scala
+++ b/samza-kv-inmemory/src/main/scala/org/apache/samza/storage/kv/inmemory/InMemoryKeyValueStore.scala
@@ -20,7 +20,7 @@ package org.apache.samza.storage.kv.inmemory
 
 import com.google.common.primitives.UnsignedBytes
 import org.apache.samza.util.Logging
-import org.apache.samza.storage.kv.{KeyValueStoreMetrics, KeyValueIterator, Entry, KeyValueStore}
+import org.apache.samza.storage.kv._
 import java.util
 
 /**
@@ -111,5 +111,15 @@ class InMemoryKeyValueStore(val metrics: KeyValueStoreMetrics = new KeyValueStor
       metrics.bytesRead.inc(found.size)
     }
     found
+  }
+
+  override def iterate(from: Array[Byte], to: Array[Byte]): KeyValueIterable[Array[Byte], Array[Byte]] = {
+    // snapshot the iterable
+    val entries = underlying.subMap(from, to).entrySet()
+    new KeyValueIterable[Array[Byte], Array[Byte]] {
+      override def iterator(): KeyValueIterator[Array[Byte], Array[Byte]] = {
+        new InMemoryIterator(entries.iterator())
+      }
+    }
   }
 }

--- a/samza-kv-inmemory/src/test/java/org/apache/samza/storage/kv/inmemory/TestInMemoryKeyValueStore.java
+++ b/samza-kv-inmemory/src/test/java/org/apache/samza/storage/kv/inmemory/TestInMemoryKeyValueStore.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.storage.kv.inmemory;
+
+import com.google.common.collect.Iterators;
+import com.google.common.primitives.Ints;
+import org.apache.samza.metrics.MetricsRegistryMap;
+import org.apache.samza.storage.kv.Entry;
+import org.apache.samza.storage.kv.KeyValueIterable;
+import org.apache.samza.storage.kv.KeyValueStoreMetrics;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestInMemoryKeyValueStore {
+  @Test
+  public void testIterate() throws Exception {
+    InMemoryKeyValueStore store = new InMemoryKeyValueStore(
+        new KeyValueStoreMetrics("testInMemory", new MetricsRegistryMap()));
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    String prefix = "prefix";
+    for(int i = 0; i < 100; i++) {
+      store.put(genKey(outputStream, prefix, i), genValue());
+    }
+
+    byte[] firstKey = genKey(outputStream, prefix, 0);
+    byte[] lastKey = genKey(outputStream, prefix, 100);
+    KeyValueIterable<byte[], byte[]> iterable = store.iterate(firstKey, lastKey);
+    // Make sure the cached Iterable won't change when new elements are added
+    store.put(genKey(outputStream, prefix, 200), genValue());
+    assertTrue(Iterators.size(iterable.iterator()) == 100);
+
+    List<Integer> keys = new ArrayList<>();
+    for (Entry<byte[], byte[]> entry : iterable) {
+      int key = Ints.fromByteArray(Arrays.copyOfRange(entry.getKey(), prefix.getBytes().length, entry.getKey().length));
+      keys.add(key);
+    }
+    assertEquals(keys, IntStream.rangeClosed(0, 99).boxed().collect(Collectors.toList()));
+
+    outputStream.close();
+    store.close();
+  }
+
+  private byte[] genKey(ByteArrayOutputStream outputStream, String prefix, int i) throws Exception {
+    outputStream.reset();
+    outputStream.write(prefix.getBytes());
+    outputStream.write(Ints.toByteArray(i));
+    return outputStream.toByteArray();
+  }
+
+  private byte[] genValue() {
+    int randomVal = ThreadLocalRandom.current().nextInt(0, 100000);
+    return Ints.toByteArray(randomVal);
+  }
+}

--- a/samza-kv-rocksdb/src/test/java/org/apache/samza/storage/kv/TestRocksDbKeyValueStoreJava.java
+++ b/samza-kv-rocksdb/src/test/java/org/apache/samza/storage/kv/TestRocksDbKeyValueStoreJava.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.storage.kv;
+
+import com.google.common.collect.Iterators;
+import com.google.common.primitives.Ints;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.MapConfig;
+import org.apache.samza.metrics.MetricsRegistryMap;
+import org.junit.Test;
+import org.rocksdb.FlushOptions;
+import org.rocksdb.Options;
+import org.rocksdb.WriteOptions;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestRocksDbKeyValueStoreJava {
+  @Test
+  public void testIterate() throws Exception {
+    Config config = new MapConfig();
+    Options options = new Options();
+    options.setCreateIfMissing(true);
+
+    File dbDir = new File(System.getProperty("java.io.tmpdir"));
+    RocksDbKeyValueStore store = new RocksDbKeyValueStore(dbDir, options, config, false, "dbStore",
+        new WriteOptions(), new FlushOptions(), new KeyValueStoreMetrics("dbStore", new MetricsRegistryMap()));
+
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    String prefix = "prefix";
+    for(int i = 0; i < 100; i++) {
+      store.put(genKey(outputStream, prefix, i), genValue());
+    }
+
+    byte[] firstKey = genKey(outputStream, prefix, 0);
+    byte[] lastKey = genKey(outputStream, prefix, 1000);
+    KeyValueIterable<byte[], byte[]> iterable = store.iterate(firstKey, lastKey);
+    // Make sure the cached Iterable won't change when new elements are added
+    store.put(genKey(outputStream, prefix, 200), genValue());
+    assertTrue(Iterators.size(iterable.iterator()) == 100);
+
+    List<Integer> keys = new ArrayList<>();
+    for (Entry<byte[], byte[]> entry : iterable) {
+      int key = Ints.fromByteArray(Arrays.copyOfRange(entry.getKey(), prefix.getBytes().length, entry.getKey().length));
+      keys.add(key);
+    }
+    assertEquals(keys, IntStream.rangeClosed(0, 99).boxed().collect(Collectors.toList()));
+
+    outputStream.close();
+    store.close();
+  }
+
+  private byte[] genKey(ByteArrayOutputStream outputStream, String prefix, int i) throws Exception {
+    outputStream.reset();
+    outputStream.write(prefix.getBytes());
+    outputStream.write(Ints.toByteArray(i));
+    return outputStream.toByteArray();
+  }
+
+  private byte[] genValue() {
+    int randomVal = ThreadLocalRandom.current().nextInt(0, 100000);
+    return Ints.toByteArray(randomVal);
+  }
+}

--- a/samza-kv-rocksdb/src/test/java/org/apache/samza/storage/kv/TestRocksDbKeyValueStoreJava.java
+++ b/samza-kv-rocksdb/src/test/java/org/apache/samza/storage/kv/TestRocksDbKeyValueStoreJava.java
@@ -48,7 +48,7 @@ public class TestRocksDbKeyValueStoreJava {
     Options options = new Options();
     options.setCreateIfMissing(true);
 
-    File dbDir = new File(System.getProperty("java.io.tmpdir"));
+    File dbDir = new File(System.getProperty("java.io.tmpdir") + "/dbStore" + System.currentTimeMillis());
     RocksDbKeyValueStore store = new RocksDbKeyValueStore(dbDir, options, config, false, "dbStore",
         new WriteOptions(), new FlushOptions(), new KeyValueStoreMetrics("dbStore", new MetricsRegistryMap()));
 

--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/AccessLoggedStore.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/AccessLoggedStore.scala
@@ -41,6 +41,7 @@ class AccessLoggedStore[K, V](
     val WRITE = 2
     val DELETE = 3
     val RANGE = 4
+    val ITERATE = 5
   }
 
   val streamName = storageConfig.getAccessLogStream(changelogSystemStreamPartition.getSystemStream.getStream)
@@ -89,6 +90,13 @@ class AccessLoggedStore[K, V](
 
   def all(): KeyValueIterator[K, V] = {
     store.all()
+  }
+
+  def iterate(from: K, to: K): KeyValueIterable[K, V] = {
+    val list : util.ArrayList[K] = new util.ArrayList[K]()
+    list.add(from)
+    list.add(to)
+    logAccess(DBOperation.ITERATE, serializeKeys(list), store.iterate(from, to))
   }
 
   def close(): Unit = {
@@ -151,5 +159,4 @@ class AccessLoggedStore[K, V](
     val bytes = keySerde.toBytes(key)
     bytes
   }
-
 }

--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/CachedStore.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/CachedStore.scala
@@ -286,6 +286,10 @@ class CachedStore[K, V](
   }
 
   def hasArrayKeys = containsArrayKeys
+
+  override def iterate(from: K, to: K): KeyValueIterable[K, V] = {
+    store.iterate(from, to)
+  }
 }
 
 private case class CacheEntry[K, V](var value: V, var dirty: mutable.DoubleLinkedList[K])

--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/KeyValueStorageEngine.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/KeyValueStorageEngine.scala
@@ -160,4 +160,11 @@ class KeyValueStorageEngine[K, V](
   }
 
   override def getStoreProperties: StoreProperties = storeProperties
+
+  override def iterate(from: K, to: K): KeyValueIterable[K, V] = {
+    updateTimer(metrics.iterateNs) {
+      metrics.iterates.inc
+      wrapperStore.iterate(from, to)
+    }
+  }
 }

--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/KeyValueStorageEngineMetrics.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/KeyValueStorageEngineMetrics.scala
@@ -33,6 +33,7 @@ class KeyValueStorageEngineMetrics(
   val puts = newCounter("puts")
   val deletes = newCounter("deletes")
   val flushes = newCounter("flushes")
+  val iterates = newCounter("iterates")
 
   val restoredMessages = newCounter("messages-restored") //Deprecated
   val restoredMessagesGauge = newGauge("restored-messages", 0)
@@ -47,6 +48,7 @@ class KeyValueStorageEngineMetrics(
   val flushNs = newTimer("flush-ns")
   val allNs = newTimer("all-ns")
   val rangeNs = newTimer("range-ns")
+  val iterateNs = newTimer("iterate-ns")
 
   override def getPrefix = storeName + "-"
 }

--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/LoggedStore.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/LoggedStore.scala
@@ -114,4 +114,7 @@ class LoggedStore[K, V](
     store.close
   }
 
+  override def iterate(from: K, to: K): KeyValueIterable[K, V] = {
+    store.iterate(from, to)
+  }
 }

--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/NullSafeKeyValueStore.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/NullSafeKeyValueStore.scala
@@ -89,4 +89,10 @@ class NullSafeKeyValueStore[K, V](store: KeyValueStore[K, V]) extends KeyValueSt
       throw new NullPointerException(msg)
     }
   }
+
+  override def iterate(from: K, to: K): KeyValueIterable[K, V] = {
+    notNull(from, NullKeyErrorMessage)
+    notNull(to, NullKeyErrorMessage)
+    store.iterate(from, to)
+  }
 }

--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/SerializedKeyValueStore.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/SerializedKeyValueStore.scala
@@ -148,4 +148,15 @@ class SerializedKeyValueStore[K, V](
     }
     bytes
   }
+
+  override def iterate(from: K, to: K): KeyValueIterable[K, V] = {
+    val fromBytes = toBytesOrNull(from, keySerde)
+    val toBytes = toBytesOrNull(to, keySerde)
+    val iterable = store.iterate(fromBytes, toBytes)
+    new KeyValueIterable[K, V] {
+      override def iterator(): KeyValueIterator[K, V] = {
+        new DeserializingIterator(iterable.iterator())
+      }
+    }
+  }
 }

--- a/samza-kv/src/test/scala/org/apache/samza/storage/kv/MockKeyValueStore.scala
+++ b/samza-kv/src/test/scala/org/apache/samza/storage/kv/MockKeyValueStore.scala
@@ -69,4 +69,8 @@ class MockKeyValueStore extends KeyValueStore[String, String] {
   override def flush() {}  // no-op
 
   override def close() { kvMap.clear() }
+
+  override def iterate(from: String, to: String): KeyValueIterable[String, String] = {
+    throw new UnsupportedOperationException("iterator() not supported")
+  }
 }


### PR DESCRIPTION
Right now for KeyValueStore we have a range query to return an iterator. For usage in BEAM, we need a iterable which will 1) create the snapshot when called, and 2) create an iterator when needed. Add the iterate() function in KeyValueStore to support it. It's implemented as follows:

1) for rocksDb, it will create the iterator when it's called, which will has a snapshot of the elements. Then every time when the iterator is needed, we will seek the iterator from beginning;

2) for inMemoryDb, it will create the snapshot submap when iterate() is called. The submap is an iterable and it can return a new iterator when needed.