### PR TITLE
Side inputs: Bug fixes

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/storage/TaskSideInputStorageManager.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/TaskSideInputStorageManager.java
@@ -34,11 +34,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.samza.Partition;
 import org.apache.samza.SamzaException;
 import org.apache.samza.config.Config;
-import org.apache.samza.config.JavaStorageConfig;
 import org.apache.samza.container.TaskName;
 import org.apache.samza.storage.kv.Entry;
 import org.apache.samza.storage.kv.KeyValueStore;
@@ -76,7 +74,6 @@ public class TaskSideInputStorageManager {
   private final StreamMetadataCache streamMetadataCache;
   private final SystemAdmins systemAdmins;
   private final TaskName taskName;
-  private final JavaStorageConfig storageConfig;
   private final Map<SystemStreamPartition, String> lastProcessedOffsets = new ConcurrentHashMap<>();
 
   private Map<SystemStreamPartition, String> startingOffsets;
@@ -92,7 +89,6 @@ public class TaskSideInputStorageManager {
       Config config,
       Clock clock) {
     this.clock = clock;
-    this.storageConfig = new JavaStorageConfig(config);
     this.stores = sideInputStores;
     this.storeBaseDir = storeBaseDir;
     this.storeToSSps = storesToSSPs;
@@ -365,9 +361,9 @@ public class TaskSideInputStorageManager {
 
   private void validateStoreConfiguration() {
     stores.forEach((storeName, storageEngine) -> {
-        if (StringUtils.isBlank(storageConfig.getSideInputsProcessorFactory(storeName))) {
+        if (!storeToProcessor.containsKey(storeName)) {
           throw new SamzaException(
-              String.format("Side inputs processor factory configuration missing for store: %s.", storeName));
+              String.format("Side inputs processor missing for store: %s.", storeName));
         }
 
         if (storageEngine.getStoreProperties().isLoggedStore()) {

--- a/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
@@ -179,7 +179,7 @@ class TaskInstance(
       trace("Processing incoming message envelope for taskName and SSP: %s, %s"
         format (taskName, incomingMessageSsp))
 
-      if (sideInputSSPs.contains(incomingMessageSsp)) {
+      if (sideInputSSPs.contains(incomingMessageSsp) && !envelope.isEndOfStream) {
         sideInputStorageManager.process(envelope)
       } else {
         if (isAsyncTask) {

--- a/samza-core/src/main/scala/org/apache/samza/system/chooser/BootstrappingChooser.scala
+++ b/samza-core/src/main/scala/org/apache/samza/system/chooser/BootstrappingChooser.scala
@@ -19,6 +19,7 @@
 
 package org.apache.samza.system.chooser
 
+import java.util.HashMap
 import org.apache.samza.metrics.MetricsHelper
 import org.apache.samza.metrics.MetricsRegistryMap
 import org.apache.samza.metrics.MetricsRegistry

--- a/samza-core/src/main/scala/org/apache/samza/system/chooser/BootstrappingChooser.scala
+++ b/samza-core/src/main/scala/org/apache/samza/system/chooser/BootstrappingChooser.scala
@@ -19,7 +19,6 @@
 
 package org.apache.samza.system.chooser
 
-import java.util.HashMap
 import org.apache.samza.metrics.MetricsHelper
 import org.apache.samza.metrics.MetricsRegistryMap
 import org.apache.samza.metrics.MetricsRegistry

--- a/samza-core/src/main/scala/org/apache/samza/util/Util.scala
+++ b/samza-core/src/main/scala/org/apache/samza/util/Util.scala
@@ -94,7 +94,7 @@ object Util extends Logging {
     * @return the [[SystemStream]] for the stream
     */
   def getSystemStreamFromNameOrId(config: Config, stream: String): SystemStream = {
-    val parts = stream.split(".")
+    val parts = stream.split("\\.")
     if (parts.length == 0 || parts.length > 2) {
       throw new SamzaException(
         String.format("Invalid stream %s. Expected to be of the format streamId or systemName.streamName", stream))


### PR DESCRIPTION
 - Use the correct regex in Util#getSystemStreamFromNameOrId
 - Handle end of stream during dispatch of message to side input
processor
 - Fix validation to check for presence of side input processor for a
given store instead of looking up the side input processor factory.