### PR TITLE
SAMZA-1817: Long Classpath Support: Generating relative path from absolute paths

### DIFF
--- a/samza-shell/src/main/bash/run-class.sh
+++ b/samza-shell/src/main/bash/run-class.sh
@@ -51,12 +51,13 @@ export JOB_LIB_DIR=$JOB_LIB_DIR
 
 function relative_path_from_to() {
  # returns relative path to $2/$target from $1/$source
- source=$1
- target=$2
+ source=$1 # This is $home_dir for this case
+ target=$2 # This is $BASE_LIB_DIR where JARS are
 
  common_part=$source # for now
  result="" # for now
 
+ # This calculates the longest common prefix
  while [[ "${target#$common_part}" == "${target}" ]]; do
      # no match, means that candidate common part is not correct
      # go up one level (reduce common part)
@@ -89,9 +90,13 @@ function relative_path_from_to() {
  echo "./$result"
 }
 
-
 # Get the relative path from current execution directory to base directory with jars
 RELATIVE_PATH_BASE_LIB=$(relative_path_from_to $home_dir $BASE_LIB_DIR)
+# If the relative path directory does not exist, resolve to absolute path
+if [ ! -d "$RELATIVE_PATH_BASE_LIB" ]; then
+   echo "Resolving to absolute path, $RELATIVE_PATH_BASE_LIB does not exist"
+   RELATIVE_PATH_BASE_LIB=$BASE_LIB_DIR
+fi
 echo RELATIVE_PATH_BASE_LIB=$RELATIVE_PATH_BASE_LIB
 
 if [ -d "$JOB_LIB_DIR" ] && [ "$JOB_LIB_DIR" != "$BASE_LIB_DIR" ]; then

--- a/samza-shell/src/main/bash/run-class.sh
+++ b/samza-shell/src/main/bash/run-class.sh
@@ -45,7 +45,7 @@ DEFAULT_LOG4J2_FILE=$base_dir/lib/log4j2.xml
 BASE_LIB_DIR="$base_dir/lib"
 # JOB_LIB_DIR will be set for yarn container in ContainerUtil.java
 # for others we set it to home_dir/lib
-JOB_LIB_DIR="${JOB_LIB_DIR:-$base_dir/lib}"
+JOB_LIB_DIR="${JOB_LIB_DIR:-$home_dir/lib}"
 
 export JOB_LIB_DIR=$JOB_LIB_DIR
 

--- a/samza-shell/src/main/bash/run-class.sh
+++ b/samza-shell/src/main/bash/run-class.sh
@@ -56,7 +56,7 @@ function relative_path_from_to() {
  target=${2%/} # This is $BASE_LIB_DIR where JARS are
 
  common_part=$source # start with common_part as source and iterate until common_part becomes $target
- result="" # for now
+ result=""
 
  # This calculates the longest common prefix
  while [[ "${target#$common_part}" == "${target}" ]]; do

--- a/samza-shell/src/main/bash/run-class.sh
+++ b/samza-shell/src/main/bash/run-class.sh
@@ -49,12 +49,13 @@ JOB_LIB_DIR="${JOB_LIB_DIR:-$home_dir/lib}"
 
 export JOB_LIB_DIR=$JOB_LIB_DIR
 
+# Usage: relative_path_from_to $source $target
+# Purpose: Given two absolute paths return relative path from $source to $destination
 function relative_path_from_to() {
- # returns relative path to $2/$target from $1/$source
- source=$1 # This is $home_dir for this case
- target=$2 # This is $BASE_LIB_DIR where JARS are
+ source=${1%/} # This is $home_dir for this case
+ target=${2%/} # This is $BASE_LIB_DIR where JARS are
 
- common_part=$source # for now
+ common_part=$source # start with common_part as source and iterate until common_part becomes $target
  result="" # for now
 
  # This calculates the longest common prefix


### PR DESCRIPTION
- We removed wildcarding to shorten the classpath since it induces indeterminism in classpath on two consecutive deploys
- This patch constructs classpath (run-class.sh) by generating the relative path from directory executing the script to target directory where jars are present. 
- From observations on deploying jobs on YARN and locally, we saw that we can save over 65% of classpath length by switching to relative paths as compared to the absolute path

