### PR TITLE
SAMZA-1638: Recreate SystemProducer on KafkaCheckpointManager.writeCheckpoint failures.

### DIFF
--- a/samza-kafka/src/test/scala/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.scala
+++ b/samza-kafka/src/test/scala/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.scala
@@ -85,7 +85,7 @@ class TestKafkaCheckpointManager extends KafkaServerTestHarness {
     val spec = new KafkaStreamSpec("id", checkpointTopic, checkpointSystemName, 1, 1, props)
     val checkPointManager = Mockito.spy(new KafkaCheckpointManager(spec, new MockSystemFactory, false, config, new NoOpMetricsRegistry))
     val newKafkaProducer: SystemProducer = Mockito.mock(classOf[SystemProducer])
-    checkPointManager.MaxRetryDurationMs = 1
+    checkPointManager.MaxRetryDurationInMillis = 1
 
     Mockito.doReturn(newKafkaProducer).when(checkPointManager).getSystemProducer()
 
@@ -146,7 +146,7 @@ class TestKafkaCheckpointManager extends KafkaServerTestHarness {
     val props = new org.apache.samza.config.KafkaConfig(config).getCheckpointTopicProperties()
     val spec = new KafkaStreamSpec("id", checkpointTopic, checkpointSystemName, 1, 1, props)
     val checkPointManager = new KafkaCheckpointManager(spec, new MockSystemFactory, false, config, new NoOpMetricsRegistry)
-    checkPointManager.MaxRetryDurationMs = 1
+    checkPointManager.MaxRetryDurationInMillis = 1
 
     checkPointManager.register(taskName)
     checkPointManager.start

--- a/samza-kafka/src/test/scala/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.scala
+++ b/samza-kafka/src/test/scala/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.scala
@@ -64,13 +64,44 @@ class TestKafkaCheckpointManager extends KafkaServerTestHarness {
   }
 
   override def generateConfigs() = {
-    val props = TestUtils.createBrokerConfigs(numBrokers, zkConnect, true)
+    val props = TestUtils.createBrokerConfigs(numBrokers, zkConnect, enableControlledShutdown = true)
     // do not use relative imports
     props.map(_root_.kafka.server.KafkaConfig.fromProps)
   }
 
+  def testWriteCheckpointShouldRecreateSystemProducerOnFailure(): Unit = {
+    val checkpointTopic = "checkpoint-topic-2"
+    val mockKafkaProducer: SystemProducer = Mockito.mock(classOf[SystemProducer])
+
+    class MockSystemFactory extends KafkaSystemFactory {
+      override def getProducer(systemName: String, config: Config, registry: MetricsRegistry): SystemProducer = {
+        mockKafkaProducer
+      }
+    }
+
+    Mockito.doThrow(new RuntimeException()).when(mockKafkaProducer).flush(taskName.getTaskName)
+
+    val props = new org.apache.samza.config.KafkaConfig(config).getCheckpointTopicProperties()
+    val spec = new KafkaStreamSpec("id", checkpointTopic, checkpointSystemName, 1, 1, props)
+    val checkPointManager = Mockito.spy(new KafkaCheckpointManager(spec, new MockSystemFactory, false, config, new NoOpMetricsRegistry))
+    val newKafkaProducer: SystemProducer = Mockito.mock(classOf[SystemProducer])
+    checkPointManager.MaxRetryDurationMs = 1
+
+    Mockito.doReturn(newKafkaProducer).when(checkPointManager).getSystemProducer()
+
+    checkPointManager.register(taskName)
+    checkPointManager.start
+    checkPointManager.writeCheckpoint(taskName, new Checkpoint(ImmutableMap.of()))
+
+    // Verifications after the test
+
+    Mockito.verify(mockKafkaProducer).stop()
+    Mockito.verify(newKafkaProducer).register(taskName.getTaskName)
+    Mockito.verify(newKafkaProducer).start()
+  }
+
   @Test
-  def testCheckpointShouldBeNullIfCheckpointTopicDoesNotExistShouldBeCreatedOnWriteAndShouldBeReadableAfterWrite {
+  def testCheckpointShouldBeNullIfCheckpointTopicDoesNotExistShouldBeCreatedOnWriteAndShouldBeReadableAfterWrite(): Unit = {
     val checkpointTopic = "checkpoint-topic-1"
     val kcm1 = createKafkaCheckpointManager(checkpointTopic)
     kcm1.register(taskName)
@@ -100,7 +131,7 @@ class TestKafkaCheckpointManager extends KafkaServerTestHarness {
   }
 
   @Test(expected = classOf[SamzaException])
-  def testWriteCheckpointShouldRetryFiniteTimesOnFailure: Unit = {
+  def testWriteCheckpointShouldRetryFiniteTimesOnFailure(): Unit = {
     val checkpointTopic = "checkpoint-topic-2"
     val mockKafkaProducer: SystemProducer = Mockito.mock(classOf[SystemProducer])
 
@@ -123,7 +154,7 @@ class TestKafkaCheckpointManager extends KafkaServerTestHarness {
   }
 
   @Test
-  def testFailOnTopicValidation {
+  def testFailOnTopicValidation(): Unit = {
     // By default, should fail if there is a topic validation error
     val checkpointTopic = "eight-partition-topic";
     val kcm1 = createKafkaCheckpointManager(checkpointTopic)
@@ -152,7 +183,7 @@ class TestKafkaCheckpointManager extends KafkaServerTestHarness {
   }
 
   @After
-  override def tearDown() {
+  override def tearDown(): Unit = {
     if (servers != null) {
       servers.foreach(_.shutdown())
       servers.foreach(server => CoreUtils.delete(server.config.logDirs))
@@ -160,17 +191,7 @@ class TestKafkaCheckpointManager extends KafkaServerTestHarness {
     super.tearDown
   }
 
-  private def getCheckpointProducerProperties() : Properties = {
-    val defaultSerializer = classOf[ByteArraySerializer].getCanonicalName
-    val props = new Properties()
-    props.putAll(ImmutableMap.of(
-      ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList,
-      ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, defaultSerializer,
-      ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, defaultSerializer))
-    props
-  }
-
-  private def getConfig() : Config = {
+  private def getConfig(): Config = {
     new MapConfig(new ImmutableMap.Builder[String, String]()
       .put(JobConfig.JOB_NAME, "some-job-name")
       .put(JobConfig.JOB_ID, "i001")
@@ -206,7 +227,7 @@ class TestKafkaCheckpointManager extends KafkaServerTestHarness {
     checkpoint
   }
 
-  private def writeCheckpoint(checkpointTopic: String, taskName: TaskName, checkpoint: Checkpoint) = {
+  private def writeCheckpoint(checkpointTopic: String, taskName: TaskName, checkpoint: Checkpoint): Unit = {
     val kcm = createKafkaCheckpointManager(checkpointTopic)
     kcm.register(taskName)
     kcm.start


### PR DESCRIPTION
Retry loop in the existing `KafkaCheckpointManager` implementation retries using the same `SystemProducer` instance on exception and does not recreate it.

When some irrecoverable exceptions occur within the `SystemProducer`, all the subsequent produce message invocations on the `SystemProducer` instance will fail. This had made the entire retry loop on `KafkaCheckpointManager` pointless.

This patch consists of the following changes:
1. This patch addresses the above problem by recreating the `SystemProducer` instance on failure and adds a unit test to verify the functionality.
2. Minor code cleanup in classes: `TestKafkaCheckpointManager` and `KafkaCheckpointManager`.