### PR TITLE
Removing regex-input static-input exclusivity check

### DIFF
--- a/samza-kafka/src/main/scala/org/apache/samza/config/RegExTopicGenerator.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/config/RegExTopicGenerator.scala
@@ -71,7 +71,8 @@ class RegExTopicGenerator extends ConfigRewriter with Logging {
       info("Generating new configs for matching stream %s." format m)
 
       if (existingInputStreams.contains(m)) {
-        throw new SamzaException("Regex '%s' matches existing, statically defined input %s." format (regex, m))
+        warn("Regex '%s' matches existing, statically defined input %s. " +
+          "Please ensure regex-defined and statically-defined inputs are exclusive." format (regex, m))
       }
 
       newInputStreams.add(m)


### PR DESCRIPTION
This PR converts a hard-check that fails in case of regex-defined input if there is an overlap 
between regex-input and task-input, to a warning. 

Why?
Because with Samza 1.0, rewrite is called multiple times to expand system descriptors, input descriptors, etc. This hard-check fails in this case causing deployment to stall. Therefore we convert it to a warning. 

NOTE: This now allows users to define stream config for their inputs which may overlap with regex-input. This was earlier explicitly disallowed by the hard-check.