### PR TITLE
SAMZA-1919; Add KafkaSystemDescriptor constructor to allow arbitrary factory class

### DIFF
--- a/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaSystemDescriptor.java
+++ b/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaSystemDescriptor.java
@@ -40,7 +40,7 @@ import org.apache.samza.serializers.Serde;
 @SuppressWarnings("unchecked")
 public class KafkaSystemDescriptor extends SystemDescriptor<KafkaSystemDescriptor>
     implements SimpleInputDescriptorProvider, OutputDescriptorProvider {
-  private static final String FACTORY_CLASS_NAME = KafkaSystemFactory.class.getName();
+  private static final String DEFAULT_FACTORY_CLASS_NAME = KafkaSystemFactory.class.getName();
   private static final String CONSUMER_ZK_CONNECT_CONFIG_KEY = "systems.%s.consumer.zookeeper.connect";
   private static final String CONSUMER_AUTO_OFFSET_RESET_CONFIG_KEY = "systems.%s.consumer.auto.offset.reset";
   private static final String CONSUMER_FETCH_THRESHOLD_CONFIG_KEY = KafkaConfig.CONSUMER_FETCH_THRESHOLD();
@@ -64,11 +64,21 @@ public class KafkaSystemDescriptor extends SystemDescriptor<KafkaSystemDescripto
    * Serdes must be provided explicitly at stream level when getting input or output descriptors.
    *
    * @param systemName name of this system
+   * @param factoryClassName factory class of this system
    */
-  public KafkaSystemDescriptor(String systemName) {
-    super(systemName, FACTORY_CLASS_NAME, null, null);
+  public KafkaSystemDescriptor(String systemName, String factoryClassName) {
+    super(systemName, factoryClassName, null, null);
   }
 
+  /**
+   * Constructs a {@link KafkaSystemDescriptor} instance with no system level serde.
+   * Serdes must be provided explicitly at stream level when getting input or output descriptors.
+   *
+   * @param systemName name of this system
+   */
+  public KafkaSystemDescriptor(String systemName) {
+    this(systemName, DEFAULT_FACTORY_CLASS_NAME);
+  }
   /**
    * {@inheritDoc}
    */


### PR DESCRIPTION
Currently KafkaSystemDescriptor is hardcoded to use org.apache.samza.system.kafka.KafkaSystemFactory as the system factory for instantiating producer/consumer/admin. Users may want to use most methods in KafkaSystemDescriptor but with a different factory class. We can meet such use-case by adding a constructor that allows user to specify the factory class name.

