### PR TITLE
Fix broken tests caused due to merging

### DIFF
--- a/samza-test/src/test/java/org/apache/samza/test/framework/FaultInjectionTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/framework/FaultInjectionTest.java
@@ -54,7 +54,6 @@ public class FaultInjectionTest extends StreamApplicationIntegrationTestHarness 
     CountDownLatch containerShutdownLatch = new CountDownLatch(1);
     Map<String, String> configs = new HashMap<>();
     configs.put(JobCoordinatorConfig.JOB_COORDINATOR_FACTORY, "org.apache.samza.zk.ZkJobCoordinatorFactory");
-    configs.put(JobCoordinatorConfig.JOB_COORDINATION_UTILS_FACTORY, "org.apache.samza.zk.ZkCoordinationUtilsFactory");
     configs.put(JobConfig.PROCESSOR_ID(), "0");
     configs.put(TaskConfig.GROUPER_FACTORY(), "org.apache.samza.container.grouper.task.GroupByContainerIdsFactory");
     configs.put(FaultInjectionStreamApp.INPUT_TOPIC_NAME_PROP, "page-views");


### PR DESCRIPTION
Due to interleaved ordering of the PRs (https://github.com/apache/samza/pull/675 and https://github.com/apache/samza/pull/673), FaultInjectionTest is broken.

