### PR TITLE
SAMZA-1826: Fix unit test failure in table tests

### DIFF
--- a/samza-test/src/test/java/org/apache/samza/test/table/PageViewToProfileJoinFunction.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/PageViewToProfileJoinFunction.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.test.table;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.samza.config.Config;
+import org.apache.samza.operators.KV;
+import org.apache.samza.operators.functions.StreamTableJoinFunction;
+import org.apache.samza.task.TaskContext;
+import org.apache.samza.test.table.TestTableData.EnrichedPageView;
+import org.apache.samza.test.table.TestTableData.PageView;
+import org.apache.samza.test.table.TestTableData.Profile;
+
+/**
+ * A {@link StreamTableJoinFunction} used by unit tests in this package
+ */
+class PageViewToProfileJoinFunction implements StreamTableJoinFunction
+    <Integer, KV<Integer, PageView>, KV<Integer, Profile>, EnrichedPageView> {
+  static Map<String, AtomicInteger> counterPerJoinFn = new HashMap<>();
+  private final String joinOpName;
+
+  public PageViewToProfileJoinFunction(String joinOpName) {
+    this.joinOpName = joinOpName;
+  }
+
+  @Override
+  public void init(Config config, TaskContext context) {
+    counterPerJoinFn.put(this.joinOpName, new AtomicInteger(0));
+  }
+
+  @Override
+  public TestTableData.EnrichedPageView apply(KV<Integer, TestTableData.PageView> m, KV<Integer, TestTableData.Profile> r) {
+    counterPerJoinFn.get(this.joinOpName).incrementAndGet();
+    return r == null ? null : new TestTableData.EnrichedPageView(m.getValue().getPageKey(), m.getKey(), r.getValue().getCompany());
+  }
+
+  @Override
+  public Integer getMessageKey(KV<Integer, TestTableData.PageView> message) {
+    return message.getKey();
+  }
+
+  @Override
+  public Integer getRecordKey(KV<Integer, TestTableData.Profile> record) {
+    return record.getKey();
+  }
+
+  public static void reset() {
+    counterPerJoinFn.clear();
+  }
+}

--- a/samza-test/src/test/java/org/apache/samza/test/table/PageViewToProfileJoinFunction.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/PageViewToProfileJoinFunction.java
@@ -18,13 +18,8 @@
  */
 package org.apache.samza.test.table;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.samza.config.Config;
 import org.apache.samza.operators.KV;
 import org.apache.samza.operators.functions.StreamTableJoinFunction;
-import org.apache.samza.task.TaskContext;
 import org.apache.samza.test.table.TestTableData.EnrichedPageView;
 import org.apache.samza.test.table.TestTableData.PageView;
 import org.apache.samza.test.table.TestTableData.Profile;
@@ -34,21 +29,9 @@ import org.apache.samza.test.table.TestTableData.Profile;
  */
 class PageViewToProfileJoinFunction implements StreamTableJoinFunction
     <Integer, KV<Integer, PageView>, KV<Integer, Profile>, EnrichedPageView> {
-  static Map<String, AtomicInteger> counterPerJoinFn = new HashMap<>();
-  private final String joinOpName;
-
-  public PageViewToProfileJoinFunction(String joinOpName) {
-    this.joinOpName = joinOpName;
-  }
-
-  @Override
-  public void init(Config config, TaskContext context) {
-    counterPerJoinFn.put(this.joinOpName, new AtomicInteger(0));
-  }
 
   @Override
   public TestTableData.EnrichedPageView apply(KV<Integer, TestTableData.PageView> m, KV<Integer, TestTableData.Profile> r) {
-    counterPerJoinFn.get(this.joinOpName).incrementAndGet();
     return r == null ? null : new TestTableData.EnrichedPageView(m.getValue().getPageKey(), m.getKey(), r.getValue().getCompany());
   }
 
@@ -62,7 +45,4 @@ class PageViewToProfileJoinFunction implements StreamTableJoinFunction
     return record.getKey();
   }
 
-  public static void reset() {
-    counterPerJoinFn.clear();
-  }
 }

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTable.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTable.java
@@ -25,8 +25,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.samza.application.StreamApplication;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.JobConfig;
@@ -42,7 +40,6 @@ import org.apache.samza.metrics.Timer;
 import org.apache.samza.operators.KV;
 import org.apache.samza.operators.MessageStream;
 import org.apache.samza.operators.functions.MapFunction;
-import org.apache.samza.operators.functions.StreamTableJoinFunction;
 import org.apache.samza.runtime.LocalApplicationRunner;
 import org.apache.samza.serializers.IntegerSerde;
 import org.apache.samza.serializers.KVSerde;
@@ -57,16 +54,13 @@ import org.apache.samza.table.ReadableTable;
 import org.apache.samza.table.Table;
 import org.apache.samza.task.TaskContext;
 import org.apache.samza.test.harness.AbstractIntegrationTestHarness;
-import org.apache.samza.test.table.TestTableData.EnrichedPageView;
-import org.apache.samza.test.table.TestTableData.PageView;
-import org.apache.samza.test.table.TestTableData.PageViewJsonSerde;
-import org.apache.samza.test.table.TestTableData.PageViewJsonSerdeFactory;
-import org.apache.samza.test.table.TestTableData.Profile;
-import org.apache.samza.test.table.TestTableData.ProfileJsonSerde;
 import org.apache.samza.test.util.ArraySystemFactory;
 import org.apache.samza.test.util.Base64Serializer;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+
+import static org.apache.samza.test.table.TestTableData.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -83,6 +77,12 @@ import static org.mockito.Mockito.verify;
  * This test class tests sendTo() and join() for local tables
  */
 public class TestLocalTable extends AbstractIntegrationTestHarness {
+
+  @Before
+  public void setUp() {
+    super.setUp();
+    PageViewToProfileJoinFunction.reset();
+  }
 
   @Test
   public void testSendTo() throws  Exception {
@@ -150,7 +150,7 @@ public class TestLocalTable extends AbstractIntegrationTestHarness {
                 return pv;
               })
             .partitionBy(PageView::getMemberId, v -> v, "p1")
-            .join(table, new PageViewToProfileJoinFunction())
+            .join(table, new PageViewToProfileJoinFunction("test-join1"))
             .sink((m, collector, coordinator) -> joined.add(m));
       };
 
@@ -205,8 +205,8 @@ public class TestLocalTable extends AbstractIntegrationTestHarness {
       KVSerde<Integer, Profile> profileKVSerde = KVSerde.of(new IntegerSerde(), new ProfileJsonSerde());
       KVSerde<Integer, PageView> pageViewKVSerde = KVSerde.of(new IntegerSerde(), new PageViewJsonSerde());
 
-      PageViewToProfileJoinFunction joinFn1 = new PageViewToProfileJoinFunction();
-      PageViewToProfileJoinFunction joinFn2 = new PageViewToProfileJoinFunction();
+      PageViewToProfileJoinFunction joinFn1 = new PageViewToProfileJoinFunction("test-dual-join1");
+      PageViewToProfileJoinFunction joinFn2 = new PageViewToProfileJoinFunction("test-dual-join2");
 
       final LocalApplicationRunner runner = new LocalApplicationRunner(new MapConfig(configs));
       final StreamApplication app = (streamGraph, cfg) -> {
@@ -250,9 +250,9 @@ public class TestLocalTable extends AbstractIntegrationTestHarness {
       assertEquals(count * partitionCount, sentToProfileTable1.size());
       assertEquals(count * partitionCount, sentToProfileTable2.size());
 
-      for (int i = 0; i < PageViewToProfileJoinFunction.seqNo; i++) {
-        assertEquals(count * partitionCount, PageViewToProfileJoinFunction.counterPerJoinFn.get(i).intValue());
-      }
+      assertEquals(2, PageViewToProfileJoinFunction.counterPerJoinFn.size());
+      assertEquals(count * partitionCount, PageViewToProfileJoinFunction.counterPerJoinFn.get("test-dual-join1").intValue());
+      assertEquals(count * partitionCount, PageViewToProfileJoinFunction.counterPerJoinFn.get("test-dual-join2").intValue());
       assertEquals(count * partitionCount, joinedPageViews1.size());
       assertEquals(count * partitionCount, joinedPageViews2.size());
       assertTrue(joinedPageViews1.get(0) instanceof EnrichedPageView);
@@ -342,39 +342,6 @@ public class TestLocalTable extends AbstractIntegrationTestHarness {
 
     public static MyMapFunction getMapFunctionByTask(String taskName) {
       return taskToMapFunctionMap.get(taskName);
-    }
-  }
-
-  static class PageViewToProfileJoinFunction implements StreamTableJoinFunction
-      <Integer, KV<Integer, PageView>, KV<Integer, Profile>, EnrichedPageView> {
-    private static Map<Integer, AtomicInteger> counterPerJoinFn = new HashMap<>();
-    private static int seqNo = 0;
-    private final int currentSeqNo;
-
-    public PageViewToProfileJoinFunction() {
-      this.currentSeqNo = seqNo++;
-    }
-
-    @Override
-    public void init(Config config, TaskContext context) {
-      counterPerJoinFn.put(this.currentSeqNo, new AtomicInteger(0));
-    }
-
-    @Override
-    public EnrichedPageView apply(KV<Integer, PageView> m, KV<Integer, Profile> r) {
-      counterPerJoinFn.get(this.currentSeqNo).incrementAndGet();
-      return r == null ? null :
-          new EnrichedPageView(m.getValue().getPageKey(), m.getKey(), r.getValue().getCompany());
-    }
-
-    @Override
-    public Integer getMessageKey(KV<Integer, PageView> message) {
-      return message.getKey();
-    }
-
-    @Override
-    public Integer getRecordKey(KV<Integer, Profile> record) {
-      return record.getKey();
     }
   }
 

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTableWithSideInputs.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTableWithSideInputs.java
@@ -44,15 +44,24 @@ import org.apache.samza.table.Table;
 import org.apache.samza.test.framework.TestRunner;
 import org.apache.samza.test.framework.stream.CollectionStream;
 import org.apache.samza.test.harness.AbstractIntegrationTestHarness;
+import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.apache.samza.test.table.TestTableData.*;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TestLocalTableWithSideInputs extends AbstractIntegrationTestHarness {
   private static final String PAGEVIEW_STREAM = "pageview";
   private static final String PROFILE_STREAM = "profile";
   private static final String ENRICHED_PAGEVIEW_STREAM = "enrichedpageview";
+
+  @Before
+  public void setUp() {
+    super.setUp();
+    PageViewToProfileJoinFunction.reset();
+  }
 
   @Test
   public void testJoinWithSideInputsTable() {
@@ -72,20 +81,20 @@ public class TestLocalTableWithSideInputs extends AbstractIntegrationTestHarness
         Arrays.asList(TestTableData.generateProfiles(5)));
   }
 
-  private void runTest(String systemName, StreamApplication app, List<TestTableData.PageView> pageViews,
-      List<TestTableData.Profile> profiles) {
+  private void runTest(String systemName, StreamApplication app, List<PageView> pageViews,
+      List<Profile> profiles) {
     Map<String, String> configs = new HashMap<>();
     configs.put(String.format(StreamConfig.SYSTEM_FOR_STREAM_ID(), PAGEVIEW_STREAM), systemName);
     configs.put(String.format(StreamConfig.SYSTEM_FOR_STREAM_ID(), PROFILE_STREAM), systemName);
     configs.put(String.format(StreamConfig.SYSTEM_FOR_STREAM_ID(), ENRICHED_PAGEVIEW_STREAM), systemName);
     configs.put(JobConfig.JOB_DEFAULT_SYSTEM(), systemName);
 
-    CollectionStream<TestTableData.PageView> pageViewStream =
+    CollectionStream<PageView> pageViewStream =
         CollectionStream.of(systemName, PAGEVIEW_STREAM, pageViews);
-    CollectionStream<TestTableData.Profile> profileStream =
+    CollectionStream<Profile> profileStream =
         CollectionStream.of(systemName, PROFILE_STREAM, profiles);
 
-    CollectionStream<TestTableData.EnrichedPageView> outputStream =
+    CollectionStream<EnrichedPageView> outputStream =
         CollectionStream.empty(systemName, ENRICHED_PAGEVIEW_STREAM);
 
     TestRunner
@@ -97,15 +106,15 @@ public class TestLocalTableWithSideInputs extends AbstractIntegrationTestHarness
         .run(Duration.ofMillis(100000));
 
     try {
-      Map<Integer, List<TestTableData.EnrichedPageView>> result = TestRunner.consumeStream(outputStream, Duration.ofMillis(1000));
-      List<TestTableData.EnrichedPageView> results = result.values().stream()
+      Map<Integer, List<EnrichedPageView>> result = TestRunner.consumeStream(outputStream, Duration.ofMillis(1000));
+      List<EnrichedPageView> results = result.values().stream()
           .flatMap(List::stream)
           .collect(Collectors.toList());
 
-      List<TestTableData.EnrichedPageView> expectedEnrichedPageviews = pageViews.stream()
+      List<EnrichedPageView> expectedEnrichedPageviews = pageViews.stream()
           .flatMap(pv -> profiles.stream()
               .filter(profile -> pv.memberId == profile.memberId)
-              .map(profile -> new TestTableData.EnrichedPageView(pv.pageKey, profile.memberId, profile.company)))
+              .map(profile -> new EnrichedPageView(pv.pageKey, profile.memberId, profile.company)))
           .collect(Collectors.toList());
 
       boolean successfulJoin = results.stream().allMatch(expectedEnrichedPageviews::contains);
@@ -127,16 +136,16 @@ public class TestLocalTableWithSideInputs extends AbstractIntegrationTestHarness
 
       graph.getInputStream(PAGEVIEW_STREAM, new NoOpSerde<TestTableData.PageView>())
           .partitionBy(TestTableData.PageView::getMemberId, v -> v, "partition-page-view")
-          .join(table, new TestLocalTable.PageViewToProfileJoinFunction())
+          .join(table, new PageViewToProfileJoinFunction("test-sideinput-join1"))
           .sendTo(graph.getOutputStream(ENRICHED_PAGEVIEW_STREAM, new NoOpSerde<>()));
     }
 
-    protected TableDescriptor<Integer, TestTableData.Profile, ?> getTableDescriptor() {
-      return new InMemoryTableDescriptor<Integer, TestTableData.Profile>(PROFILE_TABLE)
-          .withSerde(KVSerde.of(new IntegerSerde(), new TestTableData.ProfileJsonSerde()))
+    protected TableDescriptor<Integer, Profile, ?> getTableDescriptor() {
+      return new InMemoryTableDescriptor<Integer, Profile>(PROFILE_TABLE)
+          .withSerde(KVSerde.of(new IntegerSerde(), new ProfileJsonSerde()))
           .withSideInputs(ImmutableList.of(PROFILE_STREAM))
           .withSideInputsProcessor((msg, store) -> {
-              TestTableData.Profile profile = (TestTableData.Profile) msg.getMessage();
+              Profile profile = (Profile) msg.getMessage();
               int key = profile.getMemberId();
 
               return ImmutableList.of(new Entry<>(key, profile));
@@ -146,9 +155,9 @@ public class TestLocalTableWithSideInputs extends AbstractIntegrationTestHarness
 
   static class DurablePageViewProfileJoin extends PageViewProfileJoin {
     @Override
-    protected TableDescriptor<Integer, TestTableData.Profile, ?> getTableDescriptor() {
-      return new RocksDbTableDescriptor<Integer, TestTableData.Profile>(PROFILE_TABLE)
-          .withSerde(KVSerde.of(new IntegerSerde(), new TestTableData.ProfileJsonSerde()))
+    protected TableDescriptor<Integer, Profile, ?> getTableDescriptor() {
+      return new RocksDbTableDescriptor<Integer, Profile>(PROFILE_TABLE)
+          .withSerde(KVSerde.of(new IntegerSerde(), new ProfileJsonSerde()))
           .withSideInputs(ImmutableList.of(PROFILE_STREAM))
           .withSideInputsProcessor((msg, store) -> {
               TestTableData.Profile profile = (TestTableData.Profile) msg.getMessage();

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTableWithSideInputs.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTableWithSideInputs.java
@@ -44,7 +44,6 @@ import org.apache.samza.table.Table;
 import org.apache.samza.test.framework.TestRunner;
 import org.apache.samza.test.framework.stream.CollectionStream;
 import org.apache.samza.test.harness.AbstractIntegrationTestHarness;
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.apache.samza.test.table.TestTableData.*;
@@ -56,12 +55,6 @@ public class TestLocalTableWithSideInputs extends AbstractIntegrationTestHarness
   private static final String PAGEVIEW_STREAM = "pageview";
   private static final String PROFILE_STREAM = "profile";
   private static final String ENRICHED_PAGEVIEW_STREAM = "enrichedpageview";
-
-  @Before
-  public void setUp() {
-    super.setUp();
-    PageViewToProfileJoinFunction.reset();
-  }
 
   @Test
   public void testJoinWithSideInputsTable() {
@@ -136,7 +129,7 @@ public class TestLocalTableWithSideInputs extends AbstractIntegrationTestHarness
 
       graph.getInputStream(PAGEVIEW_STREAM, new NoOpSerde<TestTableData.PageView>())
           .partitionBy(TestTableData.PageView::getMemberId, v -> v, "partition-page-view")
-          .join(table, new PageViewToProfileJoinFunction("test-sideinput-join1"))
+          .join(table, new PageViewToProfileJoinFunction())
           .sendTo(graph.getOutputStream(ENRICHED_PAGEVIEW_STREAM, new NoOpSerde<>()));
     }
 

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTable.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTable.java
@@ -59,7 +59,6 @@ import org.apache.samza.test.util.Base64Serializer;
 import org.apache.samza.util.RateLimiter;
 import com.google.common.cache.CacheBuilder;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.apache.samza.test.table.TestTableData.*;
@@ -188,7 +187,7 @@ public class TestRemoteTable extends AbstractIntegrationTestHarness {
 
       streamGraph.getInputStream("PageView", new NoOpSerde<PageView>())
           .map(pv -> new KV<>(pv.getMemberId(), pv))
-          .join(inputTable, new PageViewToProfileJoinFunction("test-remote-table-join1"))
+          .join(inputTable, new PageViewToProfileJoinFunction())
           .map(m -> new KV(m.getMemberId(), m))
           .sendTo(outputTable);
     };
@@ -199,12 +198,6 @@ public class TestRemoteTable extends AbstractIntegrationTestHarness {
     int numExpected = count * partitionCount;
     Assert.assertEquals(numExpected, writtenRecords.get(testName).size());
     Assert.assertTrue(writtenRecords.get(testName).get(0) instanceof EnrichedPageView);
-  }
-
-  @Before
-  public void setUp() {
-    super.setUp();
-    PageViewToProfileJoinFunction.reset();
   }
 
   @Test


### PR DESCRIPTION
The way that we verify the join counts in PageViewToProfileJoinFunction across multiple table tests (i.e. TestLocalTable, TestRemoteTable, TestLocalTableWithSideInputs) creates some conflicts in the static counter map and triggers test failure in certain sequence of ordering of tests. Fixing it by requiring explicit name of the join functions in tests and register / verify by unique op names.