### PR TITLE
[EXPERIMENTAL] : Handle Repartitioning of Streams

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/container/grouper/stream/SystemStreamPartitionGrouper.java
+++ b/samza-api/src/main/java/org/apache/samza/container/grouper/stream/SystemStreamPartitionGrouper.java
@@ -18,6 +18,7 @@
  */
 package org.apache.samza.container.grouper.stream;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.samza.container.TaskName;
 import org.apache.samza.system.SystemStreamPartition;
 
@@ -37,5 +38,9 @@ import java.util.Set;
  * the TaskNames.
  */
 public interface SystemStreamPartitionGrouper {
-  public Map<TaskName, Set<SystemStreamPartition>> group(Set<SystemStreamPartition> ssps);
+    Map<TaskName, Set<SystemStreamPartition>> group(Set<SystemStreamPartition> ssps);
+
+    default Map<TaskName, Set<SystemStreamPartition>> group(Set<SystemStreamPartition> ssps, Map<TaskName, Set<SystemStreamPartition>> previousGrouping) {
+        throw new NotImplementedException("This function has not been implemented by current implementation");
+    }
 }

--- a/samza-core/src/main/java/org/apache/samza/container/grouper/stream/GroupByPartition.java
+++ b/samza-core/src/main/java/org/apache/samza/container/grouper/stream/GroupByPartition.java
@@ -22,6 +22,7 @@ package org.apache.samza.container.grouper.stream;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.samza.config.Config;
@@ -30,54 +31,77 @@ import org.apache.samza.container.TaskName;
 import org.apache.samza.system.SystemStreamPartition;
 
 public class GroupByPartition implements SystemStreamPartitionGrouper {
-  private TaskConfigJava taskConfig = null;
-  private Set<SystemStreamPartition> broadcastStreams = new HashSet<SystemStreamPartition>();
+    private TaskConfigJava taskConfig = null;
+    private Set<SystemStreamPartition> broadcastStreams = new HashSet<SystemStreamPartition>();
+    private boolean handleRepartitioning = true;
 
-  /**
-   * default constructor
-   */
-  public GroupByPartition() {
-  }
-
-  /**
-   * Accepts the config in the constructor
-   *
-   * @param config job's config
-   */
-  public GroupByPartition(Config config) {
-    if (config.containsKey(TaskConfigJava.BROADCAST_INPUT_STREAMS)) {
-      taskConfig = new TaskConfigJava(config);
-      this.broadcastStreams = taskConfig.getBroadcastSystemStreamPartitions();
-    }
-  }
-
-  @Override
-  public Map<TaskName, Set<SystemStreamPartition>> group(Set<SystemStreamPartition> ssps) {
-    Map<TaskName, Set<SystemStreamPartition>> groupedMap = new HashMap<TaskName, Set<SystemStreamPartition>>();
-
-    for (SystemStreamPartition ssp : ssps) {
-      // notAValidEvent the broadcast streams if there is any
-      if (broadcastStreams.contains(ssp)) {
-        continue;
-      }
-
-      TaskName taskName = new TaskName("Partition " + ssp.getPartition().getPartitionId());
-      if (!groupedMap.containsKey(taskName)) {
-        groupedMap.put(taskName, new HashSet<SystemStreamPartition>());
-      }
-      groupedMap.get(taskName).add(ssp);
+    /**
+     * default constructor
+     */
+    public GroupByPartition() {
     }
 
-    // assign the broadcast streams to all the taskNames
-    if (!broadcastStreams.isEmpty()) {
-      for (Set<SystemStreamPartition> value : groupedMap.values()) {
-        for (SystemStreamPartition ssp : broadcastStreams) {
-          value.add(ssp);
+    /**
+     * Accepts the config in the constructor
+     *
+     * @param config job's config
+     */
+    public GroupByPartition(Config config) {
+        if (config.containsKey(TaskConfigJava.BROADCAST_INPUT_STREAMS)) {
+            taskConfig = new TaskConfigJava(config);
+            this.broadcastStreams = taskConfig.getBroadcastSystemStreamPartitions();
         }
-      }
+        handleRepartitioning = Boolean.getBoolean(config.get("auto.handle.repartition"));
     }
 
-    return groupedMap;
-  }
+    @Override
+    public Map<TaskName, Set<SystemStreamPartition>> group(Set<SystemStreamPartition> ssps) {
+        return getGrouping(ssps, null);
+    }
+
+    @Override
+    public Map<TaskName, Set<SystemStreamPartition>> group(Set<SystemStreamPartition> ssps, Map<TaskName, Set<SystemStreamPartition>> previousGrouping) {
+
+        if (handleRepartitioning && !previousGrouping.isEmpty()) {
+            GroupingHelper.RepartioningHelper repartioningHelper = GroupingHelper.getGroupingForRepartition(Optional.of(ssps), Optional.of(previousGrouping));
+            if (!repartioningHelper.getNewSsps().isEmpty()) {
+                return getGrouping(repartioningHelper.getNewSsps(), repartioningHelper.getGrouping());
+            }
+            return repartioningHelper.getGrouping();
+        } else {
+            return group(ssps);
+        }
+    }
+
+    private Map<TaskName, Set<SystemStreamPartition>> getGrouping(Set<SystemStreamPartition> ssps, Map<TaskName, Set<SystemStreamPartition>> grouping) {
+        if (grouping == null) {
+            grouping = new HashMap<>();
+        }
+        if (!ssps.isEmpty()) {
+            for (SystemStreamPartition newSsp : ssps) {
+                // notAValidEvent the broadcast streams if there is any
+                if (broadcastStreams.contains(newSsp)) {
+                    continue;
+                }
+
+                TaskName taskName = new TaskName("Partition " + newSsp.getPartition().getPartitionId());
+                if (!grouping.containsKey(taskName)) {
+                    grouping.put(taskName, new HashSet<SystemStreamPartition>());
+                }
+                grouping.get(taskName).add(newSsp);
+            }
+        }
+
+        // assign the broadcast streams to all the taskNames
+        if (!broadcastStreams.isEmpty()) {
+            for (Set<SystemStreamPartition> value : grouping.values()) {
+                for (SystemStreamPartition ssp : broadcastStreams) {
+                    value.add(ssp);
+                }
+            }
+        }
+
+        return grouping;
+    }
 
 }

--- a/samza-core/src/main/java/org/apache/samza/container/grouper/stream/GroupByPartition.java
+++ b/samza-core/src/main/java/org/apache/samza/container/grouper/stream/GroupByPartition.java
@@ -30,78 +30,81 @@ import org.apache.samza.config.TaskConfigJava;
 import org.apache.samza.container.TaskName;
 import org.apache.samza.system.SystemStreamPartition;
 
+
 public class GroupByPartition implements SystemStreamPartitionGrouper {
-    private TaskConfigJava taskConfig = null;
-    private Set<SystemStreamPartition> broadcastStreams = new HashSet<SystemStreamPartition>();
-    private boolean handleRepartitioning = true;
+  private TaskConfigJava taskConfig = null;
+  private Set<SystemStreamPartition> broadcastStreams = new HashSet<SystemStreamPartition>();
+  private boolean handleRepartitioning = true;
 
-    /**
-     * default constructor
-     */
-    public GroupByPartition() {
+  /**
+   * default constructor
+   */
+  public GroupByPartition() {
+  }
+
+  /**
+   * Accepts the config in the constructor
+   *
+   * @param config job's config
+   */
+  public GroupByPartition(Config config) {
+    if (config.containsKey(TaskConfigJava.BROADCAST_INPUT_STREAMS)) {
+      taskConfig = new TaskConfigJava(config);
+      this.broadcastStreams = taskConfig.getBroadcastSystemStreamPartitions();
     }
+    handleRepartitioning = Boolean.getBoolean(config.get("auto.handle.repartition"));
+  }
 
-    /**
-     * Accepts the config in the constructor
-     *
-     * @param config job's config
-     */
-    public GroupByPartition(Config config) {
-        if (config.containsKey(TaskConfigJava.BROADCAST_INPUT_STREAMS)) {
-            taskConfig = new TaskConfigJava(config);
-            this.broadcastStreams = taskConfig.getBroadcastSystemStreamPartitions();
-        }
-        handleRepartitioning = Boolean.getBoolean(config.get("auto.handle.repartition"));
+  @Override
+  public Map<TaskName, Set<SystemStreamPartition>> group(Set<SystemStreamPartition> ssps) {
+    return getGrouping(ssps, null);
+  }
+
+  @Override
+  public Map<TaskName, Set<SystemStreamPartition>> group(Set<SystemStreamPartition> ssps,
+      Map<TaskName, Set<SystemStreamPartition>> previousGrouping) {
+
+    if (handleRepartitioning && !previousGrouping.isEmpty()) {
+      GroupingHelper.RepartioningHelper repartioningHelper =
+          GroupingHelper.getGroupingForRepartition(Optional.of(ssps), Optional.of(previousGrouping));
+      if (!repartioningHelper.getNewSsps().isEmpty()) {
+        return getGrouping(repartioningHelper.getNewSsps(), repartioningHelper.getGrouping());
+      }
+      return repartioningHelper.getGrouping();
+    } else {
+      return group(ssps);
     }
+  }
 
-    @Override
-    public Map<TaskName, Set<SystemStreamPartition>> group(Set<SystemStreamPartition> ssps) {
-        return getGrouping(ssps, null);
+  private Map<TaskName, Set<SystemStreamPartition>> getGrouping(Set<SystemStreamPartition> ssps,
+      Map<TaskName, Set<SystemStreamPartition>> grouping) {
+    if (grouping == null) {
+      grouping = new HashMap<>();
     }
-
-    @Override
-    public Map<TaskName, Set<SystemStreamPartition>> group(Set<SystemStreamPartition> ssps, Map<TaskName, Set<SystemStreamPartition>> previousGrouping) {
-
-        if (handleRepartitioning && !previousGrouping.isEmpty()) {
-            GroupingHelper.RepartioningHelper repartioningHelper = GroupingHelper.getGroupingForRepartition(Optional.of(ssps), Optional.of(previousGrouping));
-            if (!repartioningHelper.getNewSsps().isEmpty()) {
-                return getGrouping(repartioningHelper.getNewSsps(), repartioningHelper.getGrouping());
-            }
-            return repartioningHelper.getGrouping();
-        } else {
-            return group(ssps);
-        }
-    }
-
-    private Map<TaskName, Set<SystemStreamPartition>> getGrouping(Set<SystemStreamPartition> ssps, Map<TaskName, Set<SystemStreamPartition>> grouping) {
-        if (grouping == null) {
-            grouping = new HashMap<>();
-        }
-        if (!ssps.isEmpty()) {
-            for (SystemStreamPartition newSsp : ssps) {
-                // notAValidEvent the broadcast streams if there is any
-                if (broadcastStreams.contains(newSsp)) {
-                    continue;
-                }
-
-                TaskName taskName = new TaskName("Partition " + newSsp.getPartition().getPartitionId());
-                if (!grouping.containsKey(taskName)) {
-                    grouping.put(taskName, new HashSet<SystemStreamPartition>());
-                }
-                grouping.get(taskName).add(newSsp);
-            }
+    if (!ssps.isEmpty()) {
+      for (SystemStreamPartition newSsp : ssps) {
+        // notAValidEvent the broadcast streams if there is any
+        if (broadcastStreams.contains(newSsp)) {
+          continue;
         }
 
-        // assign the broadcast streams to all the taskNames
-        if (!broadcastStreams.isEmpty()) {
-            for (Set<SystemStreamPartition> value : grouping.values()) {
-                for (SystemStreamPartition ssp : broadcastStreams) {
-                    value.add(ssp);
-                }
-            }
+        TaskName taskName = new TaskName("Partition " + newSsp.getPartition().getPartitionId());
+        if (!grouping.containsKey(taskName)) {
+          grouping.put(taskName, new HashSet<SystemStreamPartition>());
         }
-
-        return grouping;
+        grouping.get(taskName).add(newSsp);
+      }
     }
 
+    // assign the broadcast streams to all the taskNames
+    if (!broadcastStreams.isEmpty()) {
+      for (Set<SystemStreamPartition> value : grouping.values()) {
+        for (SystemStreamPartition ssp : broadcastStreams) {
+          value.add(ssp);
+        }
+      }
+    }
+
+    return grouping;
+  }
 }

--- a/samza-core/src/main/java/org/apache/samza/container/grouper/stream/GroupBySystemStreamPartition.java
+++ b/samza-core/src/main/java/org/apache/samza/container/grouper/stream/GroupBySystemStreamPartition.java
@@ -30,72 +30,75 @@ import org.apache.samza.config.TaskConfigJava;
 import org.apache.samza.container.TaskName;
 import org.apache.samza.system.SystemStreamPartition;
 
+
 public class GroupBySystemStreamPartition implements SystemStreamPartitionGrouper {
-    private TaskConfigJava taskConfig = null;
-    private Set<SystemStreamPartition> broadcastStreams = new HashSet<SystemStreamPartition>();
-    private boolean handleRepartitioning = true;
+  private TaskConfigJava taskConfig = null;
+  private Set<SystemStreamPartition> broadcastStreams = new HashSet<SystemStreamPartition>();
+  private boolean handleRepartitioning = true;
 
-    /**
-     * default constructor
-     */
-    public GroupBySystemStreamPartition() {
+  /**
+   * default constructor
+   */
+  public GroupBySystemStreamPartition() {
+  }
+
+  /**
+   * A constructor that accepts job config as the parameter
+   *
+   * @param config job config
+   */
+  public GroupBySystemStreamPartition(Config config) {
+    if (config.containsKey(TaskConfigJava.BROADCAST_INPUT_STREAMS)) {
+      taskConfig = new TaskConfigJava(config);
+      broadcastStreams = taskConfig.getBroadcastSystemStreamPartitions();
+    }
+    handleRepartitioning = Boolean.getBoolean(config.get("auto.handle.repartition"));
+  }
+
+  @Override
+  public Map<TaskName, Set<SystemStreamPartition>> group(Set<SystemStreamPartition> ssps) {
+    return getGrouping(ssps, null);
+  }
+
+  public Map<TaskName, Set<SystemStreamPartition>> group(Set<SystemStreamPartition> ssps,
+      Map<TaskName, Set<SystemStreamPartition>> previousGrouping) {
+
+    if (handleRepartitioning && !previousGrouping.isEmpty()) {
+      GroupingHelper.RepartioningHelper repartioningHelper =
+          GroupingHelper.getGroupingForRepartition(Optional.of(ssps), Optional.of(previousGrouping));
+      if (!repartioningHelper.getNewSsps().isEmpty()) {
+        return getGrouping(repartioningHelper.getNewSsps(), repartioningHelper.getGrouping());
+      }
+      return repartioningHelper.getGrouping();
+    } else {
+      return group(ssps);
+    }
+  }
+
+  private Map<TaskName, Set<SystemStreamPartition>> getGrouping(Set<SystemStreamPartition> ssps,
+      Map<TaskName, Set<SystemStreamPartition>> grouping) {
+    if (grouping == null) {
+      grouping = new HashMap<>();
+    }
+    for (SystemStreamPartition ssp : ssps) {
+      if (broadcastStreams.contains(ssp)) {
+        continue;
+      }
+
+      HashSet<SystemStreamPartition> sspSet = new HashSet<SystemStreamPartition>();
+      sspSet.add(ssp);
+      grouping.put(new TaskName(ssp.toString()), sspSet);
     }
 
-    /**
-     * A constructor that accepts job config as the parameter
-     *
-     * @param config job config
-     */
-    public GroupBySystemStreamPartition(Config config) {
-        if (config.containsKey(TaskConfigJava.BROADCAST_INPUT_STREAMS)) {
-            taskConfig = new TaskConfigJava(config);
-            broadcastStreams = taskConfig.getBroadcastSystemStreamPartitions();
+    // assign the broadcast streams to all the taskNames
+    if (!broadcastStreams.isEmpty()) {
+      for (Set<SystemStreamPartition> value : grouping.values()) {
+        for (SystemStreamPartition ssp : broadcastStreams) {
+          value.add(ssp);
         }
-        handleRepartitioning = Boolean.getBoolean(config.get("auto.handle.repartition"));
+      }
     }
 
-    @Override
-    public Map<TaskName, Set<SystemStreamPartition>> group(Set<SystemStreamPartition> ssps) {
-        return getGrouping(ssps, null);
-    }
-
-    public Map<TaskName, Set<SystemStreamPartition>> group(Set<SystemStreamPartition> ssps, Map<TaskName, Set<SystemStreamPartition>> previousGrouping) {
-
-        if (handleRepartitioning && !previousGrouping.isEmpty()) {
-            GroupingHelper.RepartioningHelper repartioningHelper = GroupingHelper.getGroupingForRepartition(Optional.of(ssps), Optional.of(previousGrouping));
-            if (!repartioningHelper.getNewSsps().isEmpty()) {
-                return getGrouping(repartioningHelper.getNewSsps(), repartioningHelper.getGrouping());
-            }
-            return repartioningHelper.getGrouping();
-        } else {
-            return group(ssps);
-        }
-    }
-
-    private Map<TaskName, Set<SystemStreamPartition>> getGrouping(Set<SystemStreamPartition> ssps, Map<TaskName, Set<SystemStreamPartition>> grouping) {
-        if (grouping == null) {
-            grouping = new HashMap<>();
-        }
-        for (SystemStreamPartition ssp : ssps) {
-            if (broadcastStreams.contains(ssp)) {
-                continue;
-            }
-
-            HashSet<SystemStreamPartition> sspSet = new HashSet<SystemStreamPartition>();
-            sspSet.add(ssp);
-            grouping.put(new TaskName(ssp.toString()), sspSet);
-        }
-
-        // assign the broadcast streams to all the taskNames
-        if (!broadcastStreams.isEmpty()) {
-            for (Set<SystemStreamPartition> value : grouping.values()) {
-                for (SystemStreamPartition ssp : broadcastStreams) {
-                    value.add(ssp);
-                }
-            }
-        }
-
-        return grouping;
-    }
-
+    return grouping;
+  }
 }

--- a/samza-core/src/main/java/org/apache/samza/container/grouper/stream/GroupingHelper.java
+++ b/samza-core/src/main/java/org/apache/samza/container/grouper/stream/GroupingHelper.java
@@ -15,115 +15,115 @@ import java.util.Set;
  */
 public class GroupingHelper {
 
-    /**
-     * Compute the map of Stream name to map of PartitionId to {@link SystemStreamPartition}
-     *
-     * @param   ssps Set of {@link SystemStreamPartition}
-     * @return  map(streamName -> map(PartitionId -> Ssp)
-     */
-    public static Map<String, Map<Integer, SystemStreamPartition>> getStreamToPartitionSspMap(Optional<Set<SystemStreamPartition>> ssps) {
-        Map<String, Map<Integer, SystemStreamPartition>> streamToPartitionSspMap = new HashMap<>();
-        if (ssps.isPresent()) {
-            ssps.get().forEach((ssp) -> {
-                if (streamToPartitionSspMap.get(ssp.getStream()) == null) {
-                    Map<Integer, SystemStreamPartition> partitionSspMap = new HashMap<>();
-                    partitionSspMap.put(ssp.getPartition().getPartitionId(), ssp);
-                    streamToPartitionSspMap.put(ssp.getStream(), partitionSspMap);
-                } else {
-                    streamToPartitionSspMap.get(ssp.getStream()).put(ssp.getPartition().getPartitionId(), ssp);
-                }
+  /**
+   * Compute the map of Stream name to map of PartitionId to {@link SystemStreamPartition}
+   *
+   * @param   ssps Set of {@link SystemStreamPartition}
+   * @return map(streamName -> map(PartitionId -> Ssp)
+   */
+  public static Map<String, Map<Integer, SystemStreamPartition>> getStreamToPartitionSspMap(
+      Optional<Set<SystemStreamPartition>> ssps) {
+    Map<String, Map<Integer, SystemStreamPartition>> streamToPartitionSspMap = new HashMap<>();
+    if (ssps.isPresent()) {
+      ssps.get().forEach((ssp) -> {
+        if (streamToPartitionSspMap.get(ssp.getStream()) == null) {
+          Map<Integer, SystemStreamPartition> partitionSspMap = new HashMap<>();
+          partitionSspMap.put(ssp.getPartition().getPartitionId(), ssp);
+          streamToPartitionSspMap.put(ssp.getStream(), partitionSspMap);
+        } else {
+          streamToPartitionSspMap.get(ssp.getStream()).put(ssp.getPartition().getPartitionId(), ssp);
+        }
+      });
+    }
+
+    return streamToPartitionSspMap;
+  }
+
+  /**
+   * Returns new grouping of previous {@link SystemStreamPartition} taking in to consideration repartitioning, only if the current set of {@link SystemStreamPartition} contain them
+   *
+   * @param   currSsps
+   *          Current set of {@link SystemStreamPartition}
+   *
+   * @param   previousGrouping
+   *          Previous grouping that was available.
+   *
+   * @return  {@link RepartioningHelper}
+   */
+
+  public static RepartioningHelper getGroupingForRepartition(Optional<Set<SystemStreamPartition>> currSsps,
+      Optional<Map<TaskName, Set<SystemStreamPartition>>> previousGrouping) {
+    final Map<TaskName, Set<SystemStreamPartition>> finalGrouping = new HashMap<>();
+
+    Map<SystemStreamPartition, TaskName> prevSspToTaskMap = new HashMap<>();
+    Set<SystemStreamPartition> prevSsps = new HashSet<>();
+    if (previousGrouping.isPresent()) {
+      previousGrouping.get().forEach((k, v) -> {
+        prevSsps.addAll(v);
+        v.forEach(ssp -> prevSspToTaskMap.put(ssp, k));
+      });
+    }
+
+    Map<String, Map<Integer, SystemStreamPartition>> currStreamToSspPartitionMap = getStreamToPartitionSspMap(currSsps);
+    Map<String, Map<Integer, SystemStreamPartition>> prevStreamToSspPartitionMap =
+        getStreamToPartitionSspMap(Optional.of(prevSsps));
+
+    Set<SystemStreamPartition> newSsps = new HashSet<>();
+
+    currStreamToSspPartitionMap.forEach((stream, currPartitionToSspMap) -> {
+      if (prevStreamToSspPartitionMap.containsKey(stream)) {
+        int currPartitionCount = currPartitionToSspMap.size();
+        int prevPartitionCount = prevStreamToSspPartitionMap.get(stream).size();
+        if (currPartitionCount % prevPartitionCount == 0) {
+          int expansionFactor = currPartitionCount / prevPartitionCount;
+          for (int i = expansionFactor - 1; i >= 0; i--) {
+            Map<Integer, SystemStreamPartition> prevPartitionToSsp = prevStreamToSspPartitionMap.get(stream);
+            int multiplier = i;
+            prevPartitionToSsp.forEach((prevPartitionId, ssp) -> {
+              // get the task for the associated StreamSystemPartition
+              TaskName taskName = prevSspToTaskMap.get(ssp);
+              // compute the newly assigned partition
+              int assignedPartitionId = prevPartitionId + (multiplier * prevPartitionCount);
+              // get the newly assigned SSP from the partitionId
+              SystemStreamPartition assignedSsp = currPartitionToSspMap.get(assignedPartitionId);
+              // update the final grouping
+              if (finalGrouping.get(taskName) == null) {
+                Set<SystemStreamPartition> finalSspSet = new HashSet<>();
+                finalSspSet.add(assignedSsp);
+                finalGrouping.put(taskName, finalSspSet);
+              } else {
+                finalGrouping.get(taskName).add(assignedSsp);
+              }
             });
+          }
         }
+      } else {
+        // separate out newly added streams to group them once the existng streams have been handled.
+        newSsps.addAll(currPartitionToSspMap.values());
+      }
+    });
 
-        return streamToPartitionSspMap;
+    return new RepartioningHelper(finalGrouping, newSsps);
+  }
+
+  /**
+   * Wrapper for the new grouping for the existing {@link SystemStreamPartition} and set of {@link SystemStreamPartition} for new Streams
+   */
+  public static final class RepartioningHelper {
+    private final Map<TaskName, Set<SystemStreamPartition>> grouping;
+    private final Set<SystemStreamPartition> newSsps;
+
+    public RepartioningHelper(Map<TaskName, Set<SystemStreamPartition>> grouping, Set<SystemStreamPartition> newSsps) {
+      this.grouping = grouping;
+      this.newSsps = newSsps;
     }
 
-    /**
-     * Returns new grouping of previous {@link SystemStreamPartition} taking in to consideration repartitioning, only if the current set of {@link SystemStreamPartition} contain them
-     *
-     * @param   currSsps
-     *          Current set of {@link SystemStreamPartition}
-     *
-     * @param   previousGrouping
-     *          Previous grouping that was available.
-     *
-     * @return  {@link RepartioningHelper}
-     */
-
-    public static RepartioningHelper getGroupingForRepartition(Optional<Set<SystemStreamPartition>> currSsps, Optional<Map<TaskName, Set<SystemStreamPartition>>> previousGrouping) {
-        final Map<TaskName, Set<SystemStreamPartition>> finalGrouping = new HashMap<>();
-
-        Map<SystemStreamPartition, TaskName> prevSspToTaskMap = new HashMap<>();
-        Set<SystemStreamPartition> prevSsps = new HashSet<>();
-        if (previousGrouping.isPresent()) {
-            previousGrouping.get().forEach((k, v) -> {
-                prevSsps.addAll(v);
-                v.forEach(ssp -> prevSspToTaskMap.put(ssp, k));
-            });
-        }
-
-
-        Map<String, Map<Integer, SystemStreamPartition>> currStreamToSspPartitionMap = getStreamToPartitionSspMap(currSsps);
-        Map<String, Map<Integer, SystemStreamPartition>> prevStreamToSspPartitionMap = getStreamToPartitionSspMap(Optional.of(prevSsps));
-
-        Set<SystemStreamPartition> newSsps = new HashSet<>();
-
-        currStreamToSspPartitionMap.forEach((stream, currPartitionToSspMap) -> {
-            if (prevStreamToSspPartitionMap.containsKey(stream)) {
-                int currPartitionCount = currPartitionToSspMap.size();
-                int prevPartitionCount = prevStreamToSspPartitionMap.get(stream).size();
-                if (currPartitionCount % prevPartitionCount == 0) {
-                    int expansionFactor = currPartitionCount / prevPartitionCount;
-                    for (int i = expansionFactor - 1; i >= 0; i--) {
-                        Map<Integer, SystemStreamPartition> prevPartitionToSsp = prevStreamToSspPartitionMap.get(stream);
-                        int multiplier = i;
-                        prevPartitionToSsp.forEach((prevPartitionId, ssp) -> {
-                            // get the task for the associated StreamSystemPartition
-                            TaskName taskName = prevSspToTaskMap.get(ssp);
-                            // compute the newly assigned partition
-                            int assignedPartitionId = prevPartitionId + (multiplier * prevPartitionCount);
-                            // get the newly assigned SSP from the partitionId
-                            SystemStreamPartition assignedSsp = currPartitionToSspMap.get(assignedPartitionId);
-                            // update the final grouping
-                            if (finalGrouping.get(taskName) == null) {
-                                Set<SystemStreamPartition> finalSspSet = new HashSet<>();
-                                finalSspSet.add(assignedSsp);
-                                finalGrouping.put(taskName, finalSspSet);
-                            } else {
-                                finalGrouping.get(taskName).add(assignedSsp);
-                            }
-                        });
-                    }
-                }
-            } else {
-                // separate out newly added streams to group them once the existng streams have been handled.
-                newSsps.addAll(currPartitionToSspMap.values());
-            }
-        });
-
-        return new RepartioningHelper(finalGrouping, newSsps);
+    public Map<TaskName, Set<SystemStreamPartition>> getGrouping() {
+      return grouping;
     }
 
-    /**
-     * Wrapper for the new grouping for the existing {@link SystemStreamPartition} and set of {@link SystemStreamPartition} for new Streams
-     */
-    public static final class RepartioningHelper {
-        private final Map<TaskName, Set<SystemStreamPartition>> grouping;
-        private final Set<SystemStreamPartition> newSsps;
-
-
-        public RepartioningHelper(Map<TaskName, Set<SystemStreamPartition>> grouping, Set<SystemStreamPartition> newSsps) {
-            this.grouping = grouping;
-            this.newSsps = newSsps;
-        }
-
-        public Map<TaskName, Set<SystemStreamPartition>> getGrouping() {
-            return grouping;
-        }
-
-        public Set<SystemStreamPartition> getNewSsps() {
-            return newSsps;
-        }
+    public Set<SystemStreamPartition> getNewSsps() {
+      return newSsps;
     }
-
+  }
 }

--- a/samza-core/src/main/java/org/apache/samza/container/grouper/stream/GroupingHelper.java
+++ b/samza-core/src/main/java/org/apache/samza/container/grouper/stream/GroupingHelper.java
@@ -1,0 +1,129 @@
+package org.apache.samza.container.grouper.stream;
+
+import org.apache.samza.container.TaskName;
+import org.apache.samza.system.SystemStreamPartition;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+
+/**
+ * Helper class for Grouper
+ */
+public class GroupingHelper {
+
+    /**
+     * Compute the map of Stream name to map of PartitionId to {@link SystemStreamPartition}
+     *
+     * @param   ssps Set of {@link SystemStreamPartition}
+     * @return  map(streamName -> map(PartitionId -> Ssp)
+     */
+    public static Map<String, Map<Integer, SystemStreamPartition>> getStreamToPartitionSspMap(Optional<Set<SystemStreamPartition>> ssps) {
+        Map<String, Map<Integer, SystemStreamPartition>> streamToPartitionSspMap = new HashMap<>();
+        if (ssps.isPresent()) {
+            ssps.get().forEach((ssp) -> {
+                if (streamToPartitionSspMap.get(ssp.getStream()) == null) {
+                    Map<Integer, SystemStreamPartition> partitionSspMap = new HashMap<>();
+                    partitionSspMap.put(ssp.getPartition().getPartitionId(), ssp);
+                    streamToPartitionSspMap.put(ssp.getStream(), partitionSspMap);
+                } else {
+                    streamToPartitionSspMap.get(ssp.getStream()).put(ssp.getPartition().getPartitionId(), ssp);
+                }
+            });
+        }
+
+        return streamToPartitionSspMap;
+    }
+
+    /**
+     * Returns new grouping of previous {@link SystemStreamPartition} taking in to consideration repartitioning, only if the current set of {@link SystemStreamPartition} contain them
+     *
+     * @param   currSsps
+     *          Current set of {@link SystemStreamPartition}
+     *
+     * @param   previousGrouping
+     *          Previous grouping that was available.
+     *
+     * @return  {@link RepartioningHelper}
+     */
+
+    public static RepartioningHelper getGroupingForRepartition(Optional<Set<SystemStreamPartition>> currSsps, Optional<Map<TaskName, Set<SystemStreamPartition>>> previousGrouping) {
+        final Map<TaskName, Set<SystemStreamPartition>> finalGrouping = new HashMap<>();
+
+        Map<SystemStreamPartition, TaskName> prevSspToTaskMap = new HashMap<>();
+        Set<SystemStreamPartition> prevSsps = new HashSet<>();
+        if (previousGrouping.isPresent()) {
+            previousGrouping.get().forEach((k, v) -> {
+                prevSsps.addAll(v);
+                v.forEach(ssp -> prevSspToTaskMap.put(ssp, k));
+            });
+        }
+
+
+        Map<String, Map<Integer, SystemStreamPartition>> currStreamToSspPartitionMap = getStreamToPartitionSspMap(currSsps);
+        Map<String, Map<Integer, SystemStreamPartition>> prevStreamToSspPartitionMap = getStreamToPartitionSspMap(Optional.of(prevSsps));
+
+        Set<SystemStreamPartition> newSsps = new HashSet<>();
+
+        currStreamToSspPartitionMap.forEach((stream, currPartitionToSspMap) -> {
+            if (prevStreamToSspPartitionMap.containsKey(stream)) {
+                int currPartitionCount = currPartitionToSspMap.size();
+                int prevPartitionCount = prevStreamToSspPartitionMap.get(stream).size();
+                if (currPartitionCount % prevPartitionCount == 0) {
+                    int expansionFactor = currPartitionCount / prevPartitionCount;
+                    for (int i = expansionFactor - 1; i >= 0; i--) {
+                        Map<Integer, SystemStreamPartition> prevPartitionToSsp = prevStreamToSspPartitionMap.get(stream);
+                        int multiplier = i;
+                        prevPartitionToSsp.forEach((prevPartitionId, ssp) -> {
+                            // get the task for the associated StreamSystemPartition
+                            TaskName taskName = prevSspToTaskMap.get(ssp);
+                            // compute the newly assigned partition
+                            int assignedPartitionId = prevPartitionId + (multiplier * prevPartitionCount);
+                            // get the newly assigned SSP from the partitionId
+                            SystemStreamPartition assignedSsp = currPartitionToSspMap.get(assignedPartitionId);
+                            // update the final grouping
+                            if (finalGrouping.get(taskName) == null) {
+                                Set<SystemStreamPartition> finalSspSet = new HashSet<>();
+                                finalSspSet.add(assignedSsp);
+                                finalGrouping.put(taskName, finalSspSet);
+                            } else {
+                                finalGrouping.get(taskName).add(assignedSsp);
+                            }
+                        });
+                    }
+                }
+            } else {
+                // separate out newly added streams to group them once the existng streams have been handled.
+                newSsps.addAll(currPartitionToSspMap.values());
+            }
+        });
+
+        return new RepartioningHelper(finalGrouping, newSsps);
+    }
+
+    /**
+     * Wrapper for the new grouping for the existing {@link SystemStreamPartition} and set of {@link SystemStreamPartition} for new Streams
+     */
+    public static final class RepartioningHelper {
+        private final Map<TaskName, Set<SystemStreamPartition>> grouping;
+        private final Set<SystemStreamPartition> newSsps;
+
+
+        public RepartioningHelper(Map<TaskName, Set<SystemStreamPartition>> grouping, Set<SystemStreamPartition> newSsps) {
+            this.grouping = grouping;
+            this.newSsps = newSsps;
+        }
+
+        public Map<TaskName, Set<SystemStreamPartition>> getGrouping() {
+            return grouping;
+        }
+
+        public Set<SystemStreamPartition> getNewSsps() {
+            return newSsps;
+        }
+    }
+
+}

--- a/samza-core/src/test/java/org/apache/samza/container/grouper/stream/TestGroupByPartition.java
+++ b/samza-core/src/test/java/org/apache/samza/container/grouper/stream/TestGroupByPartition.java
@@ -31,7 +31,9 @@ import org.apache.samza.Partition;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.MapConfig;
 import org.apache.samza.container.TaskName;
+import org.apache.samza.system.SystemStream;
 import org.apache.samza.system.SystemStreamPartition;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class TestGroupByPartition {
@@ -127,4 +129,453 @@ public class TestGroupByPartition {
 
     assertEquals(expectedResult, result);
   }
+
+  @Test
+  public void testSingleStreamRepartitioning() {
+    Map<TaskName, Set<SystemStreamPartition>> prevGroupingWithSingleStream = new HashMap<>();
+    Set<SystemStreamPartition> sspSet0 = new HashSet<>();
+    sspSet0.add(new SystemStreamPartition("kafka", "PVE", new Partition(0)));
+
+    Set<SystemStreamPartition> sspSet1 = new HashSet<>();
+    sspSet1.add(new SystemStreamPartition("kafka", "PVE", new Partition(1)));
+
+    Set<SystemStreamPartition> sspSet2 = new HashSet<>();
+    sspSet2.add(new SystemStreamPartition("kafka", "PVE", new Partition(2)));
+
+    Set<SystemStreamPartition> sspSet3 = new HashSet<>();
+    sspSet3.add(new SystemStreamPartition("kafka", "PVE", new Partition(3)));
+
+    prevGroupingWithSingleStream.put(new TaskName("Partition 0"), sspSet0);
+    prevGroupingWithSingleStream.put(new TaskName("Partition 1"), sspSet1);
+    prevGroupingWithSingleStream.put(new TaskName("Partition 2"), sspSet2);
+    prevGroupingWithSingleStream.put(new TaskName("Partition 3"), sspSet3);
+
+    Set<SystemStreamPartition> currSsps = new HashSet<>();
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(0)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(1)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(2)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(3)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(4)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(5)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(6)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(7)));
+
+    // expected grouping
+    Map<TaskName, Set<SystemStreamPartition>> expectedGrouping = new HashMap<>();
+    Set<SystemStreamPartition> expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(1)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(5)));
+    expectedGrouping.put(new TaskName("Partition 1"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(4)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(0)));
+    expectedGrouping.put(new TaskName("Partition 0"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(7)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(3)));
+    expectedGrouping.put(new TaskName("Partition 3"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(6)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(2)));
+    expectedGrouping.put(new TaskName("Partition 2"), expectedSsps);
+
+    GroupByPartition groupByPartition = new GroupByPartition();
+    Map<TaskName, Set<SystemStreamPartition>> finalGrouping = groupByPartition.group(currSsps, prevGroupingWithSingleStream);
+    Assert.assertEquals(expectedGrouping, finalGrouping);
+  }
+
+  @Test
+  public void testMultipleStreamsWithSingleStreamRepartitioning() {
+    Map<TaskName, Set<SystemStreamPartition>> prevGroupingWithMultipleStreams = new HashMap<>();
+
+    Set<SystemStreamPartition> sspSet0 = new HashSet<>();
+    sspSet0 = new HashSet<>();
+    sspSet0.add(new SystemStreamPartition("kafka", "PVE", new Partition(0)));
+    sspSet0.add(new SystemStreamPartition("kafka", "URE", new Partition(0)));
+
+    Set<SystemStreamPartition> sspSet1 = new HashSet<>();
+    sspSet1 = new HashSet<>();
+    sspSet1.add(new SystemStreamPartition("kafka", "PVE", new Partition(1)));
+    sspSet1.add(new SystemStreamPartition("kafka", "URE", new Partition(1)));
+
+    Set<SystemStreamPartition> sspSet2 = new HashSet<>();
+    sspSet2 = new HashSet<>();
+    sspSet2.add(new SystemStreamPartition("kafka", "PVE", new Partition(2)));
+    sspSet2.add(new SystemStreamPartition("kafka", "URE", new Partition(2)));
+
+    Set<SystemStreamPartition> sspSet3 = new HashSet<>();
+    sspSet3 = new HashSet<>();
+    sspSet3.add(new SystemStreamPartition("kafka", "PVE", new Partition(3)));
+    sspSet3.add(new SystemStreamPartition("kafka", "URE", new Partition(3)));
+
+    prevGroupingWithMultipleStreams.put(new TaskName("Partition 0"), sspSet0);
+    prevGroupingWithMultipleStreams.put(new TaskName("Partition 1"), sspSet1);
+    prevGroupingWithMultipleStreams.put(new TaskName("Partition 2"), sspSet2);
+    prevGroupingWithMultipleStreams.put(new TaskName("Partition 3"), sspSet3);
+
+    Set<SystemStreamPartition> currSsps = new HashSet<>();
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(0)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(1)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(2)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(3)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(4)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(5)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(6)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(7)));
+
+    currSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(0)));
+    currSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(1)));
+    currSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(2)));
+    currSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(3)));
+
+    // newly added Streams
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(0)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(1)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(2)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(3)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(4)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(5)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(6)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(7)));
+
+    // expected final grouping
+    Map<TaskName, Set<SystemStreamPartition>> expectedGrouping = new HashMap<>();
+    Set<SystemStreamPartition> expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(1)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(5)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(1)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(1)));
+    expectedGrouping.put(new TaskName("Partition 1"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(4)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(0)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(0)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(0)));
+    expectedGrouping.put(new TaskName("Partition 0"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(7)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(3)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(3)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(3)));
+    expectedGrouping.put(new TaskName("Partition 3"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(6)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(2)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(2)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(2)));
+    expectedGrouping.put(new TaskName("Partition 2"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(5)));
+    expectedGrouping.put(new TaskName("Partition 5"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(4)));
+    expectedGrouping.put(new TaskName("Partition 4"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(7)));
+    expectedGrouping.put(new TaskName("Partition 7"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(6)));
+    expectedGrouping.put(new TaskName("Partition 6"), expectedSsps);
+
+    GroupByPartition groupByPartition = new GroupByPartition();
+    Map<TaskName, Set<SystemStreamPartition>> finalGrouping = groupByPartition.group(currSsps, prevGroupingWithMultipleStreams);
+    Assert.assertEquals(expectedGrouping, finalGrouping);
+  }
+
+  @Test
+  public void testOnlyNewlyAddedStreams() {
+    Map<TaskName, Set<SystemStreamPartition>> prevGroupingWithMultipleStreams = new HashMap<>();
+
+    Set<SystemStreamPartition> sspSet0 = new HashSet<>();
+    sspSet0 = new HashSet<>();
+    sspSet0.add(new SystemStreamPartition("kafka", "PVE", new Partition(0)));
+    sspSet0.add(new SystemStreamPartition("kafka", "URE", new Partition(0)));
+
+    Set<SystemStreamPartition> sspSet1 = new HashSet<>();
+    sspSet1 = new HashSet<>();
+    sspSet1.add(new SystemStreamPartition("kafka", "PVE", new Partition(1)));
+    sspSet1.add(new SystemStreamPartition("kafka", "URE", new Partition(1)));
+
+    Set<SystemStreamPartition> sspSet2 = new HashSet<>();
+    sspSet2 = new HashSet<>();
+    sspSet2.add(new SystemStreamPartition("kafka", "PVE", new Partition(2)));
+    sspSet2.add(new SystemStreamPartition("kafka", "URE", new Partition(2)));
+
+    Set<SystemStreamPartition> sspSet3 = new HashSet<>();
+    sspSet3 = new HashSet<>();
+    sspSet3.add(new SystemStreamPartition("kafka", "PVE", new Partition(3)));
+    sspSet3.add(new SystemStreamPartition("kafka", "URE", new Partition(3)));
+
+    prevGroupingWithMultipleStreams.put(new TaskName("Partition 0"), sspSet0);
+    prevGroupingWithMultipleStreams.put(new TaskName("Partition 1"), sspSet1);
+    prevGroupingWithMultipleStreams.put(new TaskName("Partition 2"), sspSet2);
+    prevGroupingWithMultipleStreams.put(new TaskName("Partition 3"), sspSet3);
+
+    Set<SystemStreamPartition> currSsps = new HashSet<>();
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(0)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(1)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(2)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(3)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(4)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(5)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(6)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(7)));
+
+    // expected Grouping
+    Map<TaskName, Set<SystemStreamPartition>> expectedGrouping = new HashMap<>();
+    Set<SystemStreamPartition> expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(1)));
+    expectedGrouping.put(new TaskName("Partition 1"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(0)));
+    expectedGrouping.put(new TaskName("Partition 0"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(3)));
+    expectedGrouping.put(new TaskName("Partition 3"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(2)));
+    expectedGrouping.put(new TaskName("Partition 2"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(5)));
+    expectedGrouping.put(new TaskName("Partition 5"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(4)));
+    expectedGrouping.put(new TaskName("Partition 4"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(7)));
+    expectedGrouping.put(new TaskName("Partition 7"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(6)));
+    expectedGrouping.put(new TaskName("Partition 6"), expectedSsps);
+
+    GroupByPartition groupByPartition = new GroupByPartition();
+    Map<TaskName, Set<SystemStreamPartition>> finalGrouping = groupByPartition.group(currSsps, prevGroupingWithMultipleStreams);
+    Assert.assertEquals(expectedGrouping, finalGrouping);
+  }
+
+
+  @Test
+  public void testRemovalAndAdditionOfStreamsWithRepartitioning() {
+    Map<TaskName, Set<SystemStreamPartition>> prevGroupingWithMultipleStreams = new HashMap<>();
+
+    Set<SystemStreamPartition> sspSet0 = new HashSet<>();
+    sspSet0 = new HashSet<>();
+    sspSet0.add(new SystemStreamPartition("kafka", "PVE", new Partition(0)));
+    sspSet0.add(new SystemStreamPartition("kafka", "URE", new Partition(0)));
+
+    Set<SystemStreamPartition> sspSet1 = new HashSet<>();
+    sspSet1 = new HashSet<>();
+    sspSet1.add(new SystemStreamPartition("kafka", "PVE", new Partition(1)));
+    sspSet1.add(new SystemStreamPartition("kafka", "URE", new Partition(1)));
+
+    Set<SystemStreamPartition> sspSet2 = new HashSet<>();
+    sspSet2 = new HashSet<>();
+    sspSet2.add(new SystemStreamPartition("kafka", "PVE", new Partition(2)));
+    sspSet2.add(new SystemStreamPartition("kafka", "URE", new Partition(2)));
+
+    Set<SystemStreamPartition> sspSet3 = new HashSet<>();
+    sspSet3 = new HashSet<>();
+    sspSet3.add(new SystemStreamPartition("kafka", "PVE", new Partition(3)));
+    sspSet3.add(new SystemStreamPartition("kafka", "URE", new Partition(3)));
+
+    prevGroupingWithMultipleStreams.put(new TaskName("Partition 0"), sspSet0);
+    prevGroupingWithMultipleStreams.put(new TaskName("Partition 1"), sspSet1);
+    prevGroupingWithMultipleStreams.put(new TaskName("Partition 2"), sspSet2);
+    prevGroupingWithMultipleStreams.put(new TaskName("Partition 3"), sspSet3);
+
+    Set<SystemStreamPartition> currSsps = new HashSet<>();
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(0)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(1)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(2)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(3)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(4)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(5)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(6)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(7)));
+
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(0)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(1)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(2)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(3)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(4)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(5)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(6)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(7)));
+
+    // expected grouping
+    Map<TaskName, Set<SystemStreamPartition>> expectedGrouping = new HashMap<>();
+    Set<SystemStreamPartition> expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(5)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(1)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(1)));
+    expectedGrouping.put(new TaskName("Partition 1"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(4)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(0)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(0)));
+    expectedGrouping.put(new TaskName("Partition 0"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(7)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(3)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(3)));
+    expectedGrouping.put(new TaskName("Partition 3"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(6)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(2)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(2)));
+    expectedGrouping.put(new TaskName("Partition 2"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(5)));
+    expectedGrouping.put(new TaskName("Partition 5"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(4)));
+    expectedGrouping.put(new TaskName("Partition 4"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(7)));
+    expectedGrouping.put(new TaskName("Partition 7"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(6)));
+    expectedGrouping.put(new TaskName("Partition 6"), expectedSsps);
+
+
+    GroupByPartition groupByPartition = new GroupByPartition();
+    Map<TaskName, Set<SystemStreamPartition>> finalGrouping = groupByPartition.group(currSsps, prevGroupingWithMultipleStreams);
+    Assert.assertEquals(expectedGrouping, finalGrouping);
+  }
+
+  @Test
+  public void testMultipleStreamRepartitioningWithNewStreams() {
+    Map<TaskName, Set<SystemStreamPartition>> prevGroupingWithMultipleStreams = new HashMap<>();
+
+    Set<SystemStreamPartition> sspSet0 = new HashSet<>();
+    sspSet0 = new HashSet<>();
+    sspSet0.add(new SystemStreamPartition("kafka", "PVE", new Partition(0)));
+    sspSet0.add(new SystemStreamPartition("kafka", "URE", new Partition(0)));
+
+    Set<SystemStreamPartition> sspSet1 = new HashSet<>();
+    sspSet1 = new HashSet<>();
+    sspSet1.add(new SystemStreamPartition("kafka", "PVE", new Partition(1)));
+    sspSet1.add(new SystemStreamPartition("kafka", "URE", new Partition(1)));
+
+    Set<SystemStreamPartition> sspSet2 = new HashSet<>();
+    sspSet2 = new HashSet<>();
+    sspSet2.add(new SystemStreamPartition("kafka", "PVE", new Partition(2)));
+    sspSet2.add(new SystemStreamPartition("kafka", "URE", new Partition(2)));
+
+    Set<SystemStreamPartition> sspSet3 = new HashSet<>();
+    sspSet3 = new HashSet<>();
+    sspSet3.add(new SystemStreamPartition("kafka", "PVE", new Partition(3)));
+    sspSet3.add(new SystemStreamPartition("kafka", "URE", new Partition(3)));
+
+    prevGroupingWithMultipleStreams.put(new TaskName("Partition 0"), sspSet0);
+    prevGroupingWithMultipleStreams.put(new TaskName("Partition 1"), sspSet1);
+    prevGroupingWithMultipleStreams.put(new TaskName("Partition 2"), sspSet2);
+    prevGroupingWithMultipleStreams.put(new TaskName("Partition 3"), sspSet3);
+
+    Set<SystemStreamPartition> currSsps = new HashSet<>();
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(0)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(1)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(2)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(3)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(4)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(5)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(6)));
+    currSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(7)));
+    currSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(0)));
+    currSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(1)));
+    currSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(2)));
+    currSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(3)));
+    currSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(4)));
+    currSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(5)));
+    currSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(6)));
+    currSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(7)));
+
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(0)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(1)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(2)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(3)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(4)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(5)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(6)));
+    currSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(7)));
+
+    // expected grouping
+    Map<TaskName, Set<SystemStreamPartition>> expectedGrouping = new HashMap<>();
+    Set<SystemStreamPartition> expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(5)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(1)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(1)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(5)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(1)));
+    expectedGrouping.put(new TaskName("Partition 1"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(0)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(4)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(0)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(4)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(0)));
+    expectedGrouping.put(new TaskName("Partition 0"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(7)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(3)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(7)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(3)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(3)));
+    expectedGrouping.put(new TaskName("Partition 3"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(2)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "PVE", new Partition(6)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(2)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "URE", new Partition(6)));
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(2)));
+    expectedGrouping.put(new TaskName("Partition 2"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(5)));
+    expectedGrouping.put(new TaskName("Partition 5"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(4)));
+    expectedGrouping.put(new TaskName("Partition 4"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(7)));
+    expectedGrouping.put(new TaskName("Partition 7"), expectedSsps);
+
+    expectedSsps = new HashSet<>();
+    expectedSsps.add(new SystemStreamPartition("kafka", "BOB", new Partition(6)));
+    expectedGrouping.put(new TaskName("Partition 6"), expectedSsps);
+
+    GroupByPartition groupByPartition = new GroupByPartition();
+    Map<TaskName, Set<SystemStreamPartition>> finalGrouping = groupByPartition.group(currSsps, prevGroupingWithMultipleStreams);
+    Assert.assertEquals(expectedGrouping, finalGrouping);
+  }
+
 }


### PR DESCRIPTION
Modified the Groupers to handle Repartitioning. This is an opt in feature and can be enabled by setting the config : "auto.handle.repartition" to true.
This patch assumes that we add a new interface in the groupers that provides access to the previous mapping of tasks to SSPs.

This assumes that the number of partitions are always increased by a factor of 2.
This also assumes that the partitioning algorithm used by the producer is "hash(key) % partitions"