### PR TITLE
SAMZA-1709 : Use lazy creation for SystemAdmins in ApplicationRunners

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/execution/StreamManager.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/StreamManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.samza.execution;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import java.util.Collection;
@@ -49,7 +50,12 @@ public class StreamManager {
 
   private final SystemAdmins systemAdmins;
 
-  public StreamManager(SystemAdmins systemAdmins) {
+  public StreamManager(Config config) {
+    this(new SystemAdmins(config));
+  }
+
+  @VisibleForTesting
+  StreamManager(SystemAdmins systemAdmins) {
     this.systemAdmins = systemAdmins;
   }
 
@@ -68,6 +74,14 @@ public class StreamManager {
         systemAdmin.createStream(stream);
       }
     }
+  }
+
+  public void start() {
+    this.systemAdmins.start();
+  }
+
+  public void stop() {
+    this.systemAdmins.stop();
   }
 
   Map<String, Integer> getStreamPartitionCounts(String systemName, Set<String> streamNames) {

--- a/samza-core/src/main/java/org/apache/samza/runtime/AbstractApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/AbstractApplicationRunner.java
@@ -151,7 +151,8 @@ public abstract class AbstractApplicationRunner extends ApplicationRunner {
     }
   }
 
-  protected SystemAdmins buildAndStartSystemAdmins() {
+  @VisibleForTesting
+  SystemAdmins buildAndStartSystemAdmins() {
     SystemAdmins systemAdmins = new SystemAdmins(this.config);
     systemAdmins.start();
     return systemAdmins;

--- a/samza-core/src/main/java/org/apache/samza/runtime/AbstractApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/AbstractApplicationRunner.java
@@ -39,7 +39,6 @@ import org.apache.samza.execution.StreamManager;
 import org.apache.samza.operators.OperatorSpecGraph;
 import org.apache.samza.operators.StreamGraphSpec;
 import org.apache.samza.system.StreamSpec;
-import org.apache.samza.system.SystemAdmins;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -159,14 +158,9 @@ public abstract class AbstractApplicationRunner extends ApplicationRunner {
   }
 
   @VisibleForTesting
-  SystemAdmins buildAndStartSystemAdmins() {
-    SystemAdmins systemAdmins = new SystemAdmins(this.config);
-    systemAdmins.start();
-    return systemAdmins;
-  }
-
-  @VisibleForTesting
-  StreamManager buildStreamManager(SystemAdmins systemAdmins) {
-    return new StreamManager(systemAdmins);
+  StreamManager buildAndStartStreamManager() {
+    StreamManager streamManager = new StreamManager(this.config);
+    streamManager.start();
+    return streamManager;
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
@@ -49,7 +49,6 @@ import org.apache.samza.operators.StreamGraphSpec;
 import org.apache.samza.processor.StreamProcessor;
 import org.apache.samza.processor.StreamProcessorLifecycleListener;
 import org.apache.samza.system.StreamSpec;
-import org.apache.samza.system.SystemAdmins;
 import org.apache.samza.task.AsyncStreamTaskFactory;
 import org.apache.samza.task.StreamTaskFactory;
 import org.apache.samza.task.TaskFactoryUtil;
@@ -159,10 +158,9 @@ public class LocalApplicationRunner extends AbstractApplicationRunner {
 
   @Override
   public void run(StreamApplication app) {
-    SystemAdmins systemAdmins = null;
+    StreamManager streamManager = null;
     try {
-      systemAdmins = buildAndStartSystemAdmins();
-      StreamManager streamManager = buildStreamManager(systemAdmins);
+      streamManager = buildAndStartStreamManager();
 
       // 1. initialize and plan
       ExecutionPlan plan = getExecutionPlan(app, streamManager);
@@ -196,8 +194,8 @@ public class LocalApplicationRunner extends AbstractApplicationRunner {
       shutdownLatch.countDown();
       throw new SamzaException(String.format("Failed to start application: %s.", app), throwable);
     } finally {
-      if (systemAdmins != null) {
-        systemAdmins.stop();
+      if (streamManager != null) {
+        streamManager.stop();
       }
     }
   }

--- a/samza-core/src/main/java/org/apache/samza/runtime/LocalContainerRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/LocalContainerRunner.java
@@ -70,7 +70,6 @@ public class LocalContainerRunner extends AbstractApplicationRunner {
 
   @Override
   public void run(StreamApplication streamApp) {
-    super.run(streamApp);
     Object taskFactory = TaskFactoryUtil.createTaskFactory(config, streamApp, this);
 
     container = SamzaContainer$.MODULE$.apply(

--- a/samza-core/src/test/java/org/apache/samza/runtime/TestApplicationRunnerMain.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestApplicationRunnerMain.java
@@ -93,13 +93,11 @@ public class TestApplicationRunnerMain {
 
     @Override
     public void run(StreamApplication streamApp) {
-      super.run(streamApp);
       runCount++;
     }
 
     @Override
     public void kill(StreamApplication streamApp) {
-      super.kill(streamApp);
       killCount++;
     }
 

--- a/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
@@ -85,7 +85,7 @@ public class TestLocalApplicationRunner {
     ExecutionPlan plan = mock(ExecutionPlan.class);
     when(plan.getIntermediateStreams()).thenReturn(Collections.singletonList(new StreamSpec("test-stream", "test-stream", "test-system")));
     when(plan.getPlanAsJson()).thenReturn("");
-    doReturn(plan).when(runner).getExecutionPlan(any());
+    doReturn(plan).when(runner).getExecutionPlan(any(), eq(streamManager));
 
     CoordinationUtilsFactory coordinationUtilsFactory = mock(CoordinationUtilsFactory.class);
     JobCoordinatorConfig mockJcConfig = mock(JobCoordinatorConfig.class);
@@ -121,7 +121,7 @@ public class TestLocalApplicationRunner {
     ExecutionPlan plan = mock(ExecutionPlan.class);
     when(plan.getIntermediateStreams()).thenReturn(Collections.singletonList(new StreamSpec("test-stream", "test-stream", "test-system")));
     when(plan.getPlanAsJson()).thenReturn("");
-    doReturn(plan).when(runner).getExecutionPlan(any());
+    doReturn(plan).when(runner).getExecutionPlan(any(), eq(streamManager));
 
     CoordinationUtils coordinationUtils = mock(CoordinationUtils.class);
     CoordinationUtilsFactory coordinationUtilsFactory = mock(CoordinationUtilsFactory.class);
@@ -190,11 +190,13 @@ public class TestLocalApplicationRunner {
     SystemAdmins systemAdmins = mock(SystemAdmins.class);
     // buildAndStartSystemAdmins already includes start, so not going to verify it gets called
     when(runner.buildAndStartSystemAdmins()).thenReturn(systemAdmins);
+    StreamManager streamManager = mock(StreamManager.class);
+    when(runner.buildStreamManager(systemAdmins)).thenReturn(streamManager);
     ExecutionPlan plan = mock(ExecutionPlan.class);
     when(plan.getIntermediateStreams()).thenReturn(Collections.emptyList());
     when(plan.getPlanAsJson()).thenReturn("");
     when(plan.getJobConfigs()).thenReturn(Collections.singletonList(new JobConfig(new MapConfig(config))));
-    doReturn(plan).when(runner).getExecutionPlan(any());
+    doReturn(plan).when(runner).getExecutionPlan(any(), eq(streamManager));
 
     StreamProcessor sp = mock(StreamProcessor.class);
     ArgumentCaptor<StreamProcessorLifecycleListener> captor =
@@ -228,11 +230,13 @@ public class TestLocalApplicationRunner {
     SystemAdmins systemAdmins = mock(SystemAdmins.class);
     // buildAndStartSystemAdmins already includes start, so not going to verify it gets called
     when(runner.buildAndStartSystemAdmins()).thenReturn(systemAdmins);
+    StreamManager streamManager = mock(StreamManager.class);
+    when(runner.buildStreamManager(systemAdmins)).thenReturn(streamManager);
     ExecutionPlan plan = mock(ExecutionPlan.class);
     when(plan.getIntermediateStreams()).thenReturn(Collections.emptyList());
     when(plan.getPlanAsJson()).thenReturn("");
     when(plan.getJobConfigs()).thenReturn(Collections.singletonList(new JobConfig(new MapConfig(config))));
-    doReturn(plan).when(runner).getExecutionPlan(any());
+    doReturn(plan).when(runner).getExecutionPlan(any(), eq(streamManager));
 
     StreamProcessor sp = mock(StreamProcessor.class);
     ArgumentCaptor<StreamProcessorLifecycleListener> captor =

--- a/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
@@ -43,7 +43,6 @@ import org.apache.samza.job.ApplicationStatus;
 import org.apache.samza.processor.StreamProcessor;
 import org.apache.samza.processor.StreamProcessorLifecycleListener;
 import org.apache.samza.system.StreamSpec;
-import org.apache.samza.system.SystemAdmins;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -80,7 +79,7 @@ public class TestLocalApplicationRunner {
     StreamApplication app = mock(StreamApplication.class);
 
     StreamManager streamManager = mock(StreamManager.class);
-    doReturn(streamManager).when(runner).buildStreamManager(any());
+    doReturn(streamManager).when(runner).buildAndStartStreamManager();
 
     ExecutionPlan plan = mock(ExecutionPlan.class);
     when(plan.getIntermediateStreams()).thenReturn(Collections.singletonList(new StreamSpec("test-stream", "test-stream", "test-system")));
@@ -104,6 +103,7 @@ public class TestLocalApplicationRunner {
     List<StreamSpec> streamSpecs = captor.getValue();
     assertEquals(streamSpecs.size(), 1);
     assertEquals(streamSpecs.get(0).getId(), "test-stream");
+    verify(streamManager).stop();
   }
 
   @Test
@@ -116,7 +116,7 @@ public class TestLocalApplicationRunner {
     StreamApplication app = mock(StreamApplication.class);
 
     StreamManager streamManager = mock(StreamManager.class);
-    doReturn(streamManager).when(runner).buildStreamManager(any());
+    doReturn(streamManager).when(runner).buildAndStartStreamManager();
 
     ExecutionPlan plan = mock(ExecutionPlan.class);
     when(plan.getIntermediateStreams()).thenReturn(Collections.singletonList(new StreamSpec("test-stream", "test-stream", "test-system")));
@@ -148,6 +148,7 @@ public class TestLocalApplicationRunner {
     List<StreamSpec> streamSpecs = captor.getValue();
     assertEquals(streamSpecs.size(), 1);
     assertEquals(streamSpecs.get(0).getId(), "test-stream");
+    verify(streamManager).stop();
   }
 
   @Test
@@ -187,11 +188,9 @@ public class TestLocalApplicationRunner {
     LocalApplicationRunner runner = spy(new LocalApplicationRunner(new MapConfig(config)));
     StreamApplication app = mock(StreamApplication.class);
 
-    SystemAdmins systemAdmins = mock(SystemAdmins.class);
-    // buildAndStartSystemAdmins already includes start, so not going to verify it gets called
-    when(runner.buildAndStartSystemAdmins()).thenReturn(systemAdmins);
+    // buildAndStartStreamManager already includes start, so not going to verify it gets called
     StreamManager streamManager = mock(StreamManager.class);
-    when(runner.buildStreamManager(systemAdmins)).thenReturn(streamManager);
+    when(runner.buildAndStartStreamManager()).thenReturn(streamManager);
     ExecutionPlan plan = mock(ExecutionPlan.class);
     when(plan.getIntermediateStreams()).thenReturn(Collections.emptyList());
     when(plan.getPlanAsJson()).thenReturn("");
@@ -216,7 +215,7 @@ public class TestLocalApplicationRunner {
     runner.waitForFinish();
 
     assertEquals(runner.status(app), ApplicationStatus.SuccessfulFinish);
-    verify(systemAdmins).stop();
+    verify(streamManager).stop();
   }
 
   @Test
@@ -227,11 +226,9 @@ public class TestLocalApplicationRunner {
     LocalApplicationRunner runner = spy(new LocalApplicationRunner(new MapConfig(config)));
     StreamApplication app = mock(StreamApplication.class);
 
-    SystemAdmins systemAdmins = mock(SystemAdmins.class);
-    // buildAndStartSystemAdmins already includes start, so not going to verify it gets called
-    when(runner.buildAndStartSystemAdmins()).thenReturn(systemAdmins);
+    // buildAndStartStreamManager already includes start, so not going to verify it gets called
     StreamManager streamManager = mock(StreamManager.class);
-    when(runner.buildStreamManager(systemAdmins)).thenReturn(streamManager);
+    when(runner.buildAndStartStreamManager()).thenReturn(streamManager);
     ExecutionPlan plan = mock(ExecutionPlan.class);
     when(plan.getIntermediateStreams()).thenReturn(Collections.emptyList());
     when(plan.getPlanAsJson()).thenReturn("");
@@ -257,7 +254,7 @@ public class TestLocalApplicationRunner {
     }
 
     assertEquals(runner.status(app), ApplicationStatus.UnsuccessfulFinish);
-    verify(systemAdmins).stop();
+    verify(streamManager).stop();
   }
 
   public static Set<StreamProcessor> getProcessors(LocalApplicationRunner runner) {

--- a/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
@@ -42,6 +42,7 @@ import org.apache.samza.job.ApplicationStatus;
 import org.apache.samza.processor.StreamProcessor;
 import org.apache.samza.processor.StreamProcessorLifecycleListener;
 import org.apache.samza.system.StreamSpec;
+import org.apache.samza.system.SystemAdmins;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -186,6 +187,9 @@ public class TestLocalApplicationRunner {
     StreamApplication app = mock(StreamApplication.class);
     doNothing().when(app).init(anyObject(), anyObject());
 
+    SystemAdmins systemAdmins = mock(SystemAdmins.class);
+    // buildAndStartSystemAdmins already includes start, so not going to verify it gets called
+    when(runner.buildAndStartSystemAdmins()).thenReturn(systemAdmins);
     ExecutionPlan plan = mock(ExecutionPlan.class);
     when(plan.getIntermediateStreams()).thenReturn(Collections.emptyList());
     when(plan.getPlanAsJson()).thenReturn("");
@@ -209,6 +213,7 @@ public class TestLocalApplicationRunner {
     runner.run(app);
 
     assertEquals(runner.status(app), ApplicationStatus.SuccessfulFinish);
+    verify(systemAdmins).stop();
   }
 
   @Test
@@ -220,6 +225,9 @@ public class TestLocalApplicationRunner {
     StreamApplication app = mock(StreamApplication.class);
     doNothing().when(app).init(anyObject(), anyObject());
 
+    SystemAdmins systemAdmins = mock(SystemAdmins.class);
+    // buildAndStartSystemAdmins already includes start, so not going to verify it gets called
+    when(runner.buildAndStartSystemAdmins()).thenReturn(systemAdmins);
     ExecutionPlan plan = mock(ExecutionPlan.class);
     when(plan.getIntermediateStreams()).thenReturn(Collections.emptyList());
     when(plan.getPlanAsJson()).thenReturn("");
@@ -244,6 +252,7 @@ public class TestLocalApplicationRunner {
     }
 
     assertEquals(runner.status(app), ApplicationStatus.UnsuccessfulFinish);
+    verify(systemAdmins).stop();
   }
 
   public static Set<StreamProcessor> getProcessors(LocalApplicationRunner runner) {

--- a/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
@@ -79,7 +79,7 @@ public class TestLocalApplicationRunner {
     doNothing().when(app).init(anyObject(), anyObject());
 
     StreamManager streamManager = mock(StreamManager.class);
-    doReturn(streamManager).when(runner).getStreamManager();
+    doReturn(streamManager).when(runner).buildStreamManager(any());
 
     ExecutionPlan plan = mock(ExecutionPlan.class);
     when(plan.getIntermediateStreams()).thenReturn(Collections.singletonList(new StreamSpec("test-stream", "test-stream", "test-system")));
@@ -115,7 +115,7 @@ public class TestLocalApplicationRunner {
     doNothing().when(app).init(anyObject(), anyObject());
 
     StreamManager streamManager = mock(StreamManager.class);
-    doReturn(streamManager).when(runner).getStreamManager();
+    doReturn(streamManager).when(runner).buildStreamManager(any());
 
     ExecutionPlan plan = mock(ExecutionPlan.class);
     when(plan.getIntermediateStreams()).thenReturn(Collections.singletonList(new StreamSpec("test-stream", "test-stream", "test-system")));

--- a/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationRunner.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationRunner.java
@@ -120,7 +120,6 @@ public class SamzaSqlApplicationRunner extends AbstractApplicationRunner {
 
   @Override
   public void run(StreamApplication streamApp) {
-    super.run(streamApp);
     Validate.isInstanceOf(SamzaSqlApplication.class, streamApp);
     appRunner.run(streamApp);
   }
@@ -128,7 +127,6 @@ public class SamzaSqlApplicationRunner extends AbstractApplicationRunner {
   @Override
   public void kill(StreamApplication streamApp) {
     appRunner.kill(streamApp);
-    super.kill(streamApp);
   }
 
   @Override

--- a/samza-test/src/test/java/org/apache/samza/test/operator/StreamApplicationIntegrationTestHarness.java
+++ b/samza-test/src/test/java/org/apache/samza/test/operator/StreamApplicationIntegrationTestHarness.java
@@ -27,6 +27,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.protocol.SecurityProtocol;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.samza.application.StreamApplication;
+import org.apache.samza.config.Config;
 import org.apache.samza.config.KafkaConfig;
 import org.apache.samza.config.MapConfig;
 import org.apache.samza.execution.TestStreamManager;
@@ -101,8 +102,6 @@ public class StreamApplicationIntegrationTestHarness extends AbstractIntegration
   private KafkaProducer producer;
   private KafkaConsumer consumer;
   protected KafkaSystemAdmin systemAdmin;
-  private StreamApplication app;
-  protected AbstractApplicationRunner runner;
 
   private int numEmptyPolls = 3;
   private static final Duration POLL_TIMEOUT_MS = Duration.ofSeconds(20);
@@ -218,25 +217,29 @@ public class StreamApplicationIntegrationTestHarness extends AbstractIntegration
    * @param streamApplication the application to run
    * @param appName the name of the application
    * @param overriddenConfigs configs to override
+   * @return RunApplicationContext which contains objects created within runApplication, to be used for verification
+   * if necessary
    */
-  public void runApplication(StreamApplication streamApplication, String appName, Map<String, String> overriddenConfigs) {
-    Map<String, String> configs = new HashMap<>();
-    configs.put("job.factory.class", "org.apache.samza.job.local.ThreadJobFactory");
-    configs.put("job.name", appName);
-    configs.put("app.class", streamApplication.getClass().getCanonicalName());
-    configs.put("serializers.registry.json.class", "org.apache.samza.serializers.JsonSerdeFactory");
-    configs.put("serializers.registry.string.class", "org.apache.samza.serializers.StringSerdeFactory");
-    configs.put("systems.kafka.samza.factory", "org.apache.samza.system.kafka.KafkaSystemFactory");
-    configs.put("systems.kafka.consumer.zookeeper.connect", zkConnect());
-    configs.put("systems.kafka.producer.bootstrap.servers", bootstrapUrl());
-    configs.put("systems.kafka.samza.key.serde", "string");
-    configs.put("systems.kafka.samza.msg.serde", "string");
-    configs.put("systems.kafka.samza.offset.default", "oldest");
-    configs.put("job.coordinator.system", "kafka");
-    configs.put("job.default.system", "kafka");
-    configs.put("job.coordinator.replication.factor", "1");
-    configs.put("task.window.ms", "1000");
-    configs.put("task.checkpoint.factory", TestStreamManager.MockCheckpointManagerFactory.class.getName());
+  protected RunApplicationContext runApplication(StreamApplication streamApplication,
+      String appName,
+      Map<String, String> overriddenConfigs) {
+    Map<String, String> configMap = new HashMap<>();
+    configMap.put("job.factory.class", "org.apache.samza.job.local.ThreadJobFactory");
+    configMap.put("job.name", appName);
+    configMap.put("app.class", streamApplication.getClass().getCanonicalName());
+    configMap.put("serializers.registry.json.class", "org.apache.samza.serializers.JsonSerdeFactory");
+    configMap.put("serializers.registry.string.class", "org.apache.samza.serializers.StringSerdeFactory");
+    configMap.put("systems.kafka.samza.factory", "org.apache.samza.system.kafka.KafkaSystemFactory");
+    configMap.put("systems.kafka.consumer.zookeeper.connect", zkConnect());
+    configMap.put("systems.kafka.producer.bootstrap.servers", bootstrapUrl());
+    configMap.put("systems.kafka.samza.key.serde", "string");
+    configMap.put("systems.kafka.samza.msg.serde", "string");
+    configMap.put("systems.kafka.samza.offset.default", "oldest");
+    configMap.put("job.coordinator.system", "kafka");
+    configMap.put("job.default.system", "kafka");
+    configMap.put("job.coordinator.replication.factor", "1");
+    configMap.put("task.window.ms", "1000");
+    configMap.put("task.checkpoint.factory", TestStreamManager.MockCheckpointManagerFactory.class.getName());
 
     // This is to prevent tests from taking a long time to stop after they're done. The issue is that
     // tearDown currently doesn't call runner.kill(app), and shuts down the Kafka and ZK servers immediately.
@@ -247,17 +250,18 @@ public class StreamApplicationIntegrationTestHarness extends AbstractIntegration
     // changelog streams. Hence we just force an unclean shutdown here to. This _should be_ OK
     // since the test method has already executed by the time the shutdown hook is called. The side effect is
     // that buffered state (e.g. changelog contents) might not be flushed correctly after the test run.
-    configs.put("task.shutdown.ms", "1");
+    configMap.put("task.shutdown.ms", "1");
 
     if (overriddenConfigs != null) {
-      configs.putAll(overriddenConfigs);
+      configMap.putAll(overriddenConfigs);
     }
 
-    app = streamApplication;
-    runner = (AbstractApplicationRunner) ApplicationRunner.fromConfig(new MapConfig(configs));
+    Config config = new MapConfig(configMap);
+    AbstractApplicationRunner runner = (AbstractApplicationRunner) ApplicationRunner.fromConfig(config);
     runner.run(streamApplication);
 
     StreamAssert.waitForComplete();
+    return new RunApplicationContext(runner, config);
   }
 
   public void setNumEmptyPolls(int numEmptyPolls) {
@@ -273,5 +277,27 @@ public class StreamApplicationIntegrationTestHarness extends AbstractIntegration
     producer.close();
     consumer.close();
     super.tearDown();
+  }
+
+  /**
+   * Container for any necessary context created during runApplication. Allows tests to access objects created within
+   * runApplication in order to do verification.
+   */
+  protected static class RunApplicationContext {
+    private final AbstractApplicationRunner runner;
+    private final Config config;
+
+    private RunApplicationContext(AbstractApplicationRunner runner, Config config) {
+      this.runner = runner;
+      this.config = config;
+    }
+
+    public AbstractApplicationRunner getRunner() {
+      return this.runner;
+    }
+
+    public Config getConfig() {
+      return this.config;
+    }
   }
 }


### PR DESCRIPTION
An instance of SystemAdmins is created when instantiating any AbstractApplicationRunner, but the SystemAdmins is only actually needed for some of the methods for some of the runners. For example, LocalApplicationRunner.kill does not need SystemAdmins, and LocalContainerRunner does not need SystemAdmins for anything.
Doing lazy instantiation allows us to more easily manage the SystemAdmins lifecycle, since it removes the need to add lifecycle hooks for the ApplicationRunner.
This also fixes the lifecycle management for SystemAdmins in ApplicationRunners.