### PR TITLE
SAMZA-1677 : Make httpcore and httpclient dependencies consistent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -236,7 +236,6 @@ project(':samza-aws') {
     compile project(":samza-core_$scalaVersion")
     compile "org.slf4j:slf4j-api:$slf4jVersion"
     runtime "org.apache.httpcomponents:httpclient:4.5.2"
-    runtime "org.apache.httpcomponents:httpcore:4.4.5"
     testCompile "junit:junit:$junitVersion"
     testCompile "org.mockito:mockito-all:$mockitoVersion"
   }


### PR DESCRIPTION
Samza currently depends on httpclient 4.5.2 and httpcore 4.4.5. However, httpclient 4.5.2 also has a direct dependency on httpcore 4.4.4, which is not backwards compatible with httpcore 4.4.5 since some classes were removed (e.g. ThreadSafe/NotThreadSafe annotation classes).

Although this does not currently cause any direct build problems, there may be cases where this conflict introduces transitive dependency conflicts. In addition, this inconsistency can cause confusion in future development if those libraries need to be used.