### PR TITLE
SAMZA-1806: Allow `task.broadcast.inputs` to be set to empty string

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/config/Config.java
+++ b/samza-api/src/main/java/org/apache/samza/config/Config.java
@@ -22,6 +22,7 @@ package org.apache.samza.config;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -154,6 +155,9 @@ public abstract class Config implements Map<String, String> {
       return defaultValue;
 
     String value = get(k);
+    if (value.isEmpty()) {
+      return Collections.emptyList();
+    }
     String[] pieces = value.split("\\s*,\\s*");
     return Arrays.asList(pieces);
   }

--- a/samza-api/src/main/java/org/apache/samza/config/Config.java
+++ b/samza-api/src/main/java/org/apache/samza/config/Config.java
@@ -22,7 +22,6 @@ package org.apache.samza.config;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -155,8 +154,8 @@ public abstract class Config implements Map<String, String> {
       return defaultValue;
 
     String value = get(k);
-    if (value.isEmpty()) {
-      return Collections.emptyList();
+    if (value.trim().isEmpty()) {
+      return defaultValue;
     }
     String[] pieces = value.split("\\s*,\\s*");
     return Arrays.asList(pieces);

--- a/samza-api/src/test/java/org/apache/samza/config/TestConfig.java
+++ b/samza-api/src/test/java/org/apache/samza/config/TestConfig.java
@@ -19,6 +19,8 @@
 
 package org.apache.samza.config;
 
+import java.util.Collections;
+import java.util.List;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -84,5 +86,44 @@ public class TestConfig {
     assertEquals("value2", sanitized.get("key2"));
     assertEquals(Config.SENSITIVE_MASK, sanitized.get("sensitive.key3"));
     assertEquals(Config.SENSITIVE_MASK, sanitized.get("sensitive.key4"));
+  }
+
+  @Test
+  public void testGetList() {
+    Map<String, String> m = new HashMap<String, String>() {
+      {
+        put("key1", " ");
+        put("key2", "");
+        put("key3", "  value1  ");
+        put("key4", "value1,value2");
+        put("key5", "value1, value2");
+        put("key6", "value1  ,   value2");
+      }
+    };
+
+    Config config = new MapConfig(m);
+    List<String> list = config.getList("key1", Collections.<String>emptyList());
+    assertEquals(0, list.size());
+
+    list = config.getList("key2", Collections.<String>emptyList());
+    assertEquals(0, list.size());
+
+    list = config.getList("key3");
+    assertEquals("  value1  ", list.get(0));
+
+    list = config.getList("key4");
+    assertEquals("value1", list.get(0));
+    assertEquals("value2", list.get(1));
+
+    list = config.getList("key5");
+    assertEquals("value1", list.get(0));
+    assertEquals("value2", list.get(1));
+
+    list = config.getList("key6");
+    assertEquals("value1", list.get(0));
+    assertEquals("value2", list.get(1));
+
+    list = config.getList("UndefinedKey", Collections.<String>emptyList());
+    assertEquals(0, list.size());
   }
 }


### PR DESCRIPTION
This fix addresses the issue that getBroadcastSystemStreamPartitions
in TaskConfigJava throws an IllegalArgumentException exception when
`task.broadcast.inputs` is set to an empty string.