### PR TITLE
SAMZA-1785: ignore timeout exception during receiver renew in eventhubs consumer

### DIFF
--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
@@ -35,6 +35,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -54,6 +55,7 @@ import org.apache.samza.system.eventhub.metrics.SamzaHistogram;
 import org.apache.samza.system.eventhub.producer.EventHubSystemProducer;
 import org.apache.samza.util.BlockingEnvelopeMap;
 import org.apache.samza.util.ShutdownUtil;
+import org.apache.samza.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,7 +101,10 @@ public class EventHubSystemConsumer extends BlockingEnvelopeMap {
 
   // Overall timeout for EventHubClient exponential backoff policy
   private static final Duration DEFAULT_EVENTHUB_RECEIVER_TIMEOUT = Duration.ofMinutes(10L);
-  private static final long DEFAULT_SHUTDOWN_TIMEOUT_MILLIS = Duration.ofSeconds(15).toMillis();
+  private static final long RENEW_SHUTDOWN_TIMEOUT_MILLIS = Duration.ofMinutes(1).toMillis();
+  // use a shorter shutdown timeout during the consumer shutdown; otherwise the rebalance
+  // in standalone may fail
+  private static final long SHUTDOWN_TIMEOUT_MILLIS = Duration.ofSeconds(15).toMillis();
 
   public static final String START_OF_STREAM = ClientConstants.START_OF_STREAM; // -1
   public static final String END_OF_STREAM = "-2";
@@ -324,8 +329,13 @@ public class EventHubSystemConsumer extends BlockingEnvelopeMap {
     String consumerGroup = config.getStreamConsumerGroup(ssp.getSystem(), streamId);
 
     try {
-      // Close current receiver
-      streamPartitionReceivers.get(ssp).close().get(DEFAULT_SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+      try {
+        // Close current receiver
+        streamPartitionReceivers.get(ssp).close().get(RENEW_SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+      } catch (TimeoutException te) {
+        LOG.warn("Timeout closing existing receiver. Moving on renewing a new one", te);
+        Util.logThreadDump("EventHubSystemConsumer.Receiver#Renew");
+      }
 
       // Recreate receiver
       PartitionReceiver receiver = eventHubClientManager.getEventHubClient()
@@ -356,24 +366,24 @@ public class EventHubSystemConsumer extends BlockingEnvelopeMap {
       @Override
       public void run() {
         try {
-          receiver.close().get(DEFAULT_SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+          receiver.close().get(SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
           LOG.error("Failed to shutdown receiver.", e);
         }
       }
-    }).collect(Collectors.toList()), "EventHubSystemConsumer.Receiver#close", DEFAULT_SHUTDOWN_TIMEOUT_MILLIS);
+    }).collect(Collectors.toList()), "EventHubSystemConsumer.Receiver#close", SHUTDOWN_TIMEOUT_MILLIS);
 
     LOG.info("Start shutting down eventhubs managers");
     ShutdownUtil.boundedShutdown(perPartitionEventHubManagers.values().stream().map(manager -> new Runnable() {
       @Override
       public void run() {
         try {
-          manager.close(DEFAULT_SHUTDOWN_TIMEOUT_MILLIS);
+          manager.close(SHUTDOWN_TIMEOUT_MILLIS);
         } catch (Exception e) {
           LOG.error("Failed to shutdown eventhubs manager.", e);
         }
       }
-    }).collect(Collectors.toList()), "EventHubSystemConsumer.ClientManager#close", DEFAULT_SHUTDOWN_TIMEOUT_MILLIS);
+    }).collect(Collectors.toList()), "EventHubSystemConsumer.ClientManager#close", SHUTDOWN_TIMEOUT_MILLIS);
 
     perPartitionEventHubManagers.clear();
     perStreamEventHubManagers.clear();


### PR DESCRIPTION
We start to see issues where we get timeout exception during renewPartitionReceiver(). 

This method is called because of some transient error and the method is supposed to renew the receiver. Before starting a new receiver, the method tries to shutdown the existing receiver to close the old connection. The shutdown of the old receiver, however, times out and the timeout exception in turn causes the entire process to exit.

While we are still investigating the root cause of the timeout problem, due to the frequency of the issue we decided to ignore the timeout exception to avoid killing the container.