### PR TITLE
SAMZA-1731: Daemonize threads spawned from SamzaEventHubClientManager.

### DIFF
--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/SamzaEventHubClientManager.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/SamzaEventHubClientManager.java
@@ -84,7 +84,7 @@ public class SamzaEventHubClientManager implements EventHubClientManager {
           .setSasKeyName(sasKeyName)
           .setSasKey(sasKey);
 
-      ThreadFactoryBuilder threadFactoryBuilder = new ThreadFactoryBuilder().setNameFormat("Samza EventHubClient Thread-%d");
+      ThreadFactoryBuilder threadFactoryBuilder = new ThreadFactoryBuilder().setNameFormat("Samza EventHubClient Thread-%d").setDaemon(true);
       eventHubClientExecutor = Executors.newFixedThreadPool(numClientThreads, threadFactoryBuilder.build());
       eventHubClient = EventHubClient.createSync(connectionStringBuilder.toString(), retryPolicy, eventHubClientExecutor);
     } catch (IOException | EventHubException e) {


### PR DESCRIPTION
**Problem:**
Existing SamzaEventHubClientManager implementation spawns non-daemon threads when instantiating EventHubClient. These non-daemon threads stalls shutdown of samza processes even when the main thread has exited.

**Fix:** 
Daemonize threads that are spawned from SamzaEventHubClientManager.