### PR TITLE
SAMZA-1890: Fix the creation of MapFunction in TestExecutionPlanner.

### DIFF
--- a/samza-core/src/test/java/org/apache/samza/execution/TestExecutionPlanner.java
+++ b/samza-core/src/test/java/org/apache/samza/execution/TestExecutionPlanner.java
@@ -179,15 +179,11 @@ public class TestExecutionPlanner {
 
         messageStream1.map(m -> m)
             .filter(m -> true)
-            .window(Windows.keyedTumblingWindow((m) -> {
-                return m;
-              }, Duration.ofMillis(8), mock(Serde.class), mock(Serde.class)), "w1");
+            .window(Windows.keyedTumblingWindow(m -> m, Duration.ofMillis(8), (Serde<KV<Object, Object>>) mock(Serde.class), (Serde<KV<Object, Object>>) mock(Serde.class)), "w1");
 
         messageStream2.map(m -> m)
             .filter(m -> true)
-            .window(Windows.keyedTumblingWindow((m) -> {
-                return m;
-              }, Duration.ofMillis(16), mock(Serde.class), mock(Serde.class)), "w2");
+            .window(Windows.keyedTumblingWindow(m -> m, Duration.ofMillis(16), (Serde<KV<Object, Object>>) mock(Serde.class), (Serde<KV<Object, Object>>) mock(Serde.class)), "w2");
 
         messageStream1.join(messageStream2, (JoinFunction<Object, KV<Object, Object>, KV<Object, Object>, KV<Object, Object>>) mock(JoinFunction.class),
           mock(Serde.class), mock(Serde.class), mock(Serde.class), Duration.ofMillis(1600), "j1").sendTo(output1);

--- a/samza-core/src/test/java/org/apache/samza/execution/TestExecutionPlanner.java
+++ b/samza-core/src/test/java/org/apache/samza/execution/TestExecutionPlanner.java
@@ -178,12 +178,16 @@ public class TestExecutionPlanner {
         OutputStream<KV<Object, Object>> output2 = appDesc.getOutputStream(output2Descriptor);
 
         messageStream1.map(m -> m)
-          .filter(m -> true)
-          .window(Windows.keyedTumblingWindow(m -> m, Duration.ofMillis(8), mock(Serde.class), mock(Serde.class)), "w1");
+            .filter(m -> true)
+            .window(Windows.keyedTumblingWindow((m) -> {
+                return m;
+              }, Duration.ofMillis(8), mock(Serde.class), mock(Serde.class)), "w1");
 
         messageStream2.map(m -> m)
-          .filter(m -> true)
-          .window(Windows.keyedTumblingWindow(m -> m, Duration.ofMillis(16), mock(Serde.class), mock(Serde.class)), "w2");
+            .filter(m -> true)
+            .window(Windows.keyedTumblingWindow((m) -> {
+                return m;
+              }, Duration.ofMillis(16), mock(Serde.class), mock(Serde.class)), "w2");
 
         messageStream1.join(messageStream2, (JoinFunction<Object, KV<Object, Object>, KV<Object, Object>, KV<Object, Object>>) mock(JoinFunction.class),
           mock(Serde.class), mock(Serde.class), mock(Serde.class), Duration.ofMillis(1600), "j1").sendTo(output1);


### PR DESCRIPTION
@dnishimura Kindly take a look.
Error: TestExecutionPlanner.java:186: error: incompatible types: cannot infer type-variable(s) M,K,T,T
          .window(Windows.keyedTumblingWindow(m -> m, Duration.ofMillis(16), mock(Serde.class), mock(Serde.class)), "w2");
                 ^(argument mismatch; T cannot be converted to Serde<KV<Object,Object>>)