### PR TITLE
Samza SQL: Code re-org to accomodate Samza SQL engine to take Calcite IR as input.

### DIFF
--- a/samza-sql/src/main/java/org/apache/samza/sql/avro/AvroRelConverter.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/avro/AvroRelConverter.java
@@ -29,6 +29,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
+import org.apache.calcite.avatica.util.ByteString;
 import org.apache.samza.SamzaException;
 import org.apache.samza.config.Config;
 import org.apache.samza.operators.KV;
@@ -173,7 +174,7 @@ public class AvroRelConverter implements SamzaRelConverter {
       case UNION:
         return convertToAvroObject(relObj, getNonNullUnionSchema(schema));
       case FIXED:
-        return new GenericData.Fixed(schema, ((String) relObj).getBytes());
+        return new GenericData.Fixed(schema, ((ByteString) relObj).getBytes());
       case ENUM:
         return new GenericData.EnumSymbol(schema, (String) relObj);
       default:

--- a/samza-sql/src/main/java/org/apache/samza/sql/data/RexToJavaCompiler.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/data/RexToJavaCompiler.java
@@ -49,6 +49,7 @@ import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexProgramBuilder;
 import org.apache.calcite.util.Pair;
 import org.apache.samza.SamzaException;
+import org.apache.samza.sql.interfaces.SamzaSqlJavaTypeFactoryImpl;
 import org.codehaus.commons.compiler.CompileException;
 import org.codehaus.commons.compiler.CompilerFactoryFactory;
 import org.codehaus.commons.compiler.IClassBodyEvaluator;
@@ -114,7 +115,7 @@ public class RexToJavaCompiler {
     final ParameterExpression root = DataContext.ROOT;
     final ParameterExpression inputValues = Expressions.parameter(Object[].class, "inputValues");
     final ParameterExpression outputValues = Expressions.parameter(Object[].class, "outputValues");
-    final JavaTypeFactoryImpl javaTypeFactory = new JavaTypeFactoryImpl(rexBuilder.getTypeFactory().getTypeSystem());
+    final JavaTypeFactoryImpl javaTypeFactory = new SamzaSqlJavaTypeFactoryImpl(rexBuilder.getTypeFactory().getTypeSystem());
 
     // public void execute(Object[] inputValues, Object[] outputValues)
     final RexToLixTranslator.InputGetter inputGetter = new RexToLixTranslator.InputGetterImpl(ImmutableList.of(

--- a/samza-sql/src/main/java/org/apache/samza/sql/dsl/SamzaSqlDslConverter.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/dsl/SamzaSqlDslConverter.java
@@ -1,0 +1,46 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.samza.sql.dsl;
+
+import java.util.Collection;
+import java.util.Collections;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.samza.sql.interfaces.DslConverter;
+import org.apache.samza.sql.planner.QueryPlanner;
+import org.apache.samza.sql.runner.SamzaSqlApplicationConfig;
+
+
+public class SamzaSqlDslConverter implements DslConverter {
+
+  private SamzaSqlApplicationConfig sqlConfig;
+
+  SamzaSqlDslConverter(SamzaSqlApplicationConfig sqlConfig) {
+    this.sqlConfig = sqlConfig;
+  }
+
+  @Override
+  public Collection<RelRoot> convertDsl(String dsl) {
+    QueryPlanner planner =
+        new QueryPlanner(sqlConfig.getRelSchemaProviders(), sqlConfig.getSystemStreamConfigsBySource(),
+            sqlConfig.getUdfMetadata());
+    final RelRoot relRoot = planner.plan(dsl);
+    return Collections.singletonList(relRoot);
+  }
+}

--- a/samza-sql/src/main/java/org/apache/samza/sql/dsl/SamzaSqlDslConverterFactory.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/dsl/SamzaSqlDslConverterFactory.java
@@ -1,0 +1,46 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.samza.sql.dsl;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.samza.config.Config;
+import org.apache.samza.sql.interfaces.DslConverter;
+import org.apache.samza.sql.interfaces.DslConverterFactory;
+import org.apache.samza.sql.runner.SamzaSqlApplicationConfig;
+import org.apache.samza.sql.testutil.SamzaSqlQueryParser;
+
+import static org.apache.samza.sql.runner.SamzaSqlApplicationConfig.*;
+
+
+public class SamzaSqlDslConverterFactory implements DslConverterFactory {
+
+  @Override
+  public DslConverter create(Config config) {
+    List<String> sql = fetchSqlFromConfig(config);
+    List<SamzaSqlQueryParser.QueryInfo> queryInfo = fetchQueryInfo(sql);
+    SamzaSqlApplicationConfig sqlConfig = new SamzaSqlApplicationConfig(config,
+        queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSources).flatMap(Collection::stream)
+            .collect(Collectors.toSet()),
+        queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
+    return new SamzaSqlDslConverter(sqlConfig);
+  }
+}

--- a/samza-sql/src/main/java/org/apache/samza/sql/impl/ConfigBasedIOResolverFactory.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/impl/ConfigBasedIOResolverFactory.java
@@ -29,6 +29,7 @@ import org.apache.samza.sql.data.SamzaSqlRelMessage;
 import org.apache.samza.sql.interfaces.SqlIOResolver;
 import org.apache.samza.sql.interfaces.SqlIOResolverFactory;
 import org.apache.samza.sql.interfaces.SqlIOConfig;
+import org.apache.samza.sql.serializers.SamzaSqlRelMessageSerdeFactory;
 import org.apache.samza.storage.kv.RocksDbTableDescriptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,7 +104,7 @@ public class ConfigBasedIOResolverFactory implements SqlIOResolverFactory {
         tableDescriptor = new RocksDbTableDescriptor("InputTable-" + name)
             .withSerde(KVSerde.of(
                 new JsonSerdeV2<>(SamzaSqlCompositeKey.class),
-                new JsonSerdeV2<>(SamzaSqlRelMessage.class)));
+                new SamzaSqlRelMessageSerdeFactory().getSerde(null, null)));
       }
 
       return new SqlIOConfig(systemName, streamName, fetchSystemConfigs(systemName), tableDescriptor);

--- a/samza-sql/src/main/java/org/apache/samza/sql/interfaces/DslConverter.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/interfaces/DslConverter.java
@@ -1,0 +1,37 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.samza.sql.interfaces;
+
+import java.util.Collection;
+import org.apache.calcite.rel.RelRoot;
+
+
+/**
+ * Samza SQL Application uses {@link DslConverter} to convert the input dsl to Calcite logical plan.
+ */
+public interface DslConverter {
+
+  /**
+   * Convert the dsl into the Calcite logical plan.
+   * @return List of Root nodes of the Calcite logical plan.
+   * If DSL represents multiple SQL statements. You might return root nodes one for each SQL statement.
+   */
+  Collection<RelRoot> convertDsl(String dsl);
+}

--- a/samza-sql/src/main/java/org/apache/samza/sql/interfaces/DslConverterFactory.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/interfaces/DslConverterFactory.java
@@ -1,0 +1,36 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.samza.sql.interfaces;
+
+import org.apache.samza.config.Config;
+
+
+/**
+ * Factory that is used to create {@link DslConverter}
+ */
+public interface DslConverterFactory {
+
+  /**
+   * Create a {@link DslConverter} given the config
+   * @param config config needed to create the {@link DslConverter}
+   * @return {@link DslConverter} object created.
+   */
+  DslConverter create(Config config);
+}

--- a/samza-sql/src/main/java/org/apache/samza/sql/interfaces/SamzaSqlDriver.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/interfaces/SamzaSqlDriver.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.samza.sql.interfaces;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Properties;
+import org.apache.calcite.adapter.java.JavaTypeFactory;
+import org.apache.calcite.avatica.AvaticaConnection;
+import org.apache.calcite.avatica.ConnectStringParser;
+import org.apache.calcite.avatica.Meta;
+import org.apache.calcite.jdbc.CalciteFactory;
+import org.apache.calcite.jdbc.Driver;
+
+
+/**
+ * Implementation of JDBC driver that does not register itself.
+ *
+ * <p>You can easily create a "vanity driver" that recognizes its own
+ * URL prefix as a sub-class of this class. Per the JDBC specification it
+ * must register itself when the class is loaded.</p>
+ *
+ * <p>Derived classes must implement {@link #createDriverVersion()} and
+ * {@link #getConnectStringPrefix()}, and may override
+ * {@link #createFactory()}.</p>
+ *
+ * <p>The provider must implement:</p>
+ * <ul>
+ *   <li>{@link Meta#prepare(Meta.ConnectionHandle, String, long)}
+ *   <li>{@link Meta#createIterable(Meta.StatementHandle, org.apache.calcite.avatica.QueryState, Meta.Signature, List, Meta.Frame)}
+ * </ul>
+ */
+public class SamzaSqlDriver extends Driver {
+
+  private JavaTypeFactory typeFactory;
+
+  public SamzaSqlDriver(JavaTypeFactory typeFactory) {
+    this.typeFactory = typeFactory;
+  }
+
+  @Override
+  public Connection connect(String url, Properties info) throws SQLException {
+    if (!acceptsURL(url)) {
+      return null;
+    }
+    final String prefix = getConnectStringPrefix();
+    assert url.startsWith(prefix);
+    final String urlSuffix = url.substring(prefix.length());
+    final Properties info2 = ConnectStringParser.parse(urlSuffix, info);
+    final AvaticaConnection connection =
+        ((CalciteFactory) factory).newConnection(this, factory, url, info2, null, typeFactory);
+    handler.onConnectionInit(connection);
+    return connection;
+  }
+}
+
+// End UnregisteredDriver.java

--- a/samza-sql/src/main/java/org/apache/samza/sql/interfaces/SamzaSqlDriver.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/interfaces/SamzaSqlDriver.java
@@ -29,21 +29,7 @@ import org.apache.calcite.jdbc.Driver;
 
 
 /**
- * Implementation of JDBC driver that does not register itself.
- *
- * <p>You can easily create a "vanity driver" that recognizes its own
- * URL prefix as a sub-class of this class. Per the JDBC specification it
- * must register itself when the class is loaded.</p>
- *
- * <p>Derived classes must implement {@link #createDriverVersion()} and
- * {@link #getConnectStringPrefix()}, and may override
- * {@link #createFactory()}.</p>
- *
- * <p>The provider must implement:</p>
- * <ul>
- *   <li>{@link Meta#prepare(Meta.ConnectionHandle, String, long)}
- *   <li>{@link Meta#createIterable(Meta.StatementHandle, org.apache.calcite.avatica.QueryState, Meta.Signature, List, Meta.Frame)}
- * </ul>
+ * Calcite JDBC driver for SamzaSQL which takes in a {@link JavaTypeFactory}
  */
 public class SamzaSqlDriver extends Driver {
 
@@ -68,5 +54,3 @@ public class SamzaSqlDriver extends Driver {
     return connection;
   }
 }
-
-// End UnregisteredDriver.java

--- a/samza-sql/src/main/java/org/apache/samza/sql/interfaces/SamzaSqlJavaTypeFactoryImpl.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/interfaces/SamzaSqlJavaTypeFactoryImpl.java
@@ -27,7 +27,9 @@ import org.apache.calcite.sql.type.SqlTypeName;
 
 
 /**
- * Extending {@link JavaTypeFactoryImpl}.
+ * Extending {@link JavaTypeFactoryImpl} to make Calcite validation work with all output types of Samza SQL UDFs
+ * (Eg: Samza SQL UDF returns an object of type {@link Object}. Using the default {@link JavaTypeFactoryImpl}
+ * results in validation failure.)
  */
 public class SamzaSqlJavaTypeFactoryImpl
     extends JavaTypeFactoryImpl {
@@ -55,6 +57,7 @@ public class SamzaSqlJavaTypeFactoryImpl
     }
     if (type instanceof JavaType) {
       SqlTypeName typeName = JavaToSqlTypeConversionRules.instance().lookup(((JavaType) type).getJavaClass());
+      // For unknown sql type names, return
       if (typeName == null) {
         typeName = SqlTypeName.ANY;
       }

--- a/samza-sql/src/main/java/org/apache/samza/sql/interfaces/SamzaSqlJavaTypeFactoryImpl.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/interfaces/SamzaSqlJavaTypeFactoryImpl.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.samza.sql.interfaces;
+
+import com.google.common.collect.Lists;
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rel.type.RelRecordType;
+import org.apache.calcite.sql.type.JavaToSqlTypeConversionRules;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+
+/**
+ * Extending {@link JavaTypeFactoryImpl}.
+ */
+public class SamzaSqlJavaTypeFactoryImpl
+    extends JavaTypeFactoryImpl {
+
+  public SamzaSqlJavaTypeFactoryImpl() {
+    this(RelDataTypeSystem.DEFAULT);
+  }
+
+  public SamzaSqlJavaTypeFactoryImpl(RelDataTypeSystem typeSystem) {
+    super(typeSystem);
+  }
+
+  @Override
+  public RelDataType toSql(RelDataType type) {
+    return toSql(this, type);
+  }
+
+  /** Converts a type in Java format to a SQL-oriented type. */
+  public static RelDataType toSql(final RelDataTypeFactory typeFactory,
+      RelDataType type) {
+    if (type instanceof RelRecordType) {
+      return typeFactory.createStructType(
+          Lists.transform(type.getFieldList(), a0 -> toSql(typeFactory, a0.getType())),
+          type.getFieldNames());
+    }
+    if (type instanceof JavaType) {
+      SqlTypeName typeName = JavaToSqlTypeConversionRules.instance().lookup(((JavaType) type).getJavaClass());
+      if (typeName == null) {
+        typeName = SqlTypeName.ANY;
+      }
+      return typeFactory.createTypeWithNullability(
+          typeFactory.createSqlType(typeName),
+          type.isNullable());
+    } else {
+      return JavaTypeFactoryImpl.toSql(typeFactory, type);
+    }
+  }
+}

--- a/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplication.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplication.java
@@ -19,16 +19,23 @@
 
 package org.apache.samza.sql.runner;
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 
-import org.apache.samza.SamzaException;
+import java.util.Set;
+import org.apache.calcite.rel.RelRoot;
 import org.apache.samza.application.StreamApplication;
 import org.apache.samza.config.Config;
 import org.apache.samza.operators.StreamGraph;
+import org.apache.samza.sql.dsl.SamzaSqlDslConverterFactory;
+import org.apache.samza.sql.interfaces.DslConverter;
+import org.apache.samza.sql.interfaces.DslConverterFactory;
 import org.apache.samza.sql.translator.QueryTranslator;
-import org.apache.samza.sql.testutil.SamzaSqlQueryParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.samza.sql.runner.SamzaSqlApplicationRunner.*;
 
 
 /**
@@ -41,12 +48,29 @@ public class SamzaSqlApplication implements StreamApplication {
   @Override
   public void init(StreamGraph streamGraph, Config config) {
     try {
-      SamzaSqlApplicationConfig sqlConfig = new SamzaSqlApplicationConfig(config);
+      // 1. Get Calcite plan
+      List<String> dslStmts = SamzaSqlApplicationConfig.fetchSqlFromConfig(config);
+
+      // TODO: Get the converter factory based on the file type. Create abstraction around this.
+      DslConverterFactory dslConverterFactory = new SamzaSqlDslConverterFactory();
+      DslConverter dslConverter = dslConverterFactory.create(config);
+      Collection<RelRoot> relRoots = dslConverter.convertDsl(String.join("\n", dslStmts));
+
+      Set<String> inputSystemStreams = new HashSet<>();
+      Set<String> outputSystemStreams = new HashSet<>();
+
+      SamzaSqlApplicationConfig.populateSystemStreams(relRoots.iterator().next().project(), inputSystemStreams,
+          outputSystemStreams);
+
+      // 2. Populate configs
+      SamzaSqlApplicationConfig sqlConfig =
+          new SamzaSqlApplicationConfig(config, inputSystemStreams, outputSystemStreams);
+
+      // 3. Translate Calcite plan to Samza stream operators
       QueryTranslator queryTranslator = new QueryTranslator(sqlConfig);
-      List<SamzaSqlQueryParser.QueryInfo> queries = sqlConfig.getQueryInfo();
-      for (SamzaSqlQueryParser.QueryInfo query : queries) {
-        LOG.info("Translating the query {} to samza stream graph", query.getSelectQuery());
-        queryTranslator.translate(query, streamGraph);
+      for (RelRoot relRoot : relRoots) {
+        LOG.info("Translating relRoot {} to samza stream graph", relRoot);
+        queryTranslator.translate(relRoot, streamGraph);
       }
     } catch (RuntimeException e) {
       LOG.error("SamzaSqlApplication threw exception.", e);

--- a/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationRunner.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationRunner.java
@@ -19,9 +19,13 @@
 
 package org.apache.samza.sql.runner;
 
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import org.apache.calcite.rel.RelRoot;
 import org.apache.commons.lang3.Validate;
 import org.apache.samza.application.StreamApplication;
 import org.apache.samza.config.Config;
@@ -31,9 +35,11 @@ import org.apache.samza.runtime.AbstractApplicationRunner;
 import org.apache.samza.runtime.ApplicationRunner;
 import org.apache.samza.runtime.LocalApplicationRunner;
 import org.apache.samza.runtime.RemoteApplicationRunner;
+import org.apache.samza.sql.dsl.SamzaSqlDslConverterFactory;
+import org.apache.samza.sql.interfaces.DslConverter;
+import org.apache.samza.sql.interfaces.DslConverterFactory;
 import org.apache.samza.sql.interfaces.SqlIOResolver;
 import org.apache.samza.sql.interfaces.SqlIOConfig;
-import org.apache.samza.sql.testutil.SamzaSqlQueryParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +55,6 @@ public class SamzaSqlApplicationRunner extends AbstractApplicationRunner {
 
   private static final Logger LOG = LoggerFactory.getLogger(SamzaSqlApplicationRunner.class);
 
-  private final Config sqlConfig;
   private final ApplicationRunner appRunner;
   private final Boolean localRunner;
 
@@ -63,32 +68,41 @@ public class SamzaSqlApplicationRunner extends AbstractApplicationRunner {
   public SamzaSqlApplicationRunner(Boolean localRunner, Config config) {
     super(config);
     this.localRunner = localRunner;
-    sqlConfig = computeSamzaConfigs(localRunner, config);
-    appRunner = ApplicationRunner.fromConfig(sqlConfig);
+    appRunner = ApplicationRunner.fromConfig(computeSamzaConfigs(localRunner, config));
   }
 
   public static Config computeSamzaConfigs(Boolean localRunner, Config config) {
     Map<String, String> newConfig = new HashMap<>();
 
+    List<String> dslStmts = SamzaSqlApplicationConfig.fetchSqlFromConfig(config);
+
+    // TODO: Get the converter factory based on the file type. Create abstraction around this.
+    DslConverterFactory dslConverterFactory = new SamzaSqlDslConverterFactory();
+    DslConverter dslConverter = dslConverterFactory.create(config);
+    Collection<RelRoot> relRoots = dslConverter.convertDsl(String.join("\n", dslStmts));
+
+    Set<String> inputSystemStreams = new HashSet<>();
+    Set<String> outputSystemStreams = new HashSet<>();
+
+    SamzaSqlApplicationConfig.populateSystemStreams(relRoots.iterator().next().project(), inputSystemStreams,
+        outputSystemStreams);
+
     SqlIOResolver ioResolver = SamzaSqlApplicationConfig.createIOResolver(config);
-    // Parse the sql and find the input stream streams
-    List<String> sqlStmts = SamzaSqlApplicationConfig.fetchSqlFromConfig(config);
 
     // This is needed because the SQL file may not be available in all the node managers.
-    String sqlJson = SamzaSqlApplicationConfig.serializeSqlStmts(sqlStmts);
+    String sqlJson = SamzaSqlApplicationConfig.serializeSqlStmts(dslStmts);
     newConfig.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, sqlJson);
 
-    List<SamzaSqlQueryParser.QueryInfo> queryInfo = SamzaSqlApplicationConfig.fetchQueryInfo(sqlStmts);
-    for (SamzaSqlQueryParser.QueryInfo query : queryInfo) {
-      // Populate stream to system mapping config for input and output system streams
-      for (String inputSource : query.getSources()) {
-        SqlIOConfig inputSystemStreamConfig = ioResolver.fetchSourceInfo(inputSource);
-        newConfig.put(String.format(CFG_FMT_SAMZA_STREAM_SYSTEM, inputSystemStreamConfig.getStreamName()),
-            inputSystemStreamConfig.getSystemName());
-        newConfig.putAll(inputSystemStreamConfig.getConfig());
-      }
+    // Populate stream to system mapping config for input and output system streams
+    for (String source : inputSystemStreams) {
+      SqlIOConfig inputSystemStreamConfig = ioResolver.fetchSourceInfo(source);
+      newConfig.put(String.format(CFG_FMT_SAMZA_STREAM_SYSTEM, inputSystemStreamConfig.getStreamName()),
+          inputSystemStreamConfig.getSystemName());
+      newConfig.putAll(inputSystemStreamConfig.getConfig());
+    }
 
-      SqlIOConfig outputSystemStreamConfig = ioResolver.fetchSinkInfo(query.getSink());
+    for (String sink : outputSystemStreams) {
+      SqlIOConfig outputSystemStreamConfig = ioResolver.fetchSinkInfo(sink);
       newConfig.put(String.format(CFG_FMT_SAMZA_STREAM_SYSTEM, outputSystemStreamConfig.getStreamName()),
           outputSystemStreamConfig.getSystemName());
       newConfig.putAll(outputSystemStreamConfig.getConfig());
@@ -133,4 +147,5 @@ public class SamzaSqlApplicationRunner extends AbstractApplicationRunner {
   public ApplicationStatus status(StreamApplication streamApp) {
     return appRunner.status(streamApp);
   }
+
 }

--- a/samza-sql/src/main/java/org/apache/samza/sql/testutil/SamzaSqlQueryParser.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/testutil/SamzaSqlQueryParser.java
@@ -24,9 +24,11 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.config.Lex;
 import org.apache.calcite.jdbc.CalciteConnection;
 import org.apache.calcite.plan.Contexts;
@@ -49,6 +51,8 @@ import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.Planner;
 import org.apache.samza.SamzaException;
+import org.apache.samza.sql.interfaces.SamzaSqlJavaTypeFactoryImpl;
+import org.apache.samza.sql.interfaces.SamzaSqlDriver;
 
 
 /**
@@ -63,11 +67,13 @@ public class SamzaSqlQueryParser {
     private final List<String> sources;
     private String selectQuery;
     private String sink;
+    private String sql;
 
-    public QueryInfo(String selectQuery, List<String> sources, String sink) {
+    public QueryInfo(String selectQuery, List<String> sources, String sink, String sql) {
       this.selectQuery = selectQuery;
       this.sink = sink;
       this.sources = sources;
+      this.sql = sql;
     }
 
     public List<String> getSources() {
@@ -80,6 +86,10 @@ public class SamzaSqlQueryParser {
 
     public String getSink() {
       return sink;
+    }
+
+    public String getSql() {
+      return sql;
     }
   }
 
@@ -116,14 +126,18 @@ public class SamzaSqlQueryParser {
       throw new SamzaException("Sql query is not of the expected format");
     }
 
-    return new QueryInfo(selectQuery, sources, sink);
+    return new QueryInfo(selectQuery, sources, sink, sql);
   }
 
   private static Planner createPlanner() {
     Connection connection;
     SchemaPlus rootSchema;
     try {
-      connection = DriverManager.getConnection("jdbc:calcite:");
+      JavaTypeFactory typeFactory = new SamzaSqlJavaTypeFactoryImpl();
+      SamzaSqlDriver driver = new SamzaSqlDriver(typeFactory);
+      DriverManager.deregisterDriver(DriverManager.getDriver("jdbc:calcite:"));
+      DriverManager.registerDriver(driver);
+      connection = driver.connect("jdbc:calcite:", new Properties());
       CalciteConnection calciteConnection = connection.unwrap(CalciteConnection.class);
       rootSchema = calciteConnection.getRootSchema();
     } catch (SQLException e) {
@@ -174,7 +188,6 @@ public class SamzaSqlQueryParser {
         getSource(basicCall.operand(0), sourceList);
       } else if (basicCall.getOperator() instanceof SqlUnnestOperator && basicCall.operand(0) instanceof SqlSelect) {
         sourceList.addAll(getSourcesFromSelectQuery(basicCall.operand(0)));
-        return;
       }
     } else if (node instanceof SqlSelect) {
       getSource(((SqlSelect) node).getFrom(), sourceList);

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/JoinTranslator.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/JoinTranslator.java
@@ -45,6 +45,7 @@ import org.apache.samza.sql.data.SamzaSqlCompositeKey;
 import org.apache.samza.sql.data.SamzaSqlRelMessage;
 import org.apache.samza.sql.interfaces.SqlIOResolver;
 import org.apache.samza.sql.interfaces.SqlIOConfig;
+import org.apache.samza.sql.serializers.SamzaSqlRelMessageSerdeFactory;
 import org.apache.samza.table.Table;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,8 +113,9 @@ class JoinTranslator {
         new SamzaSqlRelMessageJoinFunction(join.getJoinType(), isTablePosOnRight, streamKeyIds, streamFieldNames,
             tableFieldNames);
 
-    Serde<SamzaSqlCompositeKey> keySerde = new JsonSerdeV2<>(SamzaSqlCompositeKey.class);
-    Serde<SamzaSqlRelMessage> valueSerde = new JsonSerdeV2<>(SamzaSqlRelMessage.class);
+    JsonSerdeV2<SamzaSqlCompositeKey> keySerde = new JsonSerdeV2<>(SamzaSqlCompositeKey.class);
+    SamzaSqlRelMessageSerdeFactory.SamzaSqlRelMessageSerde valueSerde =
+        (SamzaSqlRelMessageSerdeFactory.SamzaSqlRelMessageSerde) new SamzaSqlRelMessageSerdeFactory().getSerde(null, null);
 
     // Always re-partition the messages from the input stream by the composite key and then join the messages
     // with the table.
@@ -125,6 +127,7 @@ class JoinTranslator {
                 "stream_" + joinId)
             .map(KV::getValue)
             .join(table, joinFn);
+    // MessageStream<SamzaSqlRelMessage> outputStream = inputStream.join(table, joinFn);
 
     context.registerMessageStream(join.getId(), outputStream);
   }

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/ModifyTranslator.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/ModifyTranslator.java
@@ -1,0 +1,102 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.apache.samza.sql.translator;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.calcite.rel.core.TableModify;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.commons.lang.Validate;
+import org.apache.samza.SamzaException;
+import org.apache.samza.config.Config;
+import org.apache.samza.operators.KV;
+import org.apache.samza.operators.MessageStream;
+import org.apache.samza.operators.MessageStreamImpl;
+import org.apache.samza.operators.OutputStream;
+import org.apache.samza.operators.StreamGraph;
+import org.apache.samza.operators.TableDescriptor;
+import org.apache.samza.operators.functions.MapFunction;
+import org.apache.samza.sql.data.SamzaSqlRelMessage;
+import org.apache.samza.sql.interfaces.SamzaRelConverter;
+import org.apache.samza.sql.interfaces.SqlIOConfig;
+import org.apache.samza.table.Table;
+import org.apache.samza.task.TaskContext;
+
+
+/**
+ * Translator to translate the TableModify in relational graph to the corresponding output streams in the StreamGraph
+ * implementation
+ */
+class ModifyTranslator {
+
+  private final Map<String, SamzaRelConverter> relMsgConverters;
+  private final Map<String, SqlIOConfig> systemStreamConfig;
+
+  ModifyTranslator(Map<String, SamzaRelConverter> converters, Map<String, SqlIOConfig> ssc) {
+    relMsgConverters = converters;
+    this.systemStreamConfig = ssc;
+  }
+
+  private static class OutputMapFunction implements MapFunction<SamzaSqlRelMessage, KV<Object, Object>> {
+    private transient SamzaRelConverter samzaMsgConverter;
+    private final String outputTopic;
+
+    OutputMapFunction(String outputTopic) {
+      this.outputTopic = outputTopic;
+    }
+
+    @Override
+    public void init(Config config, TaskContext taskContext) {
+      TranslatorContext context = (TranslatorContext) taskContext.getUserContext();
+      this.samzaMsgConverter = context.getMsgConverter(outputTopic);
+    }
+
+    @Override
+    public KV<Object, Object> apply(SamzaSqlRelMessage message) {
+      return this.samzaMsgConverter.convertToSamzaMessage(message);
+    }
+  }
+
+  void translate(final TableModify tableModify, final TranslatorContext context) {
+    StreamGraph streamGraph = context.getStreamGraph();
+    List<String> tableNameParts = tableModify.getTable().getQualifiedName();
+    String targetName = SqlIOConfig.getSourceFromSourceParts(tableNameParts);
+
+    Validate.isTrue(relMsgConverters.containsKey(targetName), String.format("Unknown source %s", targetName));
+
+    SqlIOConfig sinkConfig = systemStreamConfig.get(targetName);
+    MessageStreamImpl<SamzaSqlRelMessage> stream =
+        (MessageStreamImpl<SamzaSqlRelMessage>) context.getMessageStream(tableModify.getInput().getId());
+    MessageStream<KV<Object, Object>> outputStream = stream.map(new OutputMapFunction(targetName));
+
+    Optional<TableDescriptor> tableDescriptor = sinkConfig.getTableDescriptor();
+    if (!tableDescriptor.isPresent()) {
+      outputStream.sendTo(streamGraph.getOutputStream(sinkConfig.getStreamName()));
+    } else {
+      Table outputTable = streamGraph.getTable(tableDescriptor.get());
+      if (outputTable == null) {
+        String msg = "Failed to obtain table descriptor of " + sinkConfig.getSource();
+        throw new SamzaException(msg);
+      }
+      outputStream.sendTo(outputTable);
+    }
+  }
+}

--- a/samza-sql/src/test/java/org/apache/samza/sql/e2e/TestSamzaSqlTable.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/e2e/TestSamzaSqlTable.java
@@ -42,8 +42,8 @@ public class TestSamzaSqlTable {
 
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);
 
-    String sql1 = "Insert into testDb.testTable.`$table` select id, name from testavro.SIMPLE1";
-    List<String> sqlStmts = Arrays.asList(sql1);
+    String sql = "Insert into testDb.testTable.`$table`(id,name) select id, name from testavro.SIMPLE1";
+    List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     SamzaSqlApplicationRunner runner = new SamzaSqlApplicationRunner(true, new MapConfig(staticConfigs));
     runner.runAndWaitForFinish();
@@ -58,8 +58,8 @@ public class TestSamzaSqlTable {
     TestIOResolverFactory.TestTable.records.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);
 
-    String sql1 = "Insert into testDb.testTable.`$table` select id __key__, name from testavro.SIMPLE1";
-    List<String> sqlStmts = Arrays.asList(sql1);
+    String sql = "Insert into testDb.testTable.`$table`(id,name) select id __key__, name from testavro.SIMPLE1";
+    List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     SamzaSqlApplicationRunner runner = new SamzaSqlApplicationRunner(true, new MapConfig(staticConfigs));
     runner.runAndWaitForFinish();

--- a/samza-sql/src/test/java/org/apache/samza/sql/runner/TestSamzaSqlApplicationConfig.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/runner/TestSamzaSqlApplicationConfig.java
@@ -19,16 +19,22 @@
 
 package org.apache.samza.sql.runner;
 
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.samza.SamzaException;
 import org.apache.samza.config.MapConfig;
 import org.apache.samza.sql.impl.ConfigBasedUdfResolver;
 import org.apache.samza.sql.interfaces.SqlIOConfig;
 import org.apache.samza.sql.runner.SamzaSqlApplicationConfig;
+import org.apache.samza.sql.testutil.SamzaSqlQueryParser;
 import org.apache.samza.sql.testutil.SamzaSqlTestConfig;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.apache.samza.sql.runner.SamzaSqlApplicationConfig.*;
 
 
 public class TestSamzaSqlApplicationConfig {
@@ -39,8 +45,14 @@ public class TestSamzaSqlApplicationConfig {
     config.put(SamzaSqlApplicationConfig.CFG_SQL_STMT, "Insert into testavro.COMPLEX1 select * from testavro.SIMPLE1");
     String configUdfResolverDomain = String.format(SamzaSqlApplicationConfig.CFG_FMT_UDF_RESOLVER_DOMAIN, "config");
     int numUdfs = config.get(configUdfResolverDomain + ConfigBasedUdfResolver.CFG_UDF_CLASSES).split(",").length;
-    SamzaSqlApplicationConfig samzaSqlApplicationConfig = new SamzaSqlApplicationConfig(new MapConfig(config));
-    Assert.assertEquals(1, samzaSqlApplicationConfig.getQueryInfo().size());
+
+    List<String> sqlStmts = fetchSqlFromConfig(config);
+    List<SamzaSqlQueryParser.QueryInfo> queryInfo = fetchQueryInfo(sqlStmts);
+    SamzaSqlApplicationConfig samzaSqlApplicationConfig = new SamzaSqlApplicationConfig(new MapConfig(config),
+        queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSources).flatMap(Collection::stream)
+            .collect(Collectors.toSet()),
+        queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
+
     Assert.assertEquals(numUdfs, samzaSqlApplicationConfig.getUdfMetadata().size());
     Assert.assertEquals(1, samzaSqlApplicationConfig.getInputSystemStreamConfigBySource().size());
     Assert.assertEquals(1, samzaSqlApplicationConfig.getOutputSystemStreamConfigsBySource().size());
@@ -54,14 +66,21 @@ public class TestSamzaSqlApplicationConfig {
 
     try {
       // Fail because no SQL config
-      new SamzaSqlApplicationConfig(new MapConfig(config));
+      fetchSqlFromConfig(config);
       Assert.fail();
     } catch (SamzaException e) {
     }
 
     // Pass
     config.put(SamzaSqlApplicationConfig.CFG_SQL_STMT, "Insert into testavro.COMPLEX1 select * from testavro.SIMPLE1");
-    new SamzaSqlApplicationConfig(new MapConfig(config));
+
+    List<String> sqlStmts = fetchSqlFromConfig(config);
+    List<SamzaSqlQueryParser.QueryInfo> queryInfo = fetchQueryInfo(sqlStmts);
+    new SamzaSqlApplicationConfig(new MapConfig(config),
+        queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSources).flatMap(Collection::stream)
+            .collect(Collectors.toSet()),
+        queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
+
     testWithoutConfigShouldFail(config, SamzaSqlApplicationConfig.CFG_IO_RESOLVER);
     testWithoutConfigShouldFail(config, SamzaSqlApplicationConfig.CFG_UDF_RESOLVER);
 
@@ -79,14 +98,25 @@ public class TestSamzaSqlApplicationConfig {
   private void testWithoutConfigShouldPass(Map<String, String> config, String configKey) {
     Map<String, String> badConfigs = new HashMap<>(config);
     badConfigs.remove(configKey);
-    new SamzaSqlApplicationConfig(new MapConfig(badConfigs));
+    List<String> sqlStmts = fetchSqlFromConfig(badConfigs);
+    List<SamzaSqlQueryParser.QueryInfo> queryInfo = fetchQueryInfo(sqlStmts);
+    new SamzaSqlApplicationConfig(new MapConfig(badConfigs),
+        queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSources).flatMap(Collection::stream)
+            .collect(Collectors.toSet()),
+        queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
   }
 
   private void testWithoutConfigShouldFail(Map<String, String> config, String configKey) {
     Map<String, String> badConfigs = new HashMap<>(config);
     badConfigs.remove(configKey);
     try {
-      new SamzaSqlApplicationConfig(new MapConfig(badConfigs));
+      List<String> sqlStmts = fetchSqlFromConfig(badConfigs);
+      List<SamzaSqlQueryParser.QueryInfo> queryInfo = fetchQueryInfo(sqlStmts);
+      new SamzaSqlApplicationConfig(new MapConfig(badConfigs),
+          queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSources).flatMap(Collection::stream)
+              .collect(Collectors.toSet()),
+          queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
+
       Assert.fail();
     } catch (IllegalArgumentException e) {
       // swallow

--- a/samza-sql/src/test/java/org/apache/samza/sql/runner/TestSamzaSqlApplicationRunner.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/runner/TestSamzaSqlApplicationRunner.java
@@ -38,8 +38,8 @@ public class TestSamzaSqlApplicationRunner {
   @Test
   public void testComputeSamzaConfigs() {
     Map<String, String> configs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(10);
-    String sql1 = "Insert into testavro.outputTopic select id, MyTest(id) as long_value from testavro.SIMPLE1";
-    configs.put(SamzaSqlApplicationConfig.CFG_SQL_STMT, sql1);
+    String sql = "Insert into testavro.outputTopic(id, long_value) select id, MyTest(id) as long_value from testavro.SIMPLE1";
+    configs.put(SamzaSqlApplicationConfig.CFG_SQL_STMT, sql);
     configs.put(SamzaSqlApplicationRunner.RUNNER_CONFIG, SamzaSqlApplicationRunner.class.getName());
     MapConfig samzaConfig = new MapConfig(configs);
     Config newConfigs = SamzaSqlApplicationRunner.computeSamzaConfigs(true, samzaConfig);

--- a/samza-sql/src/test/java/org/apache/samza/sql/system/TestAvroSystemFactory.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/system/TestAvroSystemFactory.java
@@ -291,6 +291,7 @@ public class TestAvroSystemFactory implements SystemFactory {
       GenericRecord record = new GenericData.Record(ComplexRecord.SCHEMA$);
       record.put("id", index);
       record.put("string_value", "Name" + index);
+      record.put("float_value", 123.0 + index * 1.2);
       GenericData.Array<String> arrayValues =
           new GenericData.Array<>(index, ComplexRecord.SCHEMA$.getField("array_values").schema().getTypes().get(1));
       arrayValues.addAll(IntStream.range(0, index).mapToObj(String::valueOf).collect(Collectors.toList()));

--- a/samza-sql/src/test/java/org/apache/samza/sql/testutil/SamzaSqlTestConfig.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/testutil/SamzaSqlTestConfig.java
@@ -128,6 +128,9 @@ public class SamzaSqlTestConfig {
         "testavro", "SIMPLE1"), SimpleRecord.SCHEMA$.toString());
 
     staticConfigs.put(configAvroRelSchemaProviderDomain + String.format(ConfigBasedAvroRelSchemaProviderFactory.CFG_SOURCE_SCHEMA,
+        "testavro", "simpleOutputTopic"), SimpleRecord.SCHEMA$.toString());
+
+    staticConfigs.put(configAvroRelSchemaProviderDomain + String.format(ConfigBasedAvroRelSchemaProviderFactory.CFG_SOURCE_SCHEMA,
         "testavro", "outputTopic"), ComplexRecord.SCHEMA$.toString());
 
     staticConfigs.put(configAvroRelSchemaProviderDomain + String.format(ConfigBasedAvroRelSchemaProviderFactory.CFG_SOURCE_SCHEMA,


### PR DESCRIPTION
This PR has the following changes:
* Include 'INSERT INTO' sql statement for Calcite plan
* Basic DSLConverter Framework with SamzaSQL dialect as an example
* Some fixes to stream-table join wrt Serde