### PR TITLE
Fixed test failure for TestRocksDbKeyValueStoreJava#testPerf

### DIFF
--- a/samza-kv-rocksdb/src/test/java/org/apache/samza/storage/kv/TestRocksDbKeyValueStoreJava.java
+++ b/samza-kv-rocksdb/src/test/java/org/apache/samza/storage/kv/TestRocksDbKeyValueStoreJava.java
@@ -103,24 +103,27 @@ public class TestRocksDbKeyValueStoreJava {
     byte[] lastKey = genKey(outputStream, prefix, Integer.MAX_VALUE);
 
     long start;
-    KeyValueIterator iter;
 
     start = System.currentTimeMillis();
-    iter = store.range(firstKey, lastKey);
+    KeyValueIterator<byte[], byte[]> iterator1 = store.range(firstKey, lastKey);
     long rangeTime = System.currentTimeMillis() - start;
     start = System.currentTimeMillis();
-    Iterators.size(iter);
+    Iterators.size(iterator1);
     long rangeIterTime = System.currentTimeMillis() - start;
     System.out.println("range iter create time: " + rangeTime + ", iterate time: " + rangeIterTime);
-
+    iterator1.close();
     // Please comment out range query part in order to do an accurate perf test for snapshot
     start = System.currentTimeMillis();
-    iter = store.snapshot(firstKey, lastKey).iterator();
+    KeyValueSnapshot<byte[], byte[]> snapshot = store.snapshot(firstKey, lastKey);
+    KeyValueIterator<byte[], byte[]> iterator2 = snapshot.iterator();
     long snapshotTime = System.currentTimeMillis() - start;
     start = System.currentTimeMillis();
-    Iterators.size(iter);
+    Iterators.size(iterator2);
     long snapshotIterTime = System.currentTimeMillis() - start;
     System.out.println("snapshot iter create time: " + snapshotTime + ", iterate time: " + snapshotIterTime);
+    iterator2.close();
+    snapshot.close();
+    store.close();
   }
 
   private byte[] genKey(ByteArrayOutputStream outputStream, String prefix, int i) throws Exception {


### PR DESCRIPTION
Iterators (incl. those obtained from snapshots) must be closed before store close.