### PR TITLE
SAMZA-1712: Tear down ZookeeperServer connections in ZkClient on interrupts.

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/zk/ZkUtilsMetrics.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkUtilsMetrics.java
@@ -46,10 +46,16 @@ public class ZkUtilsMetrics extends MetricsBase {
    */
   public final Counter zkConnectionError;
 
+  /**
+   * Number of zookeeper data node deletions.
+   */
+  public final Counter deletions;
+
   public ZkUtilsMetrics(MetricsRegistry metricsRegistry) {
     super(metricsRegistry);
     this.reads = newCounter("reads");
     this.writes = newCounter("writes");
+    this.deletions = newCounter("deletions");
     this.subscriptions = newCounter("subscriptions");
     this.zkConnectionError = newCounter("zk-connection-errors");
   }


### PR DESCRIPTION
**Problem:** 

If a thread executing zkClient.close is interrupted, currently we swallow the ZkInterruptedException and proceed without closing the zookeeper connection. 

This leads to ephemeral nodes of StreamProcessor lurking around in zookeeper after StreamProcessor shutdown.

Users had to wait till zookeeper server session timeout for the ephemeral nodes to get deleted. 

**Change:**

Retry once on InterruptedException when closing the zkClient.

Misc changes:
* Remove unnecessary null checks.
* Remove unnecessary typecasts.