### PR TITLE
SAMZA-2018 : State restore improvements

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -502,8 +502,7 @@ object SamzaContainer extends Logging {
 
     val timerExecutor = Executors.newSingleThreadScheduledExecutor
 
-    // Create one SystemConsumer for each storeSystem in use
-    // so we create a map of SystemName to its respective SystemConsumer
+    // We create a map of store SystemName to its respective SystemConsumer
     val storeSystemConsumers: Map[String, SystemConsumer] = changeLogSystemStreams.mapValues {
       case (changeLogSystemStream) => (changeLogSystemStream.getSystem)
     }.values.toSet.map {

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -503,10 +503,9 @@ object SamzaContainer extends Logging {
     val timerExecutor = Executors.newSingleThreadScheduledExecutor
 
     // Create a map of storeName to store's SystemName
-    val storeSystems: Map[String, String] = changeLogSystemStreams.
-      map {
-        case (storeName, changeLogSystemStream) => (storeName, changeLogSystemStream.getSystem)
-      }
+    val storeSystems: Map[String, String] = changeLogSystemStreams.mapValues {
+      case (changeLogSystemStream) => (changeLogSystemStream.getSystem)
+    }
 
     info("Got store systems: %s" format storeSystems)
 
@@ -523,8 +522,6 @@ object SamzaContainer extends Logging {
     info("Created store system consumers: %s" format storeSystemConsumers)
 
     var taskStorageManagers : Map[TaskInstance, TaskStorageManager] = Map()
-    var taskSideInputManagers : Map[TaskInstance, TaskSideInputStorageManager] = Map()
-
 
     // Create taskInstances
     val taskInstances: Map[TaskName, TaskInstance] = containerModel.getTasks.values.asScala.map(taskModel => {
@@ -689,7 +686,6 @@ object SamzaContainer extends Logging {
       val taskInstance = createTaskInstance(task)
 
       taskStorageManagers += taskInstance -> storageManager
-      taskSideInputManagers += taskInstance -> sideInputStorageManager
       (taskName, taskInstance)
     }).toMap
 

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -502,21 +502,16 @@ object SamzaContainer extends Logging {
 
     val timerExecutor = Executors.newSingleThreadScheduledExecutor
 
-    // Create a map of storeName to store's SystemName
-    val storeSystems: Map[String, String] = changeLogSystemStreams.mapValues {
-      case (changeLogSystemStream) => (changeLogSystemStream.getSystem)
-    }
-
-    info("Got store systems: %s" format storeSystems)
-
     // Create one SystemConsumer for each storeSystem in use
-    // Create a map of SystemName to its respective SystemConsumer
-    val storeSystemConsumers: Map[String, SystemConsumer] = storeSystems.values.toSet.map {
-      systemName : String => (systemName, systemFactories
-        .getOrElse(systemName,
-          throw new SamzaException("Changelog system %s for stores %s does not " +
-            "exist in the config." format (systemName, storeSystems.filter(_._2.equals(systemName)))))
-        .getConsumer(systemName, config, samzaContainerMetrics.registry))
+    // so we create a map of SystemName to its respective SystemConsumer
+    val storeSystemConsumers: Map[String, SystemConsumer] = changeLogSystemStreams.mapValues {
+      case (changeLogSystemStream) => (changeLogSystemStream.getSystem)
+    }.values.toSet.map {
+      systemName: String =>
+        (systemName, systemFactories
+          .getOrElse(systemName,
+            throw new SamzaException("Changelog system %s exist in the config." format (systemName)))
+          .getConsumer(systemName, config, samzaContainerMetrics.registry))
     }.toMap
 
     info("Created store system consumers: %s" format storeSystemConsumers)

--- a/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
@@ -120,15 +120,7 @@ class TaskInstance(
     offsetManager.register(taskName, sspsToRegister)
   }
 
-  def startStores {
-    if (storageManager != null) {
-      debug("Starting storage manager for taskName: %s" format taskName)
-
-      storageManager.init
-    } else {
-      debug("Skipping storage manager initialization for taskName: %s" format taskName)
-    }
-
+  def startSideInputs {
     if (sideInputStorageManager != null) {
       debug("Starting side input storage manager for taskName: %s" format taskName)
       sideInputStorageManager.init()
@@ -298,15 +290,7 @@ class TaskInstance(
     }
   }
 
-  def shutdownStores {
-    if (storageManager != null) {
-      debug("Shutting down storage manager for taskName: %s" format taskName)
-
-      storageManager.stop
-    } else {
-      debug("Skipping storage manager shutdown for taskName: %s" format taskName)
-    }
-
+  def shutdownSideInputs {
     if (sideInputStorageManager != null) {
       debug("Shutting down side input storage manager for taskName: %s" format taskName)
       sideInputStorageManager.stop()

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -1,0 +1,101 @@
+package org.apache.samza.storage;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.samza.container.SamzaContainerMetrics;
+import org.apache.samza.container.TaskInstance;
+import org.apache.samza.metrics.Gauge;
+import org.apache.samza.system.SystemConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ContainerStorageManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ContainerStorageManager.class);
+  private Map<TaskInstance, TaskStorageManager> taskStorageManagers;
+  private SamzaContainerMetrics samzaContainerMetrics;
+
+  // Mapping of from storeSystemNames to SystemConsumers
+  private Map<String, SystemConsumer> systemConsumers;
+
+  // Size of thread-pool to be used for parallel restores
+  private int parallelRestoreThreadPoolSize;
+
+  public ContainerStorageManager(Map<TaskInstance, TaskStorageManager> taskStorageManagers,
+      Map<String, SystemConsumer> systemConsumers, SamzaContainerMetrics samzaContainerMetrics) {
+    this.taskStorageManagers = taskStorageManagers;
+    this.systemConsumers = systemConsumers;
+    this.samzaContainerMetrics = samzaContainerMetrics;
+
+    // Setting thread pool size equal to the number of tasks
+    this.parallelRestoreThreadPoolSize = taskStorageManagers.size();
+  }
+
+  public void start() throws InterruptedException {
+
+    // initialize each TaskStorageManager
+    this.taskStorageManagers.values().forEach(taskStorageManager -> taskStorageManager.init());
+
+    // Start consumers
+    this.systemConsumers.values().forEach(systemConsumer -> systemConsumer.start());
+
+    // Create a thread pool for parallel restores
+    ExecutorService executorService = Executors.newFixedThreadPool(this.parallelRestoreThreadPoolSize,
+        new ThreadFactoryBuilder().setNameFormat("Samza Restore Thread-%d").build());
+
+    this.taskStorageManagers.entrySet().forEach(task -> {
+      executorService.submit(new TaskRestoreRunnable(this.samzaContainerMetrics, task.getKey(), task.getValue()));
+    });
+
+    executorService.shutdown();
+
+    // Wait forever for all threads to finish (java-suggested pattern)
+    executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.MINUTES);
+
+    // Stop consumers
+    this.systemConsumers.values().forEach(systemConsumer -> systemConsumer.stop());
+  }
+
+  public void shutdown() {
+    this.taskStorageManagers.forEach((taskInstance, taskStorageManager) -> {
+      if (taskStorageManager != null) {
+        LOG.debug("Shutting down storage manager for taskName: {} ", taskInstance);
+        taskStorageManager.stopStores();
+      } else {
+        LOG.debug("Skipping storage manager shutdown for taskName: {}", taskInstance);
+      }
+    });
+  }
+
+  private class TaskRestoreRunnable implements Runnable {
+
+    private TaskInstance taskInstance;
+    private TaskStorageManager taskStorageManager;
+    private SamzaContainerMetrics samzaContainerMetrics;
+
+    public TaskRestoreRunnable(SamzaContainerMetrics samzaContainerMetrics, TaskInstance taskInstance,
+        TaskStorageManager taskStorageManager) {
+      this.samzaContainerMetrics = samzaContainerMetrics;
+      this.taskInstance = taskInstance;
+      this.taskStorageManager = taskStorageManager;
+    }
+
+    @Override
+    public void run() {
+      long startTime = System.currentTimeMillis();
+      LOG.info("Starting stores in task instance {}", this.taskInstance.taskName().getTaskName());
+      taskStorageManager.restoreStores();
+      long timeToRestore = System.currentTimeMillis() - startTime;
+      Gauge taskGauge = this.samzaContainerMetrics.taskStoreRestorationMetrics()
+          .getOrDefault(this.taskInstance.taskName().getTaskName(), null);
+
+      if (taskGauge != null) {
+        taskGauge.set(timeToRestore);
+      }
+    }
+  }
+}

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -89,7 +89,7 @@ public class ContainerStorageManager {
     // Submit restore callable for each taskInstance
     this.taskStorageManagers.forEach((taskInstance, taskStorageManager) -> {
         futureList.add(
-            executorService.submit(new TaskRestoreCallable(this.samzaContainerMetrics, taskInstance,taskStorageManager)));
+            executorService.submit(new TaskRestoreCallable(this.samzaContainerMetrics, taskInstance, taskStorageManager)));
       });
 
     // loop-over the future list to wait for each thread to finish, catch any exceptions during restore and throw

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -89,7 +89,7 @@ public class ContainerStorageManager {
     // Submit restore callable for each taskInstance
     this.taskStorageManagers.forEach((taskInstance, taskStorageManager) -> {
         futureList.add(
-            executorService.submit(new TaskRestoreRunnable(this.samzaContainerMetrics, taskInstance,taskStorageManager)));
+            executorService.submit(new TaskRestoreCallable(this.samzaContainerMetrics, taskInstance,taskStorageManager)));
       });
 
     // loop-over the future list to wait for each thread to finish, catch any exceptions during restore and throw
@@ -127,13 +127,13 @@ public class ContainerStorageManager {
   /** Callable for performing the restoreStores on a taskStorage manager and emitting task-restoration metric.
    *
    */
-  private class TaskRestoreRunnable implements Callable<Void> {
+  private class TaskRestoreCallable implements Callable<Void> {
 
     private TaskInstance taskInstance;
     private TaskStorageManager taskStorageManager;
     private SamzaContainerMetrics samzaContainerMetrics;
 
-    public TaskRestoreRunnable(SamzaContainerMetrics samzaContainerMetrics, TaskInstance taskInstance,
+    public TaskRestoreCallable(SamzaContainerMetrics samzaContainerMetrics, TaskInstance taskInstance,
         TaskStorageManager taskStorageManager) {
       this.samzaContainerMetrics = samzaContainerMetrics;
       this.taskInstance = taskInstance;

--- a/samza-core/src/main/scala/org/apache/samza/storage/TaskStorageManager.scala
+++ b/samza-core/src/main/scala/org/apache/samza/storage/TaskStorageManager.scala
@@ -74,9 +74,7 @@ class TaskStorageManager(
     cleanBaseDirs()
     setupBaseDirs()
     validateChangelogStreams()
-    startConsumers()
-    restoreStores()
-    stopConsumers()
+    registerSSPs()
   }
 
   private def cleanBaseDirs() {
@@ -159,7 +157,7 @@ class TaskStorageManager(
     info("Assigning oldest change log offsets for taskName %s: %s" format (taskName, changeLogOldestOffsets))
   }
 
-  private def startConsumers() {
+  private def registerSSPs() {
     debug("Starting consumers for stores.")
 
     for ((storeName, systemStream) <- changeLogSystemStreams) {
@@ -176,8 +174,6 @@ class TaskStorageManager(
         taskStoresToRestore -= storeName
       }
     }
-
-    storeConsumers.values.foreach(_.start)
   }
 
   /**
@@ -202,7 +198,7 @@ class TaskStorageManager(
     StorageManagerUtil.getStartingOffset(systemStreamPartition, admin, fileOffset, oldestOffset)
   }
 
-  private def restoreStores() {
+  def restoreStores() {
     debug("Restoring stores for task: %s." format taskName.getTaskName)
 
     for ((storeName, store) <- taskStoresToRestore) {
@@ -214,12 +210,6 @@ class TaskStorageManager(
         store.restore(systemConsumerIterator)
       }
     }
-  }
-
-  private def stopConsumers() {
-    debug("Stopping consumers for stores.")
-
-    storeConsumers.values.foreach(_.stop)
   }
 
   def flush() {

--- a/samza-core/src/test/scala/org/apache/samza/container/TestSamzaContainer.scala
+++ b/samza-core/src/test/scala/org/apache/samza/container/TestSamzaContainer.scala
@@ -157,12 +157,7 @@ class TestSamzaContainer extends AssertionsForJUnit with MockitoSugar {
     when(this.taskInstance.taskName).thenReturn(TASK_NAME)
     val restoreGauge = mock[Gauge[Long]]
     when(this.metrics.taskStoreRestorationMetrics).thenReturn(Map(TASK_NAME -> restoreGauge))
-    when(this.taskInstance.startStores).thenAnswer(new Answer[Void] {
-      override def answer(invocation: InvocationOnMock): Void = {
-        Thread.sleep(1)
-        null
-      }
-    })
+
     this.samzaContainer.startStores
     val restoreGaugeValueCaptor = ArgumentCaptor.forClass(classOf[Long])
     verify(restoreGauge).set(restoreGaugeValueCaptor.capture())
@@ -283,7 +278,7 @@ class TestSamzaContainer extends AssertionsForJUnit with MockitoSugar {
       this.producerMultiplexer,
       metrics,
       containerContext = this.containerContext,
-      applicationContainerContextOption = applicationContainerContext)
+      applicationContainerContextOption = applicationContainerContext, containerStorageManager = null)
     this.samzaContainer.setContainerListener(this.samzaContainerListener)
   }
 

--- a/samza-core/src/test/scala/org/apache/samza/processor/StreamProcessorTestUtils.scala
+++ b/samza-core/src/test/scala/org/apache/samza/processor/StreamProcessorTestUtils.scala
@@ -67,7 +67,8 @@ object StreamProcessorTestUtils {
       producerMultiplexer = producerMultiplexer,
       metrics = new SamzaContainerMetrics,
       containerContext = containerContext,
-      applicationContainerContextOption = None)
+      applicationContainerContextOption = None,
+      containerStorageManager = null)
     container
   }
 }

--- a/samza-core/src/test/scala/org/apache/samza/storage/TestContainerStorageManager.java
+++ b/samza-core/src/test/scala/org/apache/samza/storage/TestContainerStorageManager.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.storage;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import org.apache.samza.container.SamzaContainerMetrics;
+import org.apache.samza.container.TaskInstance;
+import org.apache.samza.container.TaskName;
+import org.apache.samza.system.SystemConsumer;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+
+public class TestContainerStorageManager {
+
+  private ContainerStorageManager containerStorageManager;
+  private Map<String, SystemConsumer> systemConsumers;
+  private Map<TaskInstance, TaskStorageManager> taskStorageManagers;
+  private SamzaContainerMetrics samzaContainerMetrics;
+
+  private CountDownLatch taskStorageManagersRestoreStoreCount;
+  private CountDownLatch taskStorageManagersInitCount;
+  private CountDownLatch taskStorageManagersRestoreStopCount;
+
+  private CountDownLatch systemConsumerStartCount;
+  private CountDownLatch systemConsumerStopCount;
+
+  /**
+   * Utility method for creating a mocked taskInstance and taskStorageManager and adding it to the map.
+   * @param taskname the desired taskname.
+   */
+  private void addMockedTask(String taskname) {
+    TaskInstance mockTaskInstance = Mockito.mock(TaskInstance.class);
+    Mockito.doAnswer(invocation -> {
+        return new TaskName(taskname);
+      }).when(mockTaskInstance).taskName();
+
+    TaskStorageManager mockTaskStorageManager = Mockito.mock(TaskStorageManager.class);
+    Mockito.doAnswer(invocation -> {
+        taskStorageManagersInitCount.countDown();
+        return null;
+      }).when(mockTaskStorageManager).init();
+
+    Mockito.doAnswer(invocation -> {
+        taskStorageManagersRestoreStopCount.countDown();
+        return null;
+      }).when(mockTaskStorageManager).stop();
+
+    Mockito.doAnswer(invocation -> {
+        taskStorageManagersRestoreStoreCount.countDown();
+        return null;
+      }).when(mockTaskStorageManager).restoreStores();
+
+    taskStorageManagers.put(mockTaskInstance, mockTaskStorageManager);
+  }
+
+  @Before
+  public void setUp() {
+    systemConsumers = new HashMap<>();
+    taskStorageManagers = new HashMap<>();
+
+    // add two mocked tasks
+    addMockedTask("task 1");
+    addMockedTask("task 2");
+
+    // define the expected number of invocations on taskStorageManagers' init, stop and restore count
+    // and the expected number of sysConsumer start and stop
+    this.taskStorageManagersInitCount = new CountDownLatch(2);
+    this.taskStorageManagersRestoreStoreCount = new CountDownLatch(2);
+    this.taskStorageManagersRestoreStopCount = new CountDownLatch(2);
+    this.systemConsumerStartCount = new CountDownLatch(1);
+    this.systemConsumerStopCount = new CountDownLatch(1);
+
+    // mock container metrics
+    samzaContainerMetrics = Mockito.mock(SamzaContainerMetrics.class);
+
+    // mock and setup sysconsumers
+    SystemConsumer mockSystemConsumer = Mockito.mock(SystemConsumer.class);
+    Mockito.doAnswer(invocation -> {
+        systemConsumerStartCount.countDown();
+        return null;
+      }).when(mockSystemConsumer).start();
+    Mockito.doAnswer(invocation -> {
+        systemConsumerStopCount.countDown();
+        return null;
+      }).when(mockSystemConsumer).stop();
+
+    systemConsumers.put("kafka", mockSystemConsumer);
+
+    this.containerStorageManager =
+        new ContainerStorageManager(taskStorageManagers, systemConsumers, samzaContainerMetrics);
+  }
+
+  @Test
+  public void testParallelism() {
+    this.containerStorageManager.start();
+    this.containerStorageManager.shutdown();
+    Assert.assertTrue("init count should be 0", this.taskStorageManagersInitCount.getCount() == 0);
+    Assert.assertTrue("Restore count should be 0", this.taskStorageManagersRestoreStoreCount.getCount() == 0);
+    Assert.assertTrue("stop count should be 0", this.taskStorageManagersRestoreStopCount.getCount() == 0);
+
+    Assert.assertTrue("systemConsumerStopCount count should be 0", this.systemConsumerStopCount.getCount() == 0);
+    Assert.assertTrue("systemConsumerStartCount count should be 0", this.systemConsumerStartCount.getCount() == 0);
+  }
+}


### PR DESCRIPTION
This PR makes the following changes: 

* Consumer consolidation to ensure 1 storeConsumer per system, earlier it was 1 consumer per SSP per store.
* Refactoring stores to use ContainerStorageManager with parallelization for restoration, and serial execution of sysConsumers start, stop, register, etc.