### PR TITLE
SAMZA-1947: Remove specific js/css files from rat excludes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,6 @@ rat {
     '**/bootstrap.min.css',
     '**/bootstrap.min.js',
     '**/build/**',
-    '**/google-fonts.css',
     '**/ionicons.min.css',
     '**/font-awesome.min.css',
     '**/jquery-1.11.1.min.js',

--- a/docs/css/google-fonts.css
+++ b/docs/css/google-fonts.css
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 /* latin-ext */
 @font-face {
   font-family: 'Barlow';


### PR DESCRIPTION
Internally at Linkedin we've observed that excluding specific `js` and `css` through rat gradle-plugin causes the ligradle build to not run the unit-tests. 

To fix it, this patch removes those files from rat excludes and adds the samza license to the individual files. 