### PR TITLE
SAMZA-1860: Modularize Join input validation in ExecutionPlanner

### DIFF
--- a/docs/learn/documentation/versioned/jobs/logging.md
+++ b/docs/learn/documentation/versioned/jobs/logging.md
@@ -27,7 +27,7 @@ The [hello-samza](/startup/hello-samza/{{site.version}}) project shows how to us
 
 {% highlight xml %}
 <dependency>
-  <groupId>org.slf4j</groupId>
+  <setId>org.slf4j</setId>
   <artifactId>slf4j-log4j12</artifactId>
   <scope>runtime</scope>
   <version>1.6.2</version>
@@ -101,7 +101,7 @@ Sometimes it's desirable to change the Log4J log level from `INFO` to `DEBUG` at
 
 {% highlight xml %}
 <dependency>
-  <groupId>org.apache.samza</groupId>
+  <setId>org.apache.samza</setId>
   <artifactId>samza-log4j</artifactId>
   <scope>runtime</scope>
   <version>${samza.version}</version>

--- a/docs/startup/download/index.md
+++ b/docs/startup/download/index.md
@@ -59,18 +59,18 @@ A Maven-based Samza project can pull in all required dependencies Samza dependen
 
 {% highlight xml %}
 <dependency>
-  <groupId>org.apache.samza</groupId>
+  <setId>org.apache.samza</setId>
   <artifactId>samza-api</artifactId>
   <version>0.14.1</version>
 </dependency>
 <dependency>
-  <groupId>org.apache.samza</groupId>
+  <setId>org.apache.samza</setId>
   <artifactId>samza-core_2.11</artifactId>
   <version>0.14.1</version>
   <scope>runtime</scope>
 </dependency>
 <dependency>
-  <groupId>org.apache.samza</groupId>
+  <setId>org.apache.samza</setId>
   <artifactId>samza-shell</artifactId>
   <classifier>dist</classifier>
   <type>tgz</type>
@@ -78,31 +78,31 @@ A Maven-based Samza project can pull in all required dependencies Samza dependen
   <scope>runtime</scope>
 </dependency>
 <dependency>
-  <groupId>org.apache.samza</groupId>
+  <setId>org.apache.samza</setId>
   <artifactId>samza-yarn_2.11</artifactId>
   <version>0.14.1</version>
   <scope>runtime</scope>
 </dependency>
 <dependency>
-  <groupId>org.apache.samza</groupId>
+  <setId>org.apache.samza</setId>
   <artifactId>samza-kv_2.11</artifactId>
   <version>0.14.1</version>
   <scope>runtime</scope>
 </dependency>
 <dependency>
-  <groupId>org.apache.samza</groupId>
+  <setId>org.apache.samza</setId>
   <artifactId>samza-kv-rocksdb_2.11</artifactId>
   <version>0.14.1</version>
   <scope>runtime</scope>
 </dependency>
 <dependency>
-  <groupId>org.apache.samza</groupId>
+  <setId>org.apache.samza</setId>
   <artifactId>samza-kv-inmemory_2.11</artifactId>
   <version>0.14.1</version>
   <scope>runtime</scope>
 </dependency>
 <dependency>
-  <groupId>org.apache.samza</groupId>
+  <setId>org.apache.samza</setId>
   <artifactId>samza-kafka_2.11</artifactId>
   <version>0.14.1</version>
   <scope>runtime</scope>
@@ -113,7 +113,7 @@ Samza versions less than 0.12 should use artifacts with scala version 2.10 as su
 
 {% highlight xml %}
 <dependency>
-  <groupId>org.apache.samza</groupId>
+  <setId>org.apache.samza</setId>
   <artifactId>samza-yarn_2.10</artifactId>
   <version>0.11.0</version>
 </dependency>
@@ -123,7 +123,7 @@ Samza versions less than 0.9 should include this additional dependency.
 
 {% highlight xml %}
 <dependency>
-  <groupId>org.apache.samza</groupId>
+  <setId>org.apache.samza</setId>
   <artifactId>samza-serializers_2.10</artifactId>
   <version>0.8.1</version>
 </dependency>

--- a/samza-core/src/main/java/org/apache/samza/execution/OperatorSpecGraphAnalyzer.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/OperatorSpecGraphAnalyzer.java
@@ -21,7 +21,10 @@ package org.apache.samza.execution;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.apache.samza.operators.OperatorSpecGraph;
@@ -37,53 +40,57 @@ import org.apache.samza.operators.spec.OperatorSpec;
 /* package private */ class OperatorSpecGraphAnalyzer {
 
   /**
-   * Returns a grouping of {@link InputOperatorSpec}s participating in Join operations in the provided
-   * {@code operatorSpecGraph} by the {@link JoinOperatorSpec}s corresponding to these operations.
+   * Returns a grouping of {@link InputOperatorSpec}s by the joins, i.e. {@link JoinOperatorSpec}s, they participate in.
    */
-  public static Multimap<JoinOperatorSpec, InputOperatorSpec> getJoinedInputOperatorSpecs(OperatorSpecGraph operatorSpecGraph) {
-    JoinedInputOperatorSpecVisitor joinedInputOperatorSpecVisitor = new JoinedInputOperatorSpecVisitor();
+  public static Multimap<JoinOperatorSpec, InputOperatorSpec> getJoinToInputOperatorSpecs(
+      OperatorSpecGraph operatorSpecGraph) {
 
-    // Traverse graph starting from every input operator spec, observing
-    // connectivity between input operator specs and Join operator specs.
-    Iterable<InputOperatorSpec> inputOperatorSpecs = operatorSpecGraph.getInputOperators().values();
-    for (InputOperatorSpec inputOperatorSpec : inputOperatorSpecs) {
-      traverse(inputOperatorSpec, joinedInputOperatorSpecVisitor, OperatorSpec::getRegisteredOperatorSpecs);
-    }
+    Multimap<JoinOperatorSpec, InputOperatorSpec> joinOpSpecToInputOpSpecs = HashMultimap.create();
 
-    return joinedInputOperatorSpecVisitor.getJoinOpSpecToInputOpSpecs();
-  }
+    // Traverse graph starting from every input operator spec, observing connectivity between input operator specs
+    // and Join operator specs.
+    Iterable<InputOperatorSpec> inputOpSpecs = operatorSpecGraph.getInputOperators().values();
+    for (InputOperatorSpec inputOpSpec : inputOpSpecs) {
+      // Observe all join operator specs reachable from this input operator spec.
+      JoinOperatorSpecVisitor joinOperatorSpecVisitor = new JoinOperatorSpecVisitor();
+      traverse(inputOpSpec, joinOperatorSpecVisitor, opSpec -> opSpec.getRegisteredOperatorSpecs());
 
-  /**
-   * Traverses graph starting from {@code vertex}, invoking {@code visitor} with every encountered vertex,
-   * and using {@code getNextVertexes} to determine next set of vertexes to visit.
-   */
-  private static <T> void traverse(T vertex, Consumer<T> visitor, Function<T, Iterable<? extends T>> getNextVertexes) {
-    visitor.accept(vertex);
-    for (T nextVertex : getNextVertexes.apply(vertex)) {
-      traverse(nextVertex, visitor, getNextVertexes);
-    }
-  }
-
-  /**
-   * An {@link OperatorSpecGraph} visitor that records associations between {@link InputOperatorSpec}s
-   * and the {@link JoinOperatorSpec}s they participate in or lie on a path to.
-   */
-  private static class JoinedInputOperatorSpecVisitor implements Consumer<OperatorSpec> {
-    private final Multimap<JoinOperatorSpec, InputOperatorSpec> joinOpSpecToInputOpSpecs = HashMultimap.create();
-
-    private InputOperatorSpec currentInputOpSpec;
-
-    @Override
-    public void accept(OperatorSpec operatorSpec) {
-      if (operatorSpec instanceof InputOperatorSpec) {
-        currentInputOpSpec = (InputOperatorSpec) operatorSpec;
-      } else if (operatorSpec instanceof JoinOperatorSpec) {
-        joinOpSpecToInputOpSpecs.put((JoinOperatorSpec) operatorSpec, currentInputOpSpec);
+      // Associate every encountered join operator spec with this input operator spec.
+      for (JoinOperatorSpec joinOpSpec : joinOperatorSpecVisitor.getJoinOperatorSpecs()) {
+        joinOpSpecToInputOpSpecs.put(joinOpSpec, inputOpSpec);
       }
     }
 
-    public Multimap<JoinOperatorSpec, InputOperatorSpec> getJoinOpSpecToInputOpSpecs() {
-      return Multimaps.unmodifiableMultimap(joinOpSpecToInputOpSpecs);
+    return joinOpSpecToInputOpSpecs;
+  }
+
+  /**
+   * Traverses {@link OperatorSpec}s starting from {@code startOpSpec}, invoking {@code visitor} with every encountered
+   * {@link OperatorSpec}, and using {@code getNextOpSpecs} to determine the set of {@link OperatorSpec}s to visit next.
+   */
+  private static void traverse(OperatorSpec startOpSpec, Consumer<OperatorSpec> visitor,
+      Function<OperatorSpec, Collection<OperatorSpec>> getNextOpSpecs) {
+    visitor.accept(startOpSpec);
+    for (OperatorSpec nextOpSpec : getNextOpSpecs.apply(startOpSpec)) {
+      traverse(nextOpSpec, visitor, getNextOpSpecs);
+    }
+  }
+
+  /**
+   * An {@link OperatorSpecGraph} visitor that records all {@link JoinOperatorSpec}s encountered in the graph.
+   */
+  private static class JoinOperatorSpecVisitor implements Consumer<OperatorSpec> {
+    private Set<JoinOperatorSpec> joinOpSpecs = new HashSet<>();
+
+    @Override
+    public void accept(OperatorSpec operatorSpec) {
+      if (operatorSpec instanceof JoinOperatorSpec) {
+        joinOpSpecs.add((JoinOperatorSpec) operatorSpec);
+      }
+    }
+
+    public Set<JoinOperatorSpec> getJoinOperatorSpecs() {
+      return Collections.unmodifiableSet(joinOpSpecs);
     }
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/execution/OperatorSpecGraphAnalyzer.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/OperatorSpecGraphAnalyzer.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.execution;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.apache.samza.operators.OperatorSpecGraph;
+import org.apache.samza.operators.spec.InputOperatorSpec;
+import org.apache.samza.operators.spec.JoinOperatorSpec;
+import org.apache.samza.operators.spec.OperatorSpec;
+
+
+/**
+ * A utility class that encapsulates the logic for traversing an {@link OperatorSpecGraph} and building
+ * associations between related {@link OperatorSpec}s.
+ */
+/* package private */ class OperatorSpecGraphAnalyzer {
+
+  /**
+   * Returns a grouping of {@link InputOperatorSpec}s participating in Join operations in the provided
+   * {@code operatorSpecGraph} by the {@link JoinOperatorSpec}s corresponding to these operations.
+   */
+  public static Multimap<JoinOperatorSpec, InputOperatorSpec> getJoinedInputOperatorSpecs(OperatorSpecGraph operatorSpecGraph) {
+    JoinedInputOperatorSpecVisitor joinedInputOperatorSpecVisitor = new JoinedInputOperatorSpecVisitor();
+
+    // Traverse graph starting from every input operator spec, observing
+    // connectivity between input operator specs and Join operator specs.
+    Iterable<InputOperatorSpec> inputOperatorSpecs = operatorSpecGraph.getInputOperators().values();
+    for (InputOperatorSpec inputOperatorSpec : inputOperatorSpecs) {
+      traverse(inputOperatorSpec, joinedInputOperatorSpecVisitor, OperatorSpec::getRegisteredOperatorSpecs);
+    }
+
+    return joinedInputOperatorSpecVisitor.getJoinOpSpecToInputOpSpecs();
+  }
+
+  /**
+   * Traverses graph starting from {@code vertex}, invoking {@code visitor} with every encountered vertex,
+   * and using {@code getNextVertexes} to determine next set of vertexes to visit.
+   */
+  private static <T> void traverse(T vertex, Consumer<T> visitor, Function<T, Iterable<? extends T>> getNextVertexes) {
+    visitor.accept(vertex);
+    for (T nextVertex : getNextVertexes.apply(vertex)) {
+      traverse(nextVertex, visitor, getNextVertexes);
+    }
+  }
+
+  /**
+   * An {@link OperatorSpecGraph} visitor that records associations between {@link InputOperatorSpec}s
+   * and the {@link JoinOperatorSpec}s they participate in or lie on a path to.
+   */
+  private static class JoinedInputOperatorSpecVisitor implements Consumer<OperatorSpec> {
+    private final Multimap<JoinOperatorSpec, InputOperatorSpec> joinOpSpecToInputOpSpecs = HashMultimap.create();
+
+    private InputOperatorSpec currentInputOpSpec;
+
+    @Override
+    public void accept(OperatorSpec operatorSpec) {
+      if (operatorSpec instanceof InputOperatorSpec) {
+        currentInputOpSpec = (InputOperatorSpec) operatorSpec;
+      } else if (operatorSpec instanceof JoinOperatorSpec) {
+        joinOpSpecToInputOpSpecs.put((JoinOperatorSpec) operatorSpec, currentInputOpSpec);
+      }
+    }
+
+    public Multimap<JoinOperatorSpec, InputOperatorSpec> getJoinOpSpecToInputOpSpecs() {
+      return Multimaps.unmodifiableMultimap(joinOpSpecToInputOpSpecs);
+    }
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/execution/TestExecutionPlanner.java
+++ b/samza-core/src/test/java/org/apache/samza/execution/TestExecutionPlanner.java
@@ -33,7 +33,6 @@ import org.apache.samza.application.StreamApplicationDescriptorImpl;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.JobConfig;
 import org.apache.samza.config.MapConfig;
-import org.apache.samza.config.StreamConfig;
 import org.apache.samza.config.TaskConfig;
 import org.apache.samza.operators.KV;
 import org.apache.samza.operators.MessageStream;
@@ -281,7 +280,7 @@ public class TestExecutionPlanner {
     StreamApplicationDescriptorImpl graphSpec = createStreamGraphWithJoin();
     JobGraph jobGraph = planner.createJobGraph(graphSpec.getOperatorSpecGraph());
 
-    ExecutionPlanner.fetchInputAndOutputStreamPartitions(jobGraph, streamManager);
+    planner.fetchInputAndOutputStreamPartitions(jobGraph);
     assertTrue(jobGraph.getOrCreateStreamEdge(input1Spec).getPartitionCount() == 64);
     assertTrue(jobGraph.getOrCreateStreamEdge(input2Spec).getPartitionCount() == 16);
     assertTrue(jobGraph.getOrCreateStreamEdge(input3Spec).getPartitionCount() == 32);
@@ -297,10 +296,7 @@ public class TestExecutionPlanner {
   public void testCalculateJoinInputPartitions() {
     ExecutionPlanner planner = new ExecutionPlanner(config, streamManager);
     StreamApplicationDescriptorImpl graphSpec = createStreamGraphWithJoin();
-    JobGraph jobGraph = planner.createJobGraph(graphSpec.getOperatorSpecGraph());
-
-    ExecutionPlanner.fetchInputAndOutputStreamPartitions(jobGraph, streamManager);
-    ExecutionPlanner.calculateJoinInputPartitions(jobGraph, new StreamConfig(config));
+    JobGraph jobGraph = (JobGraph) planner.plan(graphSpec.getOperatorSpecGraph());
 
     // the partitions should be the same as input1
     jobGraph.getIntermediateStreams().forEach(edge -> {
@@ -324,8 +320,7 @@ public class TestExecutionPlanner {
 
     ExecutionPlanner planner = new ExecutionPlanner(cfg, streamManager);
     StreamApplicationDescriptorImpl graphSpec = createSimpleGraph();
-    JobGraph jobGraph = planner.createJobGraph(graphSpec.getOperatorSpecGraph());
-    planner.calculatePartitions(jobGraph);
+    JobGraph jobGraph = (JobGraph) planner.plan(graphSpec.getOperatorSpecGraph());
 
     // the partitions should be the same as input1
     jobGraph.getIntermediateStreams().forEach(edge -> {


### PR DESCRIPTION
This change breaks down the validation of partition counts of input and
intermediate streams participating in Join operations into 3 separate steps:
1. Grouping `InputOperatorSpec`s by the `JoinOperatorSpec`s of the Join operations they participate in
2. Replacing `InputOperatorSpec`s with their corresponding `StreamEdge`s
3. Verifying/Inferring partition counts of input/intermediate streams

This change covers stream-stream Joins only.