### PR TITLE
SAMZA-1970: Support for physical names in InMemorySystem

### DIFF
--- a/samza-test/src/main/java/org/apache/samza/test/framework/system/descriptors/InMemoryInputDescriptor.java
+++ b/samza-test/src/main/java/org/apache/samza/test/framework/system/descriptors/InMemoryInputDescriptor.java
@@ -41,7 +41,7 @@ public class InMemoryInputDescriptor<StreamMessageType>
   }
 
   public InMemoryInputDescriptor withPhysicalName(String physicalName) {
-    withPhysicalName(physicalName);
+    super.withPhysicalName(physicalName);
     return this;
   }
 }

--- a/samza-test/src/main/java/org/apache/samza/test/framework/system/descriptors/InMemoryOutputDescriptor.java
+++ b/samza-test/src/main/java/org/apache/samza/test/framework/system/descriptors/InMemoryOutputDescriptor.java
@@ -45,7 +45,7 @@ public class InMemoryOutputDescriptor<StreamMessageType>
   }
 
   public InMemoryOutputDescriptor withPhysicalName(String physicalName) {
-    withPhysicalName(physicalName);
+    super.withPhysicalName(physicalName);
     return this;
   }
 }


### PR DESCRIPTION
if super is not there, java compiles this to this.withPhysicalName which results in StackOverflows