### PR TITLE
SAMZA-1832: Fix race condition between StreamProcessor and SamzaContainerListener

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
+++ b/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
@@ -309,8 +309,10 @@ public class StreamProcessor {
       LOGGER.info(String.format("Shutdown status of container: %s for stream processor: %s is: %b.", container, processorId, hasContainerShutdown));
     }
 
-    // We want to propagate when container shutdown times out. It is possible that the timeout exception we propagate to the
-    // local application runner maybe overwritten with the actual container failure cause in case of interleaved execution
+    // We want to propagate TimeoutException when container shutdown times out. It is possible that the timeout exception
+    // we propagate to the local application runner maybe overwritten by container failure cause in case of interleaved execution.
+    // It is acceptable since container exception is much more useful compared to timeout exception.
+    // We can infer from the logs about the fact that container shutdown timed out or not for additional inference.
     if (!hasContainerShutdown && containerException == null) {
       containerException = new TimeoutException("Container shutdown timed out.");
     }

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -878,9 +878,6 @@ class SamzaContainer(
    * @throws SamzaException, Thrown when the container has already been stopped or failed
    */
   def shutdown(): Unit = {
-    if (status == SamzaContainerStatus.STOPPED || status == SamzaContainerStatus.FAILED) {
-      throw new IllegalContainerStateException("Cannot shutdown a container with status " + status)
-    }
     shutdownRunLoop()
   }
 
@@ -1181,15 +1178,4 @@ class SamzaContainer(
       hostStatisticsMonitor.stop()
     }
   }
-}
-
-/**
- * Exception thrown when the SamzaContainer tries to transition to an illegal state.
- * {@link SamzaContainerStatus} has more details on the state transitions.
- *
- * @param s String, Message associated with the exception
- * @param t Throwable, Wrapped error/exception thrown, if any.
- */
-class IllegalContainerStateException(s: String, t: Throwable) extends SamzaException(s, t) {
-  def this(s: String) = this(s, null)
 }

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -878,6 +878,11 @@ class SamzaContainer(
    * @throws SamzaException, Thrown when the container has already been stopped or failed
    */
   def shutdown(): Unit = {
+    if (status == SamzaContainerStatus.FAILED || status == SamzaContainerStatus.STOPPED) {
+      warn("Shutdown is no-op since the container is already in state: " + status)
+      return
+    }
+
     shutdownRunLoop()
   }
 

--- a/samza-core/src/test/java/org/apache/samza/processor/TestStreamProcessor.java
+++ b/samza-core/src/test/java/org/apache/samza/processor/TestStreamProcessor.java
@@ -49,7 +49,7 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -392,14 +392,15 @@ public class TestStreamProcessor {
     ProcessorLifecycleListener lifecycleListener = Mockito.mock(ProcessorLifecycleListener.class);
     SamzaContainer mockSamzaContainer = Mockito.mock(SamzaContainer.class);
     MapConfig config = new MapConfig(ImmutableMap.of("task.shutdown.ms", "0"));
-    StreamProcessor streamProcessor = PowerMockito.spy(new StreamProcessor(config, new HashMap<>(), null, lifecycleListener, mockJobCoordinator));
+    StreamProcessor streamProcessor = new TestableStreamProcessor(config, new HashMap<>(), null,
+        lifecycleListener, mockJobCoordinator, mockSamzaContainer);
 
-    streamProcessor.container = mockSamzaContainer;
     streamProcessor.state = State.IN_REBALANCE;
     Mockito.doNothing().when(mockSamzaContainer).run();
 
     streamProcessor.jobCoordinatorListener.onNewJobModel("TestProcessorId", new JobModel(new MapConfig(), new HashMap<>()));
 
+    Mockito.verify(mockSamzaContainer, Mockito.times(1)).setContainerListener(any());
     Mockito.verify(mockSamzaContainer, Mockito.atMost(1)).run();
   }
 

--- a/samza-test/src/test/java/org/apache/samza/test/framework/FaultInjectionTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/framework/FaultInjectionTest.java
@@ -27,6 +27,7 @@ import org.apache.samza.config.Config;
 import org.apache.samza.config.JobConfig;
 import org.apache.samza.config.JobCoordinatorConfig;
 import org.apache.samza.config.TaskConfig;
+import org.apache.samza.config.ZkConfig;
 import org.apache.samza.job.ApplicationStatus;
 import org.apache.samza.serializers.JsonSerdeV2;
 import org.apache.samza.system.IncomingMessageEnvelope;
@@ -51,12 +52,14 @@ public class FaultInjectionTest extends StreamApplicationIntegrationTestHarness 
 
     CountDownLatch containerShutdownLatch = new CountDownLatch(1);
     Map<String, String> configs = new HashMap<>();
-    configs.put(JobCoordinatorConfig.JOB_COORDINATOR_FACTORY, "org.apache.samza.standalone.PassthroughJobCoordinatorFactory");
-    configs.put(JobCoordinatorConfig.JOB_COORDINATION_UTILS_FACTORY, "org.apache.samza.standalone.PassthroughCoordinationUtilsFactory");
+    configs.put(JobCoordinatorConfig.JOB_COORDINATOR_FACTORY, "org.apache.samza.zk.ZkJobCoordinatorFactory");
+    configs.put(JobCoordinatorConfig.JOB_COORDINATION_UTILS_FACTORY, "org.apache.samza.zk.ZkCoordinationUtilsFactory");
     configs.put(JobConfig.PROCESSOR_ID(), "0");
     configs.put(TaskConfig.GROUPER_FACTORY(), "org.apache.samza.container.grouper.task.GroupByContainerIdsFactory");
     configs.put(FaultInjectionStreamApp.INPUT_TOPIC_NAME_PROP, "page-views");
     configs.put(TaskConfig.INPUT_STREAMS(), "kafka.page-views");
+    configs.put(ZkConfig.ZK_CONNECT, zkConnect());
+    configs.put(JobConfig.JOB_DEBOUNCE_TIME_MS(), "5000");
 
     // we purposefully randomize the task.shutdown.ms to make sure we can consistently verify if status is unsuccessfulFinish
     // even though the reason for failure can either be container exception or container shutdown timing out.

--- a/samza-test/src/test/java/org/apache/samza/test/framework/FaultInjectionTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/framework/FaultInjectionTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.test.framework;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import org.apache.samza.application.TaskApplication;
+import org.apache.samza.application.TaskApplicationDescriptor;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.JobConfig;
+import org.apache.samza.config.JobCoordinatorConfig;
+import org.apache.samza.config.TaskConfig;
+import org.apache.samza.job.ApplicationStatus;
+import org.apache.samza.serializers.JsonSerdeV2;
+import org.apache.samza.system.IncomingMessageEnvelope;
+import org.apache.samza.system.kafka.KafkaInputDescriptor;
+import org.apache.samza.system.kafka.KafkaSystemDescriptor;
+import org.apache.samza.task.ClosableTask;
+import org.apache.samza.task.MessageCollector;
+import org.apache.samza.task.StreamTask;
+import org.apache.samza.task.StreamTaskFactory;
+import org.apache.samza.task.TaskCoordinator;
+import org.apache.samza.test.operator.data.PageView;
+import org.junit.Test;
+
+import static org.apache.samza.test.framework.TestTimerApp.*;
+import static org.junit.Assert.*;
+
+
+public class FaultInjectionTest extends StreamApplicationIntegrationTestHarness {
+  @Test
+  public void testRaceCondition() throws InterruptedException {
+    CountDownLatch startUpLatch = new CountDownLatch(1);
+    Map<String, String> configs = new HashMap<>();
+    configs.put(JobCoordinatorConfig.JOB_COORDINATOR_FACTORY, "org.apache.samza.standalone.PassthroughJobCoordinatorFactory");
+    configs.put(JobCoordinatorConfig.JOB_COORDINATION_UTILS_FACTORY, "org.apache.samza.standalone.PassthroughCoordinationUtilsFactory");
+    configs.put(JobConfig.PROCESSOR_ID(), "0");
+    configs.put(TaskConfig.GROUPER_FACTORY(), "org.apache.samza.container.grouper.task.GroupByContainerIdsFactory");
+    configs.put(FaultInjectionStreamApp.INPUT_TOPIC_NAME_PROP, "page-views");
+    configs.put(TaskConfig.INPUT_STREAMS(), "kafka.page-views");
+    configs.put("task.shutdown.ms", "10");
+    configs.put(JobConfig.PROCESSOR_ID(), "0");
+
+    createTopic(PAGE_VIEWS, 2);
+
+    // create events for the following user activity.
+    // userId: (viewId, pageId, (adIds))
+    // u1: (v1, p1, (a1)), (v2, p2, (a3))
+    // u2: (v3, p1, (a1)), (v4, p3, (a5))
+    produceMessage(PAGE_VIEWS, 0, "p1", "{\"viewId\":\"v1\",\"pageId\":\"p1\",\"userId\":\"u1\"}");
+    produceMessage(PAGE_VIEWS, 1, "p2", "{\"viewId\":\"v2\",\"pageId\":\"p2\",\"userId\":\"u1\"}");
+
+    FaultInjectionStreamApp app = new FaultInjectionStreamApp();
+    FaultInjectionStreamApp.shutdownLatch = startUpLatch;
+    RunApplicationContext context =
+        runApplication(app, "fault-injection-app", configs);
+
+    startUpLatch.await();
+    context.getRunner().kill();
+    context.getRunner().waitForFinish();
+    assertEquals(context.getRunner().status(), ApplicationStatus.UnsuccessfulFinish);
+  }
+
+  private static class FaultInjectionStreamApp implements TaskApplication {
+    public static final String SYSTEM = "kafka";
+    public static final String INPUT_TOPIC_NAME_PROP = "inputTopicName";
+    private static transient CountDownLatch shutdownLatch;
+
+    @Override
+    public void describe(TaskApplicationDescriptor appDesc) {
+      Config config = appDesc.getConfig();
+      String inputTopic = config.get(INPUT_TOPIC_NAME_PROP);
+
+      final JsonSerdeV2<PageView> serde = new JsonSerdeV2<>(PageView.class);
+      KafkaSystemDescriptor ksd = new KafkaSystemDescriptor(SYSTEM);
+      KafkaInputDescriptor<PageView> isd = ksd.getInputDescriptor(inputTopic, serde);
+      appDesc.addInputStream(isd);
+      appDesc.setTaskFactory((StreamTaskFactory) () -> new FaultInjectionTask(shutdownLatch));
+    }
+
+    private static class FaultInjectionTask implements StreamTask, ClosableTask {
+      private final transient CountDownLatch shutdownLatch;
+
+      public FaultInjectionTask(CountDownLatch shutdownLatch) {
+        this.shutdownLatch = shutdownLatch;
+      }
+
+      @Override
+      public void close() throws Exception {
+        shutdownLatch.countDown();
+      }
+
+      @Override
+      public void process(IncomingMessageEnvelope envelope, MessageCollector collector, TaskCoordinator coordinator)
+          throws Exception {
+        throw new RuntimeException("Failed");
+      }
+    }
+  }
+}

--- a/samza-test/src/test/java/org/apache/samza/test/framework/FaultInjectionTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/framework/FaultInjectionTest.java
@@ -47,6 +47,8 @@ import static org.junit.Assert.*;
 public class FaultInjectionTest extends StreamApplicationIntegrationTestHarness {
   @Test
   public void testRaceCondition() throws InterruptedException {
+    int taskShutdownInMs = (int) (Math.random() * 10000);
+
     CountDownLatch containerShutdownLatch = new CountDownLatch(1);
     Map<String, String> configs = new HashMap<>();
     configs.put(JobCoordinatorConfig.JOB_COORDINATOR_FACTORY, "org.apache.samza.standalone.PassthroughJobCoordinatorFactory");
@@ -55,7 +57,10 @@ public class FaultInjectionTest extends StreamApplicationIntegrationTestHarness 
     configs.put(TaskConfig.GROUPER_FACTORY(), "org.apache.samza.container.grouper.task.GroupByContainerIdsFactory");
     configs.put(FaultInjectionStreamApp.INPUT_TOPIC_NAME_PROP, "page-views");
     configs.put(TaskConfig.INPUT_STREAMS(), "kafka.page-views");
-    configs.put("task.shutdown.ms", "10");
+
+    // we purposefully randomize the task.shutdown.ms to make sure we can consistently verify if status is unsuccessfulFinish
+    // even though the reason for failure can either be container exception or container shutdown timing out.
+    configs.put("task.shutdown.ms", Integer.toString(taskShutdownInMs));
     configs.put(JobConfig.PROCESSOR_ID(), "0");
 
     createTopic(PAGE_VIEWS, 2);

--- a/samza-test/src/test/java/org/apache/samza/test/framework/FaultInjectionTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/framework/FaultInjectionTest.java
@@ -41,11 +41,12 @@ import org.apache.samza.task.TaskCoordinator;
 import org.apache.samza.test.operator.data.PageView;
 import org.junit.Test;
 
-import static org.apache.samza.test.framework.TestTimerApp.*;
 import static org.junit.Assert.*;
 
 
 public class FaultInjectionTest extends StreamApplicationIntegrationTestHarness {
+  private static final String PAGE_VIEWS = "page-views";
+
   @Test
   public void testRaceCondition() throws InterruptedException {
     int taskShutdownInMs = (int) (Math.random() * 10000);

--- a/samza-test/src/test/java/org/apache/samza/test/framework/StreamApplicationIntegrationTestHarness.java
+++ b/samza-test/src/test/java/org/apache/samza/test/framework/StreamApplicationIntegrationTestHarness.java
@@ -35,7 +35,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.protocol.SecurityProtocol;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.samza.application.StreamApplication;
+import org.apache.samza.application.SamzaApplication;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.KafkaConfig;
 import org.apache.samza.config.MapConfig;
@@ -48,7 +48,7 @@ import scala.Option;
 import scala.Option$;
 
 /**
- * Harness for writing integration tests for {@link StreamApplication}s.
+ * Harness for writing integration tests for {@link SamzaApplication}s.
  *
  * <p> This provides the following features for its sub-classes:
  * <ul>
@@ -74,7 +74,7 @@ import scala.Option$;
  * State persistence: {@link #tearDown()} clears all associated state (including topics and metadata) in Kafka and
  * Zookeeper. Hence, the state is not durable across invocations of {@link #tearDown()} <br/>
  *
- * Execution model: {@link StreamApplication}s are run as their own {@link org.apache.samza.job.local.ThreadJob}s.
+ * Execution model: {@link SamzaApplication}s are run as their own {@link org.apache.samza.job.local.ThreadJob}s.
  * Similarly, embedded Kafka servers and Zookeeper servers are run as their own threads.
  * {@link #produceMessage(String, int, String, String)} and {@link #consumeMessages(Collection, int)} are blocking calls.
  *
@@ -217,7 +217,7 @@ public class StreamApplicationIntegrationTestHarness extends AbstractIntegration
    * @return RunApplicationContext which contains objects created within runApplication, to be used for verification
    * if necessary
    */
-  protected RunApplicationContext runApplication(StreamApplication streamApplication,
+  protected RunApplicationContext runApplication(SamzaApplication streamApplication,
       String appName,
       Map<String, String> overriddenConfigs) {
     Map<String, String> configMap = new HashMap<>();

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
@@ -617,6 +617,9 @@ public class TestZkLocalApplicationRunner extends StandaloneIntegrationTestHarne
     // Trigger re-balancing phase, by manually adding a new processor.
 
     configMap.put(JobConfig.PROCESSOR_ID(), PROCESSOR_IDS[2]);
+
+    // Reset the task shutdown ms for 3rd application to give it ample time to shutdown cleanly
+    configMap.put(TaskConfig.SHUTDOWN_MS(), TASK_SHUTDOWN_MS);
     Config applicationConfig3 = new MapConfig(configMap);
 
     CountDownLatch processedMessagesLatch3 = new CountDownLatch(1);
@@ -629,13 +632,14 @@ public class TestZkLocalApplicationRunner extends StandaloneIntegrationTestHarne
     publishKafkaEvents(inputKafkaTopic, NUM_KAFKA_EVENTS, 2 * NUM_KAFKA_EVENTS, PROCESSOR_IDS[0]);
 
     processedMessagesLatch3.await();
+    appRunner1.waitForFinish();
+    appRunner2.waitForFinish();
 
     /**
      * If the processing has started in the third stream processor, then other two stream processors should be stopped.
      */
-    // TODO: This is a bug! Status should be unsuccessful finish.
-    assertEquals(ApplicationStatus.SuccessfulFinish, appRunner1.status());
-    assertEquals(ApplicationStatus.SuccessfulFinish, appRunner2.status());
+    assertEquals(ApplicationStatus.UnsuccessfulFinish, appRunner1.status());
+    assertEquals(ApplicationStatus.UnsuccessfulFinish, appRunner2.status());
 
     appRunner3.kill();
     appRunner3.waitForFinish();


### PR DESCRIPTION
The PR addresses the following issues

- We have few scenarios where there is a race condition between `SamzaContainerListener` and `StreamProcessor` that results in incorrect application status being propagated to client

> Consider the scenario when the container runs into an exception in run loop and triggers shutdown sequence and at the same time the user triggers a stop on the `StreamProcessor`. The user request comes in and notices that the container is already shutting down and proceeds to shutdown the job coordinator which in turns shuts down successfully and the `processorListener.onStop()` is invoked. The container eventually invokes the `SamzaContainerListener` callback and updates the exception state after the `StreamProcessor` has finished shutting down.

- Currently, we only propagate failures to `processorListener` when containerException is not null. It is possible for the samza container to take longer than `task.shutdown.ms` to shutdown in which case, we need to propagate a timeout exception to the `processorListener` as opposed assuming the shutdown was successful.

- Make container shutdown idempotent since its only setting a boolean flag to true and there is no need to throw an exception on subsequent invocations.
           1. It simplifies the interaction of other components (`StreamProcessor`) with container and prevents unnecessary check on container state to determine if its safe to call shutdown or not.
           2. Enables to reason about the impact of container state change on `StreamProcessor` easily since we restrict container interaction w/ `StreamProcessor` only via `SamzaContainerListener`. 