### PR TITLE
SAMZA-1775: add some delay before renew under transient EH exception

### DIFF
--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
@@ -479,8 +479,7 @@ public class EventHubSystemConsumer extends BlockingEnvelopeMap {
               String.format("Received transient exception from EH client. Renew partition receiver for ssp: %s", ssp),
               throwable);
           try {
-            // Even though these are transient exceptions, we don't want to retry too frequently which sometimes
-            // would spam the log
+            // Add a fixed delay so that we don't keep retrying when there are long-lasting failures
             Thread.sleep(Duration.ofSeconds(2).toMillis());
           } catch (InterruptedException e) {
             LOG.warn("Interrupted during sleep before renew", e);

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
@@ -478,6 +478,13 @@ public class EventHubSystemConsumer extends BlockingEnvelopeMap {
           LOG.warn(
               String.format("Received transient exception from EH client. Renew partition receiver for ssp: %s", ssp),
               throwable);
+          try {
+            // Even though these are transient exceptions, we don't want to retry too frequently which sometimes
+            // would spam the log
+            Thread.sleep(Duration.ofSeconds(2).toMillis());
+          } catch (InterruptedException e) {
+            LOG.warn("Interrupted during sleep before renew", e);
+          }
           // Retry creating a receiver since error likely due to timeout
           renewPartitionReceiver(ssp);
           return;


### PR DESCRIPTION
There is no delay at all before we renew the partition. This sometimes lead to spam in the log for the following messages:

Received transient exception from EH client. Renew partition receiver for ssp ...