### PR TITLE
SAMZA-1733:  Bugfix: Moving to use string for type info, to avoid ClassNotFound on deserial

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/diagnostics/DiagnosticsExceptionEvent.java
+++ b/samza-core/src/main/scala/org/apache/samza/diagnostics/DiagnosticsExceptionEvent.java
@@ -32,7 +32,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 public class DiagnosticsExceptionEvent {
 
   private long timestamp; // the timestamp associated with this exception
-  private Class exceptionType; // store the exception type separately
+  private String exceptionType; // store the exception type separately
   private String exceptionMessage; // the exception message
   private String compactExceptionStackTrace; // a compact representation of the exception's stacktrace
   private Map mdcMap;
@@ -42,7 +42,7 @@ public class DiagnosticsExceptionEvent {
   }
 
   public DiagnosticsExceptionEvent(long timestampMillis, Throwable throwable, Map mdcMap) {
-    this.exceptionType = throwable.getClass();
+    this.exceptionType = throwable.getClass().getName();
     this.exceptionMessage = throwable.getMessage();
     this.compactExceptionStackTrace = ExceptionUtils.getStackTrace(throwable);
     this.timestamp = timestampMillis;
@@ -53,7 +53,7 @@ public class DiagnosticsExceptionEvent {
     return timestamp;
   }
 
-  public Class getExceptionType() {
+  public String getExceptionType() {
     return this.exceptionType;
   }
 


### PR DESCRIPTION
Exception type was serialized as a Class. However in case of Exceptions defined in non-samza-related or user-defined libs, the ExceptionEvent fails to be serialized.