### PR TITLE
SAMZA-1733: Adding filter mechanism to MetricsSnapshotReporter

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/config/MetricsConfig.scala
+++ b/samza-core/src/main/scala/org/apache/samza/config/MetricsConfig.scala
@@ -30,6 +30,7 @@ object MetricsConfig {
   val METRICS_SNAPSHOT_REPORTER_STREAM = "metrics.reporter.%s.stream"
   val METRICS_SNAPSHOT_REPORTER_INTERVAL= "metrics.reporter.%s.interval"
   val METRICS_TIMER_ENABLED= "metrics.timer.enabled"
+  val METRICS_SNAPSHOT_REPORTER_BLACKLIST = "metrics.reporter.%s.blacklist"
 
   implicit def Config2Metrics(config: Config) = new MetricsConfig(config)
 }
@@ -42,6 +43,8 @@ class MetricsConfig(config: Config) extends ScalaMapConfig(config) {
   def getMetricsReporterStream(name: String): Option[String] = getOption(MetricsConfig.METRICS_SNAPSHOT_REPORTER_STREAM format name)
 
   def getMetricsReporterInterval(name: String): Option[String] = getOption(MetricsConfig.METRICS_SNAPSHOT_REPORTER_INTERVAL format name)
+
+  def getBlacklist(name: String): Option[String] = getOption(MetricsConfig.METRICS_SNAPSHOT_REPORTER_BLACKLIST format name)
 
   /**
    * Returns a list of all metrics names from the config file. Useful for

--- a/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporter.scala
+++ b/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporter.scala
@@ -106,22 +106,6 @@ class MetricsSnapshotReporter(
     }
   }
 
-  def shouldIgnore(group: String, metricName: String) = {
-    var isBlacklisted = blacklist.isDefined
-    val fullMetricName = group + "." + metricName
-
-    if (isBlacklisted && !blacklistedMetrics.contains(fullMetricName)) {
-      if (fullMetricName.matches(blacklist.get)) {
-        blacklistedMetrics += fullMetricName
-        info("Blacklisted metric %s because it matched blacklist: %s" format(fullMetricName, blacklist.get))
-      } else {
-        isBlacklisted = false
-      }
-    }
-
-    isBlacklisted
-  }
-
   def run {
     debug("Begin flushing metrics.")
 
@@ -178,5 +162,22 @@ class MetricsSnapshotReporter(
 
 
     debug("Finished flushing metrics.")
+  }
+
+
+  def shouldIgnore(group: String, metricName: String) = {
+    var isBlacklisted = blacklist.isDefined
+    val fullMetricName = group + "." + metricName
+
+    if (isBlacklisted && !blacklistedMetrics.contains(fullMetricName)) {
+      if (fullMetricName.matches(blacklist.get)) {
+        blacklistedMetrics += fullMetricName
+        info("Blacklisted metric %s because it matched blacklist regex: %s" format(fullMetricName, blacklist.get))
+      } else {
+        isBlacklisted = false
+      }
+    }
+
+    isBlacklisted
   }
 }

--- a/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporterFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporterFactory.scala
@@ -107,6 +107,10 @@ class MetricsSnapshotReporterFactory extends MetricsReporterFactory with Logging
       .getOrElse("60").toInt
 
     info("Setting polling interval to %d" format pollingInterval)
+
+    val blacklist = config.getBlacklist(name)
+    info("Setting blacklist to %s" format blacklist)
+
     val reporter = new MetricsSnapshotReporter(
       producer,
       systemStream,
@@ -117,7 +121,7 @@ class MetricsSnapshotReporterFactory extends MetricsReporterFactory with Logging
       version,
       samzaVersion,
       Util.getLocalHost.getHostName,
-      serde)
+      serde, blacklist)
 
     reporter.register(this.getClass.getSimpleName.toString, registry)
 

--- a/samza-core/src/test/java/org/apache/samza/metrics/TestMetricsSnapshotReporter.java
+++ b/samza-core/src/test/java/org/apache/samza/metrics/TestMetricsSnapshotReporter.java
@@ -1,0 +1,96 @@
+package org.apache.samza.metrics;
+
+import org.apache.samza.metrics.reporter.MetricsSnapshotReporter;
+import org.apache.samza.serializers.MetricsSnapshotSerdeV2;
+import org.apache.samza.system.SystemStream;
+import org.apache.samza.system.inmemory.InMemorySystemProducer;
+import org.junit.Assert;
+import org.junit.Test;
+import scala.Some;
+import scala.runtime.AbstractFunction0;
+
+
+public class TestMetricsSnapshotReporter {
+  private MetricsSnapshotReporter metricsSnapshotReporter;
+  private static final String BLACKLIST_ALL = ".*";
+  private static final String BLACKLIST_NONE = "";
+  private static final String BLACKLIST_GROUPS = ".*(SystemConsumersMetrics|CachedStoreMetrics).*";
+  private static final String BLACKLIST_ALL_BUT_TWO_GROUPS = "^(?!.*?(?:SystemConsumersMetrics|CachedStoreMetrics)).*$";
+
+  @Test
+  public void testBlacklistAll() {
+    this.metricsSnapshotReporter = getMetricsSnapshotReporter(BLACKLIST_ALL);
+
+    Assert.assertTrue("Should ignore all metrics",
+        this.metricsSnapshotReporter.shouldIgnore("org.apache.samza.system.kafka.KafkaSystemProducerMetrics",
+            "kafka-flush-ns"));
+
+    Assert.assertTrue("Should ignore all metrics",
+        this.metricsSnapshotReporter.shouldIgnore("org.apache.samza.storage.kv.LoggedStoreMetrics", "stats-ranges"));
+
+    Assert.assertTrue("Should ignore all metrics",
+        this.metricsSnapshotReporter.shouldIgnore("org.apache.samza.system.SystemProducersMetrics", "flushes"));
+  }
+
+  @Test
+  public void testBlacklistNone() {
+    this.metricsSnapshotReporter = getMetricsSnapshotReporter(BLACKLIST_NONE);
+
+    Assert.assertFalse("Should not ignore any metrics",
+        this.metricsSnapshotReporter.shouldIgnore("org.apache.samza.system.kafka.KafkaSystemProducerMetrics",
+            "kafka-flush-ns"));
+
+    Assert.assertFalse("Should not ignore any metrics",
+        this.metricsSnapshotReporter.shouldIgnore("org.apache.samza.storage.kv.LoggedStoreMetrics", "stats-ranges"));
+
+    Assert.assertFalse("Should not ignore any metrics",
+        this.metricsSnapshotReporter.shouldIgnore("org.apache.samza.system.SystemProducersMetrics", "flushes"));
+  }
+
+  @Test
+  public void testBlacklistGroup() {
+    this.metricsSnapshotReporter = getMetricsSnapshotReporter(BLACKLIST_GROUPS);
+    Assert.assertTrue("Should ignore all metrics from this group",
+        this.metricsSnapshotReporter.shouldIgnore("org.apache.samza.system.SystemConsumersMetrics", "poll-ns"));
+
+    Assert.assertTrue("Should ignore all metrics from this group",
+        this.metricsSnapshotReporter.shouldIgnore("org.apache.samza.system.SystemConsumersMetrics",
+            "unprocessed-messages"));
+
+    Assert.assertTrue("Should ignore all metrics from this group",
+        this.metricsSnapshotReporter.shouldIgnore("org.apache.samza.storage.kv.CachedStoreMetrics",
+            "storename-stats-flushes"));
+
+    Assert.assertFalse("Should not ignore any other group",
+        this.metricsSnapshotReporter.shouldIgnore("org.apache.samza.system.kafka.KafkaSystemConsumerMetrics",
+            "poll-count"));
+  }
+
+  @Test
+  public void testBlacklistAllButTwoGroups() {
+    this.metricsSnapshotReporter = getMetricsSnapshotReporter(BLACKLIST_ALL_BUT_TWO_GROUPS);
+
+    Assert.assertFalse("Should not ignore this group",
+        this.metricsSnapshotReporter.shouldIgnore("org.apache.samza.system.SystemConsumersMetrics", "poll-ns"));
+
+    Assert.assertFalse("Should not ignore this group",
+        this.metricsSnapshotReporter.shouldIgnore("org.apache.samza.storage.kv.CachedStoreMetrics",
+            "storename-stats-flushes"));
+
+    Assert.assertTrue("Should ignore all metrics from any other groups",
+        this.metricsSnapshotReporter.shouldIgnore("org.apache.samza.system.kafka.KafkaSystemConsumerMetrics",
+            "poll-count"));
+  }
+
+  private MetricsSnapshotReporter getMetricsSnapshotReporter(String blacklist) {
+    return new MetricsSnapshotReporter(new InMemorySystemProducer("test system", null),
+        new SystemStream("test system", "test stream"), 60000, "test job", "test jobID", "samza-container-0",
+        "test version", "test samza version", "test host", new MetricsSnapshotSerdeV2(), new Some<>(blacklist),
+        new AbstractFunction0<Object>() {
+          @Override
+          public Object apply() {
+            return System.currentTimeMillis();
+          }
+        });
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/metrics/TestMetricsSnapshotReporter.java
+++ b/samza-core/src/test/java/org/apache/samza/metrics/TestMetricsSnapshotReporter.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.samza.metrics;
 
 import org.apache.samza.metrics.reporter.MetricsSnapshotReporter;


### PR DESCRIPTION
This regex based filter mechanism allow for blacklisting of metrics being reporter by the Snapshot Reporter, by specifying the blacklist in config.

* Backwards compatible -- no config => reports everything.
* Regex based, e.g., 
metrics.reporter.snapshot.blacklist= 
.* 
or
^(?!.*?(?:SamzaContainerMetrics|TaskInstanceMetrics)).*$

to report only container metrics and task instance metrics. 

* Uses a hashset to ensure blacklisted metric are matched against the regex only once.