### PR TITLE
SAMZA-1972: Make Operator Timer metrics calculation configurable

### DIFF
--- a/docs/learn/documentation/versioned/jobs/configuration-table.html
+++ b/docs/learn/documentation/versioned/jobs/configuration-table.html
@@ -2239,6 +2239,23 @@
                         60 seconds.
                     </td>
                 </tr>
+                <tr>
+                    <td class="property" id="metrics-timer-enabled">metrics.timer.enabled</td>
+                    <td class="default">true</td>
+                    <td class="description">
+                        This setting enables the common timer metrics for your job, which include container metrics
+                        such as process-ns, window-ns, commit-ns, and block-ns, as well as key-value storage engine
+                        metrics such as get-ns, put-ns and range-ns.
+                    </td>
+                </tr>
+                <tr>
+                    <td class="property" id="metrics-timer-debug-eanbled">metrics.timer.debug.enabled</td>
+                    <td class="default">false</td>
+                    <td class="description">
+                        This setting enables the additional timer metrics for debugging of your job. These metrics
+                        include operator metrics such as handle-message-ns and handle-timer-ns.
+                    </td>
+                </tr>
 
                 <tr>
                     <th colspan="3" class="section" id="hdfs-system-producer"><a href="../hdfs/producer.html">Writing to HDFS</a></th>

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImpl.java
@@ -500,7 +500,8 @@ public abstract class OperatorImpl<M, RM> {
   private HighResolutionClock createHighResClock(Config config) {
     MetricsConfig metricsConfig = new MetricsConfig(config);
     // The timer metrics calculation here is only enabled for debugging
-    if (metricsConfig.getMetricsTimerEnabled() && metricsConfig.getMetricsTimerDebugEnabled()) {
+    if (metricsConfig.getMetricsTimerEnabled()
+        && metricsConfig.getMetricsTimerDebugEnabled()) {
       return System::nanoTime;
     } else {
       return () -> 0;

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImpl.java
@@ -500,7 +500,7 @@ public abstract class OperatorImpl<M, RM> {
   private HighResolutionClock createHighResClock(Config config) {
     MetricsConfig metricsConfig = new MetricsConfig(config);
     // The timer metrics calculation here is only enabled for debugging
-    if (metricsConfig.getMetricsTimerDebugEnabled()) {
+    if (metricsConfig.getMetricsTimerEnabled() && metricsConfig.getMetricsTimerDebugEnabled()) {
       return System::nanoTime;
     } else {
       return () -> 0;

--- a/samza-core/src/main/scala/org/apache/samza/config/MetricsConfig.scala
+++ b/samza-core/src/main/scala/org/apache/samza/config/MetricsConfig.scala
@@ -27,7 +27,10 @@ object MetricsConfig {
   // metrics config constants
   val METRICS_REPORTERS = "metrics.reporters"
   val METRICS_REPORTER_FACTORY = "metrics.reporter.%s.class"
+  // This flag enables the common timer metrics, e.g. process_ns
   val METRICS_TIMER_ENABLED= "metrics.timer.enabled"
+  // This flag enables more timer metrics, e.g. handle-message-ns in an operator, for debugging purpose
+  val METRICS_TIMER_DEBUG_ENABLED= "metrics.timer.debug.enabled"
 
   // The following configs are applicable only to {@link MetricsSnapshotReporter}
   // added here only to maintain backwards compatibility of config
@@ -70,4 +73,12 @@ class MetricsConfig(config: Config) extends ScalaMapConfig(config) {
    * @return Boolean flag to enable the timer metrics
    */
   def getMetricsTimerEnabled: Boolean = getBoolean(MetricsConfig.METRICS_TIMER_ENABLED, true)
+
+  /**
+    * Returns the flag to enable the debug timer metrics. These metrics
+    * are turned off by default for better performance.
+    * @return Boolean
+    */
+  def getMetricsTimerDebugEnabled: Boolean = getBoolean(MetricsConfig.METRICS_TIMER_DEBUG_ENABLED, false)
+
 }

--- a/samza-core/src/test/java/org/apache/samza/context/MockContext.java
+++ b/samza-core/src/test/java/org/apache/samza/context/MockContext.java
@@ -22,6 +22,8 @@ package org.apache.samza.context;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.MapConfig;
 
+import java.util.Collections;
+
 import static org.mockito.Mockito.*;
 
 
@@ -36,7 +38,9 @@ public class MockContext implements Context {
   private final ApplicationTaskContext applicationTaskContext = mock(ApplicationTaskContext.class);
 
   public MockContext() {
-    this(new MapConfig());
+    this(new MapConfig(
+        Collections.singletonMap("metrics.timer.debug.enabled", "true")
+    ));
   }
 
   /**

--- a/samza-core/src/test/java/org/apache/samza/operators/TestJoinOperator.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/TestJoinOperator.java
@@ -311,6 +311,7 @@ public class TestJoinOperator {
             new SystemStreamPartition("insystem", "instream2", new Partition(0))));
     when(context.getTaskContext().getTaskModel()).thenReturn(taskModel);
     when(context.getTaskContext().getTaskMetricsRegistry()).thenReturn(new MetricsRegistryMap());
+    when(context.getContainerContext().getContainerMetricsRegistry()).thenReturn(new MetricsRegistryMap());
     // need to return different stores for left and right side
     IntegerSerde integerSerde = new IntegerSerde();
     TimestampedValueSerde timestampedValueSerde = new TimestampedValueSerde(new KVSerde(integerSerde, integerSerde));

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImpl.java
@@ -53,6 +53,7 @@ public class TestOperatorImpl {
     this.context = new MockContext();
     when(this.context.getTaskContext().getTaskMetricsRegistry()).thenReturn(new MetricsRegistryMap());
     when(this.context.getTaskContext().getTaskModel()).thenReturn(mock(TaskModel.class));
+    when(this.context.getContainerContext().getContainerMetricsRegistry()).thenReturn(new MetricsRegistryMap());
   }
 
   @Test(expected = IllegalStateException.class)
@@ -100,7 +101,7 @@ public class TestOperatorImpl {
   @Test
   public void testOnMessageUpdatesMetrics() {
     ReadableMetricsRegistry mockMetricsRegistry = mock(ReadableMetricsRegistry.class);
-    when(this.context.getTaskContext().getTaskMetricsRegistry()).thenReturn(mockMetricsRegistry);
+    when(this.context.getContainerContext().getContainerMetricsRegistry()).thenReturn(mockMetricsRegistry);
     Counter mockCounter = mock(Counter.class);
     Timer mockTimer = mock(Timer.class);
     when(mockMetricsRegistry.newCounter(anyString(), anyString())).thenReturn(mockCounter);
@@ -156,7 +157,7 @@ public class TestOperatorImpl {
   @Test
   public void testOnTimerUpdatesMetrics() {
     ReadableMetricsRegistry mockMetricsRegistry = mock(ReadableMetricsRegistry.class);
-    when(this.context.getTaskContext().getTaskMetricsRegistry()).thenReturn(mockMetricsRegistry);
+    when(this.context.getContainerContext().getContainerMetricsRegistry()).thenReturn(mockMetricsRegistry);
     Counter mockMessageCounter = mock(Counter.class);
     Timer mockTimer = mock(Timer.class);
     when(mockMetricsRegistry.newCounter(anyString(), anyString())).thenReturn(mockMessageCounter);

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImplGraph.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImplGraph.java
@@ -97,6 +97,7 @@ public class TestOperatorImplGraph {
     when(taskModel.getTaskName()).thenReturn(new TaskName("task 0"));
     when(this.context.getTaskContext().getTaskModel()).thenReturn(taskModel);
     when(this.context.getTaskContext().getTaskMetricsRegistry()).thenReturn(new MetricsRegistryMap());
+    when(this.context.getContainerContext().getContainerMetricsRegistry()).thenReturn(new MetricsRegistryMap());
   }
 
   @After

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestWindowOperator.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestWindowOperator.java
@@ -99,6 +99,7 @@ public class TestWindowOperator {
     when(taskModel.getTaskName()).thenReturn(new TaskName("task 1"));
     when(this.context.getTaskContext().getTaskModel()).thenReturn(taskModel);
     when(this.context.getTaskContext().getTaskMetricsRegistry()).thenReturn(new MetricsRegistryMap());
+    when(this.context.getContainerContext().getContainerMetricsRegistry()).thenReturn(new MetricsRegistryMap());
     when(this.context.getTaskContext().getStore("jobName-jobId-window-w1"))
         .thenReturn(new TestInMemoryStore<>(storeKeySerde, storeValSerde));
   }


### PR DESCRIPTION
This patch introduces two changes:
1. Make the timer metrics in OperatorImpl to be optional, and disabled by default. Adding TimerMetrics has quite a big performance impact which affects jobs with large number of operators, so it should be turned on for debugging only.
2. Register operator-level metrics on the container metrics registry. The task level registry has too many metrics which are usually ignored by the users. Having it in the container level will reduce the total amount of metrics published as well as the memory footprint.

Tested by hello-samza and works as expected.