### PR TITLE
SAMZA-1745: Remove all usages of StreamSpec and ApplicationRunner from the operator spec and impl layers.

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/operators/functions/MapFunction.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/functions/MapFunction.java
@@ -30,7 +30,7 @@ import org.apache.samza.annotation.InterfaceStability;
  */
 @InterfaceStability.Unstable
 @FunctionalInterface
-public interface MapFunction<M, OM>  extends InitableFunction, ClosableFunction, Serializable {
+public interface MapFunction<M, OM> extends InitableFunction, ClosableFunction, Serializable {
 
   /**
    * Transforms the provided message into another message.

--- a/samza-api/src/main/java/org/apache/samza/runtime/ApplicationRunner.java
+++ b/samza-api/src/main/java/org/apache/samza/runtime/ApplicationRunner.java
@@ -24,7 +24,6 @@ import org.apache.samza.application.StreamApplication;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.ConfigException;
 import org.apache.samza.job.ApplicationStatus;
-import org.apache.samza.system.StreamSpec;
 
 import java.lang.reflect.Constructor;
 
@@ -124,25 +123,4 @@ public abstract class ApplicationRunner {
   public boolean waitForFinish(Duration timeout) {
     throw new UnsupportedOperationException(getClass().getName() + " does not support timed waitForFinish.");
   }
-
-  /**
-   * Constructs a {@link StreamSpec} from the configuration for the specified streamId.
-   *
-   * The stream configurations are read from the following properties in the config:
-   * {@code streams.{$streamId}.*}
-   * <br>
-   * All properties matching this pattern are assumed to be system-specific with two exceptions. The following two
-   * properties are Samza properties which are used to bind the stream to a system and a physical resource on that system.
-   *
-   * <ul>
-   *   <li>samza.system -         The name of the System on which this stream will be used. If this property isn't defined
-   *                              the stream will be associated with the System defined in {@code job.default.system}</li>
-   *   <li>samza.physical.name -  The system-specific name for this stream. It could be a file URN, topic name, or other identifer.
-   *                              If this property isn't defined the physical.name will be set to the streamId</li>
-   * </ul>
-   *
-   * @param streamId  The logical identifier for the stream in Samza.
-   * @return          The {@link StreamSpec} instance.
-   */
-  public abstract StreamSpec getStreamSpec(String streamId);
 }

--- a/samza-api/src/main/java/org/apache/samza/system/StreamSpec.java
+++ b/samza-api/src/main/java/org/apache/samza/system/StreamSpec.java
@@ -76,24 +76,10 @@ public class StreamSpec implements Serializable {
   private final int partitionCount;
 
   /**
-   * Bounded or unbounded stream
-   */
-  private final boolean isBounded;
-
-  /**
-   * broadcast stream to all tasks
-   */
-  private final boolean isBroadcast;
-
-  /**
    * A set of all system-specific configurations for the stream.
    */
   private final Map<String, String> config;
 
-  @Override
-  public String toString() {
-    return String.format("StreamSpec: id=%s, systemName=%s, pName=%s, partCount=%d.", id, systemName, physicalName, partitionCount);
-  }
   /**
    *  @param id           The application-unique logical identifier for the stream. It is used to distinguish between
    *                      streams in a Samza application so it must be unique in the context of one deployable unit.
@@ -107,7 +93,7 @@ public class StreamSpec implements Serializable {
    *                      Samza System abstraction. See {@link SystemFactory}
    */
   public StreamSpec(String id, String physicalName, String systemName) {
-    this(id, physicalName, systemName, DEFAULT_PARTITION_COUNT, false, false, Collections.emptyMap());
+    this(id, physicalName, systemName, DEFAULT_PARTITION_COUNT, Collections.emptyMap());
   }
 
   /**
@@ -126,7 +112,7 @@ public class StreamSpec implements Serializable {
    * @param partitionCount  The number of partitionts for the stream. A value of {@code 1} indicates unpartitioned.
    */
   public StreamSpec(String id, String physicalName, String systemName, int partitionCount) {
-    this(id, physicalName, systemName, partitionCount, false, false, Collections.emptyMap());
+    this(id, physicalName, systemName, partitionCount, Collections.emptyMap());
   }
 
   /**
@@ -141,12 +127,10 @@ public class StreamSpec implements Serializable {
    * @param systemName    The System name on which this stream will exist. Corresponds to a named implementation of the
    *                      Samza System abstraction. See {@link SystemFactory}
    *
-   * @param isBounded     The stream is bounded or not.
-   *
    * @param config        A map of properties for the stream. These may be System-specfic.
    */
-  public StreamSpec(String id, String physicalName, String systemName, boolean isBounded, Map<String, String> config) {
-    this(id, physicalName, systemName, DEFAULT_PARTITION_COUNT, isBounded, false, config);
+  public StreamSpec(String id, String physicalName, String systemName, Map<String, String> config) {
+    this(id, physicalName, systemName, DEFAULT_PARTITION_COUNT, config);
   }
 
   /**
@@ -161,16 +145,11 @@ public class StreamSpec implements Serializable {
    * @param systemName      The System name on which this stream will exist. Corresponds to a named implementation of the
    *                        Samza System abstraction. See {@link SystemFactory}
    *
-   * @param partitionCount  The number of partitionts for the stream. A value of {@code 1} indicates unpartitioned.
-   *
-   * @param isBounded       The stream is bounded or not.
-   *
-   * @param isBroadcast     This stream is broadcast or not.
+   * @param partitionCount  The number of partitions for the stream. A value of {@code 1} indicates unpartitioned.
    *
    * @param config          A map of properties for the stream. These may be System-specfic.
    */
-  public StreamSpec(String id, String physicalName, String systemName, int partitionCount,
-                    boolean isBounded, boolean isBroadcast, Map<String, String> config) {
+  public StreamSpec(String id, String physicalName, String systemName, int partitionCount, Map<String, String> config) {
     validateLogicalIdentifier("streamId", id);
     validateLogicalIdentifier("systemName", systemName);
 
@@ -183,8 +162,6 @@ public class StreamSpec implements Serializable {
     this.systemName = systemName;
     this.physicalName = physicalName;
     this.partitionCount = partitionCount;
-    this.isBounded = isBounded;
-    this.isBroadcast = isBroadcast;
 
     if (config != null) {
       this.config = Collections.unmodifiableMap(new HashMap<>(config));
@@ -202,15 +179,11 @@ public class StreamSpec implements Serializable {
    * @return                A copy of this StreamSpec with the specified partitionCount.
    */
   public StreamSpec copyWithPartitionCount(int partitionCount) {
-    return new StreamSpec(id, physicalName, systemName, partitionCount, this.isBounded, this.isBroadcast, config);
+    return new StreamSpec(id, physicalName, systemName, partitionCount, config);
   }
 
   public StreamSpec copyWithPhysicalName(String physicalName) {
-    return new StreamSpec(id, physicalName, systemName, partitionCount, this.isBounded, this.isBroadcast, config);
-  }
-
-  public StreamSpec copyWithBroadCast() {
-    return new StreamSpec(id, physicalName, systemName, partitionCount, this.isBounded, true, config);
+    return new StreamSpec(id, physicalName, systemName, partitionCount, config);
   }
 
   public String getId() {
@@ -253,14 +226,6 @@ public class StreamSpec implements Serializable {
     return id.equals(COORDINATOR_STREAM_ID);
   }
 
-  public boolean isBounded() {
-    return isBounded;
-  }
-
-  public boolean isBroadcast() {
-    return isBroadcast;
-  }
-
   private void validateLogicalIdentifier(String identifierName, String identifierValue) {
     if (identifierValue == null || !identifierValue.matches("[A-Za-z0-9_-]+")) {
       throw new IllegalArgumentException(String.format("Identifier '%s' is '%s'. It must match the expression [A-Za-z0-9_-]+", identifierName, identifierValue));
@@ -296,5 +261,10 @@ public class StreamSpec implements Serializable {
 
   public static StreamSpec createStreamAppenderStreamSpec(String physicalName, String systemName, int partitionCount) {
     return new StreamSpec(STREAM_APPENDER_ID, physicalName, systemName, partitionCount);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("StreamSpec: id=%s, systemName=%s, pName=%s, partCount=%d.", id, systemName, physicalName, partitionCount);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/config/TaskConfigJava.java
+++ b/samza-core/src/main/java/org/apache/samza/config/TaskConfigJava.java
@@ -32,6 +32,7 @@ import org.apache.samza.checkpoint.CheckpointManagerFactory;
 import org.apache.samza.metrics.MetricsRegistry;
 import org.apache.samza.system.SystemStream;
 import org.apache.samza.system.SystemStreamPartition;
+import org.apache.samza.util.StreamUtil;
 import org.apache.samza.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,7 +103,7 @@ public class TaskConfigJava extends MapConfig {
       } else {
         String systemStreamName = systemStreamPartition.substring(0, hashPosition);
         String partitionSegment = systemStreamPartition.substring(hashPosition + 1);
-        SystemStream systemStream = Util.getSystemStreamFromNames(systemStreamName);
+        SystemStream systemStream = StreamUtil.getSystemStreamFromNames(systemStreamName);
 
         if (Pattern.matches(BROADCAST_STREAM_PATTERN, partitionSegment)) {
           systemStreamPartitionSet.add(new SystemStreamPartition(systemStream, new Partition(Integer.valueOf(partitionSegment))));

--- a/samza-core/src/main/java/org/apache/samza/execution/ExecutionPlanner.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/ExecutionPlanner.java
@@ -34,6 +34,7 @@ import org.apache.samza.config.ApplicationConfig;
 import org.apache.samza.config.ClusterManagerConfig;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.JobConfig;
+import org.apache.samza.config.StreamConfig;
 import org.apache.samza.operators.OperatorSpecGraph;
 import org.apache.samza.operators.spec.JoinOperatorSpec;
 import org.apache.samza.operators.spec.OperatorSpec;
@@ -42,6 +43,8 @@ import org.apache.samza.system.SystemStream;
 import org.apache.samza.table.TableSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.samza.util.StreamUtil.*;
 
 
 /**
@@ -93,8 +96,9 @@ public class ExecutionPlanner {
    */
   /* package private */ JobGraph createJobGraph(OperatorSpecGraph specGraph) {
     JobGraph jobGraph = new JobGraph(config, specGraph);
-    Set<StreamSpec> sourceStreams = new HashSet<>(specGraph.getInputOperators().keySet());
-    Set<StreamSpec> sinkStreams = new HashSet<>(specGraph.getOutputStreams().keySet());
+    StreamConfig streamConfig = new StreamConfig(config);
+    Set<StreamSpec> sourceStreams = getStreamSpecs(specGraph.getInputOperators().keySet(), streamConfig);
+    Set<StreamSpec> sinkStreams = getStreamSpecs(specGraph.getOutputStreams().keySet(), streamConfig);
     Set<StreamSpec> intStreams = new HashSet<>(sourceStreams);
     Set<TableSpec> tables = new HashSet<>(specGraph.getTables().keySet());
     intStreams.retainAll(sinkStreams);
@@ -128,7 +132,7 @@ public class ExecutionPlanner {
    */
   /* package private */ void calculatePartitions(JobGraph jobGraph) {
     // calculate the partitions for the input streams of join operators
-    calculateJoinInputPartitions(jobGraph);
+    calculateJoinInputPartitions(jobGraph, config);
 
     // calculate the partitions for the rest of intermediate streams
     calculateIntStreamPartitions(jobGraph, config);
@@ -172,7 +176,7 @@ public class ExecutionPlanner {
   /**
    * Calculate the partitions for the input streams of join operators
    */
-  /* package private */ static void calculateJoinInputPartitions(JobGraph jobGraph) {
+  /* package private */ static void calculateJoinInputPartitions(JobGraph jobGraph, Config config) {
     // mapping from a source stream to all join specs reachable from it
     Multimap<OperatorSpec, StreamEdge> joinSpecToStreamEdges = HashMultimap.create();
     // reverse mapping of the above
@@ -183,10 +187,10 @@ public class ExecutionPlanner {
     Set<OperatorSpec> visited = new HashSet<>();
 
     jobGraph.getSpecGraph().getInputOperators().entrySet().forEach(entry -> {
-        StreamEdge streamEdge = jobGraph.getOrCreateStreamEdge(entry.getKey());
+        StreamConfig streamConfig = new StreamConfig(config);
+        StreamEdge streamEdge = jobGraph.getOrCreateStreamEdge(getStreamSpec(entry.getKey(), streamConfig));
         // Traverses the StreamGraph to find and update mappings for all Joins reachable from this input StreamEdge
-        findReachableJoins(entry.getValue(), streamEdge, joinSpecToStreamEdges, streamEdgeToJoinSpecs,
-            joinQ, visited);
+        findReachableJoins(entry.getValue(), streamEdge, joinSpecToStreamEdges, streamEdgeToJoinSpecs, joinQ, visited);
       });
 
     // At this point, joinQ contains joinSpecs where at least one of the input stream edge partitions is known.
@@ -203,7 +207,7 @@ public class ExecutionPlanner {
           } else if (partitions != edgePartitions) {
             throw  new SamzaException(String.format(
                 "Unable to resolve input partitions of stream %s for join. Expected: %d, Actual: %d",
-                edge.getFormattedSystemStream(), partitions, edgePartitions));
+                edge.getName(), partitions, edgePartitions));
           }
         }
       }
@@ -282,7 +286,7 @@ public class ExecutionPlanner {
   private static void validatePartitions(JobGraph jobGraph) {
     for (StreamEdge edge : jobGraph.getIntermediateStreamEdges()) {
       if (edge.getPartitionCount() <= 0) {
-        throw new SamzaException(String.format("Failure to assign the partitions to Stream %s", edge.getFormattedSystemStream()));
+        throw new SamzaException(String.format("Failure to assign the partitions to Stream %s", edge.getName()));
       }
     }
   }

--- a/samza-core/src/main/java/org/apache/samza/execution/JobGraph.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/JobGraph.java
@@ -87,7 +87,7 @@ import org.slf4j.LoggerFactory;
   @Override
   public List<StreamSpec> getIntermediateStreams() {
     return getIntermediateStreamEdges().stream()
-        .map(streamEdge -> streamEdge.getStreamSpec())
+        .map(StreamEdge::getStreamSpec)
         .collect(Collectors.toList());
   }
 
@@ -187,11 +187,9 @@ import org.slf4j.LoggerFactory;
     String streamId = streamSpec.getId();
     StreamEdge edge = edges.get(streamId);
     if (edge == null) {
-      edge = new StreamEdge(streamSpec, isIntermediate, config);
+      boolean isBroadcast = specGraph.getBroadcastStreams().contains(streamId);
+      edge = new StreamEdge(streamSpec, isIntermediate, isBroadcast, config);
       edges.put(streamId, edge);
-    }
-    if (streamSpec.isBroadcast()) {
-      edge.setPartitionCount(1);
     }
     return edge;
   }
@@ -262,11 +260,11 @@ import org.slf4j.LoggerFactory;
     sources.forEach(edge -> {
         if (!edge.getSourceNodes().isEmpty()) {
           throw new IllegalArgumentException(
-              String.format("Source stream %s should not have producers.", edge.getFormattedSystemStream()));
+              String.format("Source stream %s should not have producers.", edge.getName()));
         }
         if (edge.getTargetNodes().isEmpty()) {
           throw new IllegalArgumentException(
-              String.format("Source stream %s should have consumers.", edge.getFormattedSystemStream()));
+              String.format("Source stream %s should have consumers.", edge.getName()));
         }
       });
   }
@@ -278,11 +276,11 @@ import org.slf4j.LoggerFactory;
     sinks.forEach(edge -> {
         if (!edge.getTargetNodes().isEmpty()) {
           throw new IllegalArgumentException(
-              String.format("Sink stream %s should not have consumers", edge.getFormattedSystemStream()));
+              String.format("Sink stream %s should not have consumers", edge.getName()));
         }
         if (edge.getSourceNodes().isEmpty()) {
           throw new IllegalArgumentException(
-              String.format("Sink stream %s should have producers", edge.getFormattedSystemStream()));
+              String.format("Sink stream %s should have producers", edge.getName()));
         }
       });
   }
@@ -298,7 +296,7 @@ import org.slf4j.LoggerFactory;
     internalEdges.forEach(edge -> {
         if (edge.getSourceNodes().isEmpty() || edge.getTargetNodes().isEmpty()) {
           throw new IllegalArgumentException(
-              String.format("Internal stream %s should have both producers and consumers", edge.getFormattedSystemStream()));
+              String.format("Internal stream %s should have both producers and consumers", edge.getName()));
         }
       });
   }

--- a/samza-core/src/main/java/org/apache/samza/execution/JobGraphJsonGenerator.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/JobGraphJsonGenerator.java
@@ -170,10 +170,10 @@ import org.codehaus.jackson.map.ObjectMapper;
   private OperatorGraphJson buildOperatorGraphJson(JobNode jobNode) {
     OperatorGraphJson opGraph = new OperatorGraphJson();
     opGraph.inputStreams = new ArrayList<>();
-    jobNode.getSpecGraph().getInputOperators().forEach((streamSpec, operatorSpec) -> {
+    jobNode.getSpecGraph().getInputOperators().forEach((streamId, operatorSpec) -> {
         StreamJson inputJson = new StreamJson();
         opGraph.inputStreams.add(inputJson);
-        inputJson.streamId = streamSpec.getId();
+        inputJson.streamId = streamId;
         Collection<OperatorSpec> specs = operatorSpec.getRegisteredOperatorSpecs();
         inputJson.nextOperatorIds = specs.stream().map(OperatorSpec::getOpId).collect(Collectors.toSet());
 
@@ -181,9 +181,9 @@ import org.codehaus.jackson.map.ObjectMapper;
       });
 
     opGraph.outputStreams = new ArrayList<>();
-    jobNode.getSpecGraph().getOutputStreams().keySet().forEach(streamSpec -> {
+    jobNode.getSpecGraph().getOutputStreams().keySet().forEach(streamId -> {
         StreamJson outputJson = new StreamJson();
-        outputJson.streamId = streamSpec.getId();
+        outputJson.streamId = streamId;
         opGraph.outputStreams.add(outputJson);
       });
     return opGraph;
@@ -219,10 +219,10 @@ import org.codehaus.jackson.map.ObjectMapper;
 
     if (spec instanceof OutputOperatorSpec) {
       OutputStreamImpl outputStream = ((OutputOperatorSpec) spec).getOutputStream();
-      map.put("outputStreamId", outputStream.getStreamSpec().getId());
+      map.put("outputStreamId", outputStream.getStreamId());
     } else if (spec instanceof PartitionByOperatorSpec) {
       OutputStreamImpl outputStream = ((PartitionByOperatorSpec) spec).getOutputStream();
-      map.put("outputStreamId", outputStream.getStreamSpec().getId());
+      map.put("outputStreamId", outputStream.getStreamId());
     }
 
     if (spec instanceof StreamTableJoinOperatorSpec) {

--- a/samza-core/src/main/java/org/apache/samza/execution/JobNode.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/JobNode.java
@@ -49,7 +49,6 @@ import org.apache.samza.operators.spec.WindowOperatorSpec;
 import org.apache.samza.util.MathUtil;
 import org.apache.samza.serializers.Serde;
 import org.apache.samza.serializers.SerializableSerde;
-import org.apache.samza.system.StreamSpec;
 import org.apache.samza.table.TableProvider;
 import org.apache.samza.table.TableProviderFactory;
 import org.apache.samza.table.TableSpec;
@@ -135,8 +134,8 @@ public class JobNode {
     final List<String> inputs = new ArrayList<>();
     final List<String> broadcasts = new ArrayList<>();
     for (StreamEdge inEdge : inEdges) {
-      String formattedSystemStream = inEdge.getFormattedSystemStream();
-      if (inEdge.getStreamSpec().isBroadcast()) {
+      String formattedSystemStream = inEdge.getName();
+      if (inEdge.isBroadcast()) {
         broadcasts.add(formattedSystemStream + "#0");
       } else {
         inputs.add(formattedSystemStream);
@@ -228,17 +227,17 @@ public class JobNode {
     // collect all key and msg serde instances for streams
     Map<String, Serde> streamKeySerdes = new HashMap<>();
     Map<String, Serde> streamMsgSerdes = new HashMap<>();
-    Map<StreamSpec, InputOperatorSpec> inputOperators = specGraph.getInputOperators();
+    Map<String, InputOperatorSpec> inputOperators = specGraph.getInputOperators();
     inEdges.forEach(edge -> {
         String streamId = edge.getStreamSpec().getId();
-        InputOperatorSpec inputOperatorSpec = inputOperators.get(edge.getStreamSpec());
+        InputOperatorSpec inputOperatorSpec = inputOperators.get(streamId);
         streamKeySerdes.put(streamId, inputOperatorSpec.getKeySerde());
         streamMsgSerdes.put(streamId, inputOperatorSpec.getValueSerde());
       });
-    Map<StreamSpec, OutputStreamImpl> outputStreams = specGraph.getOutputStreams();
+    Map<String, OutputStreamImpl> outputStreams = specGraph.getOutputStreams();
     outEdges.forEach(edge -> {
         String streamId = edge.getStreamSpec().getId();
-        OutputStreamImpl outputStream = outputStreams.get(edge.getStreamSpec());
+        OutputStreamImpl outputStream = outputStreams.get(streamId);
         streamKeySerdes.put(streamId, outputStream.getKeySerde());
         streamMsgSerdes.put(streamId, outputStream.getValueSerde());
       });

--- a/samza-core/src/main/java/org/apache/samza/execution/StreamManager.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/StreamManager.java
@@ -37,6 +37,7 @@ import org.apache.samza.system.SystemAdmin;
 import org.apache.samza.system.SystemAdmins;
 import org.apache.samza.system.SystemStream;
 import org.apache.samza.system.SystemStreamMetadata;
+import org.apache.samza.util.StreamUtil;
 import org.apache.samza.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -128,7 +129,7 @@ public class StreamManager {
             .getOrElse(defaultValue(null));
         if (changelog != null) {
           LOGGER.info("Clear store {} changelog {}", store, changelog);
-          SystemStream systemStream = Util.getSystemStreamFromNames(changelog);
+          SystemStream systemStream = StreamUtil.getSystemStreamFromNames(changelog);
           StreamSpec spec = StreamSpec.createChangeLogStreamSpec(systemStream.getStream(), systemStream.getSystem(), 1);
           systemAdmins.getSystemAdmin(spec.getSystemName()).clearStream(spec);
         }

--- a/samza-core/src/main/java/org/apache/samza/operators/OperatorSpecGraph.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/OperatorSpecGraph.java
@@ -29,7 +29,6 @@ import org.apache.samza.operators.spec.InputOperatorSpec;
 import org.apache.samza.operators.spec.OperatorSpec;
 import org.apache.samza.operators.spec.OutputStreamImpl;
 import org.apache.samza.serializers.SerializableSerde;
-import org.apache.samza.system.StreamSpec;
 import org.apache.samza.table.TableSpec;
 
 
@@ -41,8 +40,9 @@ import org.apache.samza.table.TableSpec;
  */
 public class OperatorSpecGraph implements Serializable {
   // We use a LHM for deterministic order in initializing and closing operators.
-  private final Map<StreamSpec, InputOperatorSpec> inputOperators;
-  private final Map<StreamSpec, OutputStreamImpl> outputStreams;
+  private final Map<String, InputOperatorSpec> inputOperators;
+  private final Map<String, OutputStreamImpl> outputStreams;
+  private final Set<String> broadcastStreams;
   private final Map<TableSpec, TableImpl> tables;
   private final Set<OperatorSpec> allOpSpecs;
   private final boolean hasWindowOrJoins;
@@ -54,18 +54,23 @@ public class OperatorSpecGraph implements Serializable {
   OperatorSpecGraph(StreamGraphSpec graphSpec) {
     this.inputOperators = graphSpec.getInputOperators();
     this.outputStreams = graphSpec.getOutputStreams();
+    this.broadcastStreams = graphSpec.getBroadcastStreams();
     this.tables = graphSpec.getTables();
     this.allOpSpecs = Collections.unmodifiableSet(this.findAllOperatorSpecs());
     this.hasWindowOrJoins = checkWindowOrJoins();
     this.serializedOpSpecGraph = opSpecGraphSerde.toBytes(this);
   }
 
-  public Map<StreamSpec, InputOperatorSpec> getInputOperators() {
+  public Map<String, InputOperatorSpec> getInputOperators() {
     return inputOperators;
   }
 
-  public Map<StreamSpec, OutputStreamImpl> getOutputStreams() {
+  public Map<String, OutputStreamImpl> getOutputStreams() {
     return outputStreams;
+  }
+
+  public Set<String> getBroadcastStreams() {
+    return broadcastStreams;
   }
 
   public Map<TableSpec, TableImpl> getTables() {

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/BroadcastOperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/BroadcastOperatorImpl.java
@@ -40,9 +40,9 @@ class BroadcastOperatorImpl<M> extends OperatorImpl<M, Void> {
   private final SystemStream systemStream;
   private final String taskName;
 
-  BroadcastOperatorImpl(BroadcastOperatorSpec<M> broadcastOpSpec, TaskContext context) {
+  BroadcastOperatorImpl(BroadcastOperatorSpec<M> broadcastOpSpec, SystemStream systemStream, TaskContext context) {
     this.broadcastOpSpec = broadcastOpSpec;
-    this.systemStream = broadcastOpSpec.getOutputStream().getSystemStream();
+    this.systemStream = systemStream;
     this.taskName = context.getTaskName().getTaskName();
   }
 

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/OutputOperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/OutputOperatorImpl.java
@@ -42,10 +42,10 @@ class OutputOperatorImpl<M> extends OperatorImpl<M, Void> {
   private final OutputStreamImpl<M> outputStream;
   private final SystemStream systemStream;
 
-  OutputOperatorImpl(OutputOperatorSpec<M> outputOpSpec) {
+  OutputOperatorImpl(OutputOperatorSpec<M> outputOpSpec, SystemStream systemStream) {
     this.outputOpSpec = outputOpSpec;
     this.outputStream = outputOpSpec.getOutputStream();
-    this.systemStream = outputStream.getSystemStream();
+    this.systemStream = systemStream;
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/PartitionByOperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/PartitionByOperatorImpl.java
@@ -20,10 +20,8 @@ package org.apache.samza.operators.impl;
 
 import org.apache.samza.config.Config;
 import org.apache.samza.container.TaskContextImpl;
-import org.apache.samza.operators.KV;
 import org.apache.samza.operators.functions.MapFunction;
 import org.apache.samza.operators.spec.OperatorSpec;
-import org.apache.samza.operators.spec.OutputStreamImpl;
 import org.apache.samza.operators.spec.PartitionByOperatorSpec;
 import org.apache.samza.system.ControlMessage;
 import org.apache.samza.system.EndOfStreamMessage;
@@ -51,10 +49,10 @@ class PartitionByOperatorImpl<M, K, V> extends OperatorImpl<M, Void> {
   private final String taskName;
   private final ControlMessageSender controlMessageSender;
 
-  PartitionByOperatorImpl(PartitionByOperatorSpec<M, K, V> partitionByOpSpec, Config config, TaskContext context) {
+  PartitionByOperatorImpl(PartitionByOperatorSpec<M, K, V> partitionByOpSpec,
+      SystemStream systemStream, TaskContext context) {
     this.partitionByOpSpec = partitionByOpSpec;
-    OutputStreamImpl<KV<K, V>> outputStream = partitionByOpSpec.getOutputStream();
-    this.systemStream = outputStream.getSystemStream();
+    this.systemStream = systemStream;
     this.keyFunction = partitionByOpSpec.getKeyFunction();
     this.valueFunction = partitionByOpSpec.getValueFunction();
     this.taskName = context.getTaskName().getTaskName();
@@ -102,7 +100,6 @@ class PartitionByOperatorImpl<M, K, V> extends OperatorImpl<M, Void> {
   }
 
   private void sendControlMessage(ControlMessage message, MessageCollector collector) {
-    SystemStream outputStream = partitionByOpSpec.getOutputStream().getSystemStream();
-    controlMessageSender.send(message, outputStream, collector);
+    controlMessageSender.send(message, systemStream, collector);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/operators/spec/InputOperatorSpec.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/spec/InputOperatorSpec.java
@@ -22,7 +22,6 @@ import org.apache.samza.operators.KV;
 import org.apache.samza.operators.functions.TimerFunction;
 import org.apache.samza.operators.functions.WatermarkFunction;
 import org.apache.samza.serializers.Serde;
-import org.apache.samza.system.StreamSpec;
 
 /**
  * The spec for an operator that receives incoming messages from an input stream
@@ -34,7 +33,7 @@ import org.apache.samza.system.StreamSpec;
 public class InputOperatorSpec<K, V> extends OperatorSpec<KV<K, V>, Object> { // Object == KV<K, V> | V
 
   private final boolean isKeyed;
-  private final StreamSpec streamSpec;
+  private final String streamId;
 
   /**
    * The following {@link Serde}s are serialized by the ExecutionPlanner when generating the configs for a stream, and deserialized
@@ -43,17 +42,16 @@ public class InputOperatorSpec<K, V> extends OperatorSpec<KV<K, V>, Object> { //
   private transient final Serde<K> keySerde;
   private transient final Serde<V> valueSerde;
 
-  public InputOperatorSpec(StreamSpec streamSpec,
-      Serde<K> keySerde, Serde<V> valueSerde, boolean isKeyed, String opId) {
+  public InputOperatorSpec(String streamId, Serde<K> keySerde, Serde<V> valueSerde, boolean isKeyed, String opId) {
     super(OpCode.INPUT, opId);
-    this.streamSpec = streamSpec;
+    this.streamId = streamId;
     this.keySerde = keySerde;
     this.valueSerde = valueSerde;
     this.isKeyed = isKeyed;
   }
 
-  public StreamSpec getStreamSpec() {
-    return this.streamSpec;
+  public String getStreamId() {
+    return this.streamId;
   }
 
   public Serde<K> getKeySerde() {

--- a/samza-core/src/main/java/org/apache/samza/operators/spec/OperatorSpecs.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/spec/OperatorSpecs.java
@@ -28,7 +28,6 @@ import org.apache.samza.operators.functions.SinkFunction;
 import org.apache.samza.operators.functions.StreamTableJoinFunction;
 import org.apache.samza.operators.windows.internal.WindowInternal;
 import org.apache.samza.serializers.Serde;
-import org.apache.samza.system.StreamSpec;
 import org.apache.samza.table.TableSpec;
 
 
@@ -42,7 +41,7 @@ public class OperatorSpecs {
   /**
    * Creates an {@link InputOperatorSpec} for consuming input.
    *
-   * @param streamSpec  the stream spec for the input stream
+   * @param streamId  the stream id for the input stream
    * @param keySerde  the serde for the input key
    * @param valueSerde  the serde for the input value
    * @param isKeyed  whether the input stream is keyed
@@ -52,8 +51,8 @@ public class OperatorSpecs {
    * @return  the {@link InputOperatorSpec}
    */
   public static <K, V> InputOperatorSpec<K, V> createInputOperatorSpec(
-    StreamSpec streamSpec, Serde<K> keySerde, Serde<V> valueSerde, boolean isKeyed, String opId) {
-    return new InputOperatorSpec<>(streamSpec, keySerde, valueSerde, isKeyed, opId);
+    String streamId, Serde<K> keySerde, Serde<V> valueSerde, boolean isKeyed, String opId) {
+    return new InputOperatorSpec<>(streamId, keySerde, valueSerde, isKeyed, opId);
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/operators/spec/OutputStreamImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/spec/OutputStreamImpl.java
@@ -21,13 +21,10 @@ package org.apache.samza.operators.spec;
 import java.io.Serializable;
 import org.apache.samza.operators.OutputStream;
 import org.apache.samza.serializers.Serde;
-import org.apache.samza.system.StreamSpec;
-import org.apache.samza.system.SystemStream;
-
 
 public class OutputStreamImpl<M> implements OutputStream<M>, Serializable {
 
-  private final StreamSpec streamSpec;
+  private final String streamId;
   private final boolean isKeyed;
 
   /**
@@ -37,16 +34,15 @@ public class OutputStreamImpl<M> implements OutputStream<M>, Serializable {
   private transient final Serde keySerde;
   private transient final Serde valueSerde;
 
-  public OutputStreamImpl(StreamSpec streamSpec,
-      Serde keySerde, Serde valueSerde, boolean isKeyed) {
-    this.streamSpec = streamSpec;
+  public OutputStreamImpl(String streamId, Serde keySerde, Serde valueSerde, boolean isKeyed) {
+    this.streamId = streamId;
     this.keySerde = keySerde;
     this.valueSerde = valueSerde;
     this.isKeyed = isKeyed;
   }
 
-  public StreamSpec getStreamSpec() {
-    return streamSpec;
+  public String getStreamId() {
+    return streamId;
   }
 
   public Serde getKeySerde() {
@@ -55,10 +51,6 @@ public class OutputStreamImpl<M> implements OutputStream<M>, Serializable {
 
   public Serde getValueSerde() {
     return valueSerde;
-  }
-
-  public SystemStream getSystemStream() {
-    return this.streamSpec.toSystemStream();
   }
 
   public boolean isKeyed() {

--- a/samza-core/src/main/java/org/apache/samza/operators/stream/IntermediateMessageStreamImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/stream/IntermediateMessageStreamImpl.java
@@ -24,7 +24,6 @@ import org.apache.samza.operators.StreamGraphSpec;
 import org.apache.samza.operators.spec.InputOperatorSpec;
 import org.apache.samza.operators.spec.OperatorSpec;
 import org.apache.samza.operators.spec.OutputStreamImpl;
-import org.apache.samza.system.StreamSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,13 +50,13 @@ public class IntermediateMessageStreamImpl<M> extends MessageStreamImpl<M> imple
     this.outputStream = outputStream;
     if (inputOperatorSpec.isKeyed() != outputStream.isKeyed()) {
       LOGGER.error("Input and output streams for intermediate stream {} aren't keyed consistently. Input: {}, Output: {}",
-          new Object[]{inputOperatorSpec.getStreamSpec().getId(), inputOperatorSpec.isKeyed(), outputStream.isKeyed()});
+          new Object[]{inputOperatorSpec.getStreamId(), inputOperatorSpec.isKeyed(), outputStream.isKeyed()});
     }
     this.isKeyed = inputOperatorSpec.isKeyed() && outputStream.isKeyed();
   }
 
-  public StreamSpec getStreamSpec() {
-    return this.outputStream.getStreamSpec();
+  public String getStreamId() {
+    return this.outputStream.getStreamId();
   }
 
   public OutputStreamImpl<M> getOutputStream() {

--- a/samza-core/src/main/java/org/apache/samza/runtime/AbstractApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/AbstractApplicationRunner.java
@@ -31,7 +31,6 @@ import org.apache.samza.execution.ExecutionPlanner;
 import org.apache.samza.execution.StreamManager;
 import org.apache.samza.operators.OperatorSpecGraph;
 import org.apache.samza.operators.StreamGraphSpec;
-import org.apache.samza.system.StreamSpec;
 import org.apache.samza.system.SystemAdmins;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,16 +59,9 @@ public abstract class AbstractApplicationRunner extends ApplicationRunner {
 
   public AbstractApplicationRunner(Config config) {
     super(config);
-    this.graphSpec = new StreamGraphSpec(this, config);
+    this.graphSpec = new StreamGraphSpec(config);
     this.systemAdmins = new SystemAdmins(config);
     this.streamManager = new StreamManager(systemAdmins);
-  }
-
-  @Override
-  public StreamSpec getStreamSpec(String streamId) {
-    StreamConfig streamConfig = new StreamConfig(config);
-    String physicalName = streamConfig.getPhysicalName(streamId);
-    return getStreamSpec(streamId, physicalName);
   }
 
   @Override
@@ -82,50 +74,6 @@ public abstract class AbstractApplicationRunner extends ApplicationRunner {
     systemAdmins.stop();
   }
 
-  /**
-   * Constructs a {@link StreamSpec} from the configuration for the specified streamId.
-   *
-   * The stream configurations are read from the following properties in the config:
-   * {@code streams.{$streamId}.*}
-   * <br>
-   * All properties matching this pattern are assumed to be system-specific with one exception. The following
-   * property is a Samza property which is used to bind the stream to a system.
-   *
-   * <ul>
-   *   <li>samza.system - The name of the System on which this stream will be used. If this property isn't defined
-   *                      the stream will be associated with the System defined in {@code job.default.system}</li>
-   * </ul>
-   *
-   * @param streamId      The logical identifier for the stream in Samza.
-   * @param physicalName  The system-specific name for this stream. It could be a file URN, topic name, or other identifer.
-   * @return              The {@link StreamSpec} instance.
-   */
-  /*package private*/ StreamSpec getStreamSpec(String streamId, String physicalName) {
-    StreamConfig streamConfig = new StreamConfig(config);
-    String system = streamConfig.getSystem(streamId);
-
-    return getStreamSpec(streamId, physicalName, system);
-  }
-
-  /**
-   * Constructs a {@link StreamSpec} from the configuration for the specified streamId.
-   *
-   * The stream configurations are read from the following properties in the config:
-   * {@code streams.{$streamId}.*}
-   *
-   * @param streamId      The logical identifier for the stream in Samza.
-   * @param physicalName  The system-specific name for this stream. It could be a file URN, topic name, or other identifer.
-   * @param system        The name of the System on which this stream will be used.
-   * @return              The {@link StreamSpec} instance.
-   */
-  /*package private*/ StreamSpec getStreamSpec(String streamId, String physicalName, String system) {
-    StreamConfig streamConfig = new StreamConfig(config);
-    Map<String, String> properties = streamConfig.getStreamProperties(streamId);
-    boolean isBounded = streamConfig.getIsBounded(streamId);
-
-    return new StreamSpec(streamId, physicalName, system, isBounded, properties);
-  }
-
   public ExecutionPlan getExecutionPlan(StreamApplication app) throws Exception {
     return getExecutionPlan(app, null);
   }
@@ -134,20 +82,22 @@ public abstract class AbstractApplicationRunner extends ApplicationRunner {
   ExecutionPlan getExecutionPlan(StreamApplication app, String runId) throws Exception {
     // build stream graph
     app.init(graphSpec, config);
-
     OperatorSpecGraph specGraph = graphSpec.getOperatorSpecGraph();
-    // create the physical execution plan
+
+    // update application configs
     Map<String, String> cfg = new HashMap<>(config);
     if (StringUtils.isNoneEmpty(runId)) {
       cfg.put(ApplicationConfig.APP_RUN_ID, runId);
     }
 
-    Set<StreamSpec> inputStreams = new HashSet<>(specGraph.getInputOperators().keySet());
+    StreamConfig streamConfig = new StreamConfig(config);
+    Set<String> inputStreams = new HashSet<>(specGraph.getInputOperators().keySet());
     inputStreams.removeAll(specGraph.getOutputStreams().keySet());
-    ApplicationMode mode = inputStreams.stream().allMatch(StreamSpec::isBounded)
+    ApplicationMode mode = inputStreams.stream().allMatch(streamConfig::getIsBounded)
         ? ApplicationMode.BATCH : ApplicationMode.STREAM;
     cfg.put(ApplicationConfig.APP_MODE, mode.name());
 
+    // create the physical execution plan
     ExecutionPlanner planner = new ExecutionPlanner(new MapConfig(cfg), streamManager);
     return planner.plan(specGraph);
   }

--- a/samza-core/src/main/java/org/apache/samza/storage/ChangelogStreamManager.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/ChangelogStreamManager.java
@@ -34,7 +34,7 @@ import org.apache.samza.coordinator.stream.CoordinatorStreamManager;
 import org.apache.samza.system.StreamSpec;
 import org.apache.samza.system.SystemAdmin;
 import org.apache.samza.system.SystemStream;
-import org.apache.samza.util.Util;
+import org.apache.samza.util.StreamUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,7 +113,7 @@ public class ChangelogStreamManager {
         .stream()
         .filter(name -> StringUtils.isNotBlank(storageConfig.getChangelogStream(name)))
         .collect(Collectors.toMap(name -> name,
-            name -> Util.getSystemStreamFromNames(storageConfig.getChangelogStream(name))));
+            name -> StreamUtil.getSystemStreamFromNames(storageConfig.getChangelogStream(name))));
 
     // Get SystemAdmin for changelog store's system and attempt to create the stream
     JavaSystemConfig systemConfig = new JavaSystemConfig(config);

--- a/samza-core/src/main/java/org/apache/samza/storage/StorageRecovery.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/StorageRecovery.java
@@ -48,6 +48,7 @@ import org.apache.samza.system.SystemStream;
 import org.apache.samza.system.SystemStreamPartition;
 import org.apache.samza.util.CommandLine;
 import org.apache.samza.util.ScalaJavaUtil;
+import org.apache.samza.util.StreamUtil;
 import org.apache.samza.util.SystemClock;
 import org.apache.samza.util.Util;
 import org.slf4j.Logger;
@@ -147,7 +148,7 @@ public class StorageRecovery extends CommandLine {
       log.info("stream name for " + storeName + " is " + streamName);
 
       if (streamName != null) {
-        changeLogSystemStreams.put(storeName, Util.getSystemStreamFromNames(streamName));
+        changeLogSystemStreams.put(storeName, StreamUtil.getSystemStreamFromNames(streamName));
       }
 
       String factoryClass = config.getStorageFactoryClassName(storeName);

--- a/samza-core/src/main/java/org/apache/samza/util/StreamUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/util/StreamUtil.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.util;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.MapConfig;
+import org.apache.samza.config.StreamConfig;
+import org.apache.samza.config.StreamConfig$;
+import org.apache.samza.system.StreamSpec;
+import org.apache.samza.system.SystemStream;
+
+public class StreamUtil {
+  /**
+   * Returns a SystemStream object based on the system stream name given. For
+   * example, kafka.topic would return new SystemStream("kafka", "topic").
+   */
+  public static SystemStream getSystemStreamFromNames(String systemStreamNames) {
+    int idx = systemStreamNames.indexOf('.');
+    if (idx < 0) {
+      throw new IllegalArgumentException("No '.' in stream name '" + systemStreamNames +
+          "'. Stream names should be in the form 'system.stream'");
+    }
+    return new SystemStream(
+        systemStreamNames.substring(0, idx),
+        systemStreamNames.substring(idx + 1, systemStreamNames.length()));
+  }
+
+  /**
+   * Returns a SystemStream object based on the system stream name given. For
+   * example, kafka.topic would return new SystemStream("kafka", "topic").
+   */
+  public static String getNameFromSystemStream(SystemStream systemStream) {
+    return systemStream.getSystem() + "." + systemStream.getStream();
+  }
+
+  public static Set<StreamSpec> getStreamSpecs(Set<String> streamIds, StreamConfig streamConfig) {
+    return streamIds.stream().map(streamId -> getStreamSpec(streamId, streamConfig)).collect(Collectors.toSet());
+  }
+
+  public static StreamSpec getStreamSpec(String streamId, StreamConfig streamConfig) {
+    String physicalName = streamConfig.getPhysicalName(streamId);
+    String system = streamConfig.getSystem(streamId);
+    Map<String, String> streamProperties = streamConfig.getStreamProperties(streamId);
+    return new StreamSpec(streamId, physicalName, system, streamProperties);
+  }
+
+  /**
+   * Converts the provided list of (streamId, system, physicalName) triplets to their corresponding
+   * stream.stream-id.* configurations.
+   *
+   * @param streams a list of (streamId, system, physicalName) triplets to get the stream configuration for.
+   * @return the configuration for the provided { @code streams}
+   */
+  public static Config toStreamConfigs(List<ImmutableTriple<String, String, String>> streams) {
+    Map<String, String> configsMap = new HashMap<>();
+    streams.stream().forEach(triple -> {
+        String streamId = triple.getLeft();
+        String systemName = triple.getMiddle();
+        String physicalName = triple.getRight();
+        configsMap.put(String.format(StreamConfig$.MODULE$.SYSTEM_FOR_STREAM_ID(), streamId), systemName);
+        configsMap.put(String.format(StreamConfig$.MODULE$.PHYSICAL_NAME_FOR_STREAM_ID(), streamId), physicalName);
+      });
+    return new MapConfig(configsMap);
+  }
+}

--- a/samza-core/src/main/scala/org/apache/samza/config/StorageConfig.scala
+++ b/samza-core/src/main/scala/org/apache/samza/config/StorageConfig.scala
@@ -22,8 +22,7 @@ package org.apache.samza.config
 
 import java.util.concurrent.TimeUnit
 import scala.collection.JavaConverters._
-import org.apache.samza.util.Logging
-import org.apache.samza.util.Util
+import org.apache.samza.util.{Logging, StreamUtil}
 
 object StorageConfig {
   // stream config constants
@@ -94,7 +93,7 @@ class StorageConfig(config: Config) extends ScalaMapConfig(config) with Logging 
       .map(getChangelogStream(_))
       .filter(_.isDefined)
       // Convert "system.stream" to systemName
-      .map(systemStreamName => Util.getSystemStreamFromNames(systemStreamName.get).getSystem)
+      .map(systemStreamName => StreamUtil.getSystemStreamFromNames(systemStreamName.get).getSystem)
       .contains(systemName)
   }
 

--- a/samza-core/src/main/scala/org/apache/samza/config/TaskConfig.scala
+++ b/samza-core/src/main/scala/org/apache/samza/config/TaskConfig.scala
@@ -22,7 +22,7 @@ package org.apache.samza.config
 import org.apache.samza.checkpoint.CheckpointManager
 import org.apache.samza.metrics.MetricsRegistry
 import org.apache.samza.system.SystemStream
-import org.apache.samza.util.{Logging, Util}
+import org.apache.samza.util.{Logging, StreamUtil}
 
 object TaskConfig {
   // task config constants
@@ -78,7 +78,7 @@ class TaskConfig(config: Config) extends ScalaMapConfig(config) with Logging {
   def getInputStreams = getOption(TaskConfig.INPUT_STREAMS) match {
     case Some(streams) => if (streams.length > 0) {
       streams.split(",").map(systemStreamNames => {
-        Util.getSystemStreamFromNames(systemStreamNames.trim)
+        StreamUtil.getSystemStreamFromNames(systemStreamNames.trim)
       }).toSet
     } else {
       Set[SystemStream]()

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -323,7 +323,7 @@ object SamzaContainer extends Logging {
       .getStoreNames
       .filter(config.getChangelogStream(_).isDefined)
       .map(name => (name, config.getChangelogStream(name).get)).toMap
-      .mapValues(Util.getSystemStreamFromNames(_))
+      .mapValues(StreamUtil.getSystemStreamFromNames(_))
 
     info("Got change log system streams: %s" format changeLogSystemStreams)
 

--- a/samza-core/src/main/scala/org/apache/samza/job/local/ThreadJobFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/job/local/ThreadJobFactory.scala
@@ -28,7 +28,6 @@ import org.apache.samza.coordinator.stream.CoordinatorStreamManager
 import org.apache.samza.job.{StreamJob, StreamJobFactory}
 import org.apache.samza.metrics.{JmxServer, MetricsRegistryMap, MetricsReporter}
 import org.apache.samza.operators.StreamGraphSpec
-import org.apache.samza.runtime.LocalContainerRunner
 import org.apache.samza.storage.ChangelogStreamManager
 import org.apache.samza.task.TaskFactoryUtil
 import org.apache.samza.util.Logging
@@ -72,10 +71,9 @@ class ThreadJobFactory extends StreamJobFactory with Logging {
     val containerId = "0"
     val jmxServer = new JmxServer
     val streamApp = TaskFactoryUtil.createStreamApplication(config)
-    val appRunner = new LocalContainerRunner(jobModel, "0")
 
     val taskFactory = if (streamApp != null) {
-      val graphSpec = new StreamGraphSpec(appRunner, config)
+      val graphSpec = new StreamGraphSpec(config)
       streamApp.init(graphSpec, config)
       TaskFactoryUtil.createTaskFactory(graphSpec.getOperatorSpecGraph(), graphSpec.getContextManager)
     } else {

--- a/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporterFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporterFactory.scala
@@ -19,7 +19,7 @@
 
 package org.apache.samza.metrics.reporter
 
-import org.apache.samza.util.Logging
+import org.apache.samza.util.{Logging, StreamUtil, Util}
 import org.apache.samza.SamzaException
 import org.apache.samza.config.{ApplicationConfig, Config}
 import org.apache.samza.config.JobConfig.Config2Job
@@ -30,7 +30,6 @@ import org.apache.samza.config.SerializerConfig.Config2Serializer
 import org.apache.samza.config.TaskConfig.Config2Task
 import org.apache.samza.metrics.MetricsReporter
 import org.apache.samza.metrics.MetricsReporterFactory
-import org.apache.samza.util.Util
 import org.apache.samza.metrics.MetricsRegistryMap
 import org.apache.samza.serializers.SerdeFactory
 import org.apache.samza.system.SystemFactory
@@ -68,7 +67,7 @@ class MetricsSnapshotReporterFactory extends MetricsReporterFactory with Logging
       .getMetricsReporterStream(name)
       .getOrElse(throw new SamzaException("No metrics stream defined in config."))
 
-    val systemStream = Util.getSystemStreamFromNames(metricsSystemStreamName)
+    val systemStream = StreamUtil.getSystemStreamFromNames(metricsSystemStreamName)
 
     info("Got system stream %s." format systemStream)
 

--- a/samza-core/src/main/scala/org/apache/samza/util/Util.scala
+++ b/samza-core/src/main/scala/org/apache/samza/util/Util.scala
@@ -67,26 +67,6 @@ object Util extends Logging {
   }
 
   /**
-   * Returns a SystemStream object based on the system stream name given. For
-   * example, kafka.topic would return new SystemStream("kafka", "topic").
-   */
-  def getSystemStreamFromNames(systemStreamNames: String): SystemStream = {
-    val idx = systemStreamNames.indexOf('.')
-    if (idx < 0) {
-      throw new IllegalArgumentException("No '.' in stream name '" + systemStreamNames + "'. Stream names should be in the form 'system.stream'")
-    }
-    new SystemStream(systemStreamNames.substring(0, idx), systemStreamNames.substring(idx + 1, systemStreamNames.length))
-  }
-
-  /**
-   * Returns a SystemStream object based on the system stream name given. For
-   * example, kafka.topic would return new SystemStream("kafka", "topic").
-   */
-  def getNameFromSystemStream(systemStream: SystemStream) = {
-    systemStream.getSystem + "." + systemStream.getStream
-  }
-
-  /**
    * Returns the the first host address which is not the loopback address, or [[java.net.InetAddress#getLocalHost]] as a fallback
    *
    * @return the [[java.net.InetAddress]] which represents the localhost

--- a/samza-core/src/test/java/org/apache/samza/execution/TestStreamEdge.java
+++ b/samza-core/src/test/java/org/apache/samza/execution/TestStreamEdge.java
@@ -37,7 +37,7 @@ public class TestStreamEdge {
 
   @Test
   public void testGetStreamSpec() {
-    StreamEdge edge = new StreamEdge(spec, false, new MapConfig());
+    StreamEdge edge = new StreamEdge(spec, false, false, new MapConfig());
     assertEquals(edge.getStreamSpec(), spec);
     assertEquals(edge.getStreamSpec().getPartitionCount(), 1 /*StreamSpec.DEFAULT_PARTITION_COUNT*/);
 
@@ -50,15 +50,15 @@ public class TestStreamEdge {
     Map<String, String> config = new HashMap<>();
     config.put(ApplicationConfig.APP_MODE, ApplicationConfig.ApplicationMode.BATCH.name());
     config.put(ApplicationConfig.APP_RUN_ID, "123");
-    StreamEdge edge = new StreamEdge(spec, true, new MapConfig(config));
+    StreamEdge edge = new StreamEdge(spec, true, false, new MapConfig(config));
     assertEquals(edge.getStreamSpec().getPhysicalName(), spec.getPhysicalName() + "-123");
   }
 
   @Test
   public void testGenerateConfig() {
     // an example unbounded IO stream
-    StreamSpec spec = new StreamSpec("stream-1", "physical-stream-1", "system-1", false, Collections.singletonMap("property1", "haha"));
-    StreamEdge edge = new StreamEdge(spec, false, new MapConfig());
+    StreamSpec spec = new StreamSpec("stream-1", "physical-stream-1", "system-1", Collections.singletonMap("property1", "haha"));
+    StreamEdge edge = new StreamEdge(spec, false, false, new MapConfig());
     Config config = edge.generateConfig();
     StreamConfig streamConfig = new StreamConfig(config);
     assertEquals(streamConfig.getSystem(spec.getId()), "system-1");
@@ -68,14 +68,14 @@ public class TestStreamEdge {
     assertEquals(streamConfig.getStreamProperties(spec.getId()).get("property1"), "haha");
 
     // bounded stream
-    spec = new StreamSpec("stream-1", "physical-stream-1", "system-1", true, Collections.singletonMap("property1", "haha"));
-    edge = new StreamEdge(spec, false, new MapConfig());
+    spec = new StreamSpec("stream-1", "physical-stream-1", "system-1", Collections.singletonMap("property1", "haha"));
+    edge = new StreamEdge(spec, false, false, new MapConfig());
     config = edge.generateConfig();
     streamConfig = new StreamConfig(config);
     assertEquals(streamConfig.getIsBounded(spec.getId()), true);
 
     // intermediate stream
-    edge = new StreamEdge(spec, true, new MapConfig());
+    edge = new StreamEdge(spec, true, false, new MapConfig());
     config = edge.generateConfig();
     streamConfig = new StreamConfig(config);
     assertEquals(streamConfig.getIsIntermediateStream(spec.getId()), true);

--- a/samza-core/src/test/java/org/apache/samza/operators/TestJoinOperator.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/TestJoinOperator.java
@@ -28,12 +28,10 @@ import org.apache.samza.metrics.MetricsRegistryMap;
 import org.apache.samza.operators.functions.JoinFunction;
 import org.apache.samza.operators.impl.store.TestInMemoryStore;
 import org.apache.samza.operators.impl.store.TimestampedValueSerde;
-import org.apache.samza.runtime.ApplicationRunner;
 import org.apache.samza.serializers.IntegerSerde;
 import org.apache.samza.serializers.KVSerde;
 import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.system.OutgoingMessageEnvelope;
-import org.apache.samza.system.StreamSpec;
 import org.apache.samza.system.SystemStream;
 import org.apache.samza.system.SystemStreamPartition;
 import org.apache.samza.task.MessageCollector;
@@ -74,7 +72,6 @@ public class TestJoinOperator {
   @Before
   public void setUp() {
     Map<String, String> mapConfig = new HashMap<>();
-    mapConfig.put("app.runner.class", "org.apache.samza.runtime.LocalApplicationRunner");
     mapConfig.put("job.default.system", "insystem");
     mapConfig.put("job.name", "jobName");
     mapConfig.put("job.id", "jobId");
@@ -101,7 +98,7 @@ public class TestJoinOperator {
   public void joinWithSelfThrowsException() throws Exception {
     config.put("streams.instream.system", "insystem");
 
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(ApplicationRunner.class), config);
+    StreamGraphSpec graphSpec = new StreamGraphSpec(config);
     IntegerSerde integerSerde = new IntegerSerde();
     KVSerde<Integer, Integer> kvSerde = KVSerde.of(integerSerde, integerSerde);
     MessageStream<KV<Integer, Integer>> inStream = graphSpec.getInputStream("instream", kvSerde);
@@ -320,11 +317,7 @@ public class TestJoinOperator {
   }
 
   private StreamGraphSpec getTestJoinStreamGraph(TestJoinFunction joinFn) throws IOException {
-    ApplicationRunner runner = mock(ApplicationRunner.class);
-    when(runner.getStreamSpec("instream")).thenReturn(new StreamSpec("instream", "instream", "insystem"));
-    when(runner.getStreamSpec("instream2")).thenReturn(new StreamSpec("instream2", "instream2", "insystem"));
-
-    StreamGraphSpec graphSpec = new StreamGraphSpec(runner, config);
+    StreamGraphSpec graphSpec = new StreamGraphSpec(config);
     IntegerSerde integerSerde = new IntegerSerde();
     KVSerde<Integer, Integer> kvSerde = KVSerde.of(integerSerde, integerSerde);
     MessageStream<KV<Integer, Integer>> inStream = graphSpec.getInputStream("instream", kvSerde);

--- a/samza-core/src/test/java/org/apache/samza/operators/TestOperatorSpecGraph.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/TestOperatorSpecGraph.java
@@ -38,7 +38,6 @@ import org.apache.samza.operators.spec.OutputStreamImpl;
 import org.apache.samza.operators.spec.SinkOperatorSpec;
 import org.apache.samza.operators.spec.StreamOperatorSpec;
 import org.apache.samza.serializers.NoOpSerde;
-import org.apache.samza.system.StreamSpec;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,8 +58,8 @@ import static org.mockito.Mockito.*;
 public class TestOperatorSpecGraph {
 
   private StreamGraphSpec mockGraph;
-  private Map<StreamSpec, InputOperatorSpec> inputOpSpecMap;
-  private Map<StreamSpec, OutputStreamImpl> outputStrmMap;
+  private Map<String, InputOperatorSpec> inputOpSpecMap;
+  private Map<String, OutputStreamImpl> outputStrmMap;
   private Set<OperatorSpec> allOpSpecs;
 
   @Before
@@ -72,26 +71,26 @@ public class TestOperatorSpecGraph {
      * 1) input1 --> filter --> sendTo
      * 2) input2 --> map --> sink
      */
-    StreamSpec testInputSpec = new StreamSpec("test-input-1", "test-input-1", "kafka");
-    InputOperatorSpec testInput = new InputOperatorSpec(testInputSpec, new NoOpSerde(), new NoOpSerde(), true, "test-input-1");
+    String inputStreamId1 = "test-input-1";
+    String outputStreamId = "test-output-1";
+    InputOperatorSpec testInput = new InputOperatorSpec(inputStreamId1, new NoOpSerde(), new NoOpSerde(), true, inputStreamId1);
     StreamOperatorSpec filterOp = OperatorSpecs.createFilterOperatorSpec(m -> true, "test-filter-2");
-    StreamSpec testOutputSpec = new StreamSpec("test-output-1", "test-output-1", "kafka");
-    OutputStreamImpl outputStream1 = new OutputStreamImpl(testOutputSpec, null, null, true);
+    OutputStreamImpl outputStream1 = new OutputStreamImpl(outputStreamId, null, null, true);
     OutputOperatorSpec outputSpec = OperatorSpecs.createSendToOperatorSpec(outputStream1, "test-output-3");
     testInput.registerNextOperatorSpec(filterOp);
     filterOp.registerNextOperatorSpec(outputSpec);
-    StreamSpec testInputSpec2 = new StreamSpec("test-input-2", "test-input-2", "kafka");
-    InputOperatorSpec testInput2 = new InputOperatorSpec(testInputSpec2, new NoOpSerde(), new NoOpSerde(), true, "test-input-4");
+    String streamId2 = "test-input-2";
+    InputOperatorSpec testInput2 = new InputOperatorSpec(streamId2, new NoOpSerde(), new NoOpSerde(), true, "test-input-4");
     StreamOperatorSpec testMap = OperatorSpecs.createMapOperatorSpec(m -> m, "test-map-5");
     SinkOperatorSpec testSink = OperatorSpecs.createSinkOperatorSpec((m, mc, tc) -> { }, "test-sink-6");
     testInput2.registerNextOperatorSpec(testMap);
     testMap.registerNextOperatorSpec(testSink);
 
     this.inputOpSpecMap = new LinkedHashMap<>();
-    inputOpSpecMap.put(testInputSpec, testInput);
-    inputOpSpecMap.put(testInputSpec2, testInput2);
+    inputOpSpecMap.put(inputStreamId1, testInput);
+    inputOpSpecMap.put(streamId2, testInput2);
     this.outputStrmMap = new LinkedHashMap<>();
-    outputStrmMap.put(testOutputSpec, outputStream1);
+    outputStrmMap.put(outputStreamId, outputStream1);
     when(mockGraph.getInputOperators()).thenReturn(Collections.unmodifiableMap(inputOpSpecMap));
     when(mockGraph.getOutputStreams()).thenReturn(Collections.unmodifiableMap(outputStrmMap));
     this.allOpSpecs = new HashSet<OperatorSpec>() { {

--- a/samza-core/src/test/java/org/apache/samza/operators/TestStreamGraphSpec.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/TestStreamGraphSpec.java
@@ -31,11 +31,9 @@ import org.apache.samza.operators.spec.InputOperatorSpec;
 import org.apache.samza.operators.spec.OperatorSpec.OpCode;
 import org.apache.samza.operators.spec.OutputStreamImpl;
 import org.apache.samza.operators.stream.IntermediateMessageStreamImpl;
-import org.apache.samza.runtime.ApplicationRunner;
 import org.apache.samza.serializers.KVSerde;
 import org.apache.samza.serializers.NoOpSerde;
 import org.apache.samza.serializers.Serde;
-import org.apache.samza.system.StreamSpec;
 import org.apache.samza.table.TableSpec;
 import org.junit.Test;
 
@@ -53,82 +51,71 @@ public class TestStreamGraphSpec {
 
   @Test
   public void testGetInputStreamWithValueSerde() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mockStreamSpec);
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
 
+    String streamId = "test-stream-1";
     Serde mockValueSerde = mock(Serde.class);
-    MessageStream<TestMessageEnvelope> inputStream = graphSpec.getInputStream("test-stream-1", mockValueSerde);
+    MessageStream<TestMessageEnvelope> inputStream = graphSpec.getInputStream(streamId, mockValueSerde);
 
     InputOperatorSpec<String, TestMessageEnvelope> inputOpSpec =
         (InputOperatorSpec) ((MessageStreamImpl<TestMessageEnvelope>) inputStream).getOperatorSpec();
     assertEquals(OpCode.INPUT, inputOpSpec.getOpCode());
-    assertEquals(graphSpec.getInputOperators().get(mockStreamSpec), inputOpSpec);
-    assertEquals(mockStreamSpec, inputOpSpec.getStreamSpec());
+    assertEquals(graphSpec.getInputOperators().get(streamId), inputOpSpec);
+    assertEquals(streamId, inputOpSpec.getStreamId());
     assertTrue(inputOpSpec.getKeySerde() instanceof NoOpSerde);
     assertEquals(mockValueSerde, inputOpSpec.getValueSerde());
   }
 
   @Test
   public void testGetInputStreamWithKeyValueSerde() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mockStreamSpec);
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
 
+    String streamId = "test-stream-1";
     KVSerde mockKVSerde = mock(KVSerde.class);
     Serde mockKeySerde = mock(Serde.class);
     Serde mockValueSerde = mock(Serde.class);
     doReturn(mockKeySerde).when(mockKVSerde).getKeySerde();
     doReturn(mockValueSerde).when(mockKVSerde).getValueSerde();
-    MessageStream<TestMessageEnvelope> inputStream = graphSpec.getInputStream("test-stream-1", mockKVSerde);
+    MessageStream<TestMessageEnvelope> inputStream = graphSpec.getInputStream(streamId, mockKVSerde);
 
     InputOperatorSpec<String, TestMessageEnvelope> inputOpSpec =
         (InputOperatorSpec) ((MessageStreamImpl<TestMessageEnvelope>) inputStream).getOperatorSpec();
     assertEquals(OpCode.INPUT, inputOpSpec.getOpCode());
-    assertEquals(graphSpec.getInputOperators().get(mockStreamSpec), inputOpSpec);
-    assertEquals(mockStreamSpec, inputOpSpec.getStreamSpec());
+    assertEquals(graphSpec.getInputOperators().get(streamId), inputOpSpec);
+    assertEquals(streamId, inputOpSpec.getStreamId());
     assertEquals(mockKeySerde, inputOpSpec.getKeySerde());
     assertEquals(mockValueSerde, inputOpSpec.getValueSerde());
   }
 
   @Test(expected = NullPointerException.class)
   public void testGetInputStreamWithNullSerde() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mockStreamSpec);
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
 
     graphSpec.getInputStream("test-stream-1", null);
   }
 
   @Test
   public void testGetInputStreamWithDefaultValueSerde() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mockStreamSpec);
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
+    String streamId = "test-stream-1";
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
 
     Serde mockValueSerde = mock(Serde.class);
     graphSpec.setDefaultSerde(mockValueSerde);
-    MessageStream<TestMessageEnvelope> inputStream = graphSpec.getInputStream("test-stream-1");
+    MessageStream<TestMessageEnvelope> inputStream = graphSpec.getInputStream(streamId);
 
     InputOperatorSpec<String, TestMessageEnvelope> inputOpSpec =
         (InputOperatorSpec) ((MessageStreamImpl<TestMessageEnvelope>) inputStream).getOperatorSpec();
     assertEquals(OpCode.INPUT, inputOpSpec.getOpCode());
-    assertEquals(graphSpec.getInputOperators().get(mockStreamSpec), inputOpSpec);
-    assertEquals(mockStreamSpec, inputOpSpec.getStreamSpec());
+    assertEquals(graphSpec.getInputOperators().get(streamId), inputOpSpec);
+    assertEquals(streamId, inputOpSpec.getStreamId());
     assertTrue(inputOpSpec.getKeySerde() instanceof NoOpSerde);
     assertEquals(mockValueSerde, inputOpSpec.getValueSerde());
   }
 
   @Test
   public void testGetInputStreamWithDefaultKeyValueSerde() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mockStreamSpec);
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
+    String streamId = "test-stream-1";
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
 
     KVSerde mockKVSerde = mock(KVSerde.class);
     Serde mockKeySerde = mock(Serde.class);
@@ -136,63 +123,56 @@ public class TestStreamGraphSpec {
     doReturn(mockKeySerde).when(mockKVSerde).getKeySerde();
     doReturn(mockValueSerde).when(mockKVSerde).getValueSerde();
     graphSpec.setDefaultSerde(mockKVSerde);
-    MessageStream<TestMessageEnvelope> inputStream = graphSpec.getInputStream("test-stream-1");
+    MessageStream<TestMessageEnvelope> inputStream = graphSpec.getInputStream(streamId);
 
     InputOperatorSpec<String, TestMessageEnvelope> inputOpSpec =
         (InputOperatorSpec) ((MessageStreamImpl<TestMessageEnvelope>) inputStream).getOperatorSpec();
     assertEquals(OpCode.INPUT, inputOpSpec.getOpCode());
-    assertEquals(graphSpec.getInputOperators().get(mockStreamSpec), inputOpSpec);
-    assertEquals(mockStreamSpec, inputOpSpec.getStreamSpec());
+    assertEquals(graphSpec.getInputOperators().get(streamId), inputOpSpec);
+    assertEquals(streamId, inputOpSpec.getStreamId());
     assertEquals(mockKeySerde, inputOpSpec.getKeySerde());
     assertEquals(mockValueSerde, inputOpSpec.getValueSerde());
   }
 
   @Test
   public void testGetInputStreamWithDefaultDefaultSerde() {
-    // default default serde == user hasn't provided a default serde
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mockStreamSpec);
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
+    String streamId = "test-stream-1";
 
-    MessageStream<TestMessageEnvelope> inputStream = graphSpec.getInputStream("test-stream-1");
+    // default default serde == user hasn't provided a default serde
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
+    MessageStream<TestMessageEnvelope> inputStream = graphSpec.getInputStream(streamId);
 
     InputOperatorSpec<String, TestMessageEnvelope> inputOpSpec =
         (InputOperatorSpec) ((MessageStreamImpl<TestMessageEnvelope>) inputStream).getOperatorSpec();
     assertEquals(OpCode.INPUT, inputOpSpec.getOpCode());
-    assertEquals(graphSpec.getInputOperators().get(mockStreamSpec), inputOpSpec);
-    assertEquals(mockStreamSpec, inputOpSpec.getStreamSpec());
+    assertEquals(graphSpec.getInputOperators().get(streamId), inputOpSpec);
+    assertEquals(streamId, inputOpSpec.getStreamId());
     assertTrue(inputOpSpec.getKeySerde() instanceof NoOpSerde);
     assertTrue(inputOpSpec.getValueSerde() instanceof NoOpSerde);
   }
 
   @Test
   public void testGetInputStreamWithRelaxedTypes() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mockStreamSpec);
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
+    String streamId = "test-stream-1";
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
 
-    MessageStream<TestMessageEnvelope> inputStream = graphSpec.getInputStream("test-stream-1");
+    MessageStream<TestMessageEnvelope> inputStream = graphSpec.getInputStream(streamId);
 
     InputOperatorSpec<String, TestMessageEnvelope> inputOpSpec =
         (InputOperatorSpec) ((MessageStreamImpl<TestMessageEnvelope>) inputStream).getOperatorSpec();
     assertEquals(OpCode.INPUT, inputOpSpec.getOpCode());
-    assertEquals(graphSpec.getInputOperators().get(mockStreamSpec), inputOpSpec);
-    assertEquals(mockStreamSpec, inputOpSpec.getStreamSpec());
+    assertEquals(graphSpec.getInputOperators().get(streamId), inputOpSpec);
+    assertEquals(streamId, inputOpSpec.getStreamId());
   }
 
   @Test
   public void testMultipleGetInputStreams() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    StreamSpec mockStreamSpec1 = mock(StreamSpec.class);
-    StreamSpec mockStreamSpec2 = mock(StreamSpec.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mockStreamSpec1);
-    when(mockRunner.getStreamSpec("test-stream-2")).thenReturn(mockStreamSpec2);
+    String streamId1 = "test-stream-1";
+    String streamId2 = "test-stream-2";
 
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
-    MessageStream<Object> inputStream1 = graphSpec.getInputStream("test-stream-1");
-    MessageStream<Object> inputStream2 = graphSpec.getInputStream("test-stream-2");
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
+    MessageStream<Object> inputStream1 = graphSpec.getInputStream(streamId1);
+    MessageStream<Object> inputStream2 = graphSpec.getInputStream(streamId2);
 
     InputOperatorSpec<String, TestMessageEnvelope> inputOpSpec1 =
         (InputOperatorSpec) ((MessageStreamImpl<Object>) inputStream1).getOperatorSpec();
@@ -200,98 +180,83 @@ public class TestStreamGraphSpec {
         (InputOperatorSpec) ((MessageStreamImpl<Object>) inputStream2).getOperatorSpec();
 
     assertEquals(graphSpec.getInputOperators().size(), 2);
-    assertEquals(graphSpec.getInputOperators().get(mockStreamSpec1), inputOpSpec1);
-    assertEquals(graphSpec.getInputOperators().get(mockStreamSpec2), inputOpSpec2);
+    assertEquals(graphSpec.getInputOperators().get(streamId1), inputOpSpec1);
+    assertEquals(graphSpec.getInputOperators().get(streamId2), inputOpSpec2);
   }
 
   @Test(expected = IllegalStateException.class)
   public void testGetSameInputStreamTwice() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mock(StreamSpec.class));
-
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
-    graphSpec.getInputStream("test-stream-1");
+    String streamId = "test-stream-1";
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
+    graphSpec.getInputStream(streamId);
     // should throw exception
-    graphSpec.getInputStream("test-stream-1");
+    graphSpec.getInputStream(streamId);
   }
 
   @Test
   public void testGetOutputStreamWithValueSerde() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mockStreamSpec);
-
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
+    String streamId = "test-stream-1";
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
 
     Serde mockValueSerde = mock(Serde.class);
     OutputStream<TestMessageEnvelope> outputStream =
-        graphSpec.getOutputStream("test-stream-1", mockValueSerde);
+        graphSpec.getOutputStream(streamId, mockValueSerde);
 
     OutputStreamImpl<TestMessageEnvelope> outputStreamImpl = (OutputStreamImpl) outputStream;
-    assertEquals(graphSpec.getOutputStreams().get(mockStreamSpec), outputStreamImpl);
-    assertEquals(mockStreamSpec, outputStreamImpl.getStreamSpec());
+    assertEquals(graphSpec.getOutputStreams().get(streamId), outputStreamImpl);
+    assertEquals(streamId, outputStreamImpl.getStreamId());
     assertTrue(outputStreamImpl.getKeySerde() instanceof NoOpSerde);
     assertEquals(mockValueSerde, outputStreamImpl.getValueSerde());
   }
 
   @Test
   public void testGetOutputStreamWithKeyValueSerde() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mockStreamSpec);
-
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
+    String streamId = "test-stream-1";
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
     KVSerde mockKVSerde = mock(KVSerde.class);
     Serde mockKeySerde = mock(Serde.class);
     Serde mockValueSerde = mock(Serde.class);
     doReturn(mockKeySerde).when(mockKVSerde).getKeySerde();
     doReturn(mockValueSerde).when(mockKVSerde).getValueSerde();
     graphSpec.setDefaultSerde(mockKVSerde);
-    OutputStream<TestMessageEnvelope> outputStream = graphSpec.getOutputStream("test-stream-1", mockKVSerde);
+    OutputStream<TestMessageEnvelope> outputStream = graphSpec.getOutputStream(streamId, mockKVSerde);
 
     OutputStreamImpl<TestMessageEnvelope> outputStreamImpl = (OutputStreamImpl) outputStream;
-    assertEquals(graphSpec.getOutputStreams().get(mockStreamSpec), outputStreamImpl);
-    assertEquals(mockStreamSpec, outputStreamImpl.getStreamSpec());
+    assertEquals(graphSpec.getOutputStreams().get(streamId), outputStreamImpl);
+    assertEquals(streamId, outputStreamImpl.getStreamId());
     assertEquals(mockKeySerde, outputStreamImpl.getKeySerde());
     assertEquals(mockValueSerde, outputStreamImpl.getValueSerde());
   }
 
   @Test(expected = NullPointerException.class)
   public void testGetOutputStreamWithNullSerde() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mockStreamSpec);
+    String streamId = "test-stream-1";
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
 
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
-
-    graphSpec.getOutputStream("test-stream-1", null);
+    graphSpec.getOutputStream(streamId, null);
   }
 
   @Test
   public void testGetOutputStreamWithDefaultValueSerde() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mockStreamSpec);
+    String streamId = "test-stream-1";
 
     Serde mockValueSerde = mock(Serde.class);
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
     graphSpec.setDefaultSerde(mockValueSerde);
-    OutputStream<TestMessageEnvelope> outputStream = graphSpec.getOutputStream("test-stream-1");
+    OutputStream<TestMessageEnvelope> outputStream = graphSpec.getOutputStream(streamId);
 
     OutputStreamImpl<TestMessageEnvelope> outputStreamImpl = (OutputStreamImpl) outputStream;
-    assertEquals(graphSpec.getOutputStreams().get(mockStreamSpec), outputStreamImpl);
-    assertEquals(mockStreamSpec, outputStreamImpl.getStreamSpec());
+    assertEquals(graphSpec.getOutputStreams().get(streamId), outputStreamImpl);
+    assertEquals(streamId, outputStreamImpl.getStreamId());
     assertTrue(outputStreamImpl.getKeySerde() instanceof NoOpSerde);
     assertEquals(mockValueSerde, outputStreamImpl.getValueSerde());
   }
 
   @Test
   public void testGetOutputStreamWithDefaultKeyValueSerde() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mockStreamSpec);
+    String streamId = "test-stream-1";
 
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
     KVSerde mockKVSerde = mock(KVSerde.class);
     Serde mockKeySerde = mock(Serde.class);
     Serde mockValueSerde = mock(Serde.class);
@@ -299,89 +264,75 @@ public class TestStreamGraphSpec {
     doReturn(mockValueSerde).when(mockKVSerde).getValueSerde();
     graphSpec.setDefaultSerde(mockKVSerde);
 
-    OutputStream<TestMessageEnvelope> outputStream = graphSpec.getOutputStream("test-stream-1");
+    OutputStream<TestMessageEnvelope> outputStream = graphSpec.getOutputStream(streamId);
 
     OutputStreamImpl<TestMessageEnvelope> outputStreamImpl = (OutputStreamImpl) outputStream;
-    assertEquals(graphSpec.getOutputStreams().get(mockStreamSpec), outputStreamImpl);
-    assertEquals(mockStreamSpec, outputStreamImpl.getStreamSpec());
+    assertEquals(graphSpec.getOutputStreams().get(streamId), outputStreamImpl);
+    assertEquals(streamId, outputStreamImpl.getStreamId());
     assertEquals(mockKeySerde, outputStreamImpl.getKeySerde());
     assertEquals(mockValueSerde, outputStreamImpl.getValueSerde());
   }
 
   @Test
   public void testGetOutputStreamWithDefaultDefaultSerde() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mockStreamSpec);
+    String streamId = "test-stream-1";
 
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
 
-    OutputStream<TestMessageEnvelope> outputStream = graphSpec.getOutputStream("test-stream-1");
+    OutputStream<TestMessageEnvelope> outputStream = graphSpec.getOutputStream(streamId);
 
     OutputStreamImpl<TestMessageEnvelope> outputStreamImpl = (OutputStreamImpl) outputStream;
-    assertEquals(graphSpec.getOutputStreams().get(mockStreamSpec), outputStreamImpl);
-    assertEquals(mockStreamSpec, outputStreamImpl.getStreamSpec());
+    assertEquals(graphSpec.getOutputStreams().get(streamId), outputStreamImpl);
+    assertEquals(streamId, outputStreamImpl.getStreamId());
     assertTrue(outputStreamImpl.getKeySerde() instanceof NoOpSerde);
     assertTrue(outputStreamImpl.getValueSerde() instanceof NoOpSerde);
   }
 
   @Test(expected = IllegalStateException.class)
   public void testSetDefaultSerdeAfterGettingStreams() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mock(StreamSpec.class));
+    String streamId = "test-stream-1";
 
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
-    graphSpec.getInputStream("test-stream-1");
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
+    graphSpec.getInputStream(streamId);
     graphSpec.setDefaultSerde(mock(Serde.class)); // should throw exception
   }
 
   @Test(expected = IllegalStateException.class)
   public void testSetDefaultSerdeAfterGettingOutputStream() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mock(StreamSpec.class));
-
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
-    graphSpec.getOutputStream("test-stream-1");
+    String streamId = "test-stream-1";
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
+    graphSpec.getOutputStream(streamId);
     graphSpec.setDefaultSerde(mock(Serde.class)); // should throw exception
   }
 
   @Test(expected = IllegalStateException.class)
   public void testSetDefaultSerdeAfterGettingIntermediateStream() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mock(StreamSpec.class));
-
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
-    graphSpec.getIntermediateStream("test-stream-1", null);
+    String streamId = "test-stream-1";
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
+    graphSpec.getIntermediateStream(streamId, null);
     graphSpec.setDefaultSerde(mock(Serde.class)); // should throw exception
   }
 
   @Test(expected = IllegalStateException.class)
   public void testGetSameOutputStreamTwice() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mock(StreamSpec.class));
-
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
-    graphSpec.getOutputStream("test-stream-1");
-    graphSpec.getOutputStream("test-stream-1"); // should throw exception
+    String streamId = "test-stream-1";
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
+    graphSpec.getOutputStream(streamId);
+    graphSpec.getOutputStream(streamId); // should throw exception
   }
 
   @Test
   public void testGetIntermediateStreamWithValueSerde() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    Config mockConfig = mock(Config.class);
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    String mockStreamName = "mockStreamName";
-    when(mockRunner.getStreamSpec(mockStreamName)).thenReturn(mockStreamSpec);
-
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mockConfig);
+    String streamId = "stream-1";
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
 
     Serde mockValueSerde = mock(Serde.class);
     IntermediateMessageStreamImpl<TestMessageEnvelope> intermediateStreamImpl =
-        graphSpec.getIntermediateStream(mockStreamName, mockValueSerde);
+        graphSpec.getIntermediateStream(streamId, mockValueSerde);
 
-    assertEquals(graphSpec.getInputOperators().get(mockStreamSpec), intermediateStreamImpl.getOperatorSpec());
-    assertEquals(graphSpec.getOutputStreams().get(mockStreamSpec), intermediateStreamImpl.getOutputStream());
-    assertEquals(mockStreamSpec, intermediateStreamImpl.getStreamSpec());
+    assertEquals(graphSpec.getInputOperators().get(streamId), intermediateStreamImpl.getOperatorSpec());
+    assertEquals(graphSpec.getOutputStreams().get(streamId), intermediateStreamImpl.getOutputStream());
+    assertEquals(streamId, intermediateStreamImpl.getStreamId());
     assertTrue(intermediateStreamImpl.getOutputStream().getKeySerde() instanceof NoOpSerde);
     assertEquals(mockValueSerde, intermediateStreamImpl.getOutputStream().getValueSerde());
     assertTrue(((InputOperatorSpec) intermediateStreamImpl.getOperatorSpec()).getKeySerde() instanceof NoOpSerde);
@@ -390,13 +341,8 @@ public class TestStreamGraphSpec {
 
   @Test
   public void testGetIntermediateStreamWithKeyValueSerde() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    Config mockConfig = mock(Config.class);
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    String mockStreamName = "mockStreamName";
-    when(mockRunner.getStreamSpec(mockStreamName)).thenReturn(mockStreamSpec);
-
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mockConfig);
+    String streamId = "streamId";
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
 
     KVSerde mockKVSerde = mock(KVSerde.class);
     Serde mockKeySerde = mock(Serde.class);
@@ -404,11 +350,11 @@ public class TestStreamGraphSpec {
     doReturn(mockKeySerde).when(mockKVSerde).getKeySerde();
     doReturn(mockValueSerde).when(mockKVSerde).getValueSerde();
     IntermediateMessageStreamImpl<TestMessageEnvelope> intermediateStreamImpl =
-        graphSpec.getIntermediateStream(mockStreamName, mockKVSerde);
+        graphSpec.getIntermediateStream(streamId, mockKVSerde);
 
-    assertEquals(graphSpec.getInputOperators().get(mockStreamSpec), intermediateStreamImpl.getOperatorSpec());
-    assertEquals(graphSpec.getOutputStreams().get(mockStreamSpec), intermediateStreamImpl.getOutputStream());
-    assertEquals(mockStreamSpec, intermediateStreamImpl.getStreamSpec());
+    assertEquals(graphSpec.getInputOperators().get(streamId), intermediateStreamImpl.getOperatorSpec());
+    assertEquals(graphSpec.getOutputStreams().get(streamId), intermediateStreamImpl.getOutputStream());
+    assertEquals(streamId, intermediateStreamImpl.getStreamId());
     assertEquals(mockKeySerde, intermediateStreamImpl.getOutputStream().getKeySerde());
     assertEquals(mockValueSerde, intermediateStreamImpl.getOutputStream().getValueSerde());
     assertEquals(mockKeySerde, ((InputOperatorSpec) intermediateStreamImpl.getOperatorSpec()).getKeySerde());
@@ -417,22 +363,17 @@ public class TestStreamGraphSpec {
 
   @Test
   public void testGetIntermediateStreamWithDefaultValueSerde() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    Config mockConfig = mock(Config.class);
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    String mockStreamName = "mockStreamName";
-    when(mockRunner.getStreamSpec(mockStreamName)).thenReturn(mockStreamSpec);
-
-    StreamGraphSpec graph = new StreamGraphSpec(mockRunner, mockConfig);
+    String streamId = "streamId";
+    StreamGraphSpec graph = new StreamGraphSpec(mock(Config.class));
 
     Serde mockValueSerde = mock(Serde.class);
     graph.setDefaultSerde(mockValueSerde);
     IntermediateMessageStreamImpl<TestMessageEnvelope> intermediateStreamImpl =
-        graph.getIntermediateStream(mockStreamName, null);
+        graph.getIntermediateStream(streamId, null);
 
-    assertEquals(graph.getInputOperators().get(mockStreamSpec), intermediateStreamImpl.getOperatorSpec());
-    assertEquals(graph.getOutputStreams().get(mockStreamSpec), intermediateStreamImpl.getOutputStream());
-    assertEquals(mockStreamSpec, intermediateStreamImpl.getStreamSpec());
+    assertEquals(graph.getInputOperators().get(streamId), intermediateStreamImpl.getOperatorSpec());
+    assertEquals(graph.getOutputStreams().get(streamId), intermediateStreamImpl.getOutputStream());
+    assertEquals(streamId, intermediateStreamImpl.getStreamId());
     assertTrue(intermediateStreamImpl.getOutputStream().getKeySerde() instanceof NoOpSerde);
     assertEquals(mockValueSerde, intermediateStreamImpl.getOutputStream().getValueSerde());
     assertTrue(((InputOperatorSpec) intermediateStreamImpl.getOperatorSpec()).getKeySerde() instanceof NoOpSerde);
@@ -441,13 +382,10 @@ public class TestStreamGraphSpec {
 
   @Test
   public void testGetIntermediateStreamWithDefaultKeyValueSerde() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
     Config mockConfig = mock(Config.class);
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    String mockStreamName = "mockStreamName";
-    when(mockRunner.getStreamSpec(mockStreamName)).thenReturn(mockStreamSpec);
-
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mockConfig);
+    String streamId = "streamId";
+    
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mockConfig);
 
     KVSerde mockKVSerde = mock(KVSerde.class);
     Serde mockKeySerde = mock(Serde.class);
@@ -456,11 +394,11 @@ public class TestStreamGraphSpec {
     doReturn(mockValueSerde).when(mockKVSerde).getValueSerde();
     graphSpec.setDefaultSerde(mockKVSerde);
     IntermediateMessageStreamImpl<TestMessageEnvelope> intermediateStreamImpl =
-        graphSpec.getIntermediateStream(mockStreamName, null);
+        graphSpec.getIntermediateStream(streamId, null);
 
-    assertEquals(graphSpec.getInputOperators().get(mockStreamSpec), intermediateStreamImpl.getOperatorSpec());
-    assertEquals(graphSpec.getOutputStreams().get(mockStreamSpec), intermediateStreamImpl.getOutputStream());
-    assertEquals(mockStreamSpec, intermediateStreamImpl.getStreamSpec());
+    assertEquals(graphSpec.getInputOperators().get(streamId), intermediateStreamImpl.getOperatorSpec());
+    assertEquals(graphSpec.getOutputStreams().get(streamId), intermediateStreamImpl.getOutputStream());
+    assertEquals(streamId, intermediateStreamImpl.getStreamId());
     assertEquals(mockKeySerde, intermediateStreamImpl.getOutputStream().getKeySerde());
     assertEquals(mockValueSerde, intermediateStreamImpl.getOutputStream().getValueSerde());
     assertEquals(mockKeySerde, ((InputOperatorSpec) intermediateStreamImpl.getOperatorSpec()).getKeySerde());
@@ -469,19 +407,16 @@ public class TestStreamGraphSpec {
 
   @Test
   public void testGetIntermediateStreamWithDefaultDefaultSerde() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
     Config mockConfig = mock(Config.class);
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    String mockStreamName = "mockStreamName";
-    when(mockRunner.getStreamSpec(mockStreamName)).thenReturn(mockStreamSpec);
-
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mockConfig);
+    String streamId = "streamId";
+    
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mockConfig);
     IntermediateMessageStreamImpl<TestMessageEnvelope> intermediateStreamImpl =
-        graphSpec.getIntermediateStream(mockStreamName, null);
+        graphSpec.getIntermediateStream(streamId, null);
 
-    assertEquals(graphSpec.getInputOperators().get(mockStreamSpec), intermediateStreamImpl.getOperatorSpec());
-    assertEquals(graphSpec.getOutputStreams().get(mockStreamSpec), intermediateStreamImpl.getOutputStream());
-    assertEquals(mockStreamSpec, intermediateStreamImpl.getStreamSpec());
+    assertEquals(graphSpec.getInputOperators().get(streamId), intermediateStreamImpl.getOperatorSpec());
+    assertEquals(graphSpec.getOutputStreams().get(streamId), intermediateStreamImpl.getOutputStream());
+    assertEquals(streamId, intermediateStreamImpl.getStreamId());
     assertTrue(intermediateStreamImpl.getOutputStream().getKeySerde() instanceof NoOpSerde);
     assertTrue(intermediateStreamImpl.getOutputStream().getValueSerde() instanceof NoOpSerde);
     assertTrue(((InputOperatorSpec) intermediateStreamImpl.getOperatorSpec()).getKeySerde() instanceof NoOpSerde);
@@ -490,22 +425,18 @@ public class TestStreamGraphSpec {
 
   @Test(expected = IllegalStateException.class)
   public void testGetSameIntermediateStreamTwice() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(mock(StreamSpec.class));
-
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
     graphSpec.getIntermediateStream("test-stream-1", mock(Serde.class));
     graphSpec.getIntermediateStream("test-stream-1", mock(Serde.class));
   }
 
   @Test
   public void testGetNextOpIdIncrementsId() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
     Config mockConfig = mock(Config.class);
     when(mockConfig.get(eq(JobConfig.JOB_NAME()))).thenReturn("jobName");
     when(mockConfig.get(eq(JobConfig.JOB_ID()), anyString())).thenReturn("1234");
 
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mockConfig);
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mockConfig);
     assertEquals("jobName-1234-merge-0", graphSpec.getNextOpId(OpCode.MERGE, null));
     assertEquals("jobName-1234-join-customName", graphSpec.getNextOpId(OpCode.JOIN, "customName"));
     assertEquals("jobName-1234-map-2", graphSpec.getNextOpId(OpCode.MAP, null));
@@ -513,24 +444,22 @@ public class TestStreamGraphSpec {
 
   @Test(expected = SamzaException.class)
   public void testGetNextOpIdRejectsDuplicates() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
     Config mockConfig = mock(Config.class);
     when(mockConfig.get(eq(JobConfig.JOB_NAME()))).thenReturn("jobName");
     when(mockConfig.get(eq(JobConfig.JOB_ID()), anyString())).thenReturn("1234");
 
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mockConfig);
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mockConfig);
     assertEquals("jobName-1234-join-customName", graphSpec.getNextOpId(OpCode.JOIN, "customName"));
     graphSpec.getNextOpId(OpCode.JOIN, "customName"); // should throw
   }
 
   @Test
   public void testUserDefinedIdValidation() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
     Config mockConfig = mock(Config.class);
     when(mockConfig.get(eq(JobConfig.JOB_NAME()))).thenReturn("jobName");
     when(mockConfig.get(eq(JobConfig.JOB_ID()), anyString())).thenReturn("1234");
 
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mockConfig);
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mockConfig);
 
     // null and empty userDefinedIDs should fall back to autogenerated IDs.
     try {
@@ -562,36 +491,29 @@ public class TestStreamGraphSpec {
 
   @Test
   public void testGetInputStreamPreservesInsertionOrder() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
     Config mockConfig = mock(Config.class);
 
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mockConfig);
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mockConfig);
 
-    StreamSpec testStreamSpec1 = new StreamSpec("test-stream-1", "physical-stream-1", "test-system");
-    when(mockRunner.getStreamSpec("test-stream-1")).thenReturn(testStreamSpec1);
-
-    StreamSpec testStreamSpec2 = new StreamSpec("test-stream-2", "physical-stream-2", "test-system");
-    when(mockRunner.getStreamSpec("test-stream-2")).thenReturn(testStreamSpec2);
-
-    StreamSpec testStreamSpec3 = new StreamSpec("test-stream-3", "physical-stream-3", "test-system");
-    when(mockRunner.getStreamSpec("test-stream-3")).thenReturn(testStreamSpec3);
-
+    String testStreamId1 = "test-stream-1";
+    String testStreamId2 = "test-stream-2";
+    String testStreamId3 = "test-stream-3";
+    
     graphSpec.getInputStream("test-stream-1");
     graphSpec.getInputStream("test-stream-2");
     graphSpec.getInputStream("test-stream-3");
 
     List<InputOperatorSpec> inputSpecs = new ArrayList<>(graphSpec.getInputOperators().values());
     assertEquals(inputSpecs.size(), 3);
-    assertEquals(inputSpecs.get(0).getStreamSpec(), testStreamSpec1);
-    assertEquals(inputSpecs.get(1).getStreamSpec(), testStreamSpec2);
-    assertEquals(inputSpecs.get(2).getStreamSpec(), testStreamSpec3);
+    assertEquals(inputSpecs.get(0).getStreamId(), testStreamId1);
+    assertEquals(inputSpecs.get(1).getStreamId(), testStreamId2);
+    assertEquals(inputSpecs.get(2).getStreamId(), testStreamId3);
   }
 
   @Test
   public void testGetTable() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
     Config mockConfig = mock(Config.class);
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mockConfig);
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mockConfig);
 
     BaseTableDescriptor mockTableDescriptor = mock(BaseTableDescriptor.class);
     when(mockTableDescriptor.getTableSpec()).thenReturn(

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImplGraph.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImplGraph.java
@@ -19,8 +19,7 @@
 
 package org.apache.samza.operators.impl;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
+import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -32,7 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import org.apache.samza.Partition;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.JobConfig;
 import org.apache.samza.config.MapConfig;
@@ -54,21 +53,19 @@ import org.apache.samza.operators.functions.JoinFunction;
 import org.apache.samza.operators.functions.MapFunction;
 import org.apache.samza.operators.impl.store.TimestampedValue;
 import org.apache.samza.operators.spec.OperatorSpec.OpCode;
-import org.apache.samza.runtime.ApplicationRunner;
 import org.apache.samza.serializers.IntegerSerde;
 import org.apache.samza.serializers.KVSerde;
 import org.apache.samza.serializers.NoOpSerde;
 import org.apache.samza.serializers.Serde;
 import org.apache.samza.serializers.StringSerde;
 import org.apache.samza.storage.kv.KeyValueStore;
-import org.apache.samza.system.StreamSpec;
 import org.apache.samza.system.SystemStream;
-import org.apache.samza.system.SystemStreamPartition;
 import org.apache.samza.task.MessageCollector;
 import org.apache.samza.task.TaskContext;
 import java.util.List;
 import org.apache.samza.task.TaskCoordinator;
 import org.apache.samza.util.Clock;
+import org.apache.samza.util.StreamUtil;
 import org.apache.samza.util.SystemClock;
 import org.junit.After;
 import org.junit.Test;
@@ -76,7 +73,6 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -217,7 +213,7 @@ public class TestOperatorImplGraph {
 
   @Test
   public void testEmptyChain() {
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(ApplicationRunner.class), mock(Config.class));
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
     OperatorImplGraph opGraph =
         new OperatorImplGraph(graphSpec.getOperatorSpecGraph(), mock(Config.class), mock(TaskContextImpl.class), mock(Clock.class));
     assertEquals(0, opGraph.getAllInputOperators().size());
@@ -225,13 +221,30 @@ public class TestOperatorImplGraph {
 
   @Test
   public void testLinearChain() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    when(mockRunner.getStreamSpec(eq("input"))).thenReturn(new StreamSpec("input", "input-stream", "input-system"));
-    when(mockRunner.getStreamSpec(eq("output"))).thenReturn(mock(StreamSpec.class));
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
+    String inputStreamId = "input";
+    String inputSystem = "input-system";
+    String inputPhysicalName = "input-stream";
+    String outputStreamId = "output";
+    String outputSystem = "output-system";
+    String outputPhysicalName = "output-stream";
+    String intermediateSystem = "intermediate-system";
 
-    MessageStream<Object> inputStream = graphSpec.getInputStream("input");
-    OutputStream<Object> outputStream = graphSpec.getOutputStream("output");
+    HashMap<String, String> configs = new HashMap<>();
+    configs.put(JobConfig.JOB_NAME(), "jobName");
+    configs.put(JobConfig.JOB_ID(), "jobId");
+    configs.put(JobConfig.JOB_DEFAULT_SYSTEM(), intermediateSystem);
+
+    Config streamConfigs = StreamUtil.toStreamConfigs(ImmutableList.of(
+        ImmutableTriple.of(inputStreamId, inputSystem, inputPhysicalName),
+        ImmutableTriple.of(outputStreamId, outputSystem, outputPhysicalName)
+    ));
+    configs.putAll(streamConfigs);
+    Config config = new MapConfig(configs);
+
+    StreamGraphSpec graphSpec = new StreamGraphSpec(config);
+
+    MessageStream<Object> inputStream = graphSpec.getInputStream(inputStreamId);
+    OutputStream<Object> outputStream = graphSpec.getOutputStream(outputStreamId);
 
     inputStream
         .filter(mock(FilterFunction.class))
@@ -242,9 +255,9 @@ public class TestOperatorImplGraph {
     when(mockTaskContext.getMetricsRegistry()).thenReturn(new MetricsRegistryMap());
     when(mockTaskContext.getTaskName()).thenReturn(new TaskName("task 0"));
     OperatorImplGraph opImplGraph =
-        new OperatorImplGraph(graphSpec.getOperatorSpecGraph(), mock(Config.class), mockTaskContext, mock(Clock.class));
+        new OperatorImplGraph(graphSpec.getOperatorSpecGraph(), config, mockTaskContext, mock(Clock.class));
 
-    InputOperatorImpl inputOpImpl = opImplGraph.getInputOperator(new SystemStream("input-system", "input-stream"));
+    InputOperatorImpl inputOpImpl = opImplGraph.getInputOperator(new SystemStream(inputSystem, inputPhysicalName));
     assertEquals(1, inputOpImpl.registeredOperators.size());
 
     OperatorImpl filterOpImpl = (StreamOperatorImpl) inputOpImpl.registeredOperators.iterator().next();
@@ -262,18 +275,31 @@ public class TestOperatorImplGraph {
 
   @Test
   public void testPartitionByChain() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    when(mockRunner.getStreamSpec(eq("input"))).thenReturn(new StreamSpec("input", "input-stream", "input-system"));
-    when(mockRunner.getStreamSpec(eq("output"))).thenReturn(new StreamSpec("output", "output-stream", "output-system"));
-    when(mockRunner.getStreamSpec(eq("jobName-jobId-partition_by-p1")))
-        .thenReturn(new StreamSpec("intermediate", "intermediate-stream", "intermediate-system"));
-    Config mockConfig = mock(Config.class);
-    when(mockConfig.get(JobConfig.JOB_NAME())).thenReturn("jobName");
-    when(mockConfig.get(eq(JobConfig.JOB_ID()), anyString())).thenReturn("jobId");
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mockConfig);
-    MessageStream<Object> inputStream = graphSpec.getInputStream("input");
+    String inputStreamId = "input";
+    String inputSystem = "input-system";
+    String inputPhysicalName = "input-stream";
+    String outputStreamId = "output";
+    String outputSystem = "output-system";
+    String outputPhysicalName = "output-stream";
+    String intermediateStreamId = "jobName-jobId-partition_by-p1";
+    String intermediateSystem = "intermediate-system";
+
+    HashMap<String, String> configs = new HashMap<>();
+    configs.put(JobConfig.JOB_NAME(), "jobName");
+    configs.put(JobConfig.JOB_ID(), "jobId");
+    configs.put(JobConfig.JOB_DEFAULT_SYSTEM(), intermediateSystem);
+
+    Config streamConfigs = StreamUtil.toStreamConfigs(ImmutableList.of(
+        ImmutableTriple.of(inputStreamId, inputSystem, inputPhysicalName),
+        ImmutableTriple.of(outputStreamId, outputSystem, outputPhysicalName)
+    ));
+    configs.putAll(streamConfigs);
+    Config config = new MapConfig(configs);
+
+    StreamGraphSpec graphSpec = new StreamGraphSpec(config);
+    MessageStream<Object> inputStream = graphSpec.getInputStream(inputStreamId);
     OutputStream<KV<Integer, String>> outputStream = graphSpec
-        .getOutputStream("output", KVSerde.of(mock(IntegerSerde.class), mock(StringSerde.class)));
+        .getOutputStream(outputStreamId, KVSerde.of(mock(IntegerSerde.class), mock(StringSerde.class)));
 
     inputStream
         .partitionBy(Object::hashCode, Object::toString,
@@ -291,12 +317,12 @@ public class TestOperatorImplGraph {
     when(taskModel.getSystemStreamPartitions()).thenReturn(Collections.emptySet());
     when(mockTaskContext.getJobModel()).thenReturn(jobModel);
     SamzaContainerContext containerContext =
-        new SamzaContainerContext("0", mockConfig, Collections.singleton(new TaskName("task 0")), new MetricsRegistryMap());
+        new SamzaContainerContext("0", config, Collections.singleton(new TaskName("task 0")), new MetricsRegistryMap());
     when(mockTaskContext.getSamzaContainerContext()).thenReturn(containerContext);
     OperatorImplGraph opImplGraph =
-        new OperatorImplGraph(graphSpec.getOperatorSpecGraph(), mockConfig, mockTaskContext, mock(Clock.class));
+        new OperatorImplGraph(graphSpec.getOperatorSpecGraph(), config, mockTaskContext, mock(Clock.class));
 
-    InputOperatorImpl inputOpImpl = opImplGraph.getInputOperator(new SystemStream("input-system", "input-stream"));
+    InputOperatorImpl inputOpImpl = opImplGraph.getInputOperator(new SystemStream(inputSystem, inputPhysicalName));
     assertEquals(1, inputOpImpl.registeredOperators.size());
 
     OperatorImpl partitionByOpImpl = (PartitionByOperatorImpl) inputOpImpl.registeredOperators.iterator().next();
@@ -304,7 +330,7 @@ public class TestOperatorImplGraph {
     assertEquals(OpCode.PARTITION_BY, partitionByOpImpl.getOperatorSpec().getOpCode());
 
     InputOperatorImpl repartitionedInputOpImpl =
-        opImplGraph.getInputOperator(new SystemStream("intermediate-system", "intermediate-stream"));
+        opImplGraph.getInputOperator(new SystemStream(intermediateSystem, intermediateStreamId));
     assertEquals(1, repartitionedInputOpImpl.registeredOperators.size());
 
     OperatorImpl sendToOpImpl = (OutputOperatorImpl) repartitionedInputOpImpl.registeredOperators.iterator().next();
@@ -314,18 +340,19 @@ public class TestOperatorImplGraph {
 
   @Test
   public void testBroadcastChain() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    when(mockRunner.getStreamSpec(eq("input"))).thenReturn(new StreamSpec("input", "input-stream", "input-system"));
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
+    String inputStreamId = "input";
+    Config config = StreamUtil.toStreamConfigs(
+        ImmutableList.of(ImmutableTriple.of("input", "input-system", "input-stream")));
+    StreamGraphSpec graphSpec = new StreamGraphSpec(config);
 
-    MessageStream<Object> inputStream = graphSpec.getInputStream("input");
+    MessageStream<Object> inputStream = graphSpec.getInputStream(inputStreamId);
     inputStream.filter(mock(FilterFunction.class));
     inputStream.map(mock(MapFunction.class));
 
     TaskContextImpl mockTaskContext = mock(TaskContextImpl.class);
     when(mockTaskContext.getMetricsRegistry()).thenReturn(new MetricsRegistryMap());
     OperatorImplGraph opImplGraph =
-        new OperatorImplGraph(graphSpec.getOperatorSpecGraph(), mock(Config.class), mockTaskContext, mock(Clock.class));
+        new OperatorImplGraph(graphSpec.getOperatorSpecGraph(), config, mockTaskContext, mock(Clock.class));
 
     InputOperatorImpl inputOpImpl = opImplGraph.getInputOperator(new SystemStream("input-system", "input-stream"));
     assertEquals(2, inputOpImpl.registeredOperators.size());
@@ -337,12 +364,10 @@ public class TestOperatorImplGraph {
 
   @Test
   public void testMergeChain() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    when(mockRunner.getStreamSpec(eq("input")))
-        .thenReturn(new StreamSpec("input", "input-stream", "input-system"));
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mock(Config.class));
+    String inputStreamId = "input";
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mock(Config.class));
 
-    MessageStream<Object> inputStream = graphSpec.getInputStream("input");
+    MessageStream<Object> inputStream = graphSpec.getInputStream(inputStreamId);
     MessageStream<Object> stream1 = inputStream.filter(mock(FilterFunction.class));
     MessageStream<Object> stream2 = inputStream.map(mock(MapFunction.class));
     MessageStream<Object> mergedStream = stream1.merge(Collections.singleton(stream2));
@@ -372,20 +397,26 @@ public class TestOperatorImplGraph {
 
   @Test
   public void testJoinChain() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    when(mockRunner.getStreamSpec(eq("input1"))).thenReturn(new StreamSpec("input1", "input-stream1", "input-system"));
-    when(mockRunner.getStreamSpec(eq("input2"))).thenReturn(new StreamSpec("input2", "input-stream2", "input-system"));
-    Config mockConfig = mock(Config.class);
-    when(mockConfig.get(JobConfig.JOB_NAME())).thenReturn("jobName");
-    when(mockConfig.get(eq(JobConfig.JOB_ID()), anyString())).thenReturn("jobId");
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mockConfig);
+    String inputStreamId1 = "input1";
+    String inputStreamId2 = "input2";
+
+    HashMap<String, String> configs = new HashMap<>();
+    configs.put(JobConfig.JOB_NAME(), "jobName");
+    configs.put(JobConfig.JOB_ID(), "jobId");
+    Config streamConfigs = StreamUtil.toStreamConfigs(ImmutableList.of(
+        ImmutableTriple.of("input1", "input-system", "input-stream1"),
+        ImmutableTriple.of("input2", "input-system", "input-stream2")
+    ));
+    configs.putAll(streamConfigs);
+    Config config = new MapConfig(configs);
+    StreamGraphSpec graphSpec = new StreamGraphSpec(config);
 
     Integer joinKey = new Integer(1);
     Function<Object, Integer> keyFn = (Function & Serializable) m -> joinKey;
     JoinFunction testJoinFunction = new TestJoinFunction("jobName-jobId-join-j1",
         (BiFunction & Serializable) (m1, m2) -> KV.of(m1, m2), keyFn, keyFn);
-    MessageStream<Object> inputStream1 = graphSpec.getInputStream("input1", new NoOpSerde<>());
-    MessageStream<Object> inputStream2 = graphSpec.getInputStream("input2", new NoOpSerde<>());
+    MessageStream<Object> inputStream1 = graphSpec.getInputStream(inputStreamId1, new NoOpSerde<>());
+    MessageStream<Object> inputStream2 = graphSpec.getInputStream(inputStreamId2, new NoOpSerde<>());
     inputStream1.join(inputStream2, testJoinFunction,
         mock(Serde.class), mock(Serde.class), mock(Serde.class), Duration.ofHours(1), "j1");
 
@@ -398,7 +429,7 @@ public class TestOperatorImplGraph {
     KeyValueStore mockRightStore = mock(KeyValueStore.class);
     when(mockTaskContext.getStore(eq("jobName-jobId-join-j1-R"))).thenReturn(mockRightStore);
     OperatorImplGraph opImplGraph =
-        new OperatorImplGraph(graphSpec.getOperatorSpecGraph(), mockConfig, mockTaskContext, mock(Clock.class));
+        new OperatorImplGraph(graphSpec.getOperatorSpecGraph(), config, mockTaskContext, mock(Clock.class));
 
     // verify that join function is initialized once.
     assertEquals(TestJoinFunction.getInstanceByTaskName(mockTaskName, "jobName-jobId-join-j1").numInitCalled, 1);
@@ -434,18 +465,17 @@ public class TestOperatorImplGraph {
 
   @Test
   public void testOperatorGraphInitAndClose() {
-    ApplicationRunner mockRunner = mock(ApplicationRunner.class);
-    when(mockRunner.getStreamSpec("input1")).thenReturn(new StreamSpec("input1", "input-stream1", "input-system"));
-    when(mockRunner.getStreamSpec("input2")).thenReturn(new StreamSpec("input2", "input-stream2", "input-system"));
+    String inputStreamId1 = "input1";
+    String inputStreamId2 = "input2";
     Config mockConfig = mock(Config.class);
     TaskName mockTaskName = mock(TaskName.class);
     TaskContextImpl mockContext = mock(TaskContextImpl.class);
     when(mockContext.getTaskName()).thenReturn(mockTaskName);
     when(mockContext.getMetricsRegistry()).thenReturn(new MetricsRegistryMap());
-    StreamGraphSpec graphSpec = new StreamGraphSpec(mockRunner, mockConfig);
+    StreamGraphSpec graphSpec = new StreamGraphSpec(mockConfig);
 
-    MessageStream<Object> inputStream1 = graphSpec.getInputStream("input1");
-    MessageStream<Object> inputStream2 = graphSpec.getInputStream("input2");
+    MessageStream<Object> inputStream1 = graphSpec.getInputStream(inputStreamId1);
+    MessageStream<Object> inputStream2 = graphSpec.getInputStream(inputStreamId2);
 
     Function mapFn = (Function & Serializable) m -> m;
     inputStream1.map(new TestMapFunction<Object, Object>("1", mapFn))
@@ -471,153 +501,5 @@ public class TestOperatorImplGraph {
     assertEquals(closedOperators.get(1), "3");
     assertEquals(closedOperators.get(2), "2");
     assertEquals(closedOperators.get(3), "1");
-  }
-
-  @Test
-  public void testGetStreamToConsumerTasks() {
-    String system = "test-system";
-    String stream0 = "test-stream-0";
-    String stream1 = "test-stream-1";
-
-    SystemStreamPartition ssp0 = new SystemStreamPartition(system, stream0, new Partition(0));
-    SystemStreamPartition ssp1 = new SystemStreamPartition(system, stream0, new Partition(1));
-    SystemStreamPartition ssp2 = new SystemStreamPartition(system, stream1, new Partition(0));
-
-    TaskName task0 = new TaskName("Task 0");
-    TaskName task1 = new TaskName("Task 1");
-    Set<SystemStreamPartition> ssps = new HashSet<>();
-    ssps.add(ssp0);
-    ssps.add(ssp2);
-    TaskModel tm0 = new TaskModel(task0, ssps, new Partition(0));
-    ContainerModel cm0 = new ContainerModel("c0", 0, Collections.singletonMap(task0, tm0));
-    TaskModel tm1 = new TaskModel(task1, Collections.singleton(ssp1), new Partition(1));
-    ContainerModel cm1 = new ContainerModel("c1", 1, Collections.singletonMap(task1, tm1));
-
-    Map<String, ContainerModel> cms = new HashMap<>();
-    cms.put(cm0.getProcessorId(), cm0);
-    cms.put(cm1.getProcessorId(), cm1);
-
-    JobModel jobModel = new JobModel(new MapConfig(), cms, null);
-    Multimap<SystemStream, String> streamToTasks = OperatorImplGraph.getStreamToConsumerTasks(jobModel);
-    assertEquals(streamToTasks.get(ssp0.getSystemStream()).size(), 2);
-    assertEquals(streamToTasks.get(ssp2.getSystemStream()).size(), 1);
-  }
-
-  @Test
-  public void testGetOutputToInputStreams() {
-    Map<String, String> configMap = new HashMap<>();
-    configMap.put(JobConfig.JOB_NAME(), "test-app");
-    configMap.put(JobConfig.JOB_DEFAULT_SYSTEM(), "test-system");
-    Config config = new MapConfig(configMap);
-
-    /**
-     * the graph looks like the following. number of partitions in parentheses. quotes indicate expected value.
-     *
-     *                                    input1 -> map -> join -> partitionBy (10) -> output1
-     *                                                       |
-     *                                     input2 -> filter -|
-     *                                                       |
-     *           input3 -> filter -> partitionBy -> map -> join -> output2
-     *
-     */
-    StreamSpec input1 = new StreamSpec("input1", "input1", "system1");
-    StreamSpec input2 = new StreamSpec("input2", "input2", "system2");
-    StreamSpec input3 = new StreamSpec("input3", "input3", "system2");
-
-    StreamSpec output1 = new StreamSpec("output1", "output1", "system1");
-    StreamSpec output2 = new StreamSpec("output2", "output2", "system2");
-
-    ApplicationRunner runner = mock(ApplicationRunner.class);
-    when(runner.getStreamSpec("input1")).thenReturn(input1);
-    when(runner.getStreamSpec("input2")).thenReturn(input2);
-    when(runner.getStreamSpec("input3")).thenReturn(input3);
-    when(runner.getStreamSpec("output1")).thenReturn(output1);
-    when(runner.getStreamSpec("output2")).thenReturn(output2);
-
-    // intermediate streams used in tests
-    StreamSpec int1 = new StreamSpec("test-app-1-partition_by-p2", "test-app-1-partition_by-p2", "default-system");
-    StreamSpec int2 = new StreamSpec("test-app-1-partition_by-p1", "test-app-1-partition_by-p1", "default-system");
-    when(runner.getStreamSpec("test-app-1-partition_by-p2")).thenReturn(int1);
-    when(runner.getStreamSpec("test-app-1-partition_by-p1")).thenReturn(int2);
-
-    StreamGraphSpec graphSpec = new StreamGraphSpec(runner, config);
-    MessageStream messageStream1 = graphSpec.getInputStream("input1").map(m -> m);
-    MessageStream messageStream2 = graphSpec.getInputStream("input2").filter(m -> true);
-    MessageStream messageStream3 =
-        graphSpec.getInputStream("input3")
-            .filter(m -> true)
-            .partitionBy(m -> "hehe", m -> m, "p1")
-            .map(m -> m);
-    OutputStream<Object> outputStream1 = graphSpec.getOutputStream("output1");
-    OutputStream<Object> outputStream2 = graphSpec.getOutputStream("output2");
-
-    messageStream1
-        .join(messageStream2, mock(JoinFunction.class),
-            mock(Serde.class), mock(Serde.class), mock(Serde.class), Duration.ofHours(2), "j1")
-        .partitionBy(m -> "haha", m -> m, "p2")
-        .sendTo(outputStream1);
-    messageStream3
-        .join(messageStream2, mock(JoinFunction.class),
-            mock(Serde.class), mock(Serde.class), mock(Serde.class), Duration.ofHours(1), "j2")
-        .sendTo(outputStream2);
-
-    Multimap<SystemStream, SystemStream> outputToInput =
-        OperatorImplGraph.getIntermediateToInputStreamsMap(graphSpec.getOperatorSpecGraph());
-    Collection<SystemStream> inputs = outputToInput.get(int1.toSystemStream());
-    assertEquals(inputs.size(), 2);
-    assertTrue(inputs.contains(input1.toSystemStream()));
-    assertTrue(inputs.contains(input2.toSystemStream()));
-
-    inputs = outputToInput.get(int2.toSystemStream());
-    assertEquals(inputs.size(), 1);
-    assertEquals(inputs.iterator().next(), input3.toSystemStream());
-  }
-
-  @Test
-  public void testGetProducerTaskCountForIntermediateStreams() {
-    /**
-     * the task assignment looks like the following:
-     *
-     * input1 -----> task0, task1 -----> int1
-     *                                    ^
-     * input2 ------> task1, task2--------|
-     *                                    v
-     * input3 ------> task1 -----------> int2
-     *
-     */
-
-    SystemStream input1 = new SystemStream("system1", "intput1");
-    SystemStream input2 = new SystemStream("system2", "intput2");
-    SystemStream input3 = new SystemStream("system2", "intput3");
-
-    SystemStream int1 = new SystemStream("system1", "int1");
-    SystemStream int2 = new SystemStream("system1", "int2");
-
-
-    String task0 = "Task 0";
-    String task1 = "Task 1";
-    String task2 = "Task 2";
-
-    Multimap<SystemStream, String> streamToConsumerTasks = HashMultimap.create();
-    streamToConsumerTasks.put(input1, task0);
-    streamToConsumerTasks.put(input1, task1);
-    streamToConsumerTasks.put(input2, task1);
-    streamToConsumerTasks.put(input2, task2);
-    streamToConsumerTasks.put(input3, task1);
-    streamToConsumerTasks.put(int1, task0);
-    streamToConsumerTasks.put(int1, task1);
-    streamToConsumerTasks.put(int2, task0);
-
-    Multimap<SystemStream, SystemStream> intermediateToInputStreams = HashMultimap.create();
-    intermediateToInputStreams.put(int1, input1);
-    intermediateToInputStreams.put(int1, input2);
-
-    intermediateToInputStreams.put(int2, input2);
-    intermediateToInputStreams.put(int2, input3);
-
-    Map<SystemStream, Integer> counts = OperatorImplGraph.getProducerTaskCountForIntermediateStreams(
-        streamToConsumerTasks, intermediateToInputStreams);
-    assertTrue(counts.get(int1) == 3);
-    assertTrue(counts.get(int2) == 2);
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImplGraphUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImplGraphUtil.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.operators.impl;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.samza.Partition;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.JobConfig;
+import org.apache.samza.config.MapConfig;
+import org.apache.samza.container.TaskName;
+import org.apache.samza.job.model.ContainerModel;
+import org.apache.samza.job.model.JobModel;
+import org.apache.samza.job.model.TaskModel;
+import org.apache.samza.operators.MessageStream;
+import org.apache.samza.operators.OutputStream;
+import org.apache.samza.operators.StreamGraphSpec;
+import org.apache.samza.operators.functions.JoinFunction;
+import org.apache.samza.serializers.Serde;
+import org.apache.samza.system.SystemStream;
+import org.apache.samza.system.SystemStreamPartition;
+import org.apache.samza.util.StreamUtil;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class TestOperatorImplGraphUtil {
+  @Test
+  public void testGetStreamToConsumerTasks() {
+    String system = "test-system";
+    String streamId0 = "test-stream-0";
+    String streamId1 = "test-stream-1";
+
+    HashMap<String, String> configs = new HashMap<>();
+    configs.put(JobConfig.JOB_NAME(), "test-app");
+    configs.put(JobConfig.JOB_DEFAULT_SYSTEM(), "test-system");
+
+    Config streamConfigs = StreamUtil.toStreamConfigs(ImmutableList.of(
+        ImmutableTriple.of(streamId0, system, streamId0),
+        ImmutableTriple.of(streamId1, system, streamId1)
+    ));
+    configs.putAll(streamConfigs);
+    Config config = new MapConfig(configs);
+
+    SystemStreamPartition ssp0 = new SystemStreamPartition(system, streamId0, new Partition(0));
+    SystemStreamPartition ssp1 = new SystemStreamPartition(system, streamId0, new Partition(1));
+    SystemStreamPartition ssp2 = new SystemStreamPartition(system, streamId1, new Partition(0));
+
+    TaskName task0 = new TaskName("Task 0");
+    TaskName task1 = new TaskName("Task 1");
+    Set<SystemStreamPartition> ssps = new HashSet<>();
+    ssps.add(ssp0);
+    ssps.add(ssp2);
+    TaskModel tm0 = new TaskModel(task0, ssps, new Partition(0));
+    ContainerModel cm0 = new ContainerModel("c0", 0, Collections.singletonMap(task0, tm0));
+    TaskModel tm1 = new TaskModel(task1, Collections.singleton(ssp1), new Partition(1));
+    ContainerModel cm1 = new ContainerModel("c1", 1, Collections.singletonMap(task1, tm1));
+
+    Map<String, ContainerModel> cms = new HashMap<>();
+    cms.put(cm0.getProcessorId(), cm0);
+    cms.put(cm1.getProcessorId(), cm1);
+
+    JobModel jobModel = new JobModel(config, cms, null);
+    OperatorImplGraph.OperatorImplGraphUtil util = new OperatorImplGraph.OperatorImplGraphUtil(config);
+    Multimap<SystemStream, String> streamToTasks = util.getStreamToConsumerTasks(jobModel);
+    assertEquals(streamToTasks.get(ssp0.getSystemStream()).size(), 2);
+    assertEquals(streamToTasks.get(ssp2.getSystemStream()).size(), 1);
+  }
+
+  @Test
+  public void testGetOutputToInputStreams() {
+    String inputStreamId1 = "input1";
+    String inputStreamId2 = "input2";
+    String inputStreamId3 = "input3";
+    String inputSystem = "input-system";
+
+    String outputStreamId1 = "output1";
+    String outputStreamId2 = "output2";
+    String outputSystem = "output-system";
+
+    String intStreamId1 = "test-app-1-partition_by-p1";
+    String intStreamId2 = "test-app-1-partition_by-p2";
+    String intSystem = "test-system";
+
+    HashMap<String, String> configs = new HashMap<>();
+    configs.put(JobConfig.JOB_NAME(), "test-app");
+    configs.put(JobConfig.JOB_DEFAULT_SYSTEM(), intSystem);
+
+    Config streamConfigs = StreamUtil.toStreamConfigs(ImmutableList.of(
+        ImmutableTriple.of(inputStreamId1, inputSystem, inputStreamId1),
+        ImmutableTriple.of(inputStreamId2, inputSystem, inputStreamId2),
+        ImmutableTriple.of(inputStreamId3, inputSystem, inputStreamId3),
+        ImmutableTriple.of(outputStreamId1, outputSystem, outputStreamId1),
+        ImmutableTriple.of(outputStreamId2, outputSystem, outputStreamId2)
+    ));
+    configs.putAll(streamConfigs);
+    Config config = new MapConfig(configs);
+
+    StreamGraphSpec graphSpec = new StreamGraphSpec(config);
+    MessageStream messageStream1 = graphSpec.getInputStream(inputStreamId1).map(m -> m);
+    MessageStream messageStream2 = graphSpec.getInputStream(inputStreamId2).filter(m -> true);
+    MessageStream messageStream3 =
+        graphSpec.getInputStream(inputStreamId3)
+            .filter(m -> true)
+            .partitionBy(m -> "m", m -> m, "p1")
+            .map(m -> m);
+    OutputStream<Object> outputStream1 = graphSpec.getOutputStream(outputStreamId1);
+    OutputStream<Object> outputStream2 = graphSpec.getOutputStream(outputStreamId2);
+
+    messageStream1
+        .join(messageStream2, mock(JoinFunction.class),
+            mock(Serde.class), mock(Serde.class), mock(Serde.class), Duration.ofHours(2), "j1")
+        .partitionBy(m -> "m", m -> m, "p2")
+        .sendTo(outputStream1);
+    messageStream3
+        .join(messageStream2, mock(JoinFunction.class),
+            mock(Serde.class), mock(Serde.class), mock(Serde.class), Duration.ofHours(1), "j2")
+        .sendTo(outputStream2);
+
+    OperatorImplGraph.OperatorImplGraphUtil util = new OperatorImplGraph.OperatorImplGraphUtil(config);
+    Multimap<SystemStream, SystemStream> outputToInput =
+        util.getIntermediateToInputStreamsMap(graphSpec.getOperatorSpecGraph());
+    Collection<SystemStream> inputs = outputToInput.get(new SystemStream(intSystem, intStreamId2));
+    assertEquals(inputs.size(), 2);
+    assertTrue(inputs.contains(new SystemStream(inputSystem, inputStreamId1)));
+    assertTrue(inputs.contains(new SystemStream(inputSystem, inputStreamId2)));
+
+    inputs = outputToInput.get(new SystemStream(intSystem, intStreamId1));
+    assertEquals(inputs.size(), 1);
+    assertEquals(inputs.iterator().next(), new SystemStream(inputSystem, inputStreamId3));
+  }
+
+  @Test
+  public void testGetProducerTaskCountForIntermediateStreams() {
+    String inputStreamId1 = "input1";
+    String inputStreamId2 = "input2";
+    String inputStreamId3 = "input3";
+    String inputSystem1 = "system1";
+    String inputSystem2 = "system2";
+
+    HashMap<String, String> configs = new HashMap<>();
+    configs.put(JobConfig.JOB_NAME(), "test-app");
+    configs.put(JobConfig.JOB_DEFAULT_SYSTEM(), inputSystem1);
+
+    Config streamConfigs = StreamUtil.toStreamConfigs(ImmutableList.of(
+        ImmutableTriple.of(inputStreamId1, inputSystem1, inputStreamId1),
+        ImmutableTriple.of(inputStreamId2, inputSystem2, inputStreamId2),
+        ImmutableTriple.of(inputStreamId3, inputSystem2, inputStreamId3)
+    ));
+    configs.putAll(streamConfigs);
+    Config config = new MapConfig(configs);
+
+    SystemStream input1 = new SystemStream("system1", "intput1");
+    SystemStream input2 = new SystemStream("system2", "intput2");
+    SystemStream input3 = new SystemStream("system2", "intput3");
+
+    SystemStream int1 = new SystemStream("system1", "int1");
+    SystemStream int2 = new SystemStream("system1", "int2");
+
+
+    /**
+     * the task assignment looks like the following:
+     *
+     * input1 -----> task0, task1 -----> int1
+     *                                    ^
+     * input2 ------> task1, task2--------|
+     *                                    v
+     * input3 ------> task1 -----------> int2
+     *
+     */
+    String task0 = "Task 0";
+    String task1 = "Task 1";
+    String task2 = "Task 2";
+
+    Multimap<SystemStream, String> streamToConsumerTasks = HashMultimap.create();
+    streamToConsumerTasks.put(input1, task0);
+    streamToConsumerTasks.put(input1, task1);
+    streamToConsumerTasks.put(input2, task1);
+    streamToConsumerTasks.put(input2, task2);
+    streamToConsumerTasks.put(input3, task1);
+    streamToConsumerTasks.put(int1, task0);
+    streamToConsumerTasks.put(int1, task1);
+    streamToConsumerTasks.put(int2, task0);
+
+    Multimap<SystemStream, SystemStream> intermediateToInputStreams = HashMultimap.create();
+    intermediateToInputStreams.put(int1, input1);
+    intermediateToInputStreams.put(int1, input2);
+
+    intermediateToInputStreams.put(int2, input2);
+    intermediateToInputStreams.put(int2, input3);
+
+    OperatorImplGraph.OperatorImplGraphUtil util = new OperatorImplGraph.OperatorImplGraphUtil(config);
+    Map<SystemStream, Integer> counts = util.getProducerTaskCountForIntermediateStreams(
+        streamToConsumerTasks, intermediateToInputStreams);
+    assertTrue(counts.get(int1) == 3);
+    assertTrue(counts.get(int2) == 2);
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestWindowOperator.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestWindowOperator.java
@@ -42,13 +42,11 @@ import org.apache.samza.operators.triggers.Triggers;
 import org.apache.samza.operators.windows.AccumulationMode;
 import org.apache.samza.operators.windows.WindowPane;
 import org.apache.samza.operators.windows.Windows;
-import org.apache.samza.runtime.ApplicationRunner;
 import org.apache.samza.serializers.IntegerSerde;
 import org.apache.samza.serializers.KVSerde;
 import org.apache.samza.serializers.Serde;
 import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.system.OutgoingMessageEnvelope;
-import org.apache.samza.system.StreamSpec;
 import org.apache.samza.system.SystemStream;
 import org.apache.samza.system.SystemStreamPartition;
 import org.apache.samza.task.MessageCollector;
@@ -80,7 +78,6 @@ public class TestWindowOperator {
   private final List<Integer> integers = ImmutableList.of(1, 2, 1, 2, 1, 2, 1, 2, 3);
   private Config config;
   private TaskContextImpl taskContext;
-  private ApplicationRunner runner;
 
   @Before
   public void setup() throws Exception {
@@ -88,19 +85,16 @@ public class TestWindowOperator {
     when(config.get(JobConfig.JOB_NAME())).thenReturn("jobName");
     when(config.get(eq(JobConfig.JOB_ID()), anyString())).thenReturn("jobId");
     taskContext = mock(TaskContextImpl.class);
-    runner = mock(ApplicationRunner.class);
     Serde storeKeySerde = new TimeSeriesKeySerde(new IntegerSerde());
     Serde storeValSerde = KVSerde.of(new IntegerSerde(), new IntegerSerde());
 
     when(taskContext.getSystemStreamPartitions()).thenReturn(ImmutableSet
-        .of(new SystemStreamPartition("kafka", "integers", new Partition(0))));
+        .of(new SystemStreamPartition("kafka", "integTestExecutionPlannerers", new Partition(0))));
     when(taskContext.getMetricsRegistry()).thenReturn(new MetricsRegistryMap());
     when(taskContext.getStore("jobName-jobId-window-w1"))
         .thenReturn(new TestInMemoryStore<>(storeKeySerde, storeValSerde));
-    when(runner.getStreamSpec("integers")).thenReturn(new StreamSpec("integers", "integers", "kafka"));
 
     Map<String, String> mapConfig = new HashMap<>();
-    mapConfig.put("app.runner.class", "org.apache.samza.runtime.LocalApplicationRunner");
     mapConfig.put("job.default.system", "kafka");
     mapConfig.put("job.name", "jobName");
     mapConfig.put("job.id", "jobId");
@@ -552,7 +546,7 @@ public class TestWindowOperator {
 
   private StreamGraphSpec getKeyedTumblingWindowStreamGraph(AccumulationMode mode,
       Duration duration, Trigger<KV<Integer, Integer>> earlyTrigger) throws IOException {
-    StreamGraphSpec graph = new StreamGraphSpec(runner, config);
+    StreamGraphSpec graph = new StreamGraphSpec(config);
 
     KVSerde<Integer, Integer> kvSerde = KVSerde.of(new IntegerSerde(), new IntegerSerde());
     graph.getInputStream("integers", kvSerde)
@@ -568,7 +562,7 @@ public class TestWindowOperator {
 
   private StreamGraphSpec getTumblingWindowStreamGraph(AccumulationMode mode,
       Duration duration, Trigger<KV<Integer, Integer>> earlyTrigger) throws IOException {
-    StreamGraphSpec graph = new StreamGraphSpec(runner, config);
+    StreamGraphSpec graph = new StreamGraphSpec(config);
 
     KVSerde<Integer, Integer> kvSerde = KVSerde.of(new IntegerSerde(), new IntegerSerde());
     graph.getInputStream("integers", kvSerde)
@@ -582,7 +576,7 @@ public class TestWindowOperator {
   }
 
   private StreamGraphSpec getKeyedSessionWindowStreamGraph(AccumulationMode mode, Duration duration) throws IOException {
-    StreamGraphSpec graph = new StreamGraphSpec(runner, config);
+    StreamGraphSpec graph = new StreamGraphSpec(config);
 
     KVSerde<Integer, Integer> kvSerde = KVSerde.of(new IntegerSerde(), new IntegerSerde());
     graph.getInputStream("integers", kvSerde)
@@ -597,7 +591,7 @@ public class TestWindowOperator {
 
   private StreamGraphSpec getAggregateTumblingWindowStreamGraph(AccumulationMode mode, Duration timeDuration,
         Trigger<IntegerEnvelope> earlyTrigger) throws IOException {
-    StreamGraphSpec graph = new StreamGraphSpec(runner, config);
+    StreamGraphSpec graph = new StreamGraphSpec(config);
 
     MessageStream<KV<Integer, Integer>> integers = graph.getInputStream("integers",
         KVSerde.of(new IntegerSerde(), new IntegerSerde()));

--- a/samza-core/src/test/java/org/apache/samza/operators/spec/OperatorSpecTestUtils.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/spec/OperatorSpecTestUtils.java
@@ -31,7 +31,6 @@ import org.apache.samza.operators.TableImpl;
 import org.apache.samza.operators.functions.TimerFunction;
 import org.apache.samza.operators.functions.WatermarkFunction;
 import org.apache.samza.serializers.SerializableSerde;
-import org.apache.samza.system.StreamSpec;
 import org.apache.samza.table.TableSpec;
 
 import static org.junit.Assert.*;
@@ -105,8 +104,8 @@ public class OperatorSpecTestUtils {
     assertEquals(oTable.getTableSpec(), nTable.getTableSpec());
   }
 
-  private static void assertClonedOutputs(Map<StreamSpec, OutputStreamImpl> originalOutputs,
-      Map<StreamSpec, OutputStreamImpl> clonedOutputs) {
+  private static void assertClonedOutputs(Map<String, OutputStreamImpl> originalOutputs,
+      Map<String, OutputStreamImpl> clonedOutputs) {
     assertEquals(originalOutputs.size(), clonedOutputs.size());
     assertEquals(originalOutputs.keySet(), clonedOutputs.keySet());
     Iterator<OutputStreamImpl> oIter = originalOutputs.values().iterator();
@@ -117,12 +116,11 @@ public class OperatorSpecTestUtils {
   private static void assertClonedOutputImpl(OutputStreamImpl oOutput, OutputStreamImpl nOutput) {
     assertNotEquals(oOutput, nOutput);
     assertEquals(oOutput.isKeyed(), nOutput.isKeyed());
-    assertEquals(oOutput.getSystemStream(), nOutput.getSystemStream());
-    assertEquals(oOutput.getStreamSpec(), nOutput.getStreamSpec());
+    assertEquals(oOutput.getStreamId(), nOutput.getStreamId());
   }
 
-  private static void assertClonedInputs(Map<StreamSpec, InputOperatorSpec> originalInputs,
-      Map<StreamSpec, InputOperatorSpec> clonedInputs) {
+  private static void assertClonedInputs(Map<String, InputOperatorSpec> originalInputs,
+      Map<String, InputOperatorSpec> clonedInputs) {
     assertEquals(originalInputs.size(), clonedInputs.size());
     assertEquals(originalInputs.keySet(), clonedInputs.keySet());
     Iterator<InputOperatorSpec> oIter = originalInputs.values().iterator();
@@ -134,7 +132,7 @@ public class OperatorSpecTestUtils {
     assertNotEquals(originalInput, clonedInput);
     assertEquals(originalInput.getOpId(), clonedInput.getOpId());
     assertEquals(originalInput.getOpCode(), clonedInput.getOpCode());
-    assertEquals(originalInput.getStreamSpec(), clonedInput.getStreamSpec());
+    assertEquals(originalInput.getStreamId(), clonedInput.getStreamId());
     assertEquals(originalInput.isKeyed(), clonedInput.isKeyed());
   }
 

--- a/samza-core/src/test/java/org/apache/samza/operators/spec/TestOperatorSpec.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/spec/TestOperatorSpec.java
@@ -40,7 +40,6 @@ import org.apache.samza.serializers.KVSerde;
 import org.apache.samza.serializers.NoOpSerde;
 import org.apache.samza.serializers.Serde;
 import org.apache.samza.serializers.StringSerde;
-import org.apache.samza.system.StreamSpec;
 import org.apache.samza.table.TableSpec;
 import org.junit.Test;
 import org.mockito.internal.util.reflection.Whitebox;
@@ -50,7 +49,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 
 /**
@@ -230,9 +228,8 @@ public class TestOperatorSpec {
       }
     };
 
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
     InputOperatorSpec<String, Object> inputOperatorSpec = new InputOperatorSpec<>(
-        mockStreamSpec, new StringSerde("UTF-8"), objSerde, true, "op0");
+        "mockStreamId", new StringSerde("UTF-8"), objSerde, true, "op0");
     InputOperatorSpec<String, Object> inputOpCopy = (InputOperatorSpec<String, Object>) OperatorSpecTestUtils.copyOpSpec(inputOperatorSpec);
 
     assertNotEquals("Expected deserialized copy of operator spec should not be the same as the original operator spec", inputOperatorSpec, inputOpCopy);
@@ -254,9 +251,8 @@ public class TestOperatorSpec {
         return new byte[0];
       }
     };
-    StreamSpec mockStreamSpec = mock(StreamSpec.class);
-    OutputStreamImpl<KV<String, Object>> outputStrmImpl = new OutputStreamImpl<>(mockStreamSpec, new StringSerde("UTF-8"), objSerde, true);
-    OutputOperatorSpec<KV<String, Object>> outputOperatorSpec = new OutputOperatorSpec<KV<String, Object>>(outputStrmImpl, "op0");
+    OutputStreamImpl<KV<String, Object>> outputStrmImpl = new OutputStreamImpl<>("mockStreamId", new StringSerde("UTF-8"), objSerde, true);
+    OutputOperatorSpec<KV<String, Object>> outputOperatorSpec = new OutputOperatorSpec<>(outputStrmImpl, "op0");
     OutputOperatorSpec<KV<String, Object>> outputOpCopy = (OutputOperatorSpec<KV<String, Object>>) OperatorSpecTestUtils
         .copyOpSpec(outputOperatorSpec);
     assertNotEquals("Expected deserialized copy of operator spec should not be the same as the original operator spec", outputOperatorSpec, outputOpCopy);
@@ -276,10 +272,10 @@ public class TestOperatorSpec {
   public void testJoinOperatorSpec() {
 
     InputOperatorSpec<TestMessageEnvelope, Object> leftOpSpec = new InputOperatorSpec<>(
-        new StreamSpec("test-input-1", "test-input-1", "kafka"), new NoOpSerde<>(),
+        "test-input-1", new NoOpSerde<>(),
         new NoOpSerde<>(), false, "op0");
     InputOperatorSpec<TestMessageEnvelope, Object> rightOpSpec = new InputOperatorSpec<>(
-        new StreamSpec("test-input-2", "test-input-2", "kafka"), new NoOpSerde<>(),
+        "test-input-2", new NoOpSerde<>(),
         new NoOpSerde<>(), false, "op1");
 
     Serde<Object> objSerde = new Serde<Object>() {
@@ -341,14 +337,14 @@ public class TestOperatorSpec {
   @Test
   public void testBroadcastOperatorSpec() {
     OutputStreamImpl<TestOutputMessageEnvelope> outputStream =
-        new OutputStreamImpl<>(new StreamSpec("output-0", "outputStream-0", "kafka"), new StringSerde("UTF-8"), new JsonSerdeV2<TestOutputMessageEnvelope>(), true);
+        new OutputStreamImpl<>("output-0", new StringSerde("UTF-8"), new JsonSerdeV2<TestOutputMessageEnvelope>(), true);
     BroadcastOperatorSpec<TestOutputMessageEnvelope> broadcastOpSpec = new BroadcastOperatorSpec<>(outputStream, "broadcast-1");
     BroadcastOperatorSpec<TestOutputMessageEnvelope> broadcastOpCopy = (BroadcastOperatorSpec<TestOutputMessageEnvelope>) OperatorSpecTestUtils
         .copyOpSpec(broadcastOpSpec);
     assertNotEquals(broadcastOpCopy, broadcastOpSpec);
     assertEquals(broadcastOpCopy.getOpId(), broadcastOpSpec.getOpId());
     assertTrue(broadcastOpCopy.getOutputStream() != broadcastOpSpec.getOutputStream());
-    assertEquals(broadcastOpCopy.getOutputStream().getSystemStream(), broadcastOpSpec.getOutputStream().getSystemStream());
+    assertEquals(broadcastOpCopy.getOutputStream().getStreamId(), broadcastOpSpec.getOutputStream().getStreamId());
     assertEquals(broadcastOpCopy.getOutputStream().isKeyed(), broadcastOpSpec.getOutputStream().isKeyed());
   }
 

--- a/samza-core/src/test/java/org/apache/samza/task/TestTaskFactoryUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestTaskFactoryUtil.java
@@ -27,7 +27,6 @@ import org.apache.samza.config.Config;
 import org.apache.samza.config.ConfigException;
 import org.apache.samza.config.MapConfig;
 import org.apache.samza.operators.StreamGraphSpec;
-import org.apache.samza.runtime.ApplicationRunner;
 import org.apache.samza.testUtils.TestAsyncStreamTask;
 import org.apache.samza.testUtils.TestStreamTask;
 import org.junit.Test;
@@ -45,8 +44,6 @@ import static org.mockito.Mockito.mock;
  * Test methods to create {@link StreamTaskFactory} or {@link AsyncStreamTaskFactory} based on task class configuration
  */
 public class TestTaskFactoryUtil {
-
-  private final ApplicationRunner mockRunner = mock(ApplicationRunner.class);
 
   @Test
   public void testStreamTaskClass() {
@@ -81,7 +78,7 @@ public class TestTaskFactoryUtil {
     });
     StreamApplication streamApp = TaskFactoryUtil.createStreamApplication(config);
     assertNotNull(streamApp);
-    StreamGraphSpec graph = new StreamGraphSpec(mockRunner, config);
+    StreamGraphSpec graph = new StreamGraphSpec(config);
     streamApp.init(graph, config);
     Object retFactory = TaskFactoryUtil.createTaskFactory(graph.getOperatorSpecGraph(), null);
     assertTrue(retFactory instanceof StreamTaskFactory);

--- a/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaStreamSpec.java
+++ b/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaStreamSpec.java
@@ -110,7 +110,6 @@ public class KafkaStreamSpec extends StreamSpec {
                                 originalSpec.getSystemName(),
                                 originalSpec.getPartitionCount(),
                                 replicationFactor,
-                                originalSpec.isBroadcast(),
                                 mapToProperties(filterUnsupportedProperties(originalSpec.getConfig())));
   }
 
@@ -125,7 +124,7 @@ public class KafkaStreamSpec extends StreamSpec {
    * @param partitionCount  The number of partitions.
    */
   public KafkaStreamSpec(String id, String topicName, String systemName, int partitionCount) {
-    this(id, topicName, systemName, partitionCount, DEFAULT_REPLICATION_FACTOR, false, new Properties());
+    this(id, topicName, systemName, partitionCount, DEFAULT_REPLICATION_FACTOR, new Properties());
   }
 
   /**
@@ -146,13 +145,11 @@ public class KafkaStreamSpec extends StreamSpec {
    *
    * @param replicationFactor The number of topic replicas in the Kafka cluster for durability.
    *
-   * @param isBroadcast       The stream is broadcast or not.
-   *
    * @param properties        A set of properties for the stream. These may be System-specfic.
    */
   public KafkaStreamSpec(String id, String topicName, String systemName, int partitionCount, int replicationFactor,
-      Boolean isBroadcast, Properties properties) {
-    super(id, topicName, systemName, partitionCount, false, isBroadcast, propertiesToMap(properties));
+      Properties properties) {
+    super(id, topicName, systemName, partitionCount, propertiesToMap(properties));
 
     if (partitionCount < 1) {
       throw new IllegalArgumentException("Parameter 'partitionCount' must be > 0");
@@ -168,12 +165,12 @@ public class KafkaStreamSpec extends StreamSpec {
   @Override
   public StreamSpec copyWithPartitionCount(int partitionCount) {
     return new KafkaStreamSpec(getId(), getPhysicalName(), getSystemName(), partitionCount, getReplicationFactor(),
-        isBroadcast(), getProperties());
+        getProperties());
   }
 
   public KafkaStreamSpec copyWithReplicationFactor(int replicationFactor) {
     return new KafkaStreamSpec(getId(), getPhysicalName(), getSystemName(), getPartitionCount(), replicationFactor,
-        isBroadcast(), getProperties());
+        getProperties());
   }
 
   /**
@@ -183,7 +180,7 @@ public class KafkaStreamSpec extends StreamSpec {
    */
   public KafkaStreamSpec copyWithProperties(Properties properties) {
     return new KafkaStreamSpec(getId(), getPhysicalName(), getSystemName(), getPartitionCount(), getReplicationFactor(),
-        isBroadcast(), properties);
+        properties);
   }
 
   public int getReplicationFactor() {

--- a/samza-kafka/src/main/scala/org/apache/samza/config/KafkaConfig.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/config/KafkaConfig.scala
@@ -32,7 +32,7 @@ import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.apache.samza.SamzaException
 import org.apache.samza.config.ApplicationConfig.ApplicationMode
 import org.apache.samza.config.SystemConfig.Config2System
-import org.apache.samza.util.{Logging, Util}
+import org.apache.samza.util.{Logging, StreamUtil}
 
 import scala.collection.JavaConverters._
 
@@ -237,7 +237,7 @@ class KafkaConfig(config: Config) extends ScalaMapConfig(config) {
       val storeName = if (matcher.find()) matcher.group(1) else throw new SamzaException("Unable to find store name in the changelog configuration: " + changelogConfig + " with SystemStream: " + cn)
 
       storageConfig.getChangelogStream(storeName).foreach(changelogName => {
-        val systemStream = Util.getSystemStreamFromNames(changelogName)
+        val systemStream = StreamUtil.getSystemStreamFromNames(changelogName)
         val factoryName = config.getSystemFactory(systemStream.getSystem).getOrElse(new SamzaException("Unable to determine factory for system: " + systemStream.getSystem))
         storeToChangelog += storeName -> systemStream.getStream
       })

--- a/samza-kafka/src/main/scala/org/apache/samza/config/RegExTopicGenerator.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/config/RegExTopicGenerator.scala
@@ -21,11 +21,11 @@ package org.apache.samza.config
 
 import org.I0Itec.zkclient.ZkClient
 import kafka.utils.ZkUtils
-import org.apache.samza.config.KafkaConfig.{ Config2Kafka, REGEX_RESOLVED_STREAMS }
+import org.apache.samza.config.KafkaConfig.{Config2Kafka, REGEX_RESOLVED_STREAMS}
 import org.apache.samza.SamzaException
-import org.apache.samza.util.Util
+import org.apache.samza.util.{Logging, StreamUtil}
+
 import collection.JavaConverters._
-import org.apache.samza.util.Logging
 import scala.collection._
 import org.apache.samza.config.TaskConfig.Config2Task
 import org.apache.samza.system.SystemStream
@@ -87,7 +87,7 @@ class RegExTopicGenerator extends ConfigRewriter with Logging {
     info("Generated config values for %d new topics" format newInputStreams.size)
 
     val inputStreams = TaskConfig.INPUT_STREAMS -> (existingInputStreams ++ newInputStreams)
-      .map(Util.getNameFromSystemStream)
+      .map(StreamUtil.getNameFromSystemStream)
       .toArray
       .sortWith(_ < _)
       .mkString(",")

--- a/samza-kafka/src/main/scala/org/apache/samza/system/kafka/KafkaSystemAdmin.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/system/kafka/KafkaSystemAdmin.scala
@@ -486,10 +486,10 @@ class KafkaSystemAdmin(
       val topicName = spec.getPhysicalName
       val topicMeta = topicMetaInformation.getOrElse(topicName, throw new StreamValidationException("Unable to find topic information for topic " + topicName))
       new KafkaStreamSpec(spec.getId, topicName, systemName, spec.getPartitionCount, topicMeta.replicationFactor,
-        spec.isBroadcast, topicMeta.kafkaProps)
+        topicMeta.kafkaProps)
     } else if (spec.isCoordinatorStream){
       new KafkaStreamSpec(spec.getId, spec.getPhysicalName, systemName, 1, coordinatorStreamReplicationFactor,
-        spec.isBroadcast, coordinatorStreamProperties)
+        coordinatorStreamProperties)
     } else if (intermediateStreamProperties.contains(spec.getId)) {
       KafkaStreamSpec.fromSpec(spec).copyWithProperties(intermediateStreamProperties(spec.getId))
     } else {

--- a/samza-kafka/src/test/java/org/apache/samza/system/kafka/TestKafkaStreamSpec.java
+++ b/samza-kafka/src/test/java/org/apache/samza/system/kafka/TestKafkaStreamSpec.java
@@ -21,20 +21,20 @@ package org.apache.samza.system.kafka;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Properties;
-import org.apache.samza.runtime.TestAbstractApplicationRunner;
 import org.apache.samza.system.StreamSpec;
+import org.apache.samza.util.TestStreamUtil;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
 /**
- * See also the general StreamSpec tests in {@link TestAbstractApplicationRunner}
+ * See also the general StreamSpec tests in {@link TestStreamUtil}
  */
 public class TestKafkaStreamSpec {
 
   @Test
   public void testUnsupportedConfigStrippedFromProperties() {
-    StreamSpec original = new StreamSpec("dummyId","dummyPhysicalName", "dummySystemName", false, ImmutableMap.of("segment.bytes", "4", "replication.factor", "7"));
+    StreamSpec original = new StreamSpec("dummyId","dummyPhysicalName", "dummySystemName", ImmutableMap.of("segment.bytes", "4", "replication.factor", "7"));
 
     // First verify the original
     assertEquals("7", original.get("replication.factor"));

--- a/samza-kafka/src/test/scala/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.scala
+++ b/samza-kafka/src/test/scala/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.scala
@@ -113,7 +113,7 @@ class TestKafkaCheckpointManager extends KafkaServerTestHarness {
     Mockito.doThrow(new RuntimeException()).when(mockKafkaProducer).flush(taskName.getTaskName)
 
     val props = new org.apache.samza.config.KafkaConfig(config).getCheckpointTopicProperties()
-    val spec = new KafkaStreamSpec("id", checkpointTopic, checkpointSystemName, 1, 1, false, props)
+    val spec = new KafkaStreamSpec("id", checkpointTopic, checkpointSystemName, 1, 1, props)
     val checkPointManager = new KafkaCheckpointManager(spec, new MockSystemFactory, false, config, new NoOpMetricsRegistry)
     checkPointManager.MaxRetryDurationMs = 1
 
@@ -193,7 +193,7 @@ class TestKafkaCheckpointManager extends KafkaServerTestHarness {
 
     val systemFactory = Util.getObj(systemFactoryClassName, classOf[SystemFactory])
 
-    val spec = new KafkaStreamSpec("id", cpTopic, checkpointSystemName, 1, 1, false, props)
+    val spec = new KafkaStreamSpec("id", cpTopic, checkpointSystemName, 1, 1, props)
     new KafkaCheckpointManager(spec, systemFactory, failOnTopicValidation, config, new NoOpMetricsRegistry, serde)
   }
 

--- a/samza-sql/src/test/java/org/apache/samza/sql/translator/TestQueryTranslator.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/translator/TestQueryTranslator.java
@@ -26,11 +26,11 @@ import java.util.Map;
 import org.apache.samza.SamzaException;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.MapConfig;
+import org.apache.samza.config.StreamConfig;
 import org.apache.samza.container.TaskContextImpl;
 import org.apache.samza.container.TaskName;
 import org.apache.samza.operators.OperatorSpecGraph;
 import org.apache.samza.operators.StreamGraphSpec;
-import org.apache.samza.runtime.LocalApplicationRunner;
 import org.apache.samza.sql.data.SamzaSqlExecutionContext;
 import org.apache.samza.operators.spec.OperatorSpec;
 import org.apache.samza.sql.impl.ConfigBasedIOResolverFactory;
@@ -86,17 +86,25 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
     OperatorSpecGraph specGraph = graphSpec.getOperatorSpecGraph();
+
+    StreamConfig streamConfig = new StreamConfig(samzaConfig);
+    String inputStreamId = specGraph.getInputOperators().keySet().stream().findFirst().get();
+    String inputSystem = streamConfig.getSystem(inputStreamId);
+    String inputPhysicalName = streamConfig.getPhysicalName(inputStreamId);
+    String outputStreamId = specGraph.getOutputStreams().keySet().stream().findFirst().get();
+    String outputSystem = streamConfig.getSystem(outputStreamId);
+    String outputPhysicalName = streamConfig.getPhysicalName(outputStreamId);
+    
     Assert.assertEquals(1, specGraph.getOutputStreams().size());
-    Assert.assertEquals("testavro", specGraph.getOutputStreams().keySet().stream().findFirst().get().getSystemName());
-    Assert.assertEquals("outputTopic", specGraph.getOutputStreams().keySet().stream().findFirst().get().getPhysicalName());
+    Assert.assertEquals("testavro", outputSystem);
+    Assert.assertEquals("outputTopic", outputPhysicalName);
     Assert.assertEquals(1, specGraph.getInputOperators().size());
-    Assert.assertEquals("testavro",
-        specGraph.getInputOperators().keySet().stream().findFirst().get().getSystemName());
-    Assert.assertEquals("SIMPLE1",
-        specGraph.getInputOperators().keySet().stream().findFirst().get().getPhysicalName());
+    
+    Assert.assertEquals("testavro", inputSystem);
+    Assert.assertEquals("SIMPLE1", inputPhysicalName);
 
     validatePerTaskContextInit(graphSpec, samzaConfig);
   }
@@ -130,17 +138,24 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
     OperatorSpecGraph specGraph = graphSpec.getOperatorSpecGraph();
+
+    StreamConfig streamConfig = new StreamConfig(samzaConfig);
+    String inputStreamId = specGraph.getInputOperators().keySet().stream().findFirst().get();
+    String inputSystem = streamConfig.getSystem(inputStreamId);
+    String inputPhysicalName = streamConfig.getPhysicalName(inputStreamId);
+    String outputStreamId = specGraph.getOutputStreams().keySet().stream().findFirst().get();
+    String outputSystem = streamConfig.getSystem(outputStreamId);
+    String outputPhysicalName = streamConfig.getPhysicalName(outputStreamId);
+
     Assert.assertEquals(1, specGraph.getOutputStreams().size());
-    Assert.assertEquals("testavro", specGraph.getOutputStreams().keySet().stream().findFirst().get().getSystemName());
-    Assert.assertEquals("outputTopic", specGraph.getOutputStreams().keySet().stream().findFirst().get().getPhysicalName());
+    Assert.assertEquals("testavro", outputSystem);
+    Assert.assertEquals("outputTopic", outputPhysicalName);
     Assert.assertEquals(1, specGraph.getInputOperators().size());
-    Assert.assertEquals("testavro",
-        specGraph.getInputOperators().keySet().stream().findFirst().get().getSystemName());
-    Assert.assertEquals("COMPLEX1",
-        specGraph.getInputOperators().keySet().stream().findFirst().get().getPhysicalName());
+    Assert.assertEquals("testavro", inputSystem);
+    Assert.assertEquals("COMPLEX1", inputPhysicalName);
 
     validatePerTaskContextInit(graphSpec, samzaConfig);
   }
@@ -155,17 +170,24 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
     OperatorSpecGraph specGraph = graphSpec.getOperatorSpecGraph();
+
+    StreamConfig streamConfig = new StreamConfig(samzaConfig);
+    String inputStreamId = specGraph.getInputOperators().keySet().stream().findFirst().get();
+    String inputSystem = streamConfig.getSystem(inputStreamId);
+    String inputPhysicalName = streamConfig.getPhysicalName(inputStreamId);
+    String outputStreamId = specGraph.getOutputStreams().keySet().stream().findFirst().get();
+    String outputSystem = streamConfig.getSystem(outputStreamId);
+    String outputPhysicalName = streamConfig.getPhysicalName(outputStreamId);
+
     Assert.assertEquals(1, specGraph.getOutputStreams().size());
-    Assert.assertEquals("testavro", specGraph.getOutputStreams().keySet().stream().findFirst().get().getSystemName());
-    Assert.assertEquals("outputTopic", specGraph.getOutputStreams().keySet().stream().findFirst().get().getPhysicalName());
+    Assert.assertEquals("testavro", outputSystem);
+    Assert.assertEquals("outputTopic", outputPhysicalName);
     Assert.assertEquals(1, specGraph.getInputOperators().size());
-    Assert.assertEquals("testavro",
-        specGraph.getInputOperators().keySet().stream().findFirst().get().getSystemName());
-    Assert.assertEquals("COMPLEX1",
-        specGraph.getInputOperators().keySet().stream().findFirst().get().getPhysicalName());
+    Assert.assertEquals("testavro", inputSystem);
+    Assert.assertEquals("COMPLEX1", inputPhysicalName);
 
     validatePerTaskContextInit(graphSpec, samzaConfig);
   }
@@ -184,7 +206,7 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
   }
 
@@ -203,7 +225,7 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
   }
 
@@ -222,7 +244,7 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
   }
 
@@ -241,7 +263,7 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
   }
 
@@ -258,7 +280,7 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
   }
 
@@ -277,7 +299,7 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
   }
 
@@ -297,7 +319,7 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
   }
 
@@ -316,7 +338,7 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
   }
 
@@ -335,7 +357,7 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
   }
 
@@ -354,7 +376,7 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
   }
 
@@ -373,7 +395,7 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
   }
 
@@ -396,7 +418,7 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
   }
 
@@ -415,7 +437,7 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
   }
 
@@ -434,29 +456,40 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
     OperatorSpecGraph specGraph = graphSpec.getOperatorSpecGraph();
 
+    StreamConfig streamConfig = new StreamConfig(samzaConfig);
+    String input1StreamId = specGraph.getInputOperators().keySet().stream().findFirst().get();
+    String input1System = streamConfig.getSystem(input1StreamId);
+    String input1PhysicalName = streamConfig.getPhysicalName(input1StreamId);
+    String input2StreamId = specGraph.getInputOperators().keySet().stream().skip(1).findFirst().get();
+    String input2System = streamConfig.getSystem(input2StreamId);
+    String input2PhysicalName = streamConfig.getPhysicalName(input2StreamId);
+    String input3StreamId = specGraph.getInputOperators().keySet().stream().skip(2).findFirst().get();
+    String input3System = streamConfig.getSystem(input3StreamId);
+    String input3PhysicalName = streamConfig.getPhysicalName(input3StreamId);
+    String output1StreamId = specGraph.getOutputStreams().keySet().stream().findFirst().get();
+    String output1System = streamConfig.getSystem(output1StreamId);
+    String output1PhysicalName = streamConfig.getPhysicalName(output1StreamId);
+    String output2StreamId = specGraph.getOutputStreams().keySet().stream().skip(1).findFirst().get();
+    String output2System = streamConfig.getSystem(output2StreamId);
+    String output2PhysicalName = streamConfig.getPhysicalName(output2StreamId);
+
     Assert.assertEquals(2, specGraph.getOutputStreams().size());
-    Assert.assertEquals("kafka", specGraph.getOutputStreams().keySet().stream().findFirst().get().getSystemName());
-    Assert.assertEquals("sql-job-1-partition_by-stream_1", specGraph.getOutputStreams().keySet().stream().findFirst().get().getPhysicalName());
-    Assert.assertEquals("testavro", specGraph.getOutputStreams().keySet().stream().skip(1).findFirst().get().getSystemName());
-    Assert.assertEquals("enrichedPageViewTopic", specGraph.getOutputStreams().keySet().stream().skip(1).findFirst().get().getPhysicalName());
+    Assert.assertEquals("kafka", output1System);
+    Assert.assertEquals("sql-job-1-partition_by-stream_1", output1PhysicalName);
+    Assert.assertEquals("testavro", output2System);
+    Assert.assertEquals("enrichedPageViewTopic", output2PhysicalName);
 
     Assert.assertEquals(3, specGraph.getInputOperators().size());
-    Assert.assertEquals("testavro",
-        specGraph.getInputOperators().keySet().stream().findFirst().get().getSystemName());
-    Assert.assertEquals("PAGEVIEW",
-        specGraph.getInputOperators().keySet().stream().findFirst().get().getPhysicalName());
-    Assert.assertEquals("testavro",
-        specGraph.getInputOperators().keySet().stream().skip(1).findFirst().get().getSystemName());
-    Assert.assertEquals("PROFILE",
-        specGraph.getInputOperators().keySet().stream().skip(1).findFirst().get().getPhysicalName());
-    Assert.assertEquals("kafka",
-        specGraph.getInputOperators().keySet().stream().skip(2).findFirst().get().getSystemName());
-    Assert.assertEquals("sql-job-1-partition_by-stream_1",
-        specGraph.getInputOperators().keySet().stream().skip(2).findFirst().get().getPhysicalName());
+    Assert.assertEquals("testavro", input1System);
+    Assert.assertEquals("PAGEVIEW", input1PhysicalName);
+    Assert.assertEquals("testavro", input2System);
+    Assert.assertEquals("PROFILE", input2PhysicalName);
+    Assert.assertEquals("kafka", input3System);
+    Assert.assertEquals("sql-job-1-partition_by-stream_1", input3PhysicalName);
 
     validatePerTaskContextInit(graphSpec, samzaConfig);
   }
@@ -476,32 +509,41 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
 
     OperatorSpecGraph specGraph = graphSpec.getOperatorSpecGraph();
 
+    StreamConfig streamConfig = new StreamConfig(samzaConfig);
+    String input1StreamId = specGraph.getInputOperators().keySet().stream().findFirst().get();
+    String input1System = streamConfig.getSystem(input1StreamId);
+    String input1PhysicalName = streamConfig.getPhysicalName(input1StreamId);
+    String input2StreamId = specGraph.getInputOperators().keySet().stream().skip(1).findFirst().get();
+    String input2System = streamConfig.getSystem(input2StreamId);
+    String input2PhysicalName = streamConfig.getPhysicalName(input2StreamId);
+    String input3StreamId = specGraph.getInputOperators().keySet().stream().skip(2).findFirst().get();
+    String input3System = streamConfig.getSystem(input3StreamId);
+    String input3PhysicalName = streamConfig.getPhysicalName(input3StreamId);
+    String output1StreamId = specGraph.getOutputStreams().keySet().stream().findFirst().get();
+    String output1System = streamConfig.getSystem(output1StreamId);
+    String output1PhysicalName = streamConfig.getPhysicalName(output1StreamId);
+    String output2StreamId = specGraph.getOutputStreams().keySet().stream().skip(1).findFirst().get();
+    String output2System = streamConfig.getSystem(output2StreamId);
+    String output2PhysicalName = streamConfig.getPhysicalName(output2StreamId);
+
     Assert.assertEquals(2, specGraph.getOutputStreams().size());
-    Assert.assertEquals("kafka", specGraph.getOutputStreams().keySet().stream().findFirst().get().getSystemName());
-    Assert.assertEquals("sql-job-1-partition_by-stream_1",
-        specGraph.getOutputStreams().keySet().stream().findFirst().get().getPhysicalName());
-    Assert.assertEquals("testavro", specGraph.getOutputStreams().keySet().stream().skip(1).findFirst().get().getSystemName());
-    Assert.assertEquals("enrichedPageViewTopic",
-        specGraph.getOutputStreams().keySet().stream().skip(1).findFirst().get().getPhysicalName());
+    Assert.assertEquals("kafka", output1System);
+    Assert.assertEquals("sql-job-1-partition_by-stream_1", output1PhysicalName);
+    Assert.assertEquals("testavro", output2System);
+    Assert.assertEquals("enrichedPageViewTopic", output2PhysicalName);
 
     Assert.assertEquals(3, specGraph.getInputOperators().size());
-    Assert.assertEquals("testavro",
-        specGraph.getInputOperators().keySet().stream().findFirst().get().getSystemName());
-    Assert.assertEquals("PAGEVIEW",
-        specGraph.getInputOperators().keySet().stream().findFirst().get().getPhysicalName());
-    Assert.assertEquals("testavro",
-        specGraph.getInputOperators().keySet().stream().skip(1).findFirst().get().getSystemName());
-    Assert.assertEquals("PROFILE",
-        specGraph.getInputOperators().keySet().stream().skip(1).findFirst().get().getPhysicalName());
-    Assert.assertEquals("kafka",
-        specGraph.getInputOperators().keySet().stream().skip(2).findFirst().get().getSystemName());
-    Assert.assertEquals("sql-job-1-partition_by-stream_1",
-        specGraph.getInputOperators().keySet().stream().skip(2).findFirst().get().getPhysicalName());
+    Assert.assertEquals("testavro", input1System);
+    Assert.assertEquals("PAGEVIEW", input1PhysicalName);
+    Assert.assertEquals("testavro", input2System);
+    Assert.assertEquals("PROFILE", input2PhysicalName);
+    Assert.assertEquals("kafka", input3System);
+    Assert.assertEquals("sql-job-1-partition_by-stream_1", input3PhysicalName);
 
     validatePerTaskContextInit(graphSpec, samzaConfig);
   }
@@ -521,32 +563,41 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
 
     OperatorSpecGraph specGraph = graphSpec.getOperatorSpecGraph();
 
+    StreamConfig streamConfig = new StreamConfig(samzaConfig);
+    String input1StreamId = specGraph.getInputOperators().keySet().stream().findFirst().get();
+    String input1System = streamConfig.getSystem(input1StreamId);
+    String input1PhysicalName = streamConfig.getPhysicalName(input1StreamId);
+    String input2StreamId = specGraph.getInputOperators().keySet().stream().skip(1).findFirst().get();
+    String input2System = streamConfig.getSystem(input2StreamId);
+    String input2PhysicalName = streamConfig.getPhysicalName(input2StreamId);
+    String input3StreamId = specGraph.getInputOperators().keySet().stream().skip(2).findFirst().get();
+    String input3System = streamConfig.getSystem(input3StreamId);
+    String input3PhysicalName = streamConfig.getPhysicalName(input3StreamId);
+    String output1StreamId = specGraph.getOutputStreams().keySet().stream().findFirst().get();
+    String output1System = streamConfig.getSystem(output1StreamId);
+    String output1PhysicalName = streamConfig.getPhysicalName(output1StreamId);
+    String output2StreamId = specGraph.getOutputStreams().keySet().stream().skip(1).findFirst().get();
+    String output2System = streamConfig.getSystem(output2StreamId);
+    String output2PhysicalName = streamConfig.getPhysicalName(output2StreamId);
+
     Assert.assertEquals(2, specGraph.getOutputStreams().size());
-    Assert.assertEquals("kafka", specGraph.getOutputStreams().keySet().stream().findFirst().get().getSystemName());
-    Assert.assertEquals("sql-job-1-partition_by-stream_1",
-        specGraph.getOutputStreams().keySet().stream().findFirst().get().getPhysicalName());
-    Assert.assertEquals("testavro", specGraph.getOutputStreams().keySet().stream().skip(1).findFirst().get().getSystemName());
-    Assert.assertEquals("enrichedPageViewTopic",
-        specGraph.getOutputStreams().keySet().stream().skip(1).findFirst().get().getPhysicalName());
+    Assert.assertEquals("kafka", output1System);
+    Assert.assertEquals("sql-job-1-partition_by-stream_1", output1PhysicalName);
+    Assert.assertEquals("testavro", output2System);
+    Assert.assertEquals("enrichedPageViewTopic", output2PhysicalName);
 
     Assert.assertEquals(3, specGraph.getInputOperators().size());
-    Assert.assertEquals("testavro",
-        specGraph.getInputOperators().keySet().stream().findFirst().get().getSystemName());
-    Assert.assertEquals("PROFILE",
-        specGraph.getInputOperators().keySet().stream().findFirst().get().getPhysicalName());
-    Assert.assertEquals("testavro",
-        specGraph.getInputOperators().keySet().stream().skip(1).findFirst().get().getSystemName());
-    Assert.assertEquals("PAGEVIEW",
-        specGraph.getInputOperators().keySet().stream().skip(1).findFirst().get().getPhysicalName());
-    Assert.assertEquals("kafka",
-        specGraph.getInputOperators().keySet().stream().skip(2).findFirst().get().getSystemName());
-    Assert.assertEquals("sql-job-1-partition_by-stream_1",
-        specGraph.getInputOperators().keySet().stream().skip(2).findFirst().get().getPhysicalName());
+    Assert.assertEquals("testavro", input1System);
+    Assert.assertEquals("PROFILE", input1PhysicalName);
+    Assert.assertEquals("testavro", input2System);
+    Assert.assertEquals("PAGEVIEW", input2PhysicalName);
+    Assert.assertEquals("kafka", input3System);
+    Assert.assertEquals("sql-job-1-partition_by-stream_1", input3PhysicalName);
 
     validatePerTaskContextInit(graphSpec, samzaConfig);
   }
@@ -566,7 +617,7 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
     OperatorSpecGraph specGraph = graphSpec.getOperatorSpecGraph();
 
@@ -590,7 +641,7 @@ public class TestQueryTranslator {
     QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     SamzaSqlQueryParser.QueryInfo queryInfo = samzaSqlApplicationConfig.getQueryInfo().get(0);
     StreamGraphSpec
-        graphSpec = new StreamGraphSpec(new LocalApplicationRunner(samzaConfig), samzaConfig);
+        graphSpec = new StreamGraphSpec(samzaConfig);
     translator.translate(queryInfo, graphSpec);
   }
 }

--- a/samza-test/src/main/java/org/apache/samza/test/integration/NegateNumberTask.java
+++ b/samza-test/src/main/java/org/apache/samza/test/integration/NegateNumberTask.java
@@ -30,7 +30,7 @@ import org.apache.samza.task.StreamTask;
 import org.apache.samza.task.TaskContext;
 import org.apache.samza.task.TaskCoordinator;
 import org.apache.samza.task.TaskCoordinator.RequestScope;
-import org.apache.samza.util.Util;
+import org.apache.samza.util.StreamUtil;
 
 /**
  * A simple test job that reads strings, converts them to integers, multiplies
@@ -59,7 +59,7 @@ public class NegateNumberTask implements StreamTask, InitableTask {
     if (outputSystemStreamString == null) {
       throw new ConfigException("Missing required configuration: task.outputs");
     }
-    outputSystemStream = Util.getSystemStreamFromNames(outputSystemStreamString);
+    outputSystemStream = StreamUtil.getSystemStreamFromNames(outputSystemStreamString);
   }
 
   @Override

--- a/samza-test/src/main/scala/org/apache/samza/test/performance/TestPerformanceTask.scala
+++ b/samza-test/src/main/scala/org/apache/samza/test/performance/TestPerformanceTask.scala
@@ -27,7 +27,7 @@ import org.apache.samza.task.StreamTask
 import org.apache.samza.task.TaskCoordinator
 import org.apache.samza.task.TaskCoordinator.RequestScope
 import org.apache.samza.config.Config
-import org.apache.samza.util.{Util, Logging}
+import org.apache.samza.util.{Logging, StreamUtil}
 import org.apache.samza.system.SystemStream
 import org.apache.samza.system.OutgoingMessageEnvelope
 
@@ -85,7 +85,7 @@ class TestPerformanceTask extends StreamTask with InitableTask with Logging {
   def init(config: Config, context: TaskContext) {
     logInterval = config.getInt("task.log.interval", 10000)
     maxMessages = config.getInt("task.max.messages", 10000000)
-    outputSystemStream = Option(config.get("task.outputs", null)).map(Util.getSystemStreamFromNames(_))
+    outputSystemStream = Option(config.get("task.outputs", null)).map(StreamUtil.getSystemStreamFromNames)
   }
 
   def process(envelope: IncomingMessageEnvelope, collector: MessageCollector, coordinator: TaskCoordinator) {

--- a/samza-test/src/test/java/org/apache/samza/test/operator/RepartitionJoinWindowApp.java
+++ b/samza-test/src/test/java/org/apache/samza/test/operator/RepartitionJoinWindowApp.java
@@ -34,7 +34,6 @@ import org.apache.samza.serializers.JsonSerdeV2;
 import org.apache.samza.serializers.KVSerde;
 import org.apache.samza.serializers.StringSerde;
 import org.apache.samza.system.OutgoingMessageEnvelope;
-import org.apache.samza.system.StreamSpec;
 import org.apache.samza.system.SystemStream;
 import org.apache.samza.task.TaskCoordinator;
 import org.apache.samza.test.operator.data.AdClick;
@@ -54,7 +53,7 @@ public class RepartitionJoinWindowApp implements StreamApplication {
   public static final String INPUT_TOPIC_NAME_2_PROP = "inputTopicName2";
   public static final String OUTPUT_TOPIC_NAME_PROP = "outputTopicName";
 
-  private final List<StreamSpec> intermediateStreams = new ArrayList<>();
+  private final List<String> intermediateStreamIds = new ArrayList<>();
 
   public static void main(String[] args) throws Exception {
     CommandLine cmdLine = new CommandLine();
@@ -106,14 +105,14 @@ public class RepartitionJoinWindowApp implements StreamApplication {
           });
 
 
-    intermediateStreams.add(((IntermediateMessageStreamImpl) pageViewsRepartitionedByViewId).getStreamSpec());
-    intermediateStreams.add(((IntermediateMessageStreamImpl) adClicksRepartitionedByViewId).getStreamSpec());
-    intermediateStreams.add(((IntermediateMessageStreamImpl) userPageAdClicksByUserId).getStreamSpec());
+    intermediateStreamIds.add(((IntermediateMessageStreamImpl) pageViewsRepartitionedByViewId).getStreamId());
+    intermediateStreamIds.add(((IntermediateMessageStreamImpl) adClicksRepartitionedByViewId).getStreamId());
+    intermediateStreamIds.add(((IntermediateMessageStreamImpl) userPageAdClicksByUserId).getStreamId());
 
   }
 
-  public List<StreamSpec> getIntermediateStreams() {
-    return intermediateStreams;
+  List<String> getIntermediateStreamIds() {
+    return intermediateStreamIds;
   }
 
   private static class UserPageViewAdClicksJoiner implements JoinFunction<String, PageView, AdClick, UserPageAdClick> {

--- a/samza-test/src/test/java/org/apache/samza/test/operator/TestRepartitionJoinWindowApp.java
+++ b/samza-test/src/test/java/org/apache/samza/test/operator/TestRepartitionJoinWindowApp.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.samza.Partition;
-import org.apache.samza.system.StreamSpec;
 import org.apache.samza.system.SystemStreamMetadata;
 import org.apache.samza.system.SystemStreamMetadata.SystemStreamPartitionMetadata;
 import org.apache.samza.system.kafka.KafkaSystemAdmin;
@@ -122,14 +121,14 @@ public class TestRepartitionJoinWindowApp extends StreamApplicationIntegrationTe
 
     // Verify that messages in the intermediate stream will be deleted in 10 seconds
     long startTimeMs = System.currentTimeMillis();
-    for (StreamSpec spec: app.getIntermediateStreams()) {
+    for (String streamId: app.getIntermediateStreamIds()) {
       long remainingMessageNum = -1;
 
       while (remainingMessageNum != 0 && System.currentTimeMillis() - startTimeMs < 10000) {
         remainingMessageNum = 0;
         SystemStreamMetadata metadatas = systemAdmin.getSystemStreamMetadata(
-            new HashSet<>(Arrays.asList(spec.getPhysicalName())), new ExponentialSleepStrategy.Mock(3)
-        ).get(spec.getPhysicalName()).get();
+            new HashSet<>(Arrays.asList(streamId)), new ExponentialSleepStrategy.Mock(3)
+        ).get(streamId).get();
 
         for (Map.Entry<Partition, SystemStreamPartitionMetadata> entry : metadatas.getSystemStreamPartitionMetadata().entrySet()) {
           SystemStreamPartitionMetadata metadata = entry.getValue();


### PR DESCRIPTION
This PR is a pre-requisite for adding support for user-provided SystemDescriptors and StreamDescriptors to the High Level API.

It removes all usages of StreamSpec and ApplicationRunner from the OperatorSpec and OperatorImpl layers. DAG specification (StreamGraphSpec, OperatorSpecs) now only relies on logical streamIds (and in future, will use the user-provided StreamDescriptors). DAG execution (i.e., StreamOperatorTask, OperatorImpls) now only relies on logical streamIds and their corresponding SystemStreams, which are obtained using StreamConfig in OperatorImplGraph.

After this change, StreamSpec can be thought of as the API between StreamManager and SystemAdmins for creating and validating streams. Ideally ExecutionPlanner shouldn't rely on StreamSpec either, but it currently does so extensively, so I'll leave that refactor for later.

Additional changes:
1. ApplicationRunner is no longer responsible for creating/returning StreamSpec instances. Instances can be created directly using the StreamSpec constructors, or by using one of the util methods in the new StreamUtil class.

2. StreamSpec class no longer tracks the isBroadcast and isBounded status for streams. 
The former was being used for communicating broadcast status from the StreamGraphSpec to the planner so that it could write the broadcast input configurations. This is now done using a separate Set of broadcast streamIds in StreamGraphSpec.
The latter was being set by the ApplicationRunner based on a config, and then passed to the planner so that it could write the bounded input configs. This was redundant, so I removed it.