### PR TITLE
SAMZA-1653: Support waitForFinish in remote application runner and add waitForFinish

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/runtime/ApplicationRunner.java
+++ b/samza-api/src/main/java/org/apache/samza/runtime/ApplicationRunner.java
@@ -108,17 +108,18 @@ public abstract class ApplicationRunner {
   public abstract ApplicationStatus status(StreamApplication streamApp);
 
   /**
-   *
+   * Waits until the application finishes.
    */
   public void waitForFinish() {
     throw new UnsupportedOperationException(getClass().getName() + " does not support waitForFinish.");
   }
 
   /**
+   * Waits for the application to finish. It times out after the input duration has elapsed.
    *
-   * @param duration
+   * @param timeout time to wait for the application to finish
    */
-  public void waitForFinish(Duration duration) {
+  public void waitForFinish(Duration timeout) {
     throw new UnsupportedOperationException(getClass().getName() + " does not support waitForFinish.");
   }
 

--- a/samza-api/src/main/java/org/apache/samza/runtime/ApplicationRunner.java
+++ b/samza-api/src/main/java/org/apache/samza/runtime/ApplicationRunner.java
@@ -115,14 +115,14 @@ public abstract class ApplicationRunner {
   }
 
   /**
-   * Waits for the application to finish. It times out after the input duration has elapsed.
+   * Waits for {@code timeout} duration for the application to finish.
    *
    * @param timeout time to wait for the application to finish
    * @return true - application finished before timeout
    *         false - otherwise
    */
   public boolean waitForFinish(Duration timeout) {
-    throw new UnsupportedOperationException(getClass().getName() + " does not support waitForFinish.");
+    throw new UnsupportedOperationException(getClass().getName() + " does not support timed waitForFinish.");
   }
 
   /**

--- a/samza-api/src/main/java/org/apache/samza/runtime/ApplicationRunner.java
+++ b/samza-api/src/main/java/org/apache/samza/runtime/ApplicationRunner.java
@@ -118,8 +118,10 @@ public abstract class ApplicationRunner {
    * Waits for the application to finish. It times out after the input duration has elapsed.
    *
    * @param timeout time to wait for the application to finish
+   * @return true - application finished before timeout
+   *         false - otherwise
    */
-  public void waitForFinish(Duration timeout) {
+  public boolean waitForFinish(Duration timeout) {
     throw new UnsupportedOperationException(getClass().getName() + " does not support waitForFinish.");
   }
 

--- a/samza-api/src/main/java/org/apache/samza/runtime/ApplicationRunner.java
+++ b/samza-api/src/main/java/org/apache/samza/runtime/ApplicationRunner.java
@@ -18,6 +18,7 @@
  */
 package org.apache.samza.runtime;
 
+import java.time.Duration;
 import org.apache.samza.annotation.InterfaceStability;
 import org.apache.samza.application.StreamApplication;
 import org.apache.samza.config.Config;
@@ -105,6 +106,21 @@ public abstract class ApplicationRunner {
    * @return the status of the application
    */
   public abstract ApplicationStatus status(StreamApplication streamApp);
+
+  /**
+   *
+   */
+  public void waitForFinish() {
+    throw new UnsupportedOperationException(getClass().getName() + " does not support waitForFinish.");
+  }
+
+  /**
+   *
+   * @param duration
+   */
+  public void waitForFinish(Duration duration) {
+    throw new UnsupportedOperationException(getClass().getName() + " does not support waitForFinish.");
+  }
 
   /**
    * Constructs a {@link StreamSpec} from the configuration for the specified streamId.

--- a/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
@@ -204,8 +204,8 @@ public class LocalApplicationRunner extends AbstractApplicationRunner {
   }
 
   /**
-   * Waits until the application finishes. It times out after the input duration has elapsed.
-   * If timeout is zero or negative, then real time is not taken into consideration and the thread simply waits until notified.
+   * Waits for {@code timeout} duration for the application to finish.
+   * If timeout < 1, blocks the caller indefinitely.
    *
    * @param timeout time to wait for the application to finish
    * @return true - application finished before timeout
@@ -223,11 +223,11 @@ public class LocalApplicationRunner extends AbstractApplicationRunner {
         finished = shutdownLatch.await(timeoutInMs, TimeUnit.MILLISECONDS);
 
         if (!finished) {
-          LOG.error("Waiting to shutdown local application runner timed out.");
+          LOG.warn("Timed out waiting for application to finish.");
         }
       }
     } catch (Exception e) {
-      LOG.error("Wait for application finish failed due to", e);
+      LOG.error("Error waiting for application to finish", e);
       throw new SamzaException(e);
     }
 

--- a/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
@@ -205,7 +205,7 @@ public class LocalApplicationRunner extends AbstractApplicationRunner {
 
   /**
    * Waits for {@code timeout} duration for the application to finish.
-   * If timeout < 1, blocks the caller indefinitely.
+   * If timeout &lt; 1, blocks the caller indefinitely.
    *
    * @param timeout time to wait for the application to finish
    * @return true - application finished before timeout

--- a/samza-core/src/main/java/org/apache/samza/runtime/RemoteApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/RemoteApplicationRunner.java
@@ -182,7 +182,7 @@ public class RemoteApplicationRunner extends AbstractApplicationRunner {
     ApplicationStatus status;
 
     try {
-      while(timeoutInMs < 1 || timeElapsed <= timeoutInMs) {
+      while (timeoutInMs < 1 || timeElapsed <= timeoutInMs) {
         status = getApplicationStatus(jobConfig);
         if (status == SuccessfulFinish || status == UnsuccessfulFinish) {
           LOG.info("Application finished with status {}", status);
@@ -193,7 +193,7 @@ public class RemoteApplicationRunner extends AbstractApplicationRunner {
         timeElapsed = System.currentTimeMillis() - startTimeInMs;
       }
 
-      if(timeElapsed > timeoutInMs) {
+      if (timeElapsed > timeoutInMs) {
         LOG.error("Waiting to shutdown remote application runner timed out.");
         throw new TimeoutException("Waiting to shutdown remote application runner timed out.");
       }

--- a/samza-core/src/main/java/org/apache/samza/runtime/RemoteApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/RemoteApplicationRunner.java
@@ -167,7 +167,7 @@ public class RemoteApplicationRunner extends AbstractApplicationRunner {
 
   /**
    * Waits for {@code timeout} duration for the application to finish.
-   * If timeout < 1, blocks the caller indefinitely.
+   * If timeout &lt; 1, blocks the caller indefinitely.
    *
    * @param timeout time to wait for the application to finish
    * @return true - application finished before timeout

--- a/samza-core/src/test/java/org/apache/samza/runtime/TestRemoteApplicationRunner.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestRemoteApplicationRunner.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.runtime;
+
+import java.time.Duration;
+import org.apache.samza.SamzaException;
+import org.apache.samza.config.JobConfig;
+import org.apache.samza.config.MapConfig;
+import org.apache.samza.job.ApplicationStatus;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+
+/**
+ * A test class for {@link RemoteApplicationRunner}.
+ */
+public class TestRemoteApplicationRunner {
+  @Test
+  public void testWaitForFinishReturnsBeforeTimeout() {
+    RemoteApplicationRunner runner = spy(new RemoteApplicationRunner(new MapConfig()));
+    long startTime = System.currentTimeMillis();
+    long timeoutInMs = 5000;
+    doReturn(ApplicationStatus.SuccessfulFinish).when(runner).getApplicationStatus(any(JobConfig.class));
+    runner.waitForFinish(Duration.ofMillis(timeoutInMs));
+    assertTrue(System.currentTimeMillis() - startTime < timeoutInMs);
+  }
+
+  @Test
+  public void testWaitForFinishTimesout() {
+    RemoteApplicationRunner runner = spy(new RemoteApplicationRunner(new MapConfig()));
+    long timeoutInMs = 1000;
+
+    try {
+      doReturn(ApplicationStatus.Running).when(runner).getApplicationStatus(any(JobConfig.class));
+      runner.waitForFinish(Duration.ofMillis(timeoutInMs));
+    } catch (SamzaException e) {
+      assertNotNull(e);
+      assertEquals(e.getCause().getMessage(), "Waiting to shutdown remote application runner timed out.");
+    }
+  }
+}

--- a/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationRunner.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationRunner.java
@@ -110,7 +110,7 @@ public class SamzaSqlApplicationRunner extends AbstractApplicationRunner {
     Validate.isTrue(localRunner, "This method can be called only in standalone mode.");
     SamzaSqlApplication app = new SamzaSqlApplication();
     run(app);
-    ((LocalApplicationRunner) appRunner).waitForFinish();
+    appRunner.waitForFinish();
   }
 
   @Override


### PR DESCRIPTION
Added the following APIs to ApplicationRunner 
 `void waitForFinish()`
 `boolean waitForFinish(Duration timeout)`

Implemented the wait for finish methods in remote application runner. Note currently, there is disparity in the APIs in terms of associating runners with stream application. Ideally, we want to decide on the cardinal relation between them and change the APIs accordingly. 

The goal of the PR is limited to introduce API (waitForFinish) parity between runners in the current setup. 
@xinyuiscool 