### PR TITLE
Remove the iterable interface from KeyValueSnapshot

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/storage/kv/KeyValueSnapshot.java
+++ b/samza-api/src/main/java/org/apache/samza/storage/kv/KeyValueSnapshot.java
@@ -26,7 +26,7 @@ package org.apache.samza.storage.kv;
  * @param <K> key type
  * @param <V> value type
  */
-public interface KeyValueSnapshot<K, V> extends Iterable<Entry<K, V>> {
+public interface KeyValueSnapshot<K, V> {
   /**
    * Creates a new iterator for this snapshot. The iterator MUST be
    * closed after its execution by invoking {@link KeyValueIterator#close}.

--- a/samza-kv-inmemory/src/test/java/org/apache/samza/storage/kv/inmemory/TestInMemoryKeyValueStore.java
+++ b/samza-kv-inmemory/src/test/java/org/apache/samza/storage/kv/inmemory/TestInMemoryKeyValueStore.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.primitives.Ints;
 import org.apache.samza.metrics.MetricsRegistryMap;
 import org.apache.samza.storage.kv.Entry;
+import org.apache.samza.storage.kv.KeyValueIterator;
 import org.apache.samza.storage.kv.KeyValueSnapshot;
 import org.apache.samza.storage.kv.KeyValueStoreMetrics;
 import org.junit.Test;
@@ -57,7 +58,9 @@ public class TestInMemoryKeyValueStore {
     assertTrue(Iterators.size(snapshot.iterator()) == 100);
 
     List<Integer> keys = new ArrayList<>();
-    for (Entry<byte[], byte[]> entry : snapshot) {
+    KeyValueIterator<byte[], byte[]> iter = snapshot.iterator();
+    while (iter.hasNext()) {
+      Entry<byte[], byte[]> entry = iter.next();
       int key = Ints.fromByteArray(Arrays.copyOfRange(entry.getKey(), prefix.getBytes().length, entry.getKey().length));
       keys.add(key);
     }


### PR DESCRIPTION
The iterable interface makes it hard for the users to close it after using.