### PR TITLE
SAMZA-1938: Support use cases to run multiple sql statements in one Samza job

### DIFF
--- a/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplication.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplication.java
@@ -20,14 +20,20 @@
 package org.apache.samza.sql.runner;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.samza.application.StreamApplication;
 import org.apache.samza.application.descriptors.StreamApplicationDescriptor;
+import org.apache.samza.sql.data.SamzaSqlExecutionContext;
 import org.apache.samza.sql.dsl.SamzaSqlDslConverter;
+import org.apache.samza.sql.interfaces.SamzaRelConverter;
 import org.apache.samza.sql.translator.QueryTranslator;
+import org.apache.samza.sql.translator.TranslatorContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,12 +44,15 @@ import org.slf4j.LoggerFactory;
 public class SamzaSqlApplication implements StreamApplication {
 
   private static final Logger LOG = LoggerFactory.getLogger(SamzaSqlApplication.class);
+  private AtomicInteger queryId = new AtomicInteger(0);
 
   @Override
   public void describe(StreamApplicationDescriptor appDesc) {
     try {
       // TODO: Introduce an API to return a dsl string containing one or more sql statements.
       List<String> dslStmts = SamzaSqlDslConverter.fetchSqlFromConfig(appDesc.getConfig());
+
+      Map<Integer, TranslatorContext> translatorContextMap = new HashMap<>();
 
       // 1. Get Calcite plan
       Set<String> inputSystemStreams = new HashSet<>();
@@ -58,11 +67,29 @@ public class SamzaSqlApplication implements StreamApplication {
           new SamzaSqlApplicationConfig(appDesc.getConfig(), inputSystemStreams, outputSystemStreams);
 
       // 3. Translate Calcite plan to Samza stream operators
-      QueryTranslator queryTranslator = new QueryTranslator(sqlConfig);
+      QueryTranslator queryTranslator = new QueryTranslator(appDesc, sqlConfig);
+      SamzaSqlExecutionContext executionContext = new SamzaSqlExecutionContext(sqlConfig);
+      Map<String, SamzaRelConverter> converters = sqlConfig.getSamzaRelConverters();
       for (RelRoot relRoot : relRoots) {
         LOG.info("Translating relRoot {} to samza stream graph", relRoot);
-        queryTranslator.translate(relRoot, appDesc);
+        int qId = queryId.incrementAndGet();
+        TranslatorContext translatorContext = new TranslatorContext(appDesc, relRoot, executionContext, converters);
+        translatorContextMap.put(qId, translatorContext);
+        queryTranslator.translate(relRoot, translatorContext, qId);
       }
+
+      // 4. Set all translator contexts
+      /*
+       * TODO When serialization of ApplicationDescriptor is actually needed, then something will need to be updated here,
+       * since translatorContext is not Serializable. Currently, a new ApplicationDescriptor instance is created in each
+       * container, so it does not need to be serialized. Therefore, the translatorContext is recreated in each container
+       * and does not need to be serialized.
+       */
+      appDesc.withApplicationTaskContextFactory((jobContext,
+          containerContext,
+          taskContext,
+          applicationContainerContext) ->
+          new SamzaSqlApplicationContext(translatorContextMap));
     } catch (RuntimeException e) {
       LOG.error("SamzaSqlApplication threw exception.", e);
       throw e;

--- a/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationContext.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationContext.java
@@ -19,19 +19,20 @@
 
 package org.apache.samza.sql.runner;
 
+import java.util.Map;
 import org.apache.samza.context.ApplicationTaskContext;
 import org.apache.samza.sql.translator.TranslatorContext;
 
 
 public class SamzaSqlApplicationContext implements ApplicationTaskContext {
-  private final TranslatorContext translatorContext;
+  private Map<Integer, TranslatorContext> queryIdAndTranslatorContextMap;
 
-  public SamzaSqlApplicationContext(TranslatorContext translatorContext) {
-    this.translatorContext = translatorContext;
+  public SamzaSqlApplicationContext(Map<Integer, TranslatorContext> queryAndTranslatorContextMap) {
+    this.queryIdAndTranslatorContextMap = queryAndTranslatorContextMap;
   }
 
-  public TranslatorContext getTranslatorContext() {
-    return translatorContext;
+  public Map<Integer, TranslatorContext> getTranslatorContexts() {
+    return queryIdAndTranslatorContextMap;
   }
 
   @Override

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/QueryTranslator.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/QueryTranslator.java
@@ -19,6 +19,8 @@
 
 package org.apache.samza.sql.translator;
 
+import com.google.common.annotations.VisibleForTesting;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.calcite.rel.RelNode;
@@ -35,6 +37,7 @@ import org.apache.samza.application.descriptors.StreamApplicationDescriptor;
 import org.apache.samza.context.Context;
 import org.apache.samza.operators.KV;
 import org.apache.samza.operators.MessageStream;
+import org.apache.samza.operators.OutputStream;
 import org.apache.samza.operators.functions.MapFunction;
 import org.apache.samza.serializers.KVSerde;
 import org.apache.samza.serializers.NoOpSerde;
@@ -59,23 +62,27 @@ import org.apache.samza.table.descriptors.TableDescriptor;
  * It then walks the relational graph and then populates the Samza's {@link StreamApplicationDescriptor} accordingly.
  */
 public class QueryTranslator {
-  private final ScanTranslator scanTranslator;
-  private final ModifyTranslator modifyTranslator;
   private final SamzaSqlApplicationConfig sqlConfig;
-  private final Map<String, SamzaRelConverter> converters;
+  private final StreamApplicationDescriptor streamAppDescriptor;
+  private final Map<String, DelegatingSystemDescriptor> systemDescriptors;
+  private final Map<String, MessageStream<KV<Object, Object>>> inputMsgStreams;
+  private final Map<String, OutputStream> outputMsgStreams;
 
   private static class OutputMapFunction implements MapFunction<SamzaSqlRelMessage, KV<Object, Object>> {
     private transient SamzaRelConverter samzaMsgConverter;
     private final String outputTopic;
+    private final int queryId;
+    static OutputStream logOutputStream;
 
-    OutputMapFunction(String outputTopic) {
+    OutputMapFunction(String outputTopic, int queryId) {
       this.outputTopic = outputTopic;
+      this.queryId = queryId;
     }
 
     @Override
     public void init(Context context) {
       TranslatorContext translatorContext =
-          ((SamzaSqlApplicationContext) context.getApplicationTaskContext()).getTranslatorContext();
+          ((SamzaSqlApplicationContext) context.getApplicationTaskContext()).getTranslatorContexts().get(queryId);
       this.samzaMsgConverter = translatorContext.getMsgConverter(outputTopic);
     }
 
@@ -85,28 +92,44 @@ public class QueryTranslator {
     }
   }
 
-  public QueryTranslator(SamzaSqlApplicationConfig sqlConfig) {
+  public QueryTranslator(StreamApplicationDescriptor appDesc, SamzaSqlApplicationConfig sqlConfig) {
     this.sqlConfig = sqlConfig;
-    scanTranslator =
-        new ScanTranslator(sqlConfig.getSamzaRelConverters(), sqlConfig.getInputSystemStreamConfigBySource());
-    modifyTranslator =
-        new ModifyTranslator(sqlConfig.getSamzaRelConverters(), sqlConfig.getOutputSystemStreamConfigsBySource());
-    this.converters = sqlConfig.getSamzaRelConverters();
+    this.streamAppDescriptor = appDesc;
+    this.systemDescriptors = new HashMap<>();
+    this.outputMsgStreams = new HashMap<>();
+    this.inputMsgStreams = new HashMap<>();
   }
 
+  /**
+   * For unit testing only
+   */
+  @VisibleForTesting
   public void translate(SamzaSqlQueryParser.QueryInfo queryInfo, StreamApplicationDescriptor appDesc) {
     QueryPlanner planner =
         new QueryPlanner(sqlConfig.getRelSchemaProviders(), sqlConfig.getSystemStreamConfigsBySource(),
             sqlConfig.getUdfMetadata());
     final RelRoot relRoot = planner.plan(queryInfo.getSql());
-    translate(relRoot, appDesc);
+    int queryId = 1;
+    SamzaSqlExecutionContext executionContext = new SamzaSqlExecutionContext(sqlConfig);
+    Map<String, SamzaRelConverter> converters = sqlConfig.getSamzaRelConverters();
+    TranslatorContext translatorContext = new TranslatorContext(appDesc, relRoot, executionContext, converters);
+    translate(relRoot, translatorContext, queryId);
+    Map<Integer, TranslatorContext> translatorContexts = new HashMap<>();
+    translatorContexts.put(queryId, translatorContext.clone());
+    appDesc.withApplicationTaskContextFactory((jobContext,
+        containerContext,
+        taskContext,
+        applicationContainerContext) ->
+        new SamzaSqlApplicationContext(translatorContexts));
   }
 
-  public void translate(RelRoot relRoot, StreamApplicationDescriptor appDesc) {
-    final SamzaSqlExecutionContext executionContext = new SamzaSqlExecutionContext(this.sqlConfig);
-    final TranslatorContext translatorContext = new TranslatorContext(appDesc, relRoot, executionContext, this.converters);
+  public void translate(RelRoot relRoot, TranslatorContext translatorContext, int queryId) {
     final SqlIOResolver ioResolver = translatorContext.getExecutionContext().getSamzaSqlApplicationConfig().getIoResolver();
     final RelNode node = relRoot.project();
+    ScanTranslator scanTranslator =
+        new ScanTranslator(sqlConfig.getSamzaRelConverters(), sqlConfig.getInputSystemStreamConfigBySource(), queryId);
+    ModifyTranslator modifyTranslator =
+        new ModifyTranslator(sqlConfig.getSamzaRelConverters(), sqlConfig.getOutputSystemStreamConfigsBySource(), queryId);
 
     node.accept(new RelShuttleImpl() {
       int windowId = 0;
@@ -125,28 +148,28 @@ public class QueryTranslator {
           throw new SamzaException("Not a supported operation: " + modify.toString());
         }
         RelNode node = super.visit(modify);
-        modifyTranslator.translate(modify, translatorContext);
+        modifyTranslator.translate(modify, translatorContext, systemDescriptors, outputMsgStreams);
         return node;
       }
 
       @Override
       public RelNode visit(TableScan scan) {
         RelNode node = super.visit(scan);
-        scanTranslator.translate(scan, translatorContext);
+        scanTranslator.translate(scan, translatorContext, systemDescriptors, inputMsgStreams);
         return node;
       }
 
       @Override
       public RelNode visit(LogicalFilter filter) {
         RelNode node = visitChild(filter, 0, filter.getInput());
-        new FilterTranslator().translate(filter, translatorContext);
+        new FilterTranslator(queryId).translate(filter, translatorContext);
         return node;
       }
 
       @Override
       public RelNode visit(LogicalProject project) {
         RelNode node = super.visit(project);
-        new ProjectTranslator().translate(project, translatorContext);
+        new ProjectTranslator(queryId).translate(project, translatorContext);
         return node;
       }
 
@@ -171,36 +194,27 @@ public class QueryTranslator {
     sqlConfig.getOutputSystemStreamConfigsBySource().keySet().forEach(
         key -> {
           if (key.split("\\.")[0].equals(SamzaSqlApplicationConfig.SAMZA_SYSTEM_LOG)) {
-            sendToOutputStream(appDesc, translatorContext, node, key);
+            sendToOutputStream(streamAppDescriptor, translatorContext, node, queryId);
           }
         }
     );
-
-    /*
-     * TODO When serialization of ApplicationDescriptor is actually needed, then something will need to be updated here,
-     * since translatorContext is not Serializable. Currently, a new ApplicationDescriptor instance is created in each
-     * container, so it does not need to be serialized. Therefore, the translatorContext is recreated in each container
-     * and does not need to be serialized.
-     */
-    appDesc.withApplicationTaskContextFactory((jobContext,
-        containerContext,
-        taskContext,
-        applicationContainerContext) ->
-        new SamzaSqlApplicationContext(translatorContext.clone()));
   }
 
-  private void sendToOutputStream(StreamApplicationDescriptor appDesc, TranslatorContext context, RelNode node, String sink) {
-    SqlIOConfig sinkConfig = sqlConfig.getOutputSystemStreamConfigsBySource().get(sink);
+  private void sendToOutputStream(StreamApplicationDescriptor appDesc, TranslatorContext context, RelNode node, int queryId) {
+    SqlIOConfig sinkConfig = sqlConfig.getOutputSystemStreamConfigsBySource().get(SamzaSqlApplicationConfig.SAMZA_SYSTEM_LOG);
     MessageStream<SamzaSqlRelMessage> stream = context.getMessageStream(node.getId());
-    MessageStream<KV<Object, Object>> outputStream = stream.map(new OutputMapFunction(sink));
+    MessageStream<KV<Object, Object>> outputStream = stream.map(new OutputMapFunction(SamzaSqlApplicationConfig.SAMZA_SYSTEM_LOG, queryId));
     Optional<TableDescriptor> tableDescriptor = sinkConfig.getTableDescriptor();
     if (!tableDescriptor.isPresent()) {
       KVSerde<Object, Object> noOpKVSerde = KVSerde.of(new NoOpSerde<>(), new NoOpSerde<>());
       String systemName = sinkConfig.getSystemName();
       DelegatingSystemDescriptor
-          sd = context.getSystemDescriptors().computeIfAbsent(systemName, DelegatingSystemDescriptor::new);
+          sd = systemDescriptors.computeIfAbsent(systemName, DelegatingSystemDescriptor::new);
       GenericOutputDescriptor<KV<Object, Object>> osd = sd.getOutputDescriptor(sinkConfig.getStreamName(), noOpKVSerde);
-      outputStream.sendTo(appDesc.getOutputStream(osd));
+      if (OutputMapFunction.logOutputStream == null) {
+        OutputMapFunction.logOutputStream = appDesc.getOutputStream(osd);
+      }
+      outputStream.sendTo(OutputMapFunction.logOutputStream);
     } else {
       Table outputTable = appDesc.getTable(tableDescriptor.get());
       if (outputTable == null) {

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/ScanTranslator.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/ScanTranslator.java
@@ -46,10 +46,12 @@ class ScanTranslator {
 
   private final Map<String, SamzaRelConverter> relMsgConverters;
   private final Map<String, SqlIOConfig> systemStreamConfig;
+  private final int queryId;
 
-  ScanTranslator(Map<String, SamzaRelConverter> converters, Map<String, SqlIOConfig> ssc) {
+  ScanTranslator(Map<String, SamzaRelConverter> converters, Map<String, SqlIOConfig> ssc, int queryId) {
     relMsgConverters = converters;
     this.systemStreamConfig = ssc;
+    this.queryId = queryId;
   }
 
   private static class ScanMapFunction implements MapFunction<KV<Object, Object>, SamzaSqlRelMessage> {
@@ -58,15 +60,17 @@ class ScanTranslator {
     // initialization.
     private transient SamzaRelConverter msgConverter;
     private final String streamName;
+    private final int queryId;
 
-    ScanMapFunction(String sourceStreamName) {
+    ScanMapFunction(String sourceStreamName, int queryId) {
       this.streamName = sourceStreamName;
+      this.queryId = queryId;
     }
 
     @Override
     public void init(Context context) {
       TranslatorContext translatorContext =
-          ((SamzaSqlApplicationContext) context.getApplicationTaskContext()).getTranslatorContext();
+          ((SamzaSqlApplicationContext) context.getApplicationTaskContext()).getTranslatorContexts().get(queryId);
       this.msgConverter = translatorContext.getMsgConverter(streamName);
     }
 
@@ -76,7 +80,8 @@ class ScanTranslator {
     }
   }
 
-  void translate(final TableScan tableScan, final TranslatorContext context) {
+  void translate(final TableScan tableScan, final TranslatorContext context,
+      Map<String, DelegatingSystemDescriptor> systemDescriptors, Map<String, MessageStream<KV<Object, Object>>> inputMsgStreams) {
     StreamApplicationDescriptor streamAppDesc = context.getStreamAppDescriptor();
     List<String> tableNameParts = tableScan.getTable().getQualifiedName();
     String sourceName = SqlIOConfig.getSourceFromSourceParts(tableNameParts);
@@ -85,14 +90,15 @@ class ScanTranslator {
     SqlIOConfig sqlIOConfig = systemStreamConfig.get(sourceName);
     final String systemName = sqlIOConfig.getSystemName();
     final String streamName = sqlIOConfig.getStreamName();
+    final String source = sqlIOConfig.getSource();
 
     KVSerde<Object, Object> noOpKVSerde = KVSerde.of(new NoOpSerde<>(), new NoOpSerde<>());
     DelegatingSystemDescriptor
-        sd = context.getSystemDescriptors().computeIfAbsent(systemName, DelegatingSystemDescriptor::new);
+        sd = systemDescriptors.computeIfAbsent(systemName, DelegatingSystemDescriptor::new);
     GenericInputDescriptor<KV<Object, Object>> isd = sd.getInputDescriptor(streamName, noOpKVSerde);
-    MessageStream<KV<Object, Object>> inputStream = streamAppDesc.getInputStream(isd);
-    MessageStream<SamzaSqlRelMessage> samzaSqlRelMessageStream = inputStream.map(new ScanMapFunction(sourceName));
 
+    MessageStream<KV<Object, Object>> inputStream = inputMsgStreams.computeIfAbsent(source, v -> streamAppDesc.getInputStream(isd));
+    MessageStream<SamzaSqlRelMessage> samzaSqlRelMessageStream = inputStream.map(new ScanMapFunction(sourceName, queryId));
     context.registerMessageStream(tableScan.getId(), samzaSqlRelMessageStream);
   }
 }

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/TranslatorContext.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/TranslatorContext.java
@@ -133,13 +133,13 @@ public class TranslatorContext implements Cloneable {
 
   /**
    * Create the instance of TranslatorContext
-   * @param stramAppDesc Samza's streamAppDesc that is populated during the translation.
+   * @param streamAppDesc Samza's streamAppDesc that is populated during the translation.
    * @param relRoot Root of the relational graph from calcite.
    * @param executionContext the execution context
    * @param converters the map of schema to RelData converters
    */
-  TranslatorContext(StreamApplicationDescriptor stramAppDesc, RelRoot relRoot, SamzaSqlExecutionContext executionContext, Map<String, SamzaRelConverter> converters) {
-    this.streamAppDesc = stramAppDesc;
+  public TranslatorContext(StreamApplicationDescriptor streamAppDesc, RelRoot relRoot, SamzaSqlExecutionContext executionContext, Map<String, SamzaRelConverter> converters) {
+    this.streamAppDesc = streamAppDesc;
     this.compiler = createExpressionCompiler(relRoot);
     this.executionContext = executionContext;
     this.dataContext = new DataContextImpl();
@@ -210,10 +210,6 @@ public class TranslatorContext implements Cloneable {
 
   SamzaRelConverter getMsgConverter(String source) {
     return this.relSamzaConverters.get(source);
-  }
-
-  Map<String, DelegatingSystemDescriptor> getSystemDescriptors() {
-    return this.systemDescriptors;
   }
 
   /**

--- a/samza-sql/src/test/java/org/apache/samza/sql/testutil/SamzaSqlTestConfig.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/testutil/SamzaSqlTestConfig.java
@@ -127,6 +127,12 @@ public class SamzaSqlTestConfig {
         "testavro", "SIMPLE1"), SimpleRecord.SCHEMA$.toString());
 
     staticConfigs.put(configAvroRelSchemaProviderDomain + String.format(ConfigBasedAvroRelSchemaProviderFactory.CFG_SOURCE_SCHEMA,
+        "testavro", "SIMPLE2"), SimpleRecord.SCHEMA$.toString());
+
+    staticConfigs.put(configAvroRelSchemaProviderDomain + String.format(ConfigBasedAvroRelSchemaProviderFactory.CFG_SOURCE_SCHEMA,
+        "testavro", "SIMPLE3"), SimpleRecord.SCHEMA$.toString());
+
+    staticConfigs.put(configAvroRelSchemaProviderDomain + String.format(ConfigBasedAvroRelSchemaProviderFactory.CFG_SOURCE_SCHEMA,
         "testavro", "simpleOutputTopic"), SimpleRecord.SCHEMA$.toString());
 
     staticConfigs.put(configAvroRelSchemaProviderDomain + String.format(ConfigBasedAvroRelSchemaProviderFactory.CFG_SOURCE_SCHEMA,

--- a/samza-sql/src/test/java/org/apache/samza/sql/translator/TestFilterTranslator.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/translator/TestFilterTranslator.java
@@ -21,6 +21,8 @@ package org.apache.samza.sql.translator;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.calcite.DataContext;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalFilter;
@@ -82,7 +84,7 @@ public class TestFilterTranslator extends TranslatorTestBase {
     when(mockCompiler.compile(any(), any())).thenReturn(mockExpr);
 
     // Apply translate() method to verify that we are getting the correct filter operator constructed
-    FilterTranslator filterTranslator = new FilterTranslator();
+    FilterTranslator filterTranslator = new FilterTranslator(1);
     filterTranslator.translate(mockFilter, mockContext);
     // make sure that context has been registered with LogicFilter and output message streams
     verify(mockContext, times(1)).registerRelNode(2, mockFilter);
@@ -95,7 +97,9 @@ public class TestFilterTranslator extends TranslatorTestBase {
 
     // Verify that the describe() method will establish the context for the filter function
     Context context = mock(Context.class);
-    when(context.getApplicationTaskContext()).thenReturn(new SamzaSqlApplicationContext(mockContext));
+    Map<Integer, TranslatorContext> mockContexts= new HashMap<>();
+    mockContexts.put(1, mockContext);
+    when(context.getApplicationTaskContext()).thenReturn(new SamzaSqlApplicationContext(mockContexts));
     filterSpec.getTransformFn().init(context);
     FilterFunction filterFn = (FilterFunction) Whitebox.getInternalState(filterSpec, "filterFn");
     assertNotNull(filterFn);

--- a/samza-sql/src/test/java/org/apache/samza/sql/translator/TestProjectTranslator.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/translator/TestProjectTranslator.java
@@ -21,7 +21,9 @@ package org.apache.samza.sql.translator;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.calcite.DataContext;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalProject;
@@ -100,7 +102,7 @@ public class TestProjectTranslator extends TranslatorTestBase {
     when(mockCompiler.compile(any(), any())).thenReturn(mockExpr);
 
     // Apply translate() method to verify that we are getting the correct map operator constructed
-    ProjectTranslator projectTranslator = new ProjectTranslator();
+    ProjectTranslator projectTranslator = new ProjectTranslator(1);
     projectTranslator.translate(mockProject, mockContext);
     // make sure that context has been registered with LogicFilter and output message streams
     verify(mockContext, times(1)).registerRelNode(2, mockProject);
@@ -113,7 +115,9 @@ public class TestProjectTranslator extends TranslatorTestBase {
 
     // Verify that the bootstrap() method will establish the context for the map function
     Context context = mock(Context.class);
-    when(context.getApplicationTaskContext()).thenReturn(new SamzaSqlApplicationContext(mockContext));
+    Map<Integer, TranslatorContext> mockContexts= new HashMap<>();
+    mockContexts.put(1, mockContext);
+    when(context.getApplicationTaskContext()).thenReturn(new SamzaSqlApplicationContext(mockContexts));
     projectSpec.getTransformFn().init(context);
     MapFunction mapFn = (MapFunction) Whitebox.getInternalState(projectSpec, "mapFn");
     assertNotNull(mapFn);
@@ -202,7 +206,7 @@ public class TestProjectTranslator extends TranslatorTestBase {
     when(mockCompiler.compile(any(), any())).thenReturn(mockExpr);
 
     // Apply translate() method to verify that we are getting the correct map operator constructed
-    ProjectTranslator projectTranslator = new ProjectTranslator();
+    ProjectTranslator projectTranslator = new ProjectTranslator(1);
     projectTranslator.translate(mockProject, mockContext);
     // make sure that context has been registered with LogicFilter and output message streams
     verify(mockContext, times(1)).registerRelNode(2, mockProject);
@@ -246,7 +250,9 @@ public class TestProjectTranslator extends TranslatorTestBase {
 
     // Verify that the describe() method will establish the context for the map function
     Context context = mock(Context.class);
-    when(context.getApplicationTaskContext()).thenReturn(new SamzaSqlApplicationContext(mockContext));
+    Map<Integer, TranslatorContext> mockContexts= new HashMap<>();
+    mockContexts.put(1, mockContext);
+    when(context.getApplicationTaskContext()).thenReturn(new SamzaSqlApplicationContext(mockContexts));
     projectSpec.getTransformFn().init(context);
     MapFunction mapFn = (MapFunction) Whitebox.getInternalState(projectSpec, "mapFn");
     assertNotNull(mapFn);

--- a/samza-sql/src/test/java/org/apache/samza/sql/translator/TestQueryTranslator.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/translator/TestQueryTranslator.java
@@ -51,29 +51,6 @@ import static org.junit.Assert.assertTrue;
 
 public class TestQueryTranslator {
 
-  // Helper functions to validate the cloned copies of TranslatorContext and SamzaSqlExecutionContext
-  private void validateClonedTranslatorContext(TranslatorContext originContext, TranslatorContext clonedContext) {
-    Assert.assertNotEquals(originContext, clonedContext);
-    assertTrue(originContext.getExpressionCompiler() == clonedContext.getExpressionCompiler());
-    assertTrue(originContext.getStreamAppDescriptor() == clonedContext.getStreamAppDescriptor());
-    assertTrue(Whitebox.getInternalState(originContext, "relSamzaConverters") == Whitebox.getInternalState(clonedContext, "relSamzaConverters"));
-    assertTrue(Whitebox.getInternalState(originContext, "messageStreams") == Whitebox.getInternalState(clonedContext, "messageStreams"));
-    assertTrue(Whitebox.getInternalState(originContext, "relNodes") == Whitebox.getInternalState(clonedContext, "relNodes"));
-    Assert.assertNotEquals(originContext.getDataContext(), clonedContext.getDataContext());
-    validateClonedExecutionContext(originContext.getExecutionContext(), clonedContext.getExecutionContext());
-  }
-
-  private void validateClonedExecutionContext(SamzaSqlExecutionContext originContext,
-      SamzaSqlExecutionContext clonedContext) {
-    Assert.assertNotEquals(originContext, clonedContext);
-    assertTrue(
-        Whitebox.getInternalState(originContext, "sqlConfig") == Whitebox.getInternalState(clonedContext, "sqlConfig"));
-    assertTrue(Whitebox.getInternalState(originContext, "udfMetadata") == Whitebox.getInternalState(clonedContext,
-        "udfMetadata"));
-    assertTrue(Whitebox.getInternalState(originContext, "udfInstances") != Whitebox.getInternalState(clonedContext,
-        "udfInstances"));
-  }
-
   private final Map<String, String> configs = new HashMap<>();
 
   @Before
@@ -95,8 +72,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl appDesc = new StreamApplicationDescriptorImpl(streamApp -> { },samzaConfig);
+    QueryTranslator translator = new QueryTranslator(appDesc, samzaSqlApplicationConfig);
 
     translator.translate(queryInfo.get(0), appDesc);
     OperatorSpecGraph specGraph = appDesc.getOperatorSpecGraph();
@@ -116,20 +93,6 @@ public class TestQueryTranslator {
 
     Assert.assertEquals("testavro", inputSystem);
     Assert.assertEquals("SIMPLE1", inputPhysicalName);
-
-    validatePerTaskContextInit(appDesc, samzaConfig);
-  }
-
-  private void validatePerTaskContextInit(StreamApplicationDescriptorImpl appDesc, Config samzaConfig) {
-    // make sure that each task context would have a separate instance of cloned TranslatorContext
-    ApplicationTaskContext contextPerTaskOne =
-        appDesc.getApplicationTaskContextFactory().get().create(null, null, null, null);
-    ApplicationTaskContext contextPerTaskTwo =
-        appDesc.getApplicationTaskContextFactory().get().create(null, null, null, null);
-    assertTrue(contextPerTaskOne instanceof SamzaSqlApplicationContext);
-    assertTrue(contextPerTaskTwo instanceof SamzaSqlApplicationContext);
-    validateClonedTranslatorContext(((SamzaSqlApplicationContext) contextPerTaskOne).getTranslatorContext(),
-        ((SamzaSqlApplicationContext) contextPerTaskTwo).getTranslatorContext());
   }
 
   @Test
@@ -146,8 +109,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
 
     translator.translate(queryInfo.get(0), streamAppDesc);
     OperatorSpecGraph specGraph = streamAppDesc.getOperatorSpecGraph();
@@ -166,8 +129,6 @@ public class TestQueryTranslator {
     Assert.assertEquals(1, specGraph.getInputOperators().size());
     Assert.assertEquals("testavro", inputSystem);
     Assert.assertEquals("COMPLEX1", inputPhysicalName);
-
-    validatePerTaskContextInit(streamAppDesc, samzaConfig);
   }
 
   @Test
@@ -185,8 +146,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
 
     translator.translate(queryInfo.get(0), streamAppDesc);
     OperatorSpecGraph specGraph = streamAppDesc.getOperatorSpecGraph();
@@ -205,8 +166,6 @@ public class TestQueryTranslator {
     Assert.assertEquals(1, specGraph.getInputOperators().size());
     Assert.assertEquals("testavro", inputSystem);
     Assert.assertEquals("COMPLEX1", inputPhysicalName);
-
-    validatePerTaskContextInit(streamAppDesc, samzaConfig);
   }
 
   @Test (expected = SamzaException.class)
@@ -227,8 +186,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
 
     translator.translate(queryInfo.get(0), streamAppDesc);
   }
@@ -252,13 +211,13 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
 
     translator.translate(queryInfo.get(0), streamAppDesc);
   }
 
-  @Test (expected = IllegalStateException.class)
+  @Test (expected = SamzaException.class)
   public void testTranslateStreamTableJoinWithSelfJoinOperator() {
     Map<String, String> config = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, 1);
     String sql =
@@ -277,8 +236,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
 
     translator.translate(queryInfo.get(0), streamAppDesc);
   }
@@ -302,8 +261,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
     translator.translate(queryInfo.get(0), streamAppDesc);
   }
 
@@ -324,8 +283,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
     translator.translate(queryInfo.get(0), streamAppDesc);
   }
 
@@ -348,8 +307,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
     translator.translate(queryInfo.get(0), streamAppDesc);
   }
 
@@ -373,8 +332,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
     translator.translate(queryInfo.get(0), streamAppDesc);
   }
 
@@ -397,8 +356,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
     translator.translate(queryInfo.get(0), streamAppDesc);
   }
 
@@ -421,8 +380,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
     translator.translate(queryInfo.get(0), streamAppDesc);
   }
 
@@ -445,8 +404,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
     translator.translate(queryInfo.get(0), streamAppDesc);
   }
 
@@ -469,8 +428,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
     translator.translate(queryInfo.get(0), streamAppDesc);
   }
 
@@ -497,8 +456,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
     translator.translate(queryInfo.get(0), streamAppDesc);
   }
 
@@ -521,8 +480,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
     translator.translate(queryInfo.get(0), streamAppDesc);
   }
 
@@ -545,8 +504,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
 
     translator.translate(queryInfo.get(0), streamAppDesc);
     OperatorSpecGraph specGraph = streamAppDesc.getOperatorSpecGraph();
@@ -581,8 +540,6 @@ public class TestQueryTranslator {
     Assert.assertEquals("PROFILE", input2PhysicalName);
     Assert.assertEquals("kafka", input3System);
     Assert.assertEquals("sql-job-1-partition_by-stream_1", input3PhysicalName);
-
-    validatePerTaskContextInit(streamAppDesc, samzaConfig);
   }
 
   @Test
@@ -604,8 +561,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
 
     translator.translate(queryInfo.get(0), streamAppDesc);
 
@@ -641,8 +598,6 @@ public class TestQueryTranslator {
     Assert.assertEquals("PROFILE", input2PhysicalName);
     Assert.assertEquals("kafka", input3System);
     Assert.assertEquals("sql-job-1-partition_by-stream_1", input3PhysicalName);
-
-    validatePerTaskContextInit(streamAppDesc, samzaConfig);
   }
 
   @Test
@@ -664,8 +619,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
     translator.translate(queryInfo.get(0), streamAppDesc);
 
     OperatorSpecGraph specGraph = streamAppDesc.getOperatorSpecGraph();
@@ -700,8 +655,6 @@ public class TestQueryTranslator {
     Assert.assertEquals("PAGEVIEW", input2PhysicalName);
     Assert.assertEquals("kafka", input3System);
     Assert.assertEquals("sql-job-1-partition_by-stream_1", input3PhysicalName);
-
-    validatePerTaskContextInit(streamAppDesc, samzaConfig);
   }
 
   @Test
@@ -723,8 +676,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
 
     translator.translate(queryInfo.get(0), streamAppDesc);
     OperatorSpecGraph specGraph = streamAppDesc.getOperatorSpecGraph();
@@ -753,8 +706,8 @@ public class TestQueryTranslator {
             .collect(Collectors.toSet()),
         queryInfo.stream().map(SamzaSqlQueryParser.QueryInfo::getSink).collect(Collectors.toSet()));
 
-    QueryTranslator translator = new QueryTranslator(samzaSqlApplicationConfig);
     StreamApplicationDescriptorImpl streamAppDesc = new StreamApplicationDescriptorImpl(streamApp -> { }, samzaConfig);
+    QueryTranslator translator = new QueryTranslator(streamAppDesc, samzaSqlApplicationConfig);
     translator.translate(queryInfo.get(0), streamAppDesc);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is to support the following user scenarios:
1. support users to run multiple Sql statements in the same job.
- sql1 = "Insert into testavro.simpleOutputTopic select * from testavro.SIMPLE1";
-  sql2 = "Insert into testavro.SIMPLE3 select * from testavro.SIMPLE2";

2. Support fan-out use case. For example, 
- sql1 = "Insert into testavro.SIMPLE2 select * from testavro.SIMPLE1";
- sql2 = "Insert into testavro.SIMPLE3 select * from testavro.SIMPLE1";

3. Support fan-in use case. For example,
- sql1 = "Insert into testavro.simpleOutputTopic select * from testavro.SIMPLE2";
- sql2 = "Insert into testavro.simpleOutputTopic select * from testavro.SIMPLE1";

This PR makes the information about `SystemDescriptors`,  `MessageStream of input sources` and `OutputStream` stored in `QueryTranslator`. The reason is that those information belongs to the job and each job has only one `QueryTranslator` object.

## How was this patch tested?
1. Add unit tests
2. Testing in Samza SQL shell.
