### PR TITLE
Schedule ZkBarrierChangeHandler into debounce queue for execution. 

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/zk/ScheduleAfterDebounceTime.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ScheduleAfterDebounceTime.java
@@ -50,7 +50,7 @@ public class ScheduleAfterDebounceTime {
   private Optional<ScheduledTaskCallback> scheduledTaskCallback;
 
   // Responsible for scheduling delayed actions.
-  private final ScheduledExecutorService scheduledExecutorService;
+  private ScheduledExecutorService scheduledExecutorService;
 
   /**
    * A map from actionName to {@link ScheduledFuture} of task scheduled for execution.
@@ -175,7 +175,7 @@ public class ScheduleAfterDebounceTime {
             LOG.warn("Action: {} is interrupted.", actionName);
             doCleanUpOnTaskException(new InterruptedException());
           } else {
-            LOG.info("Action: {} completed successfully.", actionName);
+            LOG.debug("Action: {} completed successfully.", actionName);
           }
         }
       } catch (Throwable throwable) {

--- a/samza-core/src/main/java/org/apache/samza/zk/ScheduleAfterDebounceTime.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ScheduleAfterDebounceTime.java
@@ -50,7 +50,7 @@ public class ScheduleAfterDebounceTime {
   private Optional<ScheduledTaskCallback> scheduledTaskCallback;
 
   // Responsible for scheduling delayed actions.
-  private ScheduledExecutorService scheduledExecutorService;
+  private final ScheduledExecutorService scheduledExecutorService;
 
   /**
    * A map from actionName to {@link ScheduledFuture} of task scheduled for execution.
@@ -175,7 +175,7 @@ public class ScheduleAfterDebounceTime {
             LOG.warn("Action: {} is interrupted.", actionName);
             doCleanUpOnTaskException(new InterruptedException());
           } else {
-            LOG.debug("Action: {} completed successfully.", actionName);
+            LOG.info("Action: {} completed successfully.", actionName);
           }
         }
       } catch (Throwable throwable) {

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
@@ -119,10 +119,6 @@ public class ZkJobCoordinator implements JobCoordinator, ZkControllerListener {
     leaderElector = new ZkLeaderElector(processorId, zkUtils);
     leaderElector.setLeaderElectorListener(new LeaderElectorListenerImpl());
     this.zkController = new ZkControllerImpl(processorId, zkUtils, this, leaderElector);
-    this.barrier =  new ZkBarrierForVersionUpgrade(
-        zkUtils.getKeyBuilder().getJobModelVersionBarrierPrefix(),
-        zkUtils,
-        new ZkBarrierListenerImpl());
     this.debounceTimeMs = new JobConfig(config).getDebounceTimeMs();
     this.reporters = MetricsReporterLoader.getMetricsReporters(new MetricsConfig(config), processorId);
     debounceTimer = new ScheduleAfterDebounceTime(processorId);
@@ -130,6 +126,7 @@ public class ZkJobCoordinator implements JobCoordinator, ZkControllerListener {
         LOG.error("Received exception in debounce timer! Stopping the job coordinator", throwable);
         stop();
       });
+    this.barrier =  new ZkBarrierForVersionUpgrade(zkUtils.getKeyBuilder().getJobModelVersionBarrierPrefix(), zkUtils, new ZkBarrierListenerImpl(), debounceTimer);
     systemAdmins = new SystemAdmins(config);
     streamMetadataCache = new StreamMetadataCache(systemAdmins, METADATA_CACHE_TTL_MS, SystemClock.instance());
   }

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkBarrierForVersionUpgrade.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkBarrierForVersionUpgrade.java
@@ -37,10 +37,10 @@ import org.junit.Test;
 
 import static junit.framework.Assert.*;
 
-
-// TODO: Rename this such that it is clear that it is an integration test and NOT unit test
 public class TestZkBarrierForVersionUpgrade {
   private static final String BARRIER_VERSION = "1";
+
+  private final ScheduleAfterDebounceTime debounceTimer = new ScheduleAfterDebounceTime("TEST_PROCESSOR_ID");
   private static EmbeddedZookeeper zkServer = null;
   private static String testZkConnectionString = null;
   private ZkUtils zkUtils;
@@ -105,8 +105,8 @@ public class TestZkBarrierForVersionUpgrade {
     CountDownLatch latch = new CountDownLatch(2);
     TestZkBarrierListener listener = new TestZkBarrierListener(latch, State.DONE);
 
-    ZkBarrierForVersionUpgrade processor1Barrier = new ZkBarrierForVersionUpgrade(barrierId, zkUtils, listener);
-    ZkBarrierForVersionUpgrade processor2Barrier = new ZkBarrierForVersionUpgrade(barrierId, zkUtils1, listener);
+    ZkBarrierForVersionUpgrade processor1Barrier = new ZkBarrierForVersionUpgrade(barrierId, zkUtils, listener, debounceTimer);
+    ZkBarrierForVersionUpgrade processor2Barrier = new ZkBarrierForVersionUpgrade(barrierId, zkUtils1, listener, debounceTimer);
 
     processor1Barrier.create(BARRIER_VERSION, processors);
 
@@ -140,8 +140,8 @@ public class TestZkBarrierForVersionUpgrade {
     CountDownLatch latch = new CountDownLatch(2);
     TestZkBarrierListener listener = new TestZkBarrierListener(latch, State.TIMED_OUT);
 
-    ZkBarrierForVersionUpgrade processor1Barrier = new ZkBarrierForVersionUpgrade(barrierId, zkUtils, listener);
-    ZkBarrierForVersionUpgrade processor2Barrier = new ZkBarrierForVersionUpgrade(barrierId, zkUtils1, listener);
+    ZkBarrierForVersionUpgrade processor1Barrier = new ZkBarrierForVersionUpgrade(barrierId, zkUtils, listener, debounceTimer);
+    ZkBarrierForVersionUpgrade processor2Barrier = new ZkBarrierForVersionUpgrade(barrierId, zkUtils1, listener, debounceTimer);
 
     processor1Barrier.create(BARRIER_VERSION, processors);
 
@@ -172,8 +172,8 @@ public class TestZkBarrierForVersionUpgrade {
 
     CountDownLatch latch = new CountDownLatch(2);
     TestZkBarrierListener listener = new TestZkBarrierListener(latch, State.DONE);
-    ZkBarrierForVersionUpgrade processor1Barrier = new ZkBarrierForVersionUpgrade(barrierId, zkUtils, listener);
-    ZkBarrierForVersionUpgrade processor2Barrier = new ZkBarrierForVersionUpgrade(barrierId, zkUtils1, listener);
+    ZkBarrierForVersionUpgrade processor1Barrier = new ZkBarrierForVersionUpgrade(barrierId, zkUtils, listener, debounceTimer);
+    ZkBarrierForVersionUpgrade processor2Barrier = new ZkBarrierForVersionUpgrade(barrierId, zkUtils1, listener, debounceTimer);
 
     processor1Barrier.create(BARRIER_VERSION, processors);
 
@@ -201,8 +201,8 @@ public class TestZkBarrierForVersionUpgrade {
 
     CountDownLatch latch = new CountDownLatch(2);
     TestZkBarrierListener listener = new TestZkBarrierListener(latch, State.TIMED_OUT);
-    ZkBarrierForVersionUpgrade processor1Barrier = new ZkBarrierForVersionUpgrade(barrierId, zkUtils, listener);
-    ZkBarrierForVersionUpgrade processor2Barrier = new ZkBarrierForVersionUpgrade(barrierId, zkUtils1, listener);
+    ZkBarrierForVersionUpgrade processor1Barrier = new ZkBarrierForVersionUpgrade(barrierId, zkUtils, listener, debounceTimer);
+    ZkBarrierForVersionUpgrade processor2Barrier = new ZkBarrierForVersionUpgrade(barrierId, zkUtils1, listener, debounceTimer);
 
     processor1Barrier.create(BARRIER_VERSION, processors);
 

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkUtils.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkUtils.java
@@ -325,7 +325,7 @@ public class TestZkUtils {
   public void testCleanUpZkBarrierVersion() {
     String root = zkUtils.getKeyBuilder().getJobModelVersionBarrierPrefix();
     zkUtils.getZkClient().createPersistent(root, true);
-    ZkBarrierForVersionUpgrade barrier = new ZkBarrierForVersionUpgrade(root, zkUtils, null);
+    ZkBarrierForVersionUpgrade barrier = new ZkBarrierForVersionUpgrade(root, zkUtils, null, null);
     for (int i = 200; i < 210; i++) {
       barrier.create(String.valueOf(i), new ArrayList<>(Arrays.asList(i + "a", i + "b", i + "c")));
     }


### PR DESCRIPTION
In existing implementation, `ZkBarrierChangeHandler` is executed from the `ZkEventThread` and has following drawbacks:
* `ZkWatch` events are buffered into a in-memory queue(maintained by ZkClient) and delivered one at a time to ZkClient listener implementations. If the exeuction of a delivered `ZkWatch` event is in progress, then no other `ZkWatch` event will be delivered to the listeners. If `ZkBarrierChangeHandler` is executed from `ZkEventThread`,  any increase in processing latency will delay the delivery of other `ZkWatch` events(buffered in in-memory queue of ZkClient).
* During session expiration(zkConnection error scenario), buffering all events into `ScheduleAfterDebounceTime` helps us to garbage collect older generation events(to ensure correctness and not execute older generation `ZkWatch` events). 