### PR TITLE
SAMZA-1794: setting application acl in launch context 

### DIFF
--- a/docs/learn/documentation/versioned/jobs/configuration-table.html
+++ b/docs/learn/documentation/versioned/jobs/configuration-table.html
@@ -2106,6 +2106,26 @@
                 </tr>
 
                 <tr>
+                    <td class="property" id="yarn-job-view-acl">yarn.job.view.acl</td>
+                    <td class="default"></td>
+                    <td class="description">
+                        This is for secured YARN cluster only.
+                        The 'viewing' acl of the YARN application that controls who can view the application (e.g. application status, logs).
+                        See <a href="https://hadoop.apache.org/docs/r2.6.0/api/org/apache/hadoop/yarn/api/records/ApplicationAccessType.html">ApplicationAccessType</a> for more details.
+                    </td>
+                </tr>
+
+                <tr>
+                    <td class="property" id="yarn-job-modify-acl">yarn.job.modify.acl</td>
+                    <td class="default"></td>
+                    <td class="description">
+                        This is for secured YARN cluster only.
+                        The 'modify' acl of the YARN application that controls who can modify the application (e.g. killing the application).
+                        See <a href="https://hadoop.apache.org/docs/r2.6.0/api/org/apache/hadoop/yarn/api/records/ApplicationAccessType.html">ApplicationAccessType</a> for more details.
+                    </td>
+                </tr>
+
+                <tr>
                     <td class="property" id="yarn-token-renewal-interval-seconds">yarn.token.renewal.interval.seconds</td>
                     <td class="default"></td>
                     <td class="description">

--- a/samza-yarn/src/main/java/org/apache/samza/config/YarnConfig.java
+++ b/samza-yarn/src/main/java/org/apache/samza/config/YarnConfig.java
@@ -115,6 +115,22 @@ public class YarnConfig extends MapConfig {
    */
   public static final String YARN_JOB_STAGING_DIRECTORY = "yarn.job.staging.directory";
 
+  /**
+   * For secured YARN cluster only.
+   * The 'viewing' acl of the YARN application. This controls who can view the application,
+   * for example, application status, logs.
+   * {@link org.apache.hadoop.yarn.api.records.ApplicationAccessType} for more details
+   */
+  public static final String YARN_APPLICATION_VIEW_ACL = "yarn.job.view.acl";
+
+  /**
+   * For secured YARN cluster only.
+   * The 'modify' acl of the YARN application. This controls who can modify the application,
+   * for example, killing the job.
+   * {@link org.apache.hadoop.yarn.api.records.ApplicationAccessType} for more details
+   */
+  public static final String YARN_APPLICATION_MODIFY_ACL = "yarn.job.modify.acl";
+
   public YarnConfig(Config config) {
     super(config);
   }
@@ -190,4 +206,13 @@ public class YarnConfig extends MapConfig {
   public String getYarnJobStagingDirectory() {
     return get(YARN_JOB_STAGING_DIRECTORY, null);
   }
+
+  public String getYarnApplicationViewAcl() {
+    return get(YARN_APPLICATION_VIEW_ACL, null);
+  }
+
+  public String getYarnApplicationModifyAcl() {
+    return get(YARN_APPLICATION_MODIFY_ACL, null);
+  }
+
 }

--- a/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnClusterResourceManager.java
+++ b/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnClusterResourceManager.java
@@ -651,6 +651,11 @@ public class YarnClusterResourceManager extends ClusterResourceManager implement
     context.setCommands(new ArrayList<String>() {{add(cmd);}});
     context.setLocalResources(localResourceMap);
 
+    if (UserGroupInformation.isSecurityEnabled()) {
+      SamzaContainerSecurityManager securityManager = new SamzaContainerSecurityManager(config, new YarnConfiguration());
+      securityManager.setApplicationAcl(context);
+    }
+
     log.debug("Setting localResourceMap to {}", localResourceMap);
     log.debug("Setting context to {}", context);
 

--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/ClientHelper.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/ClientHelper.scala
@@ -52,11 +52,13 @@ import org.apache.samza.job.ApplicationStatus.New
 import org.apache.samza.job.ApplicationStatus.Running
 import org.apache.samza.job.ApplicationStatus.SuccessfulFinish
 import org.apache.samza.job.ApplicationStatus.UnsuccessfulFinish
-import org.apache.samza.util.Logging
+import org.apache.samza.util.{Logging, Util}
 import java.io.IOException
 import java.nio.ByteBuffer
 
 import org.apache.http.impl.client.HttpClientBuilder
+import org.apache.samza.container.SamzaContainer.info
+import org.apache.samza.container.SecurityManagerFactory
 import org.apache.samza.webapp.ApplicationMasterRestClient
 
 object ClientHelper {
@@ -191,11 +193,14 @@ class ClientHelper(conf: Configuration) extends Logging {
       }
     }
 
-    if (UserGroupInformation.isSecurityEnabled()) {
+    if (UserGroupInformation.isSecurityEnabled) {
       validateJobConfig(config)
 
       setupSecurityToken(fs, containerCtx)
       info("set security token for %s" format appId.get)
+
+      val securityManager = new SamzaContainerSecurityManager(config, new YarnConfiguration())
+      securityManager.setApplicationAcl(containerCtx)
 
       val amLocalResources = setupAMLocalResources(fs, Option(yarnConfig.getYarnKerberosPrincipal), Option(yarnConfig.getYarnKerberosKeytab))
       localResources ++= amLocalResources

--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/SamzaContainerSecurityManager.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/SamzaContainerSecurityManager.scala
@@ -19,23 +19,23 @@
 
 package org.apache.samza.job.yarn
 
+import java.util.concurrent.{Executors, TimeUnit}
+
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.FileSystem
-import org.apache.hadoop.fs.Path
-import org.apache.hadoop.security.Credentials
-import org.apache.hadoop.security.UserGroupInformation
-import org.apache.samza.config.Config
-import org.apache.samza.config.YarnConfig
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.security.{Credentials, UserGroupInformation}
+import org.apache.hadoop.yarn.api.records.{ApplicationAccessType, ContainerLaunchContext}
+import org.apache.samza.config.{Config, YarnConfig}
 import org.apache.samza.container.SecurityManager
 import org.apache.samza.util.Logging
 
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
+import scala.collection.JavaConverters._
+import scala.collection.mutable.HashMap
 
 class SamzaContainerSecurityManager(config: Config, hadoopConfig: Configuration) extends SecurityManager with Logging {
   private val InitialDelayInSeconds = 60
-  
+
   private val tokenRenewExecutor = Executors.newSingleThreadScheduledExecutor(
     new ThreadFactoryBuilder()
       .setNameFormat("Samza ContainerSecurityManager TokenRenewer Thread-%d")
@@ -43,6 +43,23 @@ class SamzaContainerSecurityManager(config: Config, hadoopConfig: Configuration)
       .build())
 
   private var lastRefreshTimestamp = 0L
+
+  def setApplicationAcl(ctx: ContainerLaunchContext) = {
+    val yarnConfig = new YarnConfig(config)
+    val viewAcl = yarnConfig.getYarnApplicationViewAcl
+    val modifyAcl = yarnConfig.getYarnApplicationModifyAcl
+    val acls: HashMap[ApplicationAccessType, String] = HashMap[ApplicationAccessType, String]()
+    if (viewAcl != null) {
+      acls += ApplicationAccessType.VIEW_APP -> viewAcl
+    }
+    if (modifyAcl != null) {
+      acls += ApplicationAccessType.MODIFY_APP -> modifyAcl
+    }
+    if (acls.nonEmpty) {
+      info("setting application acls in launch context: %s" format acls)
+      ctx.setApplicationACLs(acls.asJava)
+    }
+  }
 
   def start() = {
     val yarnConfig = new YarnConfig(config)


### PR DESCRIPTION
Currently we don't set application acl for container launch context. See https://hadoop.apache.org/docs/r2.6.4/api/org/apache/hadoop/yarn/api/records/ContainerLaunchContext.html#setApplicationACLs(java.util.Map)

This could potentially cause problem if samza job is running on a secured YARN cluster. Say user A submits the job, then by default only user A can view the log and the status of the job. Even worse case is that user A submits the job through some proxy account, then even user A herself/himself couldn't access to logs/status of the application.

We need to make some changes for the YARN application submission to set application acls in launch context as configured.