### PR TITLE
Minor: KafkaConfig should treat empty changelog name as no changelog.

### DIFF
--- a/samza-kafka/src/main/scala/org/apache/samza/config/KafkaConfig.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/config/KafkaConfig.scala
@@ -236,10 +236,11 @@ class KafkaConfig(config: Config) extends ScalaMapConfig(config) {
       val matcher = pattern.matcher(changelogConfig)
       val storeName = if (matcher.find()) matcher.group(1) else throw new SamzaException("Unable to find store name in the changelog configuration: " + changelogConfig + " with SystemStream: " + cn)
 
-      val changelogName = storageConfig.getChangelogStream(storeName).getOrElse(throw new SamzaException("unable to get SystemStream for store:" + changelogConfig));
-      val systemStream = Util.getSystemStreamFromNames(changelogName)
-      val factoryName = config.getSystemFactory(systemStream.getSystem).getOrElse(new SamzaException("Unable to determine factory for system: " + systemStream.getSystem))
-      storeToChangelog += storeName -> systemStream.getStream
+      storageConfig.getChangelogStream(storeName).foreach(changelogName => {
+        val systemStream = Util.getSystemStreamFromNames(changelogName)
+        val factoryName = config.getSystemFactory(systemStream.getSystem).getOrElse(new SamzaException("Unable to determine factory for system: " + systemStream.getSystem))
+        storeToChangelog += storeName -> systemStream.getStream
+      })
     }
     storeToChangelog
   }


### PR DESCRIPTION
If a store changelog stream name is empty, treat is as a non-changelogged store instead of throwing an exception.