### PR TITLE
SAMZA-1952: StreamPartitionCountMonitor for standalone.

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
@@ -350,10 +350,15 @@ public class ZkJobCoordinator implements JobCoordinator {
       metrics.isLeader.set(true);
       zkUtils.subscribeToProcessorChange(new ProcessorChangeHandler(zkUtils));
       if (!new StorageConfig(config).hasDurableStores()) {
+        // 1. Stop if there's a existing StreamPartitionCountMonitor running.
+        if (streamPartitionCountMonitor != null) {
+          streamPartitionCountMonitor.stop();
+        }
+        // 2. Start a new instance of StreamPartitionCountMonitor.
         streamPartitionCountMonitor = getPartitionCountMonitor();
         streamPartitionCountMonitor.start();
       }
-      debounceTimer.scheduleAfterDebounceTime(ON_PROCESSOR_CHANGE, debounceTimeMs, () -> doOnProcessorChange());
+      debounceTimer.scheduleAfterDebounceTime(ON_PROCESSOR_CHANGE, debounceTimeMs, ZkJobCoordinator.this::doOnProcessorChange);
     }
   }
 

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
@@ -20,7 +20,6 @@ package org.apache.samza.zk;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.HashMap;
 import java.util.List;
@@ -38,12 +37,14 @@ import org.apache.samza.config.JobConfig;
 import org.apache.samza.config.MapConfig;
 import org.apache.samza.config.MetricsConfig;
 import org.apache.samza.config.TaskConfigJava;
+import org.apache.samza.config.StorageConfig;
 import org.apache.samza.config.ZkConfig;
 import org.apache.samza.container.TaskName;
 import org.apache.samza.coordinator.JobCoordinator;
 import org.apache.samza.coordinator.JobCoordinatorListener;
 import org.apache.samza.coordinator.JobModelManager;
 import org.apache.samza.coordinator.LeaderElectorListener;
+import org.apache.samza.coordinator.StreamPartitionCountMonitor;
 import org.apache.samza.job.model.ContainerModel;
 import org.apache.samza.job.model.JobModel;
 import org.apache.samza.metrics.MetricsRegistry;
@@ -53,6 +54,7 @@ import org.apache.samza.runtime.ProcessorIdGenerator;
 import org.apache.samza.storage.ChangelogStreamManager;
 import org.apache.samza.system.StreamMetadataCache;
 import org.apache.samza.system.SystemAdmins;
+import org.apache.samza.system.SystemStream;
 import org.apache.samza.util.MetricsReporterLoader;
 import org.apache.samza.util.SystemClock;
 import org.apache.samza.util.Util;
@@ -67,7 +69,7 @@ public class ZkJobCoordinator implements JobCoordinator {
   private static final Logger LOG = LoggerFactory.getLogger(ZkJobCoordinator.class);
   // TODO: MetadataCache timeout has to be 0 for the leader so that it can always have the latest information associated
   // with locality. Since host-affinity is not yet implemented, this can be fixed as part of SAMZA-1197
-  private static final int METADATA_CACHE_TTL_MS = 5000;
+  private static final int METADATA_CACHE_TTL_MS = 10;
   private static final int NUM_VERSIONS_TO_LEAVE = 10;
 
   // Action name when the JobModel version changes
@@ -105,9 +107,11 @@ public class ZkJobCoordinator implements JobCoordinator {
   @VisibleForTesting
   ScheduleAfterDebounceTime debounceTimer;
 
+  @VisibleForTesting
+  StreamPartitionCountMonitor streamPartitionCountMonitor = null;
+
   ZkJobCoordinator(Config config, MetricsRegistry metricsRegistry, ZkUtils zkUtils) {
     this.config = config;
-
     this.metrics = new ZkJobCoordinatorMetrics(metricsRegistry);
 
     this.processorId = createProcessorId(config);
@@ -179,6 +183,10 @@ public class ZkJobCoordinator implements JobCoordinator {
         LOG.debug("Shutting down metrics.");
         shutdownMetrics();
 
+        if (streamPartitionCountMonitor != null) {
+          streamPartitionCountMonitor.stop();
+        }
+
         if (coordinatorListener != null) {
           coordinatorListener.onCoordinatorStop();
         }
@@ -233,13 +241,11 @@ public class ZkJobCoordinator implements JobCoordinator {
   public void onProcessorChange(List<String> processors) {
     if (leaderElector.amILeader()) {
       LOG.info("ZkJobCoordinator::onProcessorChange - list of processors changed. List size=" + processors.size());
-      debounceTimer.scheduleAfterDebounceTime(ON_PROCESSOR_CHANGE, debounceTimeMs, () -> doOnProcessorChange(processors));
+      debounceTimer.scheduleAfterDebounceTime(ON_PROCESSOR_CHANGE, debounceTimeMs, this::doOnProcessorChange);
     }
   }
 
-  void doOnProcessorChange(List<String> processors) {
-    // if list of processors is empty - it means we are called from 'onBecomeLeader'
-    // TODO: Handle empty currentProcessorIds.
+  void doOnProcessorChange() {
     List<String> currentProcessorIds = zkUtils.getSortedActiveProcessorsIDs();
     Set<String> uniqueProcessorIds = new HashSet<>(currentProcessorIds);
 
@@ -320,16 +326,34 @@ public class ZkJobCoordinator implements JobCoordinator {
     return new JobModel(new MapConfig(), model.getContainers());
   }
 
+  @VisibleForTesting
+  StreamPartitionCountMonitor getPartitionCountMonitor() {
+    StreamMetadataCache streamMetadata = new StreamMetadataCache(systemAdmins, 0, SystemClock.instance());
+    Set<SystemStream> inputStreamsToMonitor = new TaskConfigJava(config).getAllInputStreams();
+
+    return new StreamPartitionCountMonitor(
+            inputStreamsToMonitor,
+            streamMetadata,
+            metrics.getMetricsRegistry(),
+            new JobConfig(config).getMonitorPartitionChangeFrequency(),
+            streamsChanged -> {
+        if (leaderElector.amILeader()) {
+          debounceTimer.scheduleAfterDebounceTime(ON_PROCESSOR_CHANGE, 0, this::doOnProcessorChange);
+        }
+      });
+  }
+
   class LeaderElectorListenerImpl implements LeaderElectorListener {
     @Override
     public void onBecomingLeader() {
       LOG.info("ZkJobCoordinator::onBecomeLeader - I became the leader");
       metrics.isLeader.set(true);
       zkUtils.subscribeToProcessorChange(new ProcessorChangeHandler(zkUtils));
-      debounceTimer.scheduleAfterDebounceTime(ON_PROCESSOR_CHANGE, debounceTimeMs, () -> {
-          // actual actions to do are the same as onProcessorChange
-          doOnProcessorChange(new ArrayList<>());
-        });
+      if (!new StorageConfig(config).hasDurableStores()) {
+        streamPartitionCountMonitor = getPartitionCountMonitor();
+        streamPartitionCountMonitor.start();
+      }
+      debounceTimer.scheduleAfterDebounceTime(ON_PROCESSOR_CHANGE, debounceTimeMs, () -> doOnProcessorChange());
     }
   }
 
@@ -371,10 +395,8 @@ public class ZkJobCoordinator implements JobCoordinator {
           LOG.warn("Barrier for version " + version + " timed out.");
           if (leaderElector.amILeader()) {
             LOG.info("Leader will schedule a new job model generation");
-            debounceTimer.scheduleAfterDebounceTime(ON_PROCESSOR_CHANGE, debounceTimeMs, () -> {
-                // actual actions to do are the same as onProcessorChange
-                doOnProcessorChange(new ArrayList<>());
-              });
+            // actual actions to do are the same as onProcessorChange
+            debounceTimer.scheduleAfterDebounceTime(ON_PROCESSOR_CHANGE, debounceTimeMs, ZkJobCoordinator.this::doOnProcessorChange);
           }
         }
       }
@@ -477,6 +499,11 @@ public class ZkJobCoordinator implements JobCoordinator {
           if (leaderElector.amILeader()) {
             leaderElector.resignLeadership();
           }
+
+          if (streamPartitionCountMonitor != null) {
+            streamPartitionCountMonitor.stop();
+          }
+
           /**
            * After this event, one amongst the following two things could potentially happen:
            * A. On successful reconnect to another zookeeper server in ensemble, this processor is going to
@@ -513,7 +540,6 @@ public class ZkJobCoordinator implements JobCoordinator {
         default:
           // received SyncConnected, ConnectedReadOnly, and SaslAuthenticated. NoOp
           LOG.info("Got ZK event " + state.toString() + " for processor=" + processorId + ". Continue");
-          return;
       }
     }
 

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
@@ -69,7 +69,7 @@ public class ZkJobCoordinator implements JobCoordinator {
   private static final Logger LOG = LoggerFactory.getLogger(ZkJobCoordinator.class);
   // TODO: MetadataCache timeout has to be 0 for the leader so that it can always have the latest information associated
   // with locality. Since host-affinity is not yet implemented, this can be fixed as part of SAMZA-1197
-  private static final int METADATA_CACHE_TTL_MS = 10;
+  private static final int METADATA_CACHE_TTL_MS = 5000;
   private static final int NUM_VERSIONS_TO_LEAVE = 10;
 
   // Action name when the JobModel version changes

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
@@ -680,9 +680,11 @@ public class TestZkLocalApplicationRunner extends StandaloneIntegrationTestHarne
     // Increase the partition count of input kafka topic to 100.
     AdminUtils.addPartitions(zkUtils(), inputKafkaTopic, 100, "", true, RackAwareMode.Enforced$.MODULE$);
 
+    long jobModelWaitTimeInMillis = 10;
     while (Objects.equals(zkUtils.getJobModelVersion(), jobModelVersion)) {
       LOGGER.info("Waiting for new jobModel to be published");
-      Thread.sleep(1000);
+      Thread.sleep(jobModelWaitTimeInMillis);
+      jobModelWaitTimeInMillis = jobModelWaitTimeInMillis * 2;
     }
 
     String newJobModelVersion = zkUtils.getJobModelVersion();


### PR DESCRIPTION
This patch adds the capability to detect the partition change of the input streams of a stateless standalone jobs and trigger a re-balancing phase(which will essentially account for new partitions from input stream and distribute it to the live processors of the group). 

Existing partition count detection of input streams is broken in yarn for stateful jobs. This will be addressed for both yarn and standalone as a part of #622 