### PR TITLE
SAMZA-1733: Defaulting to non-null serde, in case none is specified

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporterFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporterFactory.scala
@@ -31,7 +31,7 @@ import org.apache.samza.config.TaskConfig.Config2Task
 import org.apache.samza.metrics.MetricsReporter
 import org.apache.samza.metrics.MetricsReporterFactory
 import org.apache.samza.metrics.MetricsRegistryMap
-import org.apache.samza.serializers.SerdeFactory
+import org.apache.samza.serializers.{MetricsSnapshotSerdeV2, SerdeFactory}
 import org.apache.samza.system.SystemFactory
 
 class MetricsSnapshotReporterFactory extends MetricsReporterFactory with Logging {
@@ -97,7 +97,7 @@ class MetricsSnapshotReporterFactory extends MetricsReporterFactory with Logging
         case _ => null
       }
     } else {
-      null
+      new MetricsSnapshotSerdeV2
     }
 
     info("Got serde %s." format serde)


### PR DESCRIPTION
Currently, if no system or stream serde is specified the SnapshotReporter simply crashes 
because a MetricsSnapshot cannot be serialized using a 
ByteArraySerializer (what it defaults to). 

This change ensures that in this case the MetricsSnapshotReporter defaults to a valid constructor.