### PR TITLE
SAMZA-1741: fix issue that EH consumer taking too long to shutdown

### DIFF
--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
@@ -367,7 +367,11 @@ public class EventHubSystemConsumer extends BlockingEnvelopeMap {
     ShutdownUtil.boundedShutdown(perPartitionEventHubManagers.values().stream().map(manager -> new Runnable() {
       @Override
       public void run() {
-        manager.close(DEFAULT_SHUTDOWN_TIMEOUT_MILLIS);
+        try {
+          manager.close(DEFAULT_SHUTDOWN_TIMEOUT_MILLIS);
+        } catch (Exception e) {
+          LOG.error("Failed to shutdown eventhubs manager.", e);
+        }
       }
     }).collect(Collectors.toList()), "EventHubSystemConsumer.ClientManager#close", DEFAULT_SHUTDOWN_TIMEOUT_MILLIS);
 

--- a/samza-core/src/main/java/org/apache/samza/util/ShutdownUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/util/ShutdownUtil.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.util;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Shutdown related utils
+ */
+public class ShutdownUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(ShutdownUtil.class);
+
+  /**
+   * A helper to facilitate shutting down a set of resources in parallel to enforce a bounded shutdown time.
+   * The helper function instantiates an {@link ExecutorService} to execute the "shutdown function", and will
+   * await the termination for given timeout. If shutdown remains unfinished in the end, the whole thread dump
+   * will be printed to help debugging.
+   *
+   * The shutdown is performed with best-effort. Depending on the implementation of the shutdown function, resource
+   * leak might be possible.
+   *
+   * @param shutdownFunction the shutdown function will be provided with an ExecutorService and is supposed to
+   *                         submit all the shutdown tasks via the given executor
+   * @param message message that will show in the thread name and the thread dump
+   * @param timeoutMs timeout in ms
+   */
+  public static void boundedShutdown(Function<ExecutorService, Void> shutdownFunction, String message, long timeoutMs) {
+    ExecutorService shutdownExecutorService = Executors.newCachedThreadPool(new ThreadFactory() {
+      private final AtomicInteger counter = new AtomicInteger(0);
+      @Override
+      public Thread newThread(Runnable r) {
+        Thread thread = new Thread(r);
+        thread.setDaemon(true);
+        thread.setName(message + "-" + counter.incrementAndGet());
+        return thread;
+      }
+    });
+    shutdownFunction.apply(shutdownExecutorService);
+    shutdownExecutorService.shutdown();
+    try {
+      shutdownExecutorService.awaitTermination(timeoutMs, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      LOG.error("Shutdown was interrupted for " + message, e);
+    }
+
+    if (!shutdownExecutorService.isTerminated()) {
+      LOG.error("Shutdown function for {} remains unfinished after timeout({}ms) or interruption", message, timeoutMs);
+      Util.logThreadDump(message);
+      shutdownExecutorService.shutdownNow();
+    } else {
+      LOG.info("Shutdown complete for {}", message);
+    }
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/util/ShutdownUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/util/ShutdownUtil.java
@@ -22,12 +22,12 @@ package org.apache.samza.util;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 
 /**
@@ -51,16 +51,8 @@ public class ShutdownUtil {
    * @return true if all tasks terminate in the end
    */
   public static boolean boundedShutdown(List<Runnable> shutdownTasks, String message, long timeoutMs) {
-    ExecutorService shutdownExecutorService = Executors.newCachedThreadPool(new ThreadFactory() {
-      private final AtomicInteger counter = new AtomicInteger(0);
-      @Override
-      public Thread newThread(Runnable r) {
-        Thread thread = new Thread(r);
-        thread.setDaemon(true);
-        thread.setName(message + "-" + counter.incrementAndGet());
-        return thread;
-      }
-    });
+    ExecutorService shutdownExecutorService = Executors.newCachedThreadPool(
+        new ThreadFactoryBuilder().setNameFormat(message + "-%d").setDaemon(true).build());
     shutdownTasks.forEach(shutdownExecutorService::submit);
     shutdownExecutorService.shutdown();
     try {

--- a/samza-core/src/test/java/org/apache/samza/util/TestShutdownUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/util/TestShutdownUtil.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.util;
+
+import java.time.Duration;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class TestShutdownUtil {
+  @Test
+  public void testBoundedShutdown() throws Exception {
+    long longTimeout = Duration.ofSeconds(60).toMillis();
+    long shortTimeout = Duration.ofMillis(100).toMillis();
+    long start = System.currentTimeMillis();
+    ShutdownUtil.boundedShutdown(es -> {
+        es.submit(() -> {
+            try {
+              Thread.sleep(shortTimeout);
+            } catch (Exception e) {
+              Assert.fail(e.getMessage());
+            }
+          });
+        return null;
+      }, "testLongTimeout", longTimeout);
+    long end = System.currentTimeMillis();
+    System.out.print("Time taken: ");
+    System.out.println(end - start);
+    Assert.assertTrue("boundedShutdown should complete if the shutdown function completes earlier",
+        (end - start) < longTimeout / 2);
+
+    start = System.currentTimeMillis();
+    ShutdownUtil.boundedShutdown(es -> {
+        es.submit(() -> {
+            try {
+              Thread.sleep(longTimeout);
+            } catch (Exception e) {
+              Assert.fail(e.getMessage());
+            }
+          });
+        return null;
+      }, "testShortTimeout", shortTimeout);
+    end = System.currentTimeMillis();
+    System.out.print("Time taken: ");
+    System.out.println(end - start);
+    Assert.assertTrue("boundedShutdown should complete even if the shutdown function takes long time",
+        (end - start) < longTimeout / 2);
+  }
+}


### PR DESCRIPTION
1.  lower the shutdown timeout from 1 min to 15 seconds
2. make sure EventHubManagers are shutdown in parallel
3. print a thread dump when we do fail during shutdown