### PR TITLE
SAMZA-1821: fix the IllegalStateException complaining duplicate key when fetching systemStream configs

### DIFF
--- a/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationConfig.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationConfig.java
@@ -113,13 +113,13 @@ public class SamzaSqlApplicationConfig {
     inputSystemStreamConfigBySource = queryInfo.stream()
         .map(QueryInfo::getSources)
         .flatMap(Collection::stream)
-        .collect(Collectors.toMap(Function.identity(), src -> ioResolver.fetchSourceInfo(src)));
+        .collect(Collectors.toMap(Function.identity(), ioResolver::fetchSourceInfo, (src1, src2) -> src1));
 
     Set<SqlIOConfig> systemStreamConfigs = new HashSet<>(inputSystemStreamConfigBySource.values());
 
     outputSystemStreamConfigsBySource = queryInfo.stream()
         .map(QueryInfo::getSink)
-        .collect(Collectors.toMap(Function.identity(), x -> ioResolver.fetchSinkInfo(x)));
+        .collect(Collectors.toMap(Function.identity(), ioResolver::fetchSinkInfo, (src1, src2) -> src1));
     systemStreamConfigs.addAll(outputSystemStreamConfigsBySource.values());
 
     relSchemaProvidersBySource = systemStreamConfigs.stream()

--- a/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationConfig.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationConfig.java
@@ -113,13 +113,15 @@ public class SamzaSqlApplicationConfig {
     inputSystemStreamConfigBySource = queryInfo.stream()
         .map(QueryInfo::getSources)
         .flatMap(Collection::stream)
-        .collect(Collectors.toMap(Function.identity(), ioResolver::fetchSourceInfo, (src1, src2) -> src1));
+        .distinct()
+        .collect(Collectors.toMap(Function.identity(), ioResolver::fetchSourceInfo));
 
     Set<SqlIOConfig> systemStreamConfigs = new HashSet<>(inputSystemStreamConfigBySource.values());
 
     outputSystemStreamConfigsBySource = queryInfo.stream()
         .map(QueryInfo::getSink)
-        .collect(Collectors.toMap(Function.identity(), ioResolver::fetchSinkInfo, (src1, src2) -> src1));
+        .distinct()
+        .collect(Collectors.toMap(Function.identity(), ioResolver::fetchSinkInfo));
     systemStreamConfigs.addAll(outputSystemStreamConfigsBySource.values());
 
     relSchemaProvidersBySource = systemStreamConfigs.stream()

--- a/samza-sql/src/test/java/org/apache/samza/sql/testutil/TestSamzaSqlFileParser.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/testutil/TestSamzaSqlFileParser.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
 
-import org.apache.samza.sql.testutil.SqlFileParser;
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR is to fix IllegalStateException complaining duplicate key when fetching resource configs in SamzaSqlApplicationConfig.

## How was this patch tested?
Pass the local build and current unit tests.
Added a new unit test.