### PR TITLE
SAMZA-1795 table: add common retry for IO functions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,6 +184,7 @@ project(":samza-core_$scalaVersion") {
     compile "org.eclipse.jetty:jetty-webapp:$jettyVersion"
     compile "org.scala-lang:scala-library:$scalaLibVersion"
     compile "org.slf4j:slf4j-api:$slf4jVersion"
+    compile "net.jodah:failsafe:$failsafeVersion"
     testCompile project(":samza-api").sourceSets.test.output
     testCompile "junit:junit:$junitVersion"
     testCompile "org.mockito:mockito-core:$mockitoVersion"

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -45,4 +45,5 @@
   yarnVersion = "2.6.1"
   zkClientVersion = "0.8"
   zookeeperVersion = "3.4.6"
+  failsafeVersion = "1.1.0"
 }

--- a/samza-core/src/main/java/org/apache/samza/table/remote/RemoteReadWriteTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/RemoteReadWriteTable.java
@@ -43,11 +43,11 @@ import com.google.common.base.Preconditions;
  * @param <V> the type of the value in this table
  */
 public class RemoteReadWriteTable<K, V> extends RemoteReadableTable<K, V> implements ReadWriteTable<K, V> {
-  private final TableWriteFunction<K, V> writeFn;
 
   private DefaultTableWriteMetrics writeMetrics;
 
   @VisibleForTesting
+  final TableWriteFunction<K, V> writeFn;
   final TableRateLimiter writeRateLimiter;
 
   public RemoteReadWriteTable(String tableId, TableReadFunction readFn, TableWriteFunction writeFn,

--- a/samza-core/src/main/java/org/apache/samza/table/remote/RemoteReadableTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/RemoteReadableTable.java
@@ -80,10 +80,10 @@ public class RemoteReadableTable<K, V> implements ReadableTable<K, V> {
   protected final ExecutorService callbackExecutor;
   protected final ExecutorService tableExecutor;
 
-  private final TableReadFunction<K, V> readFn;
   private DefaultTableReadMetrics readMetrics;
 
   @VisibleForTesting
+  final TableReadFunction<K, V> readFn;
   final TableRateLimiter<K, V> readRateLimiter;
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTableDescriptor.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTableDescriptor.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.apache.samza.operators.BaseTableDescriptor;
 import org.apache.samza.table.TableSpec;
+import org.apache.samza.table.retry.TableRetryPolicy;
 import org.apache.samza.table.utils.SerdeUtils;
 import org.apache.samza.util.EmbeddedTaggedRateLimiter;
 import org.apache.samza.util.RateLimiter;
@@ -70,6 +71,9 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
   private TableRateLimiter.CreditFunction<K, V> readCreditFn;
   private TableRateLimiter.CreditFunction<K, V> writeCreditFn;
 
+  private TableRetryPolicy readRetryPolicy;
+  private TableRetryPolicy writeRetryPolicy;
+
   // By default execute future callbacks on the native client threads
   // ie. no additional thread pool for callbacks.
   private int asyncCallbackPoolSize = -1;
@@ -115,13 +119,23 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
           "write credit function", writeCreditFn));
     }
 
+    if (readRetryPolicy != null) {
+      tableSpecConfig.put(RemoteTableProvider.READ_RETRY_POLICY, SerdeUtils.serialize(
+          "read retry policy", readRetryPolicy));
+    }
+
+    if (writeRetryPolicy != null) {
+      tableSpecConfig.put(RemoteTableProvider.WRITE_RETRY_POLICY, SerdeUtils.serialize(
+          "write retry policy", writeRetryPolicy));
+    }
+
     tableSpecConfig.put(RemoteTableProvider.ASYNC_CALLBACK_POOL_SIZE, String.valueOf(asyncCallbackPoolSize));
 
     return new TableSpec(tableId, serde, RemoteTableProviderFactory.class.getName(), tableSpecConfig);
   }
 
   /**
-   * Use specified TableReadFunction with remote table.
+   * Use specified TableReadFunction with remote table and a retry policy.
    * @param readFn read function instance
    * @return this table descriptor instance
    */
@@ -132,13 +146,41 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
   }
 
   /**
-   * Use specified TableWriteFunction with remote table.
+   * Use specified TableWriteFunction with remote table and a retry policy.
    * @param writeFn write function instance
    * @return this table descriptor instance
    */
   public RemoteTableDescriptor<K, V> withWriteFunction(TableWriteFunction<K, V> writeFn) {
     Preconditions.checkNotNull(writeFn, "null write function");
     this.writeFn = writeFn;
+    return this;
+  }
+
+  /**
+   * Use specified TableReadFunction with remote table.
+   * @param readFn read function instance
+   * @param retryPolicy retry policy for the read function
+   * @return this table descriptor instance
+   */
+  public RemoteTableDescriptor<K, V> withReadFunction(TableReadFunction<K, V> readFn, TableRetryPolicy retryPolicy) {
+    Preconditions.checkNotNull(readFn, "null read function");
+    Preconditions.checkNotNull(retryPolicy, "null retry policy");
+    this.readFn = readFn;
+    this.readRetryPolicy = retryPolicy;
+    return this;
+  }
+
+  /**
+   * Use specified TableWriteFunction with remote table.
+   * @param writeFn write function instance
+   * @param retryPolicy retry policy for the write function
+   * @return this table descriptor instance
+   */
+  public RemoteTableDescriptor<K, V> withWriteFunction(TableWriteFunction<K, V> writeFn, TableRetryPolicy retryPolicy) {
+    Preconditions.checkNotNull(writeFn, "null write function");
+    Preconditions.checkNotNull(retryPolicy, "null retry policy");
+    this.writeFn = writeFn;
+    this.writeRetryPolicy = retryPolicy;
     return this;
   }
 

--- a/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTableProvider.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTableProvider.java
@@ -94,7 +94,7 @@ public class RemoteTableProvider extends BaseTableProvider {
     TableRetryPolicy readRetryPolicy = deserializeObject(READ_RETRY_POLICY);
     TableRetryPolicy writeRetryPolicy = null;
 
-    if (readRetryPolicy != null || writeRetryPolicy != null) {
+    if ((readRetryPolicy != null || writeRetryPolicy != null) && retryExecutor == null) {
       retryExecutor = Executors.newSingleThreadScheduledExecutor(runnable -> {
           Thread thread = new Thread(runnable);
           thread.setName("table-retry-executor");

--- a/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTableProvider.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTableProvider.java
@@ -25,11 +25,16 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.samza.table.Table;
 import org.apache.samza.table.TableSpec;
+import org.apache.samza.table.retry.RetriableReadFunction;
+import org.apache.samza.table.retry.RetriableWriteFunction;
+import org.apache.samza.table.retry.TableRetryPolicy;
 import org.apache.samza.table.utils.BaseTableProvider;
 import org.apache.samza.table.utils.SerdeUtils;
+import org.apache.samza.table.utils.TableMetricsUtil;
 import org.apache.samza.util.RateLimiter;
 
 import static org.apache.samza.table.remote.RemoteTableDescriptor.RL_READ_TAG;
@@ -47,6 +52,8 @@ public class RemoteTableProvider extends BaseTableProvider {
   static final String READ_CREDIT_FN = "io.read.credit.func";
   static final String WRITE_CREDIT_FN = "io.write.credit.func";
   static final String ASYNC_CALLBACK_POOL_SIZE = "io.async.callback.pool.size";
+  static final String READ_RETRY_POLICY = "io.read.retry.policy";
+  static final String WRITE_RETRY_POLICY = "io.write.retry.policy";
 
   private final boolean readOnly;
   private final List<RemoteReadableTable<?, ?>> tables = new ArrayList<>();
@@ -58,6 +65,7 @@ public class RemoteTableProvider extends BaseTableProvider {
    */
   private static Map<String, ExecutorService> tableExecutors = new ConcurrentHashMap<>();
   private static Map<String, ExecutorService> callbackExecutors = new ConcurrentHashMap<>();
+  private static ScheduledExecutorService retryExecutor;
 
   public RemoteTableProvider(TableSpec tableSpec) {
     super(tableSpec);
@@ -72,7 +80,7 @@ public class RemoteTableProvider extends BaseTableProvider {
     RemoteReadableTable table;
     String tableId = tableSpec.getId();
 
-    TableReadFunction<?, ?> readFn = getReadFn();
+    TableReadFunction readFn = getReadFn();
     RateLimiter rateLimiter = deserializeObject(RATE_LIMITER);
     if (rateLimiter != null) {
       rateLimiter.init(containerContext.config, taskContext);
@@ -83,11 +91,33 @@ public class RemoteTableProvider extends BaseTableProvider {
     TableRateLimiter.CreditFunction<?, ?> writeCreditFn;
     TableRateLimiter writeRateLimiter = null;
 
+    TableRetryPolicy readRetryPolicy = deserializeObject(READ_RETRY_POLICY);
+    TableRetryPolicy writeRetryPolicy = null;
+
+    if (readRetryPolicy != null || writeRetryPolicy != null) {
+      retryExecutor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+          Thread thread = new Thread(runnable);
+          thread.setName("table-retry-executor");
+          thread.setDaemon(true);
+          return thread;
+        });
+    }
+
+    if (readRetryPolicy != null) {
+      readFn = new RetriableReadFunction<>(readRetryPolicy, readFn, retryExecutor);
+    }
+
+    TableWriteFunction writeFn = getWriteFn();
+
     boolean isRateLimited = readRateLimiter.isRateLimited();
     if (!readOnly) {
       writeCreditFn = deserializeObject(WRITE_CREDIT_FN);
       writeRateLimiter = new TableRateLimiter(tableSpec.getId(), rateLimiter, writeCreditFn, RL_WRITE_TAG);
       isRateLimited |= writeRateLimiter.isRateLimited();
+      writeRetryPolicy = deserializeObject(WRITE_RETRY_POLICY);
+      if (writeRetryPolicy != null) {
+        writeFn = new RetriableWriteFunction(writeRetryPolicy, writeFn, retryExecutor);
+      }
     }
 
     // Optional executor for future callback/completion. Shared by both read and write operations.
@@ -116,8 +146,16 @@ public class RemoteTableProvider extends BaseTableProvider {
       table = new RemoteReadableTable(tableSpec.getId(), readFn, readRateLimiter,
           tableExecutors.get(tableId), callbackExecutors.get(tableId));
     } else {
-      table = new RemoteReadWriteTable(tableSpec.getId(), readFn, getWriteFn(), readRateLimiter,
+      table = new RemoteReadWriteTable(tableSpec.getId(), readFn, writeFn, readRateLimiter,
           writeRateLimiter, tableExecutors.get(tableId), callbackExecutors.get(tableId));
+    }
+
+    TableMetricsUtil metricsUtil = new TableMetricsUtil(containerContext, taskContext, table, tableId);
+    if (readRetryPolicy != null) {
+      ((RetriableReadFunction) readFn).setMetrics(metricsUtil);
+    }
+    if (writeRetryPolicy != null) {
+      ((RetriableWriteFunction) writeFn).setMetrics(metricsUtil);
     }
 
     table.init(containerContext, taskContext);

--- a/samza-core/src/main/java/org/apache/samza/table/remote/TableReadFunction.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/TableReadFunction.java
@@ -102,14 +102,10 @@ public interface TableReadFunction<K, V> extends Serializable, InitableFunction,
 
   /**
    * Determine whether the current operation can be retried with the last thrown exception.
-   * The default implementation disables retries for any type of exceptions. This can be
-   * overridden to customize the policy based on the data store protocol.
    * @param exception exception thrown by a table operation
    * @return whether the operation can be retried
    */
-  default boolean isRetriable(Throwable exception) {
-    return false;
-  }
+  boolean isRetriable(Throwable exception);
 
   // optionally implement readObject() to initialize transient states
 }

--- a/samza-core/src/main/java/org/apache/samza/table/remote/TableReadFunction.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/TableReadFunction.java
@@ -100,5 +100,16 @@ public interface TableReadFunction<K, V> extends Serializable, InitableFunction,
             .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().join())));
   }
 
+  /**
+   * Determine whether the current operation can be retried with the last thrown exception.
+   * The default implementation disables retries for any type of exceptions. This can be
+   * overridden to customize the policy based on the data store protocol.
+   * @param exception exception thrown by a table operation
+   * @return whether the operation can be retried
+   */
+  default boolean isRetriable(Throwable exception) {
+    return false;
+  }
+
   // optionally implement readObject() to initialize transient states
 }

--- a/samza-core/src/main/java/org/apache/samza/table/remote/TableWriteFunction.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/TableWriteFunction.java
@@ -143,6 +143,17 @@ public interface TableWriteFunction<K, V> extends Serializable, InitableFunction
   }
 
   /**
+   * Determine whether the current operation can be retried with the last thrown exception.
+   * The default implementation disables retries for any type of exceptions. This can be
+   * overridden to customize the policy based on the data store protocol.
+   * @param exception exception thrown by a table operation
+   * @return whether the operation can be retried
+   */
+  default boolean isRetriable(Throwable exception) {
+    return false;
+  }
+
+  /**
    * Flush the remote store (optional)
    */
   default void flush() {

--- a/samza-core/src/main/java/org/apache/samza/table/remote/TableWriteFunction.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/TableWriteFunction.java
@@ -144,14 +144,10 @@ public interface TableWriteFunction<K, V> extends Serializable, InitableFunction
 
   /**
    * Determine whether the current operation can be retried with the last thrown exception.
-   * The default implementation disables retries for any type of exceptions. This can be
-   * overridden to customize the policy based on the data store protocol.
    * @param exception exception thrown by a table operation
    * @return whether the operation can be retried
    */
-  default boolean isRetriable(Throwable exception) {
-    return false;
-  }
+  boolean isRetriable(Throwable exception);
 
   /**
    * Flush the remote store (optional)

--- a/samza-core/src/main/java/org/apache/samza/table/retry/FailsafeAdapter.java
+++ b/samza-core/src/main/java/org/apache/samza/table/retry/FailsafeAdapter.java
@@ -72,7 +72,7 @@ class FailsafeAdapter {
       failSafePolicy.withJitter(policy.getJitter().toMillis(), TimeUnit.MILLISECONDS);
     }
 
-    failSafePolicy.retryOn(e -> policy.getRetryOn().test(e));
+    failSafePolicy.retryOn(e -> policy.getRetryPredicate().test(e));
 
     return failSafePolicy;
   }

--- a/samza-core/src/main/java/org/apache/samza/table/retry/FailsafeAdapter.java
+++ b/samza-core/src/main/java/org/apache/samza/table/retry/FailsafeAdapter.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.retry;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import org.apache.samza.SamzaException;
+
+import net.jodah.failsafe.AsyncFailsafe;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+
+
+/**
+ * Helper class adapting the generic {@link TableRetryPolicy} to a failsafe {@link RetryPolicy} and
+ * creating failsafe retryer instances with proper metrics management.
+ */
+class FailsafeAdapter {
+  /**
+   * Convert the {@link TableRetryPolicy} to failsafe {@link RetryPolicy}.
+   * @param isRetriable predicate to signal retriable exceptions.
+   * @return this policy instance
+   */
+  static RetryPolicy valueOf(Predicate<Throwable> isRetriable, TableRetryPolicy policy) {
+    RetryPolicy failSafePolicy = new RetryPolicy();
+
+    switch (policy.getBackoffType()) {
+      case NONE:
+        break;
+
+      case FIXED:
+        failSafePolicy.withDelay(policy.getSleepTime().toMillis(), TimeUnit.MILLISECONDS);
+        break;
+
+      case RANDOM:
+        failSafePolicy.withDelay(policy.getRandomMin().toMillis(), policy.getRandomMax().toMillis(), TimeUnit.MILLISECONDS);
+        break;
+
+      case EXPONENTIAL:
+        failSafePolicy.withBackoff(policy.getSleepTime().toMillis(), policy.getExponentialMaxSleep().toMillis(), TimeUnit.MILLISECONDS,
+            policy.getExponentialFactor());
+        break;
+
+      default:
+        throw new SamzaException("Unknown retry policy type.");
+    }
+
+    if (policy.getMaxDuration() != null) {
+      failSafePolicy.withMaxDuration(policy.getMaxDuration().toMillis(), TimeUnit.MILLISECONDS);
+    }
+    if (policy.getMaxAttempts() != null) {
+      failSafePolicy.withMaxRetries(policy.getMaxAttempts());
+    }
+    if (policy.getJitter() != null && policy.getBackoffType() != TableRetryPolicy.BackoffType.RANDOM) {
+      failSafePolicy.withJitter(policy.getJitter().toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    failSafePolicy.retryOn((e) -> isRetriable.test(e));
+
+    return failSafePolicy;
+  }
+
+  /**
+   * Obtain an async failsafe retryer instance with the specified policy, metrics, and executor service.
+   * @param retryPolicy retry policy
+   * @param metrics retry metrics
+   * @param retryExec executor service for scheduling async retries
+   * @return {@link net.jodah.failsafe.AsyncFailsafe} instance
+   */
+  static AsyncFailsafe<?> failsafe(RetryPolicy retryPolicy, RetryMetrics metrics, ScheduledExecutorService retryExec) {
+    long startMs = System.currentTimeMillis();
+    return Failsafe.with(retryPolicy).with(retryExec)
+        .onRetry(e -> metrics.retryCount.inc())
+        .onRetriesExceeded(e -> {
+            metrics.retryTimer.update(System.currentTimeMillis() - startMs);
+            metrics.permFailureCount.inc();
+          })
+        .onSuccess((e, ctx) -> {
+            if (ctx.getExecutions() > 1) {
+              metrics.retryTimer.update(System.currentTimeMillis() - startMs);
+            } else {
+              metrics.successCount.inc();
+            }
+          });
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/table/retry/FailsafeAdapter.java
+++ b/samza-core/src/main/java/org/apache/samza/table/retry/FailsafeAdapter.java
@@ -21,7 +21,6 @@ package org.apache.samza.table.retry;
 
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
 
 import org.apache.samza.SamzaException;
 
@@ -37,10 +36,9 @@ import net.jodah.failsafe.RetryPolicy;
 class FailsafeAdapter {
   /**
    * Convert the {@link TableRetryPolicy} to failsafe {@link RetryPolicy}.
-   * @param isRetriable predicate to signal retriable exceptions.
    * @return this policy instance
    */
-  static RetryPolicy valueOf(Predicate<Throwable> isRetriable, TableRetryPolicy policy) {
+  static RetryPolicy valueOf(TableRetryPolicy policy) {
     RetryPolicy failSafePolicy = new RetryPolicy();
 
     switch (policy.getBackoffType()) {
@@ -74,7 +72,7 @@ class FailsafeAdapter {
       failSafePolicy.withJitter(policy.getJitter().toMillis(), TimeUnit.MILLISECONDS);
     }
 
-    failSafePolicy.retryOn((e) -> isRetriable.test(e));
+    failSafePolicy.retryOn(e -> policy.getRetryOn().test(e));
 
     return failSafePolicy;
   }

--- a/samza-core/src/main/java/org/apache/samza/table/retry/RetriableReadFunction.java
+++ b/samza-core/src/main/java/org/apache/samza/table/retry/RetriableReadFunction.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.retry;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.apache.samza.SamzaException;
+import org.apache.samza.table.remote.TableReadFunction;
+import org.apache.samza.table.utils.TableMetricsUtil;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import net.jodah.failsafe.AsyncFailsafe;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+
+
+/**
+ * Wrapper for a {@link TableReadFunction} instance to add common retry
+ * support with a {@link TableRetryPolicy}. This wrapper is created by
+ * {@link org.apache.samza.table.remote.RemoteTableProvider} when a retry
+ * policy is specified together with the {@link TableReadFunction}.
+ *
+ * Actual retry mechanism is provided by the failsafe library. Retry is
+ * attempted in an async way with a {@link ScheduledExecutorService}.
+ *
+ * @param <K> the type of the key in this table
+ * @param <V> the type of the value in this table
+ */
+public class RetriableReadFunction<K, V> implements TableReadFunction<K, V> {
+  private final RetryPolicy retryPolicy;
+  private final TableReadFunction<K, V> readFn;
+  private final ScheduledExecutorService retryExecutor;
+
+  @VisibleForTesting
+  RetryMetrics retryMetrics;
+
+  public RetriableReadFunction(TableRetryPolicy policy, TableReadFunction<K, V> readFn,
+      ScheduledExecutorService retryExecutor) {
+    Preconditions.checkNotNull(policy);
+    Preconditions.checkNotNull(readFn);
+    Preconditions.checkNotNull(retryExecutor);
+
+    this.readFn = readFn;
+    this.retryExecutor = retryExecutor;
+    this.retryPolicy = policy.toFailsafePolicy(readFn::isRetriable);
+  }
+
+  @Override
+  public CompletableFuture<V> getAsync(K key) {
+    return getFailsafe()
+        .future(k -> readFn.getAsync(key))
+        .exceptionally(e -> {
+            throw new SamzaException("Failed to get the record for " + key + " after retries.", e);
+          });
+  }
+
+  @Override
+  public CompletableFuture<Map<K, V>> getAllAsync(Collection<K> keys) {
+    return getFailsafe()
+        .future(k -> readFn.getAllAsync(keys))
+        .exceptionally(e -> {
+            throw new SamzaException("Failed to get the records for " + keys + " after retries.", e);
+          });
+  }
+
+  private AsyncFailsafe<?> getFailsafe() {
+    long startMs = System.currentTimeMillis();
+    return Failsafe.with(retryPolicy).with(retryExecutor)
+        .onRetry(e -> retryMetrics.retryCount.inc())
+        .onRetriesExceeded(e -> retryMetrics.retryTimer.update(System.currentTimeMillis() - startMs))
+        .onSuccess((e, ctx) -> {
+            if (ctx.getExecutions() > 1) {
+              retryMetrics.retryTimer.update(System.currentTimeMillis() - startMs);
+            } else {
+              retryMetrics.successCount.inc();
+            }
+          });
+  }
+
+  @Override
+  public boolean isRetriable(Throwable exception) {
+    return readFn.isRetriable(exception);
+  }
+
+  /**
+   * Initialize retry-related metrics
+   * @param metricsUtil metrics util
+   */
+  public void setMetrics(TableMetricsUtil metricsUtil) {
+    this.retryMetrics = new RetryMetrics("reader", metricsUtil);
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/table/retry/RetriableReadFunction.java
+++ b/samza-core/src/main/java/org/apache/samza/table/retry/RetriableReadFunction.java
@@ -63,7 +63,8 @@ public class RetriableReadFunction<K, V> implements TableReadFunction<K, V> {
 
     this.readFn = readFn;
     this.retryExecutor = retryExecutor;
-    this.retryPolicy = FailsafeAdapter.valueOf((ex) -> readFn.isRetriable(ex), policy);
+    policy.withRetryOn((ex) -> readFn.isRetriable(ex) || policy.getRetryOn().test(ex));
+    this.retryPolicy = FailsafeAdapter.valueOf(policy);
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/table/retry/RetriableWriteFunction.java
+++ b/samza-core/src/main/java/org/apache/samza/table/retry/RetriableWriteFunction.java
@@ -63,7 +63,8 @@ public class RetriableWriteFunction<K, V> implements TableWriteFunction<K, V> {
 
     this.writeFn = writeFn;
     this.retryExecutor = retryExecutor;
-    this.retryPolicy = FailsafeAdapter.valueOf((ex) -> writeFn.isRetriable(ex), policy);
+    policy.withRetryOn((ex) -> writeFn.isRetriable(ex) || policy.getRetryOn().test(ex));
+    this.retryPolicy = FailsafeAdapter.valueOf(policy);
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/table/retry/RetriableWriteFunction.java
+++ b/samza-core/src/main/java/org/apache/samza/table/retry/RetriableWriteFunction.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.retry;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.apache.samza.SamzaException;
+import org.apache.samza.storage.kv.Entry;
+import org.apache.samza.table.remote.TableWriteFunction;
+import org.apache.samza.table.utils.TableMetricsUtil;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import net.jodah.failsafe.AsyncFailsafe;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+
+
+/**
+ * Wrapper for a {@link TableWriteFunction} instance to add common retry
+ * support with a {@link TableRetryPolicy}. This wrapper is created by
+ * {@link org.apache.samza.table.remote.RemoteTableProvider} when a retry
+ * policy is specified together with the {@link TableWriteFunction}.
+ *
+ * Actual retry mechanism is provided by the failsafe library. Retry is
+ * attempted in an async way with a {@link ScheduledExecutorService}.
+ *
+ * @param <K> the type of the key in this table
+ * @param <V> the type of the value in this table
+ */
+public class RetriableWriteFunction<K, V> implements TableWriteFunction<K, V> {
+  private final RetryPolicy retryPolicy;
+  private final TableWriteFunction<K, V> writeFn;
+  private final ScheduledExecutorService retryExecutor;
+
+  @VisibleForTesting
+  RetryMetrics retryMetrics;
+
+  public RetriableWriteFunction(TableRetryPolicy policy, TableWriteFunction<K, V> writeFn,
+      ScheduledExecutorService retryExecutor)  {
+    Preconditions.checkNotNull(policy);
+    Preconditions.checkNotNull(writeFn);
+    Preconditions.checkNotNull(retryExecutor);
+
+    this.writeFn = writeFn;
+    this.retryExecutor = retryExecutor;
+    this.retryPolicy = policy.toFailsafePolicy(writeFn::isRetriable);
+  }
+
+  @Override
+  public CompletableFuture<Void> putAsync(K key, V record) {
+    return failsafe()
+        .future(k -> writeFn.putAsync(key, record))
+        .exceptionally(e -> {
+            throw new SamzaException("Failed to get the record for " + key + " after retries.", e);
+          });
+  }
+
+  @Override
+  public CompletableFuture<Void> putAllAsync(Collection<Entry<K, V>> records) {
+    return failsafe()
+        .future(k -> writeFn.putAllAsync(records))
+        .exceptionally(e -> {
+            throw new SamzaException("Failed to put records after retries.", e);
+          });
+  }
+
+  @Override
+  public CompletableFuture<Void> deleteAsync(K key) {
+    return failsafe()
+        .future(k -> writeFn.deleteAsync(key))
+        .exceptionally(e -> {
+            throw new SamzaException("Failed to delete the record for " + key + " after retries.", e);
+          });
+  }
+
+  @Override
+  public CompletableFuture<Void> deleteAllAsync(Collection<K> keys) {
+    return failsafe()
+        .future(k -> writeFn.deleteAllAsync(keys))
+        .exceptionally(e -> {
+            throw new SamzaException("Failed to delete the records for " + keys + " after retries.", e);
+          });
+  }
+
+  @Override
+  public boolean isRetriable(Throwable exception) {
+    return writeFn.isRetriable(exception);
+  }
+
+  private AsyncFailsafe<?> failsafe() {
+    long startMs = System.currentTimeMillis();
+    return Failsafe.with(retryPolicy).with(retryExecutor)
+        .onRetry(e -> retryMetrics.retryCount.inc())
+        .onRetriesExceeded(e -> retryMetrics.retryTimer.update(System.currentTimeMillis() - startMs))
+        .onSuccess((e, ctx) -> {
+            if (ctx.getExecutions() > 1) {
+              retryMetrics.retryTimer.update(System.currentTimeMillis() - startMs);
+            } else {
+              retryMetrics.successCount.inc();
+            }
+          });
+  }
+
+  /**
+   * Initialize retry-related metrics.
+   * @param metricsUtil metrics util
+   */
+  public void setMetrics(TableMetricsUtil metricsUtil) {
+    this.retryMetrics = new RetryMetrics("writer", metricsUtil);
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/table/retry/RetryMetrics.java
+++ b/samza-core/src/main/java/org/apache/samza/table/retry/RetryMetrics.java
@@ -40,6 +40,11 @@ class RetryMetrics {
   final Counter successCount;
 
   /**
+   * Number of operations that failed permanently and exhausted all retries
+   */
+  final Counter permFailureCount;
+
+  /**
    * Total time spent in each IO; this is updated only
    * when at least one retries have been attempted.
    */
@@ -48,6 +53,7 @@ class RetryMetrics {
   public RetryMetrics(String prefix, TableMetricsUtil metricsUtil) {
     retryCount = metricsUtil.newCounter(prefix + "-retry-count");
     successCount = metricsUtil.newCounter(prefix + "-success-count");
+    permFailureCount = metricsUtil.newCounter(prefix + "-perm-failure-count");
     retryTimer = metricsUtil.newTimer(prefix + "-retry-timer");
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/table/retry/RetryMetrics.java
+++ b/samza-core/src/main/java/org/apache/samza/table/retry/RetryMetrics.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.retry;
+
+import org.apache.samza.metrics.Counter;
+import org.apache.samza.metrics.Timer;
+import org.apache.samza.table.utils.TableMetricsUtil;
+
+
+/**
+ * Wrapper of retry-related metrics common to both {@link RetriableReadFunction} and
+ * {@link RetriableWriteFunction}.
+ */
+class RetryMetrics {
+  /**
+   * Number of retries executed (excluding the first attempt)
+   */
+  final Counter retryCount;
+
+  /**
+   * Number of successes with only the first attempt
+   */
+  final Counter successCount;
+
+  /**
+   * Total time spent in each IO; this is updated only
+   * when at least one retries have been attempted.
+   */
+  final Timer retryTimer;
+
+  public RetryMetrics(String prefix, TableMetricsUtil metricsUtil) {
+    retryCount = metricsUtil.newCounter(prefix + "-retry-count");
+    successCount = metricsUtil.newCounter(prefix + "-success-count");
+    retryTimer = metricsUtil.newTimer(prefix + "-retry-timer");
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/table/retry/TableRetryPolicy.java
+++ b/samza-core/src/main/java/org/apache/samza/table/retry/TableRetryPolicy.java
@@ -82,7 +82,7 @@ public class TableRetryPolicy implements Serializable {
   }
 
   // By default no custom retry predicate so retry decision is made solely by the table functions
-  private RetryPredicate isRetriable = (ex) -> false;
+  private RetryPredicate retryPredicate = (ex) -> false;
 
   /**
    * Set the sleepTime time for the fixed backoff policy.
@@ -173,12 +173,12 @@ public class TableRetryPolicy implements Serializable {
    * Set the predicate to use for identifying retriable exceptions. If specified, table
    * retry logic will consult both such predicate and table function and retry will be
    * attempted if either option returns true.
-   * @param isRetriable predicate for retriable exception identification
+   * @param retryPredicate predicate for retriable exception identification
    * @return this policy instance
    */
-  public TableRetryPolicy withRetryOn(RetryPredicate isRetriable) {
-    Preconditions.checkNotNull(isRetriable);
-    this.isRetriable = isRetriable;
+  public TableRetryPolicy withRetryPredicate(RetryPredicate retryPredicate) {
+    Preconditions.checkNotNull(retryPredicate);
+    this.retryPredicate = retryPredicate;
     return this;
   }
 
@@ -251,7 +251,7 @@ public class TableRetryPolicy implements Serializable {
   /**
    * @return Custom predicate for retriable exception identification or null if not specified.
    */
-  public RetryPredicate getRetryOn() {
-    return isRetriable;
+  public RetryPredicate getRetryPredicate() {
+    return retryPredicate;
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/table/retry/TableRetryPolicy.java
+++ b/samza-core/src/main/java/org/apache/samza/table/retry/TableRetryPolicy.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.retry;
+
+import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import org.apache.samza.SamzaException;
+
+import net.jodah.failsafe.RetryPolicy;
+
+
+/**
+ * Common retry policy parameters for table IO. This serves as an abstraction on top of
+ * retry libraries. This common policy supports below features:
+ *  - backoff modes: fixed, random, exponential
+ *  - termination modes: by attempts, by duration
+ *  - jitter
+ *
+ * Retry libraries can implement a subset or all features as described by this common policy.
+ * Currently, the policy object can be translated into {@link RetryPolicy} of failsafe library.
+ */
+public class TableRetryPolicy implements Serializable {
+  enum BackoffType { NONE, FIXED, RANDOM, EXPONENTIAL }
+
+  // Backoff parameters
+  private long sleepMs;
+  private long randomMinMs;
+  private long randomMaxMs;
+  private double exponentialFactor;
+  private long exponentialMaxSleepMs;
+  private long jitterMs;
+
+  // By default no early termination
+  private int maxAttempts = -1;
+  private long maxDelayMs = Long.MAX_VALUE;
+
+  // By default no backoff during retries
+  private BackoffType backoffType = BackoffType.NONE;
+
+  /**
+   * Set the sleep time for the fixed backoff policy.
+   * @param sleepMs sleep time in milliseconds
+   * @return this policy instance
+   */
+  public TableRetryPolicy withFixedBackoff(long sleepMs) {
+    this.sleepMs = sleepMs;
+    this.backoffType = BackoffType.FIXED;
+    return this;
+  }
+
+  /**
+   * Set the sleep time for the random backoff policy. The actual sleep time
+   * before each attempt is randomly selected between {@code [minSleepMs, maxSleepMs]}
+   * @param minSleepMs lower bound sleep time in milliseconds
+   * @param maxSleepMs upper bound sleep time in milliseconds
+   * @return this policy instance
+   */
+  public TableRetryPolicy withRandomBackoff(long minSleepMs, long maxSleepMs) {
+    this.randomMinMs = minSleepMs;
+    this.randomMaxMs = maxSleepMs;
+    this.backoffType = BackoffType.RANDOM;
+    return this;
+  }
+
+  /**
+   * Set the parameters for the exponential backoff policy. The actual sleep time
+   * is exponentially incremented up to the {@code maxSleepMs} and multiplying
+   * successive delays by the {@code factor}.
+   * @param sleepMs initial sleep time in milliseconds
+   * @param maxSleepMs upper bound sleep time in milliseconds
+   * @param factor exponential factor for backoff
+   * @return this policy instance
+   */
+  public TableRetryPolicy withExponentialBackoff(long sleepMs, long maxSleepMs, double factor) {
+    this.sleepMs = sleepMs;
+    this.exponentialMaxSleepMs = maxSleepMs;
+    this.exponentialFactor = factor;
+    this.backoffType = BackoffType.EXPONENTIAL;
+    return this;
+  }
+
+  /**
+   * Set the jitter for the backoff policy to provide additional randomness.
+   * If this is set, a random value between {@code [0, jitter]} will be added
+   * to each sleep time.
+   * @param jitterMs initial sleep time in milliseconds
+   * @return this policy instance
+   */
+  public TableRetryPolicy withJitter(long jitterMs) {
+    this.jitterMs = jitterMs;
+    return this;
+  }
+
+  /**
+   * Set maximum number of attempts before terminating the operation.
+   * @param maxAttempts number of attempts
+   * @return this policy instance
+   */
+  public TableRetryPolicy withStopAfterAttempts(int maxAttempts) {
+    this.maxAttempts = maxAttempts;
+    return this;
+  }
+
+  /**
+   * Set maximum total delay (sleep + execution) before terminating the operation.
+   * @param maxDelayMs delay time in milliseconds
+   * @return this policy instance
+   */
+  public TableRetryPolicy withStopAfterDelay(long maxDelayMs) {
+    this.maxDelayMs = maxDelayMs;
+    return this;
+  }
+
+  /**
+   * Convert the TableRetryPolicy to failsafe {@link RetryPolicy}.
+   * @param isRetriable predicate to signal retriable exceptions.
+   * @return this policy instance
+   */
+  RetryPolicy toFailsafePolicy(Predicate<Throwable> isRetriable) {
+    RetryPolicy policy = new RetryPolicy();
+    policy.withMaxDuration(maxDelayMs, TimeUnit.MILLISECONDS);
+    policy.withMaxRetries(maxAttempts);
+    if (jitterMs != 0) {
+      policy.withJitter(jitterMs, TimeUnit.MILLISECONDS);
+    }
+    policy.retryOn((e) -> isRetriable.test(e));
+
+    switch (backoffType) {
+      case NONE:
+        break;
+
+      case FIXED:
+        policy.withDelay(sleepMs, TimeUnit.MILLISECONDS);
+        break;
+
+      case RANDOM:
+        policy.withDelay(randomMinMs, randomMaxMs, TimeUnit.MILLISECONDS);
+        break;
+
+      case EXPONENTIAL:
+        policy.withBackoff(sleepMs, exponentialMaxSleepMs, TimeUnit.MILLISECONDS, exponentialFactor);
+        break;
+
+      default:
+        throw new SamzaException("Unknown retry policy type.");
+    }
+
+    return policy;
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/table/remote/TestRemoteTableDescriptor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/TestRemoteTableDescriptor.java
@@ -141,7 +141,9 @@ public class TestRemoteTableDescriptor {
   private void doTestDeserializeReadFunctionAndLimiter(boolean rateOnly, boolean rlGets, boolean rlPuts) {
     int numRateLimitOps = (rlGets ? 1 : 0) + (rlPuts ? 1 : 0);
     RemoteTableDescriptor<String, String> desc = new RemoteTableDescriptor("1");
-    desc.withReadFunction(mock(TableReadFunction.class), new TableRetryPolicy());
+    TableRetryPolicy retryPolicy = new TableRetryPolicy();
+    retryPolicy.withRetryOn((ex) -> false);
+    desc.withReadFunction(mock(TableReadFunction.class), retryPolicy);
     desc.withWriteFunction(mock(TableWriteFunction.class));
     desc.withAsyncCallbackExecutorPoolSize(10);
 

--- a/samza-core/src/test/java/org/apache/samza/table/remote/TestRemoteTableDescriptor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/TestRemoteTableDescriptor.java
@@ -142,7 +142,7 @@ public class TestRemoteTableDescriptor {
     int numRateLimitOps = (rlGets ? 1 : 0) + (rlPuts ? 1 : 0);
     RemoteTableDescriptor<String, String> desc = new RemoteTableDescriptor("1");
     TableRetryPolicy retryPolicy = new TableRetryPolicy();
-    retryPolicy.withRetryOn((ex) -> false);
+    retryPolicy.withRetryPredicate((ex) -> false);
     desc.withReadFunction(mock(TableReadFunction.class), retryPolicy);
     desc.withWriteFunction(mock(TableWriteFunction.class));
     desc.withAsyncCallbackExecutorPoolSize(10);

--- a/samza-core/src/test/java/org/apache/samza/table/retry/TestRetriableTableFunctions.java
+++ b/samza-core/src/test/java/org/apache/samza/table/retry/TestRetriableTableFunctions.java
@@ -19,6 +19,7 @@
 
 package org.apache.samza.table.retry;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -65,7 +66,7 @@ public class TestRetriableTableFunctions {
   public void testFirstTimeSuccessGet() throws Exception {
     String tableId = "testFirstTimeSuccessGet";
     TableRetryPolicy policy = new TableRetryPolicy();
-    policy.withFixedBackoff(100);
+    policy.withFixedBackoff(Duration.ofMillis(100));
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
     doReturn(true).when(readFn).isRetriable(any());
     doReturn(CompletableFuture.completedFuture("bar")).when(readFn).getAsync(anyString());
@@ -83,7 +84,7 @@ public class TestRetriableTableFunctions {
   public void testRetryEngagedGet() throws Exception {
     String tableId = "testRetryEngagedGet";
     TableRetryPolicy policy = new TableRetryPolicy();
-    policy.withFixedBackoff(10);
+    policy.withFixedBackoff(Duration.ofMillis(10));
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
     doReturn(true).when(readFn).isRetriable(any());
 
@@ -116,8 +117,8 @@ public class TestRetriableTableFunctions {
   public void testRetryExhaustedTimeGet() throws Exception {
     String tableId = "testRetryExhaustedTime";
     TableRetryPolicy policy = new TableRetryPolicy();
-    policy.withFixedBackoff(5);
-    policy.withStopAfterDelay(100);
+    policy.withFixedBackoff(Duration.ofMillis(5));
+    policy.withStopAfterDelay(Duration.ofMillis(100));
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
     doReturn(true).when(readFn).isRetriable(any());
 
@@ -144,7 +145,7 @@ public class TestRetriableTableFunctions {
   public void testRetryExhaustedAttemptsGet() throws Exception {
     String tableId = "testRetryExhaustedAttempts";
     TableRetryPolicy policy = new TableRetryPolicy();
-    policy.withFixedBackoff(5);
+    policy.withFixedBackoff(Duration.ofMillis(5));
     policy.withStopAfterAttempts(10);
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
     doReturn(true).when(readFn).isRetriable(any());
@@ -172,7 +173,7 @@ public class TestRetriableTableFunctions {
   public void testFirstTimeSuccessPut() throws Exception {
     String tableId = "testFirstTimeSuccessPut";
     TableRetryPolicy policy = new TableRetryPolicy();
-    policy.withFixedBackoff(100);
+    policy.withFixedBackoff(Duration.ofMillis(100));
     TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
     doReturn(true).when(writeFn).isRetriable(any());
     doReturn(CompletableFuture.completedFuture("bar")).when(writeFn).putAsync(anyString(), anyString());
@@ -190,7 +191,7 @@ public class TestRetriableTableFunctions {
   public void testRetryEngagedPut() throws Exception {
     String tableId = "testRetryEngagedPut";
     TableRetryPolicy policy = new TableRetryPolicy();
-    policy.withFixedBackoff(10);
+    policy.withFixedBackoff(Duration.ofMillis(10));
     TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).putAllAsync(any());
     doReturn(true).when(writeFn).isRetriable(any());
@@ -224,8 +225,8 @@ public class TestRetriableTableFunctions {
   public void testRetryExhaustedTimePut() throws Exception {
     String tableId = "testRetryExhaustedTimePut";
     TableRetryPolicy policy = new TableRetryPolicy();
-    policy.withFixedBackoff(5);
-    policy.withStopAfterDelay(100);
+    policy.withFixedBackoff(Duration.ofMillis(5));
+    policy.withStopAfterDelay(Duration.ofMillis(100));
     TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
     doReturn(true).when(writeFn).isRetriable(any());
 
@@ -252,7 +253,7 @@ public class TestRetriableTableFunctions {
   public void testRetryExhaustedAttemptsPut() throws Exception {
     String tableId = "testRetryExhaustedAttemptsPut";
     TableRetryPolicy policy = new TableRetryPolicy();
-    policy.withFixedBackoff(5);
+    policy.withFixedBackoff(Duration.ofMillis(5));
     policy.withStopAfterAttempts(10);
     TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
     doReturn(true).when(writeFn).isRetriable(any());

--- a/samza-core/src/test/java/org/apache/samza/table/retry/TestRetriableTableFunctions.java
+++ b/samza-core/src/test/java/org/apache/samza/table/retry/TestRetriableTableFunctions.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.retry;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.apache.samza.container.SamzaContainerContext;
+import org.apache.samza.storage.kv.Entry;
+import org.apache.samza.table.Table;
+import org.apache.samza.table.remote.TableReadFunction;
+import org.apache.samza.table.remote.TableWriteFunction;
+import org.apache.samza.table.remote.TestRemoteTable;
+import org.apache.samza.table.utils.TableMetricsUtil;
+import org.apache.samza.task.TaskContext;
+import org.junit.Test;
+
+import junit.framework.Assert;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+
+public class TestRetriableTableFunctions {
+  private final ScheduledExecutorService schedExec = Executors.newSingleThreadScheduledExecutor();
+
+  public TableMetricsUtil getMetricsUtil(String tableId) {
+    Table table = mock(Table.class);
+    SamzaContainerContext cntCtx = mock(SamzaContainerContext.class);
+    TaskContext taskCtx = TestRemoteTable.getMockTaskContext();
+    return new TableMetricsUtil(cntCtx, taskCtx, table, tableId);
+  }
+
+  @Test
+  public void testFirstTimeSuccessGet() throws Exception {
+    String tableId = "testFirstTimeSuccessGet";
+    TableRetryPolicy policy = new TableRetryPolicy();
+    policy.withFixedBackoff(100);
+    TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
+    doReturn(true).when(readFn).isRetriable(any());
+    doReturn(CompletableFuture.completedFuture("bar")).when(readFn).getAsync(anyString());
+    RetriableReadFunction<String, String> retryIO = new RetriableReadFunction<>(policy, readFn, schedExec);
+    retryIO.setMetrics(getMetricsUtil(tableId));
+    Assert.assertEquals("bar", retryIO.getAsync("foo").get());
+    verify(readFn, times(1)).getAsync(anyString());
+
+    Assert.assertEquals(0, retryIO.retryMetrics.retryCount.getCount());
+    Assert.assertEquals(1, retryIO.retryMetrics.successCount.getCount());
+    Assert.assertEquals(0, retryIO.retryMetrics.retryTimer.getSnapshot().getMax());
+  }
+
+  @Test
+  public void testRetryEngagedGet() throws Exception {
+    String tableId = "testRetryEngagedGet";
+    TableRetryPolicy policy = new TableRetryPolicy();
+    policy.withFixedBackoff(10);
+    TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
+    doReturn(true).when(readFn).isRetriable(any());
+
+    int [] times = new int[] {0};
+    Map<String, String> map = new HashMap<>();
+    map.put("foo1", "bar1");
+    map.put("foo2", "bar2");
+    doAnswer(invocation -> {
+        CompletableFuture<Map<String, String>> future = new CompletableFuture();
+        if (times[0] > 0) {
+          future.complete(map);
+        } else {
+          times[0]++;
+          future.completeExceptionally(new RuntimeException("test exception"));
+        }
+        return future;
+      }).when(readFn).getAllAsync(any());
+
+    RetriableReadFunction<String, String> retryIO = new RetriableReadFunction<>(policy, readFn, schedExec);
+    retryIO.setMetrics(getMetricsUtil(tableId));
+    Assert.assertEquals(map, retryIO.getAllAsync(Arrays.asList("foo1", "foo2")).get());
+    verify(readFn, times(2)).getAllAsync(any());
+
+    Assert.assertEquals(1, retryIO.retryMetrics.retryCount.getCount());
+    Assert.assertEquals(0, retryIO.retryMetrics.successCount.getCount());
+    Assert.assertTrue(retryIO.retryMetrics.retryTimer.getSnapshot().getMax() > 0);
+  }
+
+  @Test
+  public void testRetryExhaustedTimeGet() throws Exception {
+    String tableId = "testRetryExhaustedTime";
+    TableRetryPolicy policy = new TableRetryPolicy();
+    policy.withFixedBackoff(5);
+    policy.withStopAfterDelay(100);
+    TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
+    doReturn(true).when(readFn).isRetriable(any());
+
+    CompletableFuture<String> future = new CompletableFuture();
+    future.completeExceptionally(new RuntimeException("test exception"));
+    doReturn(future).when(readFn).getAsync(anyString());
+
+    RetriableReadFunction<String, String> retryIO = new RetriableReadFunction<>(policy, readFn, schedExec);
+    retryIO.setMetrics(getMetricsUtil(tableId));
+    try {
+      retryIO.getAsync("foo").get();
+      Assert.fail();
+    } catch (ExecutionException e) {
+    }
+
+    // Conservatively: must be at least 3 attempts with 5ms backoff and 100ms maxDelay
+    verify(readFn, atLeast(3)).getAsync(anyString());
+    Assert.assertTrue(retryIO.retryMetrics.retryCount.getCount() >= 3);
+    Assert.assertEquals(0, retryIO.retryMetrics.successCount.getCount());
+    Assert.assertTrue(retryIO.retryMetrics.retryTimer.getSnapshot().getMax() > 0);
+  }
+
+  @Test
+  public void testRetryExhaustedAttemptsGet() throws Exception {
+    String tableId = "testRetryExhaustedAttempts";
+    TableRetryPolicy policy = new TableRetryPolicy();
+    policy.withFixedBackoff(5);
+    policy.withStopAfterAttempts(10);
+    TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
+    doReturn(true).when(readFn).isRetriable(any());
+
+    CompletableFuture<String> future = new CompletableFuture();
+    future.completeExceptionally(new RuntimeException("test exception"));
+    doReturn(future).when(readFn).getAllAsync(any());
+
+    RetriableReadFunction<String, String> retryIO = new RetriableReadFunction<>(policy, readFn, schedExec);
+    retryIO.setMetrics(getMetricsUtil(tableId));
+    try {
+      retryIO.getAllAsync(Arrays.asList("foo1", "foo2")).get();
+      Assert.fail();
+    } catch (ExecutionException e) {
+    }
+
+    // 1 initial try + 10 retries
+    verify(readFn, times(11)).getAllAsync(any());
+    Assert.assertEquals(10, retryIO.retryMetrics.retryCount.getCount());
+    Assert.assertEquals(0, retryIO.retryMetrics.successCount.getCount());
+    Assert.assertTrue(retryIO.retryMetrics.retryTimer.getSnapshot().getMax() > 0);
+  }
+
+  @Test
+  public void testFirstTimeSuccessPut() throws Exception {
+    String tableId = "testFirstTimeSuccessPut";
+    TableRetryPolicy policy = new TableRetryPolicy();
+    policy.withFixedBackoff(100);
+    TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
+    doReturn(true).when(writeFn).isRetriable(any());
+    doReturn(CompletableFuture.completedFuture("bar")).when(writeFn).putAsync(anyString(), anyString());
+    RetriableWriteFunction<String, String> retryIO = new RetriableWriteFunction<>(policy, writeFn, schedExec);
+    retryIO.setMetrics(getMetricsUtil(tableId));
+    retryIO.putAsync("foo", "bar").get();
+    verify(writeFn, times(1)).putAsync(anyString(), anyString());
+
+    Assert.assertEquals(0, retryIO.retryMetrics.retryCount.getCount());
+    Assert.assertEquals(1, retryIO.retryMetrics.successCount.getCount());
+    Assert.assertEquals(0, retryIO.retryMetrics.retryTimer.getSnapshot().getMax());
+  }
+
+  @Test
+  public void testRetryEngagedPut() throws Exception {
+    String tableId = "testRetryEngagedPut";
+    TableRetryPolicy policy = new TableRetryPolicy();
+    policy.withFixedBackoff(10);
+    TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
+    doReturn(CompletableFuture.completedFuture(null)).when(writeFn).putAllAsync(any());
+    doReturn(true).when(writeFn).isRetriable(any());
+
+    int [] times = new int[] {0};
+    List<Entry<String, String>> records = new ArrayList<>();
+    records.add(new Entry<>("foo1", "bar1"));
+    records.add(new Entry<>("foo2", "bar2"));
+    doAnswer(invocation -> {
+        CompletableFuture<Map<String, String>> future = new CompletableFuture();
+        if (times[0] > 0) {
+          future.complete(null);
+        } else {
+          times[0]++;
+          future.completeExceptionally(new RuntimeException("test exception"));
+        }
+        return future;
+      }).when(writeFn).putAllAsync(any());
+
+    RetriableWriteFunction<String, String> retryIO = new RetriableWriteFunction<>(policy, writeFn, schedExec);
+    retryIO.setMetrics(getMetricsUtil(tableId));
+    retryIO.putAllAsync(records).get();
+    verify(writeFn, times(2)).putAllAsync(any());
+
+    Assert.assertEquals(1, retryIO.retryMetrics.retryCount.getCount());
+    Assert.assertEquals(0, retryIO.retryMetrics.successCount.getCount());
+    Assert.assertTrue(retryIO.retryMetrics.retryTimer.getSnapshot().getMax() > 0);
+  }
+
+  @Test
+  public void testRetryExhaustedTimePut() throws Exception {
+    String tableId = "testRetryExhaustedTimePut";
+    TableRetryPolicy policy = new TableRetryPolicy();
+    policy.withFixedBackoff(5);
+    policy.withStopAfterDelay(100);
+    TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
+    doReturn(true).when(writeFn).isRetriable(any());
+
+    CompletableFuture<String> future = new CompletableFuture();
+    future.completeExceptionally(new RuntimeException("test exception"));
+    doReturn(future).when(writeFn).deleteAsync(anyString());
+
+    RetriableWriteFunction<String, String> retryIO = new RetriableWriteFunction<>(policy, writeFn, schedExec);
+    retryIO.setMetrics(getMetricsUtil(tableId));
+    try {
+      retryIO.deleteAsync("foo").get();
+      Assert.fail();
+    } catch (ExecutionException e) {
+    }
+
+    // Conservatively: must be at least 3 attempts with 5ms backoff and 100ms maxDelay
+    verify(writeFn, atLeast(3)).deleteAsync(anyString());
+    Assert.assertTrue(retryIO.retryMetrics.retryCount.getCount() >= 3);
+    Assert.assertEquals(0, retryIO.retryMetrics.successCount.getCount());
+    Assert.assertTrue(retryIO.retryMetrics.retryTimer.getSnapshot().getMax() > 0);
+  }
+
+  @Test
+  public void testRetryExhaustedAttemptsPut() throws Exception {
+    String tableId = "testRetryExhaustedAttemptsPut";
+    TableRetryPolicy policy = new TableRetryPolicy();
+    policy.withFixedBackoff(5);
+    policy.withStopAfterAttempts(10);
+    TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
+    doReturn(true).when(writeFn).isRetriable(any());
+
+    CompletableFuture<String> future = new CompletableFuture();
+    future.completeExceptionally(new RuntimeException("test exception"));
+    doReturn(future).when(writeFn).deleteAllAsync(any());
+
+    RetriableWriteFunction<String, String> retryIO = new RetriableWriteFunction<>(policy, writeFn, schedExec);
+    retryIO.setMetrics(getMetricsUtil(tableId));
+    try {
+      retryIO.deleteAllAsync(Arrays.asList("foo1", "foo2")).get();
+      Assert.fail();
+    } catch (ExecutionException e) {
+    }
+
+    // 1 initial try + 10 retries
+    verify(writeFn, times(11)).deleteAllAsync(any());
+    Assert.assertEquals(10, retryIO.retryMetrics.retryCount.getCount());
+    Assert.assertEquals(0, retryIO.retryMetrics.successCount.getCount());
+    Assert.assertTrue(retryIO.retryMetrics.retryTimer.getSnapshot().getMax() > 0);
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/table/retry/TestRetriableTableFunctions.java
+++ b/samza-core/src/test/java/org/apache/samza/table/retry/TestRetriableTableFunctions.java
@@ -284,7 +284,7 @@ public class TestRetriableTableFunctions {
     policy.withFixedBackoff(Duration.ofMillis(100));
 
     // Retry should be attempted based on the custom classification, ie. retry on NPE
-    policy.withRetryOn(ex -> ex instanceof NullPointerException);
+    policy.withRetryPredicate(ex -> ex instanceof NullPointerException);
 
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
 

--- a/samza-core/src/test/java/org/apache/samza/table/retry/TestTableRetryPolicy.java
+++ b/samza-core/src/test/java/org/apache/samza/table/retry/TestTableRetryPolicy.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.retry;
+
+import java.time.Duration;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.jodah.failsafe.RetryPolicy;
+
+
+public class TestTableRetryPolicy {
+  @Test
+  public void testNoRetry() {
+    TableRetryPolicy retryPolicy = new TableRetryPolicy();
+    Assert.assertEquals(TableRetryPolicy.BackoffType.NONE, retryPolicy.getBackoffType());
+  }
+
+  @Test
+  public void testFixedRetry() {
+    TableRetryPolicy retryPolicy = new TableRetryPolicy();
+    retryPolicy.withFixedBackoff(Duration.ofMillis(1000));
+    retryPolicy.withJitter(Duration.ofMillis(100));
+    retryPolicy.withStopAfterAttempts(4);
+    Assert.assertEquals(TableRetryPolicy.BackoffType.FIXED, retryPolicy.getBackoffType());
+    RetryPolicy fsRetry = FailsafeAdapter.valueOf((e) -> true, retryPolicy);
+    Assert.assertEquals(1000, fsRetry.getDelay().toMillis());
+    Assert.assertEquals(100, fsRetry.getJitter().toMillis());
+    Assert.assertEquals(4, fsRetry.getMaxRetries());
+  }
+
+  @Test
+  public void testRandomRetry() {
+    TableRetryPolicy retryPolicy = new TableRetryPolicy();
+    retryPolicy.withRandomBackoff(Duration.ofMillis(1000), Duration.ofMillis(2000));
+    retryPolicy.withJitter(Duration.ofMillis(100)); // no-op
+    Assert.assertEquals(TableRetryPolicy.BackoffType.RANDOM, retryPolicy.getBackoffType());
+    RetryPolicy fsRetry = FailsafeAdapter.valueOf((e) -> true, retryPolicy);
+    Assert.assertEquals(1000, fsRetry.getDelayMin().toMillis());
+    Assert.assertEquals(2000, fsRetry.getDelayMax().toMillis());
+  }
+
+  @Test
+  public void testExponentialRetry() {
+    TableRetryPolicy retryPolicy = new TableRetryPolicy();
+    retryPolicy.withExponentialBackoff(Duration.ofMillis(1000), Duration.ofMillis(2000), 1.5);
+    retryPolicy.withJitter(Duration.ofMillis(100));
+    Assert.assertEquals(TableRetryPolicy.BackoffType.EXPONENTIAL, retryPolicy.getBackoffType());
+    RetryPolicy fsRetry = FailsafeAdapter.valueOf((e) -> true, retryPolicy);
+    Assert.assertEquals(1000, fsRetry.getDelay().toMillis());
+    Assert.assertEquals(2000, fsRetry.getMaxDelay().toMillis());
+    Assert.assertEquals(1.5, fsRetry.getDelayFactor(), 0.001);
+    Assert.assertEquals(100, fsRetry.getJitter().toMillis());
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/table/retry/TestTableRetryPolicy.java
+++ b/samza-core/src/test/java/org/apache/samza/table/retry/TestTableRetryPolicy.java
@@ -41,10 +41,11 @@ public class TestTableRetryPolicy {
     retryPolicy.withJitter(Duration.ofMillis(100));
     retryPolicy.withStopAfterAttempts(4);
     Assert.assertEquals(TableRetryPolicy.BackoffType.FIXED, retryPolicy.getBackoffType());
-    RetryPolicy fsRetry = FailsafeAdapter.valueOf((e) -> true, retryPolicy);
+    RetryPolicy fsRetry = FailsafeAdapter.valueOf(retryPolicy);
     Assert.assertEquals(1000, fsRetry.getDelay().toMillis());
     Assert.assertEquals(100, fsRetry.getJitter().toMillis());
     Assert.assertEquals(4, fsRetry.getMaxRetries());
+    Assert.assertNotNull(retryPolicy.getRetryOn());
   }
 
   @Test
@@ -53,7 +54,7 @@ public class TestTableRetryPolicy {
     retryPolicy.withRandomBackoff(Duration.ofMillis(1000), Duration.ofMillis(2000));
     retryPolicy.withJitter(Duration.ofMillis(100)); // no-op
     Assert.assertEquals(TableRetryPolicy.BackoffType.RANDOM, retryPolicy.getBackoffType());
-    RetryPolicy fsRetry = FailsafeAdapter.valueOf((e) -> true, retryPolicy);
+    RetryPolicy fsRetry = FailsafeAdapter.valueOf(retryPolicy);
     Assert.assertEquals(1000, fsRetry.getDelayMin().toMillis());
     Assert.assertEquals(2000, fsRetry.getDelayMax().toMillis());
   }
@@ -64,10 +65,18 @@ public class TestTableRetryPolicy {
     retryPolicy.withExponentialBackoff(Duration.ofMillis(1000), Duration.ofMillis(2000), 1.5);
     retryPolicy.withJitter(Duration.ofMillis(100));
     Assert.assertEquals(TableRetryPolicy.BackoffType.EXPONENTIAL, retryPolicy.getBackoffType());
-    RetryPolicy fsRetry = FailsafeAdapter.valueOf((e) -> true, retryPolicy);
+    RetryPolicy fsRetry = FailsafeAdapter.valueOf(retryPolicy);
     Assert.assertEquals(1000, fsRetry.getDelay().toMillis());
     Assert.assertEquals(2000, fsRetry.getMaxDelay().toMillis());
     Assert.assertEquals(1.5, fsRetry.getDelayFactor(), 0.001);
     Assert.assertEquals(100, fsRetry.getJitter().toMillis());
+  }
+
+  @Test
+  public void testCustomRetryPredicate() {
+    TableRetryPolicy retryPolicy = new TableRetryPolicy();
+    retryPolicy.withRetryOn((e) -> e instanceof IllegalArgumentException);
+    Assert.assertTrue(retryPolicy.getRetryOn().test(new IllegalArgumentException()));
+    Assert.assertFalse(retryPolicy.getRetryOn().test(new NullPointerException()));
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/table/retry/TestTableRetryPolicy.java
+++ b/samza-core/src/test/java/org/apache/samza/table/retry/TestTableRetryPolicy.java
@@ -45,7 +45,7 @@ public class TestTableRetryPolicy {
     Assert.assertEquals(1000, fsRetry.getDelay().toMillis());
     Assert.assertEquals(100, fsRetry.getJitter().toMillis());
     Assert.assertEquals(4, fsRetry.getMaxRetries());
-    Assert.assertNotNull(retryPolicy.getRetryOn());
+    Assert.assertNotNull(retryPolicy.getRetryPredicate());
   }
 
   @Test
@@ -75,8 +75,8 @@ public class TestTableRetryPolicy {
   @Test
   public void testCustomRetryPredicate() {
     TableRetryPolicy retryPolicy = new TableRetryPolicy();
-    retryPolicy.withRetryOn((e) -> e instanceof IllegalArgumentException);
-    Assert.assertTrue(retryPolicy.getRetryOn().test(new IllegalArgumentException()));
-    Assert.assertFalse(retryPolicy.getRetryOn().test(new NullPointerException()));
+    retryPolicy.withRetryPredicate((e) -> e instanceof IllegalArgumentException);
+    Assert.assertTrue(retryPolicy.getRetryPredicate().test(new IllegalArgumentException()));
+    Assert.assertFalse(retryPolicy.getRetryPredicate().test(new NullPointerException()));
   }
 }

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestTableDescriptorsProvider.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestTableDescriptorsProvider.java
@@ -24,6 +24,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
 import org.apache.samza.config.Config;
 import org.apache.samza.config.ConfigException;
 import org.apache.samza.config.ConfigRewriter;
@@ -116,15 +118,27 @@ public class TestTableDescriptorsProvider {
   public static class MySampleNonTableDescriptorsProvider {
   }
 
+  static class MyReadFunction implements TableReadFunction {
+    @Override
+    public CompletableFuture getAsync(Object key) {
+      return null;
+    }
+
+    @Override
+    public boolean isRetriable(Throwable exception) {
+      return false;
+    }
+  }
+
   public static class MySampleTableDescriptorsProvider implements TableDescriptorsProvider {
     @Override
     public List<TableDescriptor> getTableDescriptors(Config config) {
       List<TableDescriptor> tableDescriptors = new ArrayList<>();
       final RateLimiter readRateLimiter = mock(RateLimiter.class);
-      final TableReadFunction readRemoteTable = (TableReadFunction) key -> null;
+      final MyReadFunction readFn = new MyReadFunction();
 
       tableDescriptors.add(new RemoteTableDescriptor<>("remote-table-1")
-          .withReadFunction(readRemoteTable)
+          .withReadFunction(readFn)
           .withRateLimiter(readRateLimiter, null, null)
           .withSerde(KVSerde.of(new StringSerde(), new LongSerde())));
       tableDescriptors.add(new RocksDbTableDescriptor("local-table-1")


### PR DESCRIPTION
Add common retry functionality to table IO functions for data stores
that do not have native retry support. We use failsafe as the retry
library.