### PR TITLE
SAMZA-1707: Samza onTimer method triggering before init

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/task/EpochTimeScheduler.java
+++ b/samza-core/src/main/java/org/apache/samza/task/EpochTimeScheduler.java
@@ -48,7 +48,7 @@ public class EpochTimeScheduler {
   private final ScheduledExecutorService executor;
   private final Map<Object, ScheduledFuture> scheduledFutures = new ConcurrentHashMap<>();
   private final Map<TimerKey<?>, ScheduledCallback> readyTimers = new ConcurrentHashMap<>();
-  private TimerListener timerListener;
+  private volatile TimerListener timerListener;
 
   public static EpochTimeScheduler create(ScheduledExecutorService executor) {
     return new EpochTimeScheduler(executor);

--- a/samza-core/src/main/java/org/apache/samza/task/EpochTimeScheduler.java
+++ b/samza-core/src/main/java/org/apache/samza/task/EpochTimeScheduler.java
@@ -83,6 +83,10 @@ public class EpochTimeScheduler {
 
   void registerListener(TimerListener listener) {
     timerListener = listener;
+
+    if (!readyTimers.isEmpty()) {
+      timerListener.onTimer();
+    }
   }
 
   public Map<TimerKey<?>, ScheduledCallback> removeReadyTimers() {

--- a/samza-test/src/test/java/org/apache/samza/test/functions/SchedulerFunctionTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/functions/SchedulerFunctionTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.test.functions;
+
+import org.apache.samza.application.StreamApplication;
+import org.apache.samza.application.descriptors.StreamApplicationDescriptor;
+import org.apache.samza.operators.Scheduler;
+import org.apache.samza.operators.functions.MapFunction;
+import org.apache.samza.operators.functions.ScheduledFunction;
+import org.apache.samza.serializers.StringSerde;
+import org.apache.samza.test.framework.TestRunner;
+import org.apache.samza.test.framework.system.descriptors.InMemoryInputDescriptor;
+import org.apache.samza.test.framework.system.descriptors.InMemorySystemDescriptor;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SchedulerFunctionTest {
+  static AtomicBoolean timerFired = new AtomicBoolean(false);
+
+  @Test
+  public void testImmediateTimer() {
+    final InMemorySystemDescriptor isd = new InMemorySystemDescriptor("test");
+    final InMemoryInputDescriptor<String> imid = isd.getInputDescriptor("test-input", new StringSerde());
+
+    StreamApplication app = new StreamApplication() {
+      @Override
+      public void describe(StreamApplicationDescriptor appDescriptor) {
+
+        appDescriptor.getInputStream(imid)
+            .map(new TestSchedulerFunction());
+      }
+    };
+
+    TestRunner
+        .of(app)
+        .addInputStream(imid, Arrays.asList("a"))
+        .run(Duration.ofSeconds(1));
+
+    assertTrue(timerFired.get());
+  }
+
+  static class TestSchedulerFunction implements MapFunction<String, Void>, ScheduledFunction<String, Void> {
+
+
+    @Override
+    public Void apply(String message) {
+      return null;
+    }
+
+    @Override
+    public void schedule(Scheduler<String> scheduler) {
+      scheduler.schedule("haha", System.currentTimeMillis());
+    }
+
+    @Override
+    public Collection<Void> onCallback(String key, long timestamp) {
+      assertFalse(timerFired.get());
+
+      timerFired.compareAndSet(false, true);
+
+      return Collections.emptyList();
+    }
+  }
+}

--- a/samza-test/src/test/java/org/apache/samza/test/functions/TestSchedulerFunction.java
+++ b/samza-test/src/test/java/org/apache/samza/test/functions/TestSchedulerFunction.java
@@ -25,7 +25,6 @@ import org.apache.samza.operators.Scheduler;
 import org.apache.samza.operators.functions.MapFunction;
 import org.apache.samza.operators.functions.ScheduledFunction;
 import org.apache.samza.serializers.IntegerSerde;
-import org.apache.samza.serializers.StringSerde;
 import org.apache.samza.test.framework.TestRunner;
 import org.apache.samza.test.framework.system.descriptors.InMemoryInputDescriptor;
 import org.apache.samza.test.framework.system.descriptors.InMemorySystemDescriptor;
@@ -59,7 +58,7 @@ public class TestSchedulerFunction {
 
     TestRunner
         .of(app)
-        .addInputStream(imid, Arrays.asList(1, 2, 3))
+        .addInputStream(imid, Arrays.asList(1, 2, 3, 4, 5))
         .run(Duration.ofSeconds(1));
 
     assertTrue(timerFired.get());

--- a/samza-test/src/test/java/org/apache/samza/test/functions/TestSchedulerFunction.java
+++ b/samza-test/src/test/java/org/apache/samza/test/functions/TestSchedulerFunction.java
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class SchedulerFunctionTest {
+public class TestSchedulerFunction {
   static AtomicBoolean timerFired = new AtomicBoolean(false);
 
   @Test
@@ -52,7 +52,7 @@ public class SchedulerFunctionTest {
       public void describe(StreamApplicationDescriptor appDescriptor) {
 
         appDescriptor.getInputStream(imid)
-            .map(new TestSchedulerFunction());
+            .map(new TestFunction());
       }
     };
 
@@ -64,8 +64,7 @@ public class SchedulerFunctionTest {
     assertTrue(timerFired.get());
   }
 
-  static class TestSchedulerFunction implements MapFunction<String, Void>, ScheduledFunction<String, Void> {
-
+  private static class TestFunction implements MapFunction<String, Void>, ScheduledFunction<String, Void> {
 
     @Override
     public Void apply(String message) {


### PR DESCRIPTION
Currently there was a bug when registering a timer with a very short amount of delay, it might not be invoked since it depends on the creation of the run loop. This patch fixed the problem by double checking the ready timers when run loop is created (listener is registered.)