### PR TITLE
SAMZA-1733: Create diagnostic topic if diagnostics enabled

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/config/MetricsConfig.scala
+++ b/samza-core/src/main/scala/org/apache/samza/config/MetricsConfig.scala
@@ -31,6 +31,7 @@ object MetricsConfig {
   val METRICS_SNAPSHOT_REPORTER_INTERVAL= "metrics.reporter.%s.interval"
   val METRICS_TIMER_ENABLED= "metrics.timer.enabled"
   val METRICS_SNAPSHOT_REPORTER_BLACKLIST = "metrics.reporter.%s.blacklist"
+  val METRICS_SNAPSHOT_REPORTER_NAME_FOR_DIAGNOSTICS = "diagnosticsreporter"
 
   implicit def Config2Metrics(config: Config) = new MetricsConfig(config)
 }


### PR DESCRIPTION
* Current SnapshotReporter semantics are to specify stream as <SYS-NAME>.<STREAM-NAME> 

* We create topic in JobRunner so that AM can also emit metrics (if desired). 

