### PR TITLE
SAMZA-1762: Fix Memory link in the Timer Registry Map

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -57,6 +57,10 @@ Then sign it:
 
     gpg --sign --armor --detach-sig build/distribution/source/apache-samza-*.tgz
 
+Create SHA1 signature:
+
+    gpg --print-md SHA1 ./build/distribution/source/apache-samza-*.tgz > ./build/distribution/source/apache-samza-*.tgz.sha1
+
 Make a signed git tag for the release candidate:
 
     git tag -s release-$VERSION-rc0 -m "Apache Samza $VERSION release candidate 0"
@@ -64,6 +68,22 @@ Make a signed git tag for the release candidate:
 Push the release tag to remote repository:
 
     git push origin release-$VERSION-rc0
+
+Build the tarball for samza-tool:
+
+    ./gradlew releaseToolsTarGz
+
+Then sign it:
+
+    gpg --sign --armor --detach-sig ./samza-tools/build/distributions/samza-tools-*.tgz
+
+Create MD5 signature:
+
+    gpg --print-md MD5 ./samza-tools/build/distributions/samza-tools-*.tgz > ./samza-tools/build/distributions/samza-tools-*.tgz.md5
+
+Create SHA1 signature:
+
+    gpg --print-md SHA1 ./build/distribution/source/apache-samza-*.tgz > ./build/distribution/source/apache-samza-*.tgz.sha1
 
 Edit `$HOME/.gradle/gradle.properties` and add your GPG key information:
 

--- a/samza-core/src/main/java/org/apache/samza/task/SystemTimerScheduler.java
+++ b/samza-core/src/main/java/org/apache/samza/task/SystemTimerScheduler.java
@@ -63,6 +63,7 @@ public class SystemTimerScheduler {
 
     final long delay = timestamp - System.currentTimeMillis();
     final ScheduledFuture<?> scheduledFuture = executor.schedule(() -> {
+        scheduledFutures.remove(key);
         readyTimers.put(TimerKey.of(key, timestamp), callback);
 
         if (timerListener != null) {


### PR DESCRIPTION
Found a memory leak in the SystemTimerScheduler which does not remove the timers from scheduledFutures after the timers are fired. This caused memory problem for Samza jobs using TimerFn feature. This patch fixes this issue.