### PR TITLE
SAMZA-1832: Fix race condition between StreamProcessor and SamzaContainerListener

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
+++ b/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
@@ -405,7 +405,7 @@ public class StreamProcessor {
 
     @Override
     public void afterStart() {
-      LOGGER.warn("Received container start notification for container: {} in stream processor: {}.",
+      LOGGER.info("Received container start notification for container: {} in stream processor: {}.",
           container, processorId);
       if (!processorOnStartCalled) {
         processorListener.afterStart();
@@ -423,7 +423,7 @@ public class StreamProcessor {
     public void afterStop() {
       containerShutdownLatch.countDown();
 
-      if (compareNotInAndSet(state, ImmutableSet.of(STOPPING, STOPPED, START_REBALANCE), STOPPING)) {
+      if (compareNotInAndSet(state, ImmutableSet.of(STOPPING, STOPPED, START_REBALANCE, IN_REBALANCE), STOPPING)) {
         LOGGER.info("Container: {} stopped. Stopping the stream processor: {}.", container, processorId);
         jobCoordinator.stop();
       } else {

--- a/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
+++ b/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
@@ -317,7 +317,7 @@ public class StreamProcessor {
           stopSamzaContainer();
 
           LOGGER.info("Entering re-balance phase with a barrier on container shutdown for the stream processor: {}", processorId);
-          boolean inRebalance = transitionWithBarrier(state, START_REBALANCE
+          boolean inRebalance = compareAndSetWithBarrier(state, START_REBALANCE
               , IN_REBALANCE, containerShutdownLatch, Duration.ofMillis(taskShutdownMs));
 
           // failed to transition to IN_REBALANCE either container shutdown failed or barrier timed out
@@ -360,7 +360,7 @@ public class StreamProcessor {
 
         if (state.get() == STOPPING) {
           LOGGER.info("Attempting to shutdown stream processor: {} with a barrier on container shutdown.", processorId);
-          boolean stopped = transitionWithBarrier(state, STOPPING, STOPPED, containerShutdownLatch, Duration.ofMillis(taskShutdownMs));
+          boolean stopped = compareAndSetWithBarrier(state, STOPPING, STOPPED, containerShutdownLatch, Duration.ofMillis(taskShutdownMs));
 
           if (containerException != null) {
             processorListener.afterFailure(containerException);
@@ -390,7 +390,7 @@ public class StreamProcessor {
 
         if (state.get() == STOPPING) {
           LOGGER.info("Attempting to shutdown stream processor: {} with a barrier on container shutdown.", processorId);
-          if (!transitionWithBarrier(state, STOPPING, STOPPED, containerShutdownLatch, Duration.ofMillis(taskShutdownMs))) {
+          if (!compareAndSetWithBarrier(state, STOPPING, STOPPED, containerShutdownLatch, Duration.ofMillis(taskShutdownMs))) {
             executorService.shutdownNow();
           }
 

--- a/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
+++ b/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
@@ -223,7 +223,7 @@ public class StreamProcessor {
       jobCoordinator.start();
 
       if (!state.compareAndSet(NEW, STARTED)) {
-        LOGGER.info("Failed to transition to {} from {}Stream processor has already started and the current state {}", state.get());
+        LOGGER.info("Failed to transition to STARTED since the current state is {} and not {}", state.get(), NEW);
         // todo: Should stop be invoked or do we throw exception?
         // todo: We ideally want to call stop to make sure resources spun by jobcoordinator.start() are cleaned up
       }
@@ -345,7 +345,7 @@ public class StreamProcessor {
           executorService.submit(container);
         } else {
           LOGGER.info("Ignoring onNewJobModel invocation since the current state is {} and not {}.",
-              state.get(), State.IN_REBALANCE);
+              state.get(), IN_REBALANCE);
         }
       }
 

--- a/samza-core/src/main/java/org/apache/samza/util/StateTransitionUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/util/StateTransitionUtil.java
@@ -44,7 +44,7 @@ public class StateTransitionUtil {
    * @return true if current state is one of the expected value and transition was successful; false otherwise
    */
   public static <T> boolean compareAndSet(AtomicReference<T> reference, Set<T> expectedValues, T update) {
-    while(true) {
+    while (true) {
       T currentValue = reference.get();
       if (expectedValues.contains(currentValue)) {
         if (reference.compareAndSet(currentValue, update)) {
@@ -67,13 +67,13 @@ public class StateTransitionUtil {
    * @return true if current state is not in the blacklisted values and transition was successful; false otherwise
    */
   public static <T> boolean compareNotInAndSet(AtomicReference<T> reference, Set<T> blacklistedValues, T update) {
-    while(true) {
+    while (true) {
       T currentValue = reference.get();
       if (blacklistedValues.contains(currentValue)) {
         return false;
       }
 
-      if(reference.compareAndSet(currentValue, update)) {
+      if (reference.compareAndSet(currentValue, update)) {
         return true;
       }
     }

--- a/samza-core/src/main/java/org/apache/samza/util/StateTransitionUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/util/StateTransitionUtil.java
@@ -83,12 +83,13 @@ public class StateTransitionUtil {
     }
 
     try {
-      if (timeout == Duration.ZERO) {
+      if (timeout.isNegative()) {
         barrier.await();
       } else {
         boolean completed = barrier.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
         if (!completed) {
           LOG.error("Failed to transition from {} to {} due to barrier timeout.", currentState, desiredState);
+          return false;
         }
       }
     } catch (InterruptedException e) {

--- a/samza-core/src/main/java/org/apache/samza/util/StateTransitionUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/util/StateTransitionUtil.java
@@ -27,58 +27,77 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
+/**
+ * A utility class to perform complex state transitions.
+ */
 public class StateTransitionUtil {
   private static final Logger LOG = LoggerFactory.getLogger(StateTransitionUtil.class);
 
   /**
+   * Atomically sets the value to the given updated value if current value is one of the expected values.
    *
-   * @param reference
-   * @param expectedValues
-   * @param value
-   * @param <T>
-   * @return
+   * @param reference the atomic reference
+   * @param expectedValues set of expected values
+   * @param update the new value
+   * @param <T> type of the atomic reference
+   *
+   * @return true if current state is one of the expected value and transition was successful; false otherwise
    */
-  public static <T> boolean compareAndSet(AtomicReference<T> reference, Set<T> expectedValues, T value) {
-    T currentValue = reference.get();
-    if (expectedValues.contains(currentValue)) {
-      return reference.compareAndSet(currentValue, value);
+  public static <T> boolean compareAndSet(AtomicReference<T> reference, Set<T> expectedValues, T update) {
+    while(true) {
+      T currentValue = reference.get();
+      if (expectedValues.contains(currentValue)) {
+        if (reference.compareAndSet(currentValue, update)) {
+          return true;
+        }
+      } else {
+        return false;
+      }
     }
-
-    return false;
   }
 
   /**
+   * Atomically sets the value to the given updated value if the black listed values does not contain current value.
    *
-   * @param reference
-   * @param blacklistedValues
-   * @param value
-   * @param <T>
-   * @return
+   * @param reference the atomic reference
+   * @param blacklistedValues set of blacklisted values
+   * @param update the new value
+   * @param <T> type of the atomic reference
+   *
+   * @return true if current state is not in the blacklisted values and transition was successful; false otherwise
    */
-  public static <T> boolean compareNotInAndSet(AtomicReference<T> reference, Set<T> blacklistedValues, T value) {
-    T currentValue = reference.get();
-    if (blacklistedValues.contains(currentValue)) {
-      return false;
-    }
+  public static <T> boolean compareNotInAndSet(AtomicReference<T> reference, Set<T> blacklistedValues, T update) {
+    while(true) {
+      T currentValue = reference.get();
+      if (blacklistedValues.contains(currentValue)) {
+        return false;
+      }
 
-    return reference.compareAndSet(currentValue, value);
+      if(reference.compareAndSet(currentValue, update)) {
+        return true;
+      }
+    }
   }
 
   /**
+   * Atomically sets the value to the updated value if the current value == expected value and the barrier
+   * latch counts down to zero. If the barrier times out determined by the timeout parameter, the atomic reference
+   * is not updated.
    *
-   * @param reference
-   * @param currentState
-   * @param desiredState
-   * @param barrier
-   * @param timeout
-   * @param <T>
-   * @return
+   * @param reference the atomic reference
+   * @param expect the expected value
+   * @param update the new value
+   * @param barrier the barrier latch
+   * @param timeout the timeout for barrier
+   * @param <T> type of the atomic reference
+   *
+   * @return true if current state == expected value and the barrier completed and transition was successful; false otherwise
    */
-  public static <T> boolean transitionWithBarrier(AtomicReference<T> reference, T currentState, T desiredState,
+  public static <T> boolean transitionWithBarrier(AtomicReference<T> reference, T expect, T update,
       CountDownLatch barrier, Duration timeout) {
-    if (reference.get() != currentState) {
-      LOG.error("Failed to transition from {} to {}", currentState, desiredState);
-      throw new IllegalStateException("Cannot transition to " + desiredState + " from state "  + currentState
+    if (reference.get() != expect) {
+      LOG.error("Failed to transition from {} to {}", expect, update);
+      throw new IllegalStateException("Cannot transition to " + update + " from state "  + expect
           + " since the current state is " + reference.get());
     }
 
@@ -88,15 +107,15 @@ public class StateTransitionUtil {
       } else {
         boolean completed = barrier.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
         if (!completed) {
-          LOG.error("Failed to transition from {} to {} due to barrier timeout.", currentState, desiredState);
+          LOG.error("Failed to transition from {} to {} due to barrier timeout.", expect, update);
           return false;
         }
       }
     } catch (InterruptedException e) {
-      LOG.error("Failed to transition from {} to {} due to {}", new Object[] {currentState, desiredState, e});
+      LOG.error("Failed to transition from {} to {} due to {}", new Object[] {expect, update, e});
       return false;
     }
 
-    return reference.compareAndSet(currentState, desiredState);
+    return reference.compareAndSet(expect, update);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/util/StateTransitionUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/util/StateTransitionUtil.java
@@ -19,7 +19,7 @@
 package org.apache.samza.util;
 
 import java.time.Duration;
-import java.util.Set;
+import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -43,7 +43,7 @@ public class StateTransitionUtil {
    *
    * @return true if current state is one of the expected value and transition was successful; false otherwise
    */
-  public static <T> boolean compareAndSet(AtomicReference<T> reference, Set<T> expectedValues, T update) {
+  public static <T> boolean compareAndSet(AtomicReference<T> reference, Collection<T> expectedValues, T update) {
     while (true) {
       T currentValue = reference.get();
       if (expectedValues.contains(currentValue)) {
@@ -66,7 +66,7 @@ public class StateTransitionUtil {
    *
    * @return true if current state is not in the blacklisted values and transition was successful; false otherwise
    */
-  public static <T> boolean compareNotInAndSet(AtomicReference<T> reference, Set<T> blacklistedValues, T update) {
+  public static <T> boolean compareNotInAndSet(AtomicReference<T> reference, Collection<T> blacklistedValues, T update) {
     while (true) {
       T currentValue = reference.get();
       if (blacklistedValues.contains(currentValue)) {
@@ -93,7 +93,7 @@ public class StateTransitionUtil {
    *
    * @return true if current state == expected value and the barrier completed and transition was successful; false otherwise
    */
-  public static <T> boolean transitionWithBarrier(AtomicReference<T> reference, T expect, T update,
+  public static <T> boolean compareAndSetWithBarrier(AtomicReference<T> reference, T expect, T update,
       CountDownLatch barrier, Duration timeout) {
     if (reference.get() != expect) {
       LOG.error("Failed to transition from {} to {}", expect, update);

--- a/samza-core/src/main/java/org/apache/samza/util/StateTransitionUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/util/StateTransitionUtil.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.util;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class StateTransitionUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(StateTransitionUtil.class);
+
+  /**
+   *
+   * @param reference
+   * @param expectedValues
+   * @param value
+   * @param <T>
+   * @return
+   */
+  public static <T> boolean compareAndSet(AtomicReference<T> reference, Set<T> expectedValues, T value) {
+    T currentValue = reference.get();
+    if (expectedValues.contains(currentValue)) {
+      return reference.compareAndSet(currentValue, value);
+    }
+
+    return false;
+  }
+
+  /**
+   *
+   * @param reference
+   * @param blacklistedValues
+   * @param value
+   * @param <T>
+   * @return
+   */
+  public static <T> boolean compareNotInAndSet(AtomicReference<T> reference, Set<T> blacklistedValues, T value) {
+    T currentValue = reference.get();
+    if (blacklistedValues.contains(currentValue)) {
+      return false;
+    }
+
+    return reference.compareAndSet(currentValue, value);
+  }
+
+  /**
+   *
+   * @param reference
+   * @param currentState
+   * @param desiredState
+   * @param barrier
+   * @param timeout
+   * @param <T>
+   * @return
+   */
+  public static <T> boolean transitionWithBarrier(AtomicReference<T> reference, T currentState, T desiredState,
+      CountDownLatch barrier, Duration timeout) {
+    if (reference.get() != currentState) {
+      LOG.error("Failed to transition from {} to {}", currentState, desiredState);
+      throw new IllegalStateException("Cannot transition to " + desiredState + " from state "  + currentState
+          + " since the current state is " + reference.get());
+    }
+
+    try {
+      if (timeout == Duration.ZERO) {
+        barrier.await();
+      } else {
+        boolean completed = barrier.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        if (!completed) {
+          LOG.error("Failed to transition from {} to {} due to barrier timeout.", currentState, desiredState);
+        }
+      }
+    } catch (InterruptedException e) {
+      LOG.error("Failed to transition from {} to {} due to {}", new Object[] {currentState, desiredState, e});
+      return false;
+    }
+
+    return reference.compareAndSet(currentState, desiredState);
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/processor/TestStreamProcessor.java
+++ b/samza-core/src/test/java/org/apache/samza/processor/TestStreamProcessor.java
@@ -45,12 +45,8 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.PrepareOnlyThisForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.*;
@@ -368,9 +364,9 @@ public class TestStreamProcessor {
      */
     Mockito.doNothing().when(mockJobCoordinator).start();
     Mockito.doAnswer(ans -> {
-      streamProcessor.state.set(State.STOPPING);
-      return null;
-    }).when(mockJobCoordinator).stop();
+        streamProcessor.state.set(State.STOPPING);
+        return null;
+      }).when(mockJobCoordinator).stop();
     Mockito.doNothing().when(mockSamzaContainer).shutdown();
     Mockito.when(mockSamzaContainer.hasStopped()).thenReturn(false);
     Mockito.when(mockSamzaContainer.getStatus())

--- a/samza-core/src/test/java/org/apache/samza/processor/TestStreamProcessor.java
+++ b/samza-core/src/test/java/org/apache/samza/processor/TestStreamProcessor.java
@@ -405,7 +405,7 @@ public class TestStreamProcessor {
     streamProcessor.jobCoordinatorListener.onNewJobModel("TestProcessorId", new JobModel(new MapConfig(), new HashMap<>()));
 
     Mockito.verify(mockSamzaContainer, Mockito.times(1)).setContainerListener(any());
-    Mockito.verify(mockSamzaContainer, Mockito.atLeast(1)).run();
+    Mockito.verify(mockSamzaContainer, Mockito.atMost(1)).run();
   }
 
   @Test

--- a/samza-core/src/test/java/org/apache/samza/util/TestStateTransitionUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/util/TestStateTransitionUtil.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.util;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Test class for {@link StateTransitionUtil}
+ */
+public class TestStateTransitionUtil {
+  private static final List<String> STATES = ImmutableList.of("A", "B", "C", "D", "E");
+  private static final Map<String, List<String>> VALID_TRANSITIONS = new ImmutableMap.Builder<String, List<String>>()
+      .put("A", ImmutableList.of("C", "D"))
+      .put("B", ImmutableList.of("D", "E"))
+      .put("C", ImmutableList.of("D", "A", "E"))
+      .put("D", ImmutableList.of("A", "B"))
+      .put("E", ImmutableList.of("B", "C"))
+      .build();
+
+  private static final Map<String, List<String>> INVALID_TRANSITIONS = new ImmutableMap.Builder<String, List<String>>()
+      .put("A", ImmutableList.of("A", "B", "E"))
+      .put("B", ImmutableList.of("A", "B", "C"))
+      .put("C", ImmutableList.of("B", "C"))
+      .put("D", ImmutableList.of("C", "D", "E"))
+      .put("E", ImmutableList.of("A", "D", "E"))
+      .build();
+
+  private static final Random RANDOM = new Random();
+
+  @Test
+  public void testCompareAndSet() {
+    AtomicReference<String> reference = new AtomicReference<>();
+
+    for (String desiredState : STATES) {
+      String currentState = STATES.get(RANDOM.nextInt(STATES.size()));
+      reference.set(currentState);
+
+      boolean actual = StateTransitionUtil.compareAndSet(reference, VALID_TRANSITIONS.get(desiredState), desiredState);
+      boolean expected = VALID_TRANSITIONS.get(desiredState).contains(currentState);
+      assertEquals(expected, actual);
+    }
+  }
+
+  @Test
+  public void testCompareNotInAndSet() {
+    AtomicReference<String> reference = new AtomicReference<>();
+
+    for (String desiredState : STATES) {
+      String currentState = STATES.get(RANDOM.nextInt(STATES.size()));
+      reference.set(currentState);
+
+      boolean actual = StateTransitionUtil.compareNotInAndSet(reference, INVALID_TRANSITIONS.get(desiredState), desiredState);
+      boolean expected = !INVALID_TRANSITIONS.get(desiredState).contains(currentState);
+      assertEquals(expected, actual);
+    }
+  }
+
+  @Test
+  public void testCompareAndSetWithBarrierTimeout() {
+    String currentState = STATES.get(RANDOM.nextInt(STATES.size()));
+    String desiredState = STATES.get(RANDOM.nextInt(STATES.size()));
+    AtomicReference<String> reference = new AtomicReference<>(currentState);
+
+    final CountDownLatch barrier = new CountDownLatch(1);
+    Duration timeout = Duration.ofMillis(RANDOM.nextInt(1000));
+    boolean transitionResult = StateTransitionUtil.compareAndSetWithBarrier(reference, currentState, desiredState, barrier, timeout);
+
+    assertFalse(transitionResult);
+  }
+
+  @Test
+  public void testCompareAndSetWithBarrierAlreadyCompleted() {
+    String currentState = STATES.get(RANDOM.nextInt(STATES.size()));
+    String desiredState = STATES.get(RANDOM.nextInt(STATES.size()));
+    AtomicReference<String> reference = new AtomicReference<>(currentState);
+
+    final CountDownLatch barrier = new CountDownLatch(0);
+    Duration timeout = Duration.ofMillis(RANDOM.nextInt(1000));
+    boolean transitionResult = StateTransitionUtil.compareAndSetWithBarrier(reference, currentState, desiredState, barrier, timeout);
+
+    assertTrue(transitionResult);
+  }
+
+  @Test
+  public void testCompareAndSetWithBarrierCompletionWithStateChange() {
+    String currentState = STATES.get(RANDOM.nextInt(STATES.size()));
+    String desiredState = STATES.get(RANDOM.nextInt(STATES.size()));
+    AtomicReference<String> reference = new AtomicReference<>(currentState);
+
+    final CountDownLatch barrier = new CountDownLatch(1);
+    Duration timeout = Duration.ofMillis(RANDOM.nextInt(1000));
+
+    CompletableFuture.runAsync(() -> {
+        try {
+          Thread.sleep(timeout.toMillis());
+        }   catch (InterruptedException e) {
+
+        }
+
+        for (String state : STATES) {
+          if (!currentState.equals(state)) {
+            reference.set(state);
+            break;
+          }
+        }
+        barrier.countDown();
+      });
+
+    boolean transitionResult = StateTransitionUtil.compareAndSetWithBarrier(reference, currentState, desiredState, barrier, Duration.ofMillis(-1));
+    assertFalse(transitionResult);
+  }
+
+  @Test
+  public void testCompareAndSetWithBarrierCompletion() {
+    String currentState = STATES.get(RANDOM.nextInt(STATES.size()));
+    String desiredState = STATES.get(RANDOM.nextInt(STATES.size()));
+    AtomicReference<String> reference = new AtomicReference<>(currentState);
+
+    final CountDownLatch barrier = new CountDownLatch(1);
+    Duration timeout = Duration.ofMillis(RANDOM.nextInt(1000));
+
+    CompletableFuture.runAsync(() -> {
+        try {
+          Thread.sleep(timeout.toMillis());
+        } catch (InterruptedException e) {
+
+        }
+
+        barrier.countDown();
+      });
+
+    boolean transitionResult = StateTransitionUtil.compareAndSetWithBarrier(reference, currentState, desiredState, barrier, Duration.ofMillis(-1));
+    assertTrue(transitionResult);
+  }
+}

--- a/samza-test/src/test/java/org/apache/samza/test/framework/FaultInjectionTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/framework/FaultInjectionTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.test.framework;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.samza.application.StreamApplication;
+import org.apache.samza.application.StreamApplicationDescriptor;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.JobConfig;
+import org.apache.samza.config.JobCoordinatorConfig;
+import org.apache.samza.operators.MessageStream;
+import org.apache.samza.serializers.JsonSerdeV2;
+import org.apache.samza.system.kafka.KafkaInputDescriptor;
+import org.apache.samza.system.kafka.KafkaSystemDescriptor;
+import org.apache.samza.test.operator.data.PageView;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.apache.samza.test.framework.TestTimerApp.*;
+
+
+public class FaultInjectionTest extends StreamApplicationIntegrationTestHarness {
+
+  @Before
+  public void setup() {
+    // create topics
+    createTopic(PAGE_VIEWS, 2);
+
+    // create events for the following user activity.
+    // userId: (viewId, pageId, (adIds))
+    // u1: (v1, p1, (a1)), (v2, p2, (a3))
+    // u2: (v3, p1, (a1)), (v4, p3, (a5))
+    produceMessage(PAGE_VIEWS, 0, "p1", "{\"viewId\":\"v1\",\"pageId\":\"p1\",\"userId\":\"u1\"}");
+    produceMessage(PAGE_VIEWS, 1, "p2", "{\"viewId\":\"v2\",\"pageId\":\"p2\",\"userId\":\"u1\"}");
+  }
+
+  @Test
+  public void testRaceCondition() throws InterruptedException {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(JobCoordinatorConfig.JOB_COORDINATOR_FACTORY, "org.apache.samza.standalone.PassthroughJobCoordinatorFactory");
+    configs.put("job.systemstreampartition.grouper.factory", "org.apache.samza.container.grouper.stream.AllSspToSingleTaskGrouperFactory");
+    configs.put("task.name.grouper.factory", "org.apache.samza.container.grouper.task.SingleContainerGrouperFactory");
+    configs.put(JobCoordinatorConfig.JOB_COORDINATION_UTILS_FACTORY, "org.apache.samza.standalone.PassthroughCoordinationUtilsFactory");
+    configs.put(FaultInjectionStreamApp.INPUT_TOPIC_NAME_PROP, "page-views");
+    configs.put("task.shutdown.ms", "10000");
+    configs.put(JobConfig.PROCESSOR_ID(), "0");
+
+    RunApplicationContext context =
+        runApplication(new FaultInjectionStreamApp(), "fault-injection-app", configs);
+    Thread.sleep(1000);
+    context.getRunner().kill();
+    context.getRunner().waitForFinish();
+    System.out.println("Application status: " + context.getRunner().status());
+  }
+
+  private static class FaultInjectionStreamApp implements StreamApplication {
+    public static final String SYSTEM = "kafka";
+    public static final String INPUT_TOPIC_NAME_PROP = "inputTopicName";
+
+    @Override
+    public void describe(StreamApplicationDescriptor appDesc) {
+      Config config = appDesc.getConfig();
+      String inputTopic = config.get(INPUT_TOPIC_NAME_PROP);
+
+      final JsonSerdeV2<PageView> serde = new JsonSerdeV2<>(PageView.class);
+      KafkaSystemDescriptor ksd = new KafkaSystemDescriptor(SYSTEM);
+      KafkaInputDescriptor<PageView> isd = ksd.getInputDescriptor(inputTopic, serde);
+      final MessageStream<PageView> broadcastPageViews = appDesc
+          .getInputStream(isd)
+          .map(message -> {
+              throw new RuntimeException("failed");
+            });
+    }
+  }
+}

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
@@ -617,6 +617,9 @@ public class TestZkLocalApplicationRunner extends StandaloneIntegrationTestHarne
     // Trigger re-balancing phase, by manually adding a new processor.
 
     configMap.put(JobConfig.PROCESSOR_ID(), PROCESSOR_IDS[2]);
+
+    // Reset the task shutdown ms for 3rd application to give it ample time to shutdown cleanly
+    configMap.put(TaskConfig.SHUTDOWN_MS(), TASK_SHUTDOWN_MS);
     Config applicationConfig3 = new MapConfig(configMap);
 
     CountDownLatch processedMessagesLatch3 = new CountDownLatch(1);
@@ -638,7 +641,7 @@ public class TestZkLocalApplicationRunner extends StandaloneIntegrationTestHarne
 
     appRunner3.kill();
     appRunner3.waitForFinish();
-    assertEquals(ApplicationStatus.UnsuccessfulFinish, appRunner3.status());
+    assertEquals(ApplicationStatus.SuccessfulFinish, appRunner3.status());
   }
 
 }

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
@@ -633,13 +633,12 @@ public class TestZkLocalApplicationRunner extends StandaloneIntegrationTestHarne
     /**
      * If the processing has started in the third stream processor, then other two stream processors should be stopped.
      */
-    // TODO: This is a bug! Status should be unsuccessful finish.
-    assertEquals(ApplicationStatus.SuccessfulFinish, appRunner1.status());
-    assertEquals(ApplicationStatus.SuccessfulFinish, appRunner2.status());
+    assertEquals(ApplicationStatus.UnsuccessfulFinish, appRunner1.status());
+    assertEquals(ApplicationStatus.UnsuccessfulFinish, appRunner2.status());
 
     appRunner3.kill();
     appRunner3.waitForFinish();
-    assertEquals(ApplicationStatus.SuccessfulFinish, appRunner3.status());
+    assertEquals(ApplicationStatus.UnsuccessfulFinish, appRunner3.status());
   }
 
 }


### PR DESCRIPTION
The PR addresses the following issues

- We have few scenarios where there is a race condition between `SamzaContainerListener` and `StreamProcessor` that results in incorrect application status being propagated to client

> 1. Consider the scenario when the container runs into an exception in run loop and triggers shutdown sequence and at the same time the user triggers a stop on the `StreamProcessor`. The user request comes in and notices that the container is already shutting down and proceeds to shutdown the job coordinator which in turns shuts down successfully and the `processorListener.onStop()` is invoked. The container eventually invokes the `SamzaContainerListener` callback and updates the exception state after the `StreamProcessor` has finished shutting down.
> 2. Consider the scenario when the user invokes start on the stream processor followed by a stop. During the `StreamProcessor` shutdown sequence we can have different status propagated to the client based on when we receive the start notification from container. If we receive the notification prior to invoking `processListener.onStop()` as part of `StreamProcessor` shutdown sequence, we return `successfulFinish` while if the notification is received after, we return `unsuccessfulFinish`.

 
- `SamzaContainer` sets the status flag to failed as soon as it runs into an exception in the runloop. This is problematic because it is possible for `StreamProcessor` to assume the container has shutdown correctly even though container is still in the shutdown sequence. `StreamProcessor` uses `container.hasStopped()` to determine the shutdown status of the container. Internally, this method returns true if the status is either `FAILED` or `STOPPED`. 
- During rebalance phase, due to above mentioned bugs, it possible that we have a unclean shutdown but still proceed to wait for new job model in some cases and proceed to `StreamProcessor` shutdown in others. 
- Currently, we only propagate failures to `processorListener` when containerException is not null. It is possible for the samza container to take longer than `task.shutdown.ms` to shutdown in which case, we need to propagate a timeout exception to the `processorListener` as opposed assuming the shutdown was successful.
