### PR TITLE
SAMZA-1768: Handle corrupted OFFSET file

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/storage/StorageManagerUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/StorageManagerUtil.java
@@ -128,7 +128,11 @@ public class StorageManagerUtil {
 
     if (offsetFileRef.exists()) {
       LOG.info("Found offset file in storage partition directory: {}", storePath);
-      offset = FileUtil.readWithChecksum(offsetFileRef);
+      try {
+        offset = FileUtil.readWithChecksum(offsetFileRef);
+      } catch (Exception e) {
+        LOG.warn("Fail to read offset file of " + storePath);
+      }
     } else {
       LOG.info("No offset file found in storage partition directory: {}", storePath);
     }

--- a/samza-core/src/main/java/org/apache/samza/storage/StorageManagerUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/StorageManagerUtil.java
@@ -131,7 +131,7 @@ public class StorageManagerUtil {
       try {
         offset = FileUtil.readWithChecksum(offsetFileRef);
       } catch (Exception e) {
-        LOG.warn("Fail to read offset file of " + storePath, e);
+        LOG.warn("Failed to read offset file in storage partition directory: {}", storePath, e);
       }
     } else {
       LOG.info("No offset file found in storage partition directory: {}", storePath);

--- a/samza-core/src/main/java/org/apache/samza/storage/StorageManagerUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/StorageManagerUtil.java
@@ -131,7 +131,7 @@ public class StorageManagerUtil {
       try {
         offset = FileUtil.readWithChecksum(offsetFileRef);
       } catch (Exception e) {
-        LOG.warn("Fail to read offset file of " + storePath);
+        LOG.warn("Fail to read offset file of " + storePath, e);
       }
     } else {
       LOG.info("No offset file found in storage partition directory: {}", storePath);

--- a/samza-core/src/main/scala/org/apache/samza/util/FileUtil.scala
+++ b/samza-core/src/main/scala/org/apache/samza/util/FileUtil.scala
@@ -36,7 +36,6 @@ object FileUtil {
     * */
   def writeWithChecksum(file: File, data: String): Unit = {
     val checksum = getChecksum(data)
-
     val tmpFilePath = file.getAbsolutePath + ".tmp"
     val tmpFile = new File(tmpFilePath)
     var oos: ObjectOutputStream = null

--- a/samza-core/src/main/scala/org/apache/samza/util/FileUtil.scala
+++ b/samza-core/src/main/scala/org/apache/samza/util/FileUtil.scala
@@ -45,17 +45,17 @@ object FileUtil {
       oos = new ObjectOutputStream(fos)
       oos.writeLong(checksum)
       oos.writeUTF(data)
-
-      //atomic swap of tmp and real offset file
-      try {
-        Files.move(tmpFile.toPath, file.toPath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
-      } catch {
-        case e: AtomicMoveNotSupportedException =>
-          Files.move(tmpFile.toPath, file.toPath, StandardCopyOption.REPLACE_EXISTING)
-      }
     } finally {
       oos.close()
       fos.close()
+    }
+
+    //atomic swap of tmp and real offset file
+    try {
+      Files.move(tmpFile.toPath, file.toPath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+    } catch {
+      case e: AtomicMoveNotSupportedException =>
+        Files.move(tmpFile.toPath, file.toPath, StandardCopyOption.REPLACE_EXISTING)
     }
   }
 

--- a/samza-core/src/main/scala/org/apache/samza/util/FileUtil.scala
+++ b/samza-core/src/main/scala/org/apache/samza/util/FileUtil.scala
@@ -45,13 +45,13 @@ object FileUtil {
       oos = new ObjectOutputStream(fos)
       oos.writeLong(checksum)
       oos.writeUTF(data)
+
+      //atomic swap of tmp and real offset file
+      Files.move(tmpFile.toPath, file.toPath, StandardCopyOption.ATOMIC_MOVE)
     } finally {
       oos.close()
       fos.close()
     }
-
-    //atomic swap of tmp and real offset file
-    Files.move(tmpFile.toPath, file.toPath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
   }
 
   /**

--- a/samza-core/src/main/scala/org/apache/samza/util/FileUtil.scala
+++ b/samza-core/src/main/scala/org/apache/samza/util/FileUtil.scala
@@ -22,6 +22,7 @@
 package org.apache.samza.util
 
 import java.io.{File, FileInputStream, FileOutputStream, ObjectInputStream, ObjectOutputStream}
+import java.nio.file.{StandardCopyOption, CopyOption, Path, Files}
 import java.util.zip.CRC32
 
 import org.apache.samza.util.Util.info
@@ -35,10 +36,13 @@ object FileUtil {
     * */
   def writeWithChecksum(file: File, data: String): Unit = {
     val checksum = getChecksum(data)
+
+    val tmpFilePath = file.getAbsolutePath + ".tmp"
+    val tmpFile = new File(tmpFilePath)
     var oos: ObjectOutputStream = null
     var fos: FileOutputStream = null
     try {
-      fos = new FileOutputStream(file)
+      fos = new FileOutputStream(tmpFile)
       oos = new ObjectOutputStream(fos)
       oos.writeLong(checksum)
       oos.writeUTF(data)
@@ -46,6 +50,9 @@ object FileUtil {
       oos.close()
       fos.close()
     }
+
+    //atomic swap of tmp and real offset file
+    Files.move(tmpFile.toPath, file.toPath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
   }
 
   /**

--- a/samza-core/src/main/scala/org/apache/samza/util/FileUtil.scala
+++ b/samza-core/src/main/scala/org/apache/samza/util/FileUtil.scala
@@ -22,7 +22,7 @@
 package org.apache.samza.util
 
 import java.io.{File, FileInputStream, FileOutputStream, ObjectInputStream, ObjectOutputStream}
-import java.nio.file.{StandardCopyOption, CopyOption, Path, Files}
+import java.nio.file._
 import java.util.zip.CRC32
 
 import org.apache.samza.util.Util.info
@@ -47,7 +47,12 @@ object FileUtil {
       oos.writeUTF(data)
 
       //atomic swap of tmp and real offset file
-      Files.move(tmpFile.toPath, file.toPath, StandardCopyOption.ATOMIC_MOVE)
+      try {
+        Files.move(tmpFile.toPath, file.toPath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+      } catch {
+        case e: AtomicMoveNotSupportedException =>
+          Files.move(tmpFile.toPath, file.toPath, StandardCopyOption.REPLACE_EXISTING)
+      }
     } finally {
       oos.close()
       fos.close()

--- a/samza-core/src/test/scala/org/apache/samza/util/TestFileUtil.scala
+++ b/samza-core/src/test/scala/org/apache/samza/util/TestFileUtil.scala
@@ -49,6 +49,28 @@ class TestFileUtil {
   }
 
   @Test
+  def testWriteDataToFileWithExistingOffsetFile() {
+    // Invoke test
+    val file = new File(System.getProperty("java.io.tmpdir"), "test2")
+    // write the same file three times
+    FileUtil.writeWithChecksum(file, data)
+    FileUtil.writeWithChecksum(file, data)
+    FileUtil.writeWithChecksum(file, data)
+
+    // Check that file exists
+    assertTrue("File was not created!", file.exists())
+    val fis = new FileInputStream(file)
+    val ois = new ObjectInputStream(fis)
+
+    // Check content of the file is as expected
+    assertEquals(checksum, ois.readLong())
+    assertEquals(data, ois.readUTF())
+    ois.close()
+    fis.close()
+  }
+
+
+  @Test
   def testReadDataFromFile() {
     // Setup
     val fos = new FileOutputStream(file)

--- a/samza-kv-rocksdb/src/main/scala/org/apache/samza/storage/kv/RocksDbKeyValueStore.scala
+++ b/samza-kv-rocksdb/src/main/scala/org/apache/samza/storage/kv/RocksDbKeyValueStore.scala
@@ -92,6 +92,7 @@ object RocksDbKeyValueStore extends Logging {
 
       (configuredMetrics ++ rocksDbMetrics)
         .foreach(property => metrics.newGauge(property, () =>
+          // Check isOwningHandle flag. The db is open iff the flag is true.
           if (rocksDb.isOwningHandle) {
             rocksDb.getProperty(property)
           } else {

--- a/samza-kv-rocksdb/src/main/scala/org/apache/samza/storage/kv/RocksDbKeyValueStore.scala
+++ b/samza-kv-rocksdb/src/main/scala/org/apache/samza/storage/kv/RocksDbKeyValueStore.scala
@@ -91,7 +91,13 @@ object RocksDbKeyValueStore extends Logging {
         .toSet
 
       (configuredMetrics ++ rocksDbMetrics)
-        .foreach(property => metrics.newGauge(property, () => rocksDb.getProperty(property)))
+        .foreach(property => metrics.newGauge(property, () =>
+          if (rocksDb.isOwningHandle) {
+            rocksDb.getProperty(property)
+          } else {
+            "0"
+          }
+        ))
 
       rocksDb
     } catch {


### PR DESCRIPTION
This patch addresses the following tickets:

SAMZA-1778: SIGSEGV when reading properties (metrics) on a closed RocksDB store
SAMZA-1777: Logged store OFFSET file write during flush should be atomic
SAMZA-1768: Handle corrupted OFFSET file elegantly