### PR TITLE
SAMZA-1720: Remove javafx.util dependency from samza-sql tests.

### DIFF
--- a/samza-sql/src/test/java/org/apache/samza/sql/TestSamzaSqlRelMessageSerde.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/TestSamzaSqlRelMessageSerde.java
@@ -23,10 +23,10 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javafx.util.Pair;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.samza.config.MapConfig;
 import org.apache.samza.operators.KV;
 import org.apache.samza.sql.avro.AvroRelConverter;
@@ -96,7 +96,7 @@ public class TestSamzaSqlRelMessageSerde {
     GenericData.Record streetNumRecord = new GenericData.Record(StreetNumRecord.SCHEMA$);
     streetNumRecord.put("number", 1200);
     addressRecord.put("streetnum", streetNumRecord);
-    return new Pair<>(nestedRecordAvroRelConverter.convertToRelMessage(new KV<>("key", record)), record);
+    return Pair.of(nestedRecordAvroRelConverter.convertToRelMessage(new KV<>("key", record)), record);
   }
 
 }

--- a/samza-sql/src/test/java/org/apache/samza/sql/TestSamzaSqlRelRecordSerde.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/TestSamzaSqlRelRecordSerde.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.samza.config.MapConfig;
 import org.apache.samza.sql.avro.AvroRelConverter;
 import org.apache.samza.sql.avro.AvroRelSchemaProvider;
@@ -36,8 +37,6 @@ import org.apache.samza.sql.serializers.SamzaSqlRelRecordSerdeFactory;
 import org.apache.samza.system.SystemStream;
 import org.junit.Assert;
 import org.junit.Test;
-
-import javafx.util.Pair;
 
 import static org.apache.samza.sql.serializers.SamzaSqlRelRecordSerdeFactory.SamzaSqlRelRecordSerde;
 import static org.apache.samza.sql.data.SamzaSqlRelMessage.SamzaSqlRelRecord;


### PR DESCRIPTION
In samza-sql module, currently few test classes(`TestSamzaSqlRelMessageSerde` and `TestSamzaSqlRelRecordSerde`) are dependent upon `javafx.util.Pair` class(coming from `javafx` module). `javafx.util.Pair` is not supported by default in all JDK builds(example; open-jdk java-8 doesn't support `javafx` module) and it belongs to `javafx` package which is primarily used for developing GUI applications. This dependency is removed and replaced with `Pair` class from `apache-commons`.