### PR TITLE
Samza-1752: Pass full config to the IO resolver

### DIFF
--- a/samza-sql/src/main/java/org/apache/samza/sql/impl/ConfigBasedIOResolverFactory.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/impl/ConfigBasedIOResolverFactory.java
@@ -47,8 +47,8 @@ public class ConfigBasedIOResolverFactory implements SqlIOResolverFactory {
   public static final String CFG_FMT_SAMZA_PREFIX = "systems.%s.";
 
   @Override
-  public SqlIOResolver create(Config config, Config fullConfig) {
-    return new ConfigBasedIOResolver(config);
+  public SqlIOResolver create(Config resolverConfig, Config fullConfig) {
+    return new ConfigBasedIOResolver(resolverConfig);
   }
 
   private class ConfigBasedIOResolver implements SqlIOResolver {

--- a/samza-sql/src/main/java/org/apache/samza/sql/impl/ConfigBasedIOResolverFactory.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/impl/ConfigBasedIOResolverFactory.java
@@ -47,7 +47,7 @@ public class ConfigBasedIOResolverFactory implements SqlIOResolverFactory {
   public static final String CFG_FMT_SAMZA_PREFIX = "systems.%s.";
 
   @Override
-  public SqlIOResolver create(Config config) {
+  public SqlIOResolver create(Config config, Config fullConfig) {
     return new ConfigBasedIOResolver(config);
   }
 

--- a/samza-sql/src/main/java/org/apache/samza/sql/interfaces/SqlIOResolverFactory.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/interfaces/SqlIOResolverFactory.java
@@ -29,8 +29,9 @@ public interface SqlIOResolverFactory {
 
   /**
    * Create the {@link SqlIOResolver}. This is called during the application initialization.
-   * @param config config for the SqlIOResolver
+   * @param resolverConfig config specifically supplied for this SqlIOResolver
+   * @param fullConfig the full config object received by the application.
    * @return Returns the created {@link SqlIOResolver}
    */
-  SqlIOResolver create(Config config);
+  SqlIOResolver create(Config resolverConfig, Config fullConfig);
 }

--- a/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationConfig.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationConfig.java
@@ -187,7 +187,7 @@ public class SamzaSqlApplicationConfig {
     String sourceResolveValue = config.get(CFG_IO_RESOLVER);
     Validate.notEmpty(sourceResolveValue, "ioResolver config is not set or empty");
     return initializePlugin("SqlIOResolver", sourceResolveValue, config, CFG_FMT_SOURCE_RESOLVER_DOMAIN,
-        (o, c) -> ((SqlIOResolverFactory) o).create(c));
+        (o, c) -> ((SqlIOResolverFactory) o).create(c, config));
   }
 
   private UdfResolver createUdfResolver(Map<String, String> config) {

--- a/samza-sql/src/test/java/org/apache/samza/sql/testutil/TestIOResolverFactory.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/testutil/TestIOResolverFactory.java
@@ -50,7 +50,7 @@ public class TestIOResolverFactory implements SqlIOResolverFactory {
   public static final String TEST_TABLE_ID = "testDbId";
 
   @Override
-  public SqlIOResolver create(Config config) {
+  public SqlIOResolver create(Config config, Config fullConfig) {
     return new TestIOResolver(config);
   }
 


### PR DESCRIPTION
SQL IO Resolver needs full configs so that it can filter out the configs specific to the source that the SQL application is interested in. This change provides the IO resolver with the full config.