### PR TITLE
SAMZA-1725: Set travis build idle time out to 20 minutes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ jdk:
   - oraclejdk8
 
 script:
-  - ./gradlew clean build
+  ## travis_wait increases build idle-wait time from 10 minutes to 20 minutes.
+  - travis_wait 20 ./gradlew clean build
   - type sonar-scanner &>/dev/null; if [ $? -eq 0 ]; then sonar-scanner; else echo "Not running sonar"; fi
 
 before_cache:

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ rat {
     '**/*.svg',
     '**/*.ttf',
     '**/*.woff',
+    '*.log',
     '**/hs_err_pid*.log',
     '**/.classpath',
     '**/.cache/**',


### PR DESCRIPTION
**Problem:**
Currently, average build time of samza codebase is 15 to 20 minutes. However, travis has a build idle timeout of 10 minutes and fails the build if the gradle build command doesn't log anything to console
for 10 minutes(occurs when running tests in samza-test module).

Sample travis build failure error:
```
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
```

**Fix:** 
Increasing the build idle-wait timeout value to 20 minutes.

