### PR TITLE
SAMZA-929 : Set initialDelay in tokenRenewExecutor schedule to 0

### DIFF
--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/SamzaAppMasterSecurityManager.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/SamzaAppMasterSecurityManager.scala
@@ -74,7 +74,7 @@ class SamzaAppMasterSecurityManager(config: Config, hadoopConf: Configuration) e
       }
     }
 
-    tokenRenewExecutor.scheduleAtFixedRate(tokenRenewRunnable, renewalInterval, renewalInterval, TimeUnit.SECONDS)
+    tokenRenewExecutor.scheduleAtFixedRate(tokenRenewRunnable, 0, renewalInterval, TimeUnit.SECONDS)
   }
 
   private def loginFromKeytab(principal: String, keytab: String, credentialsFile: String) = {


### PR DESCRIPTION
Changed initialDelay in tokenRenewExecutor scheduler to 0 so that it can re-login using the keytab as soon as the application master container starts.  This way even if application master restarts after the delegation token in launcher context has expired, it will be able to use the new token to launch other containers.