### PR TITLE
SAMZA-1807 table-api: inline async helpers

### DIFF
--- a/samza-core/src/test/java/org/apache/samza/table/remote/TestRemoteTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/TestRemoteTable.java
@@ -67,9 +67,9 @@ public class TestRemoteTable {
     ExecutorService tableExecutor = Executors.newSingleThreadExecutor();
 
     if (writeFn == null) {
-      table = new RemoteReadableTable<K, V>(tableId, readFn, readRateLimiter, tableExecutor, cbExecutor);
+      table = new RemoteReadableTable<>(tableId, readFn, readRateLimiter, tableExecutor, cbExecutor);
     } else {
-      table = new RemoteReadWriteTable<K, V>(tableId, readFn, writeFn, readRateLimiter, writeRateLimiter, tableExecutor, cbExecutor);
+      table = new RemoteReadWriteTable<>(tableId, readFn, writeFn, readRateLimiter, writeRateLimiter, tableExecutor, cbExecutor);
     }
 
     TaskContext taskContext = mock(TaskContext.class);


### PR DESCRIPTION
Currently we have a set of helper methods, execute() for various
table access methods. Some of them are only called by one place and some
are called in two places. This change inlines the async handling back to
the table methods and removed the helpers.