### PR TITLE
SAMZA-1817: Adding pathing jar support for Long Classpath

### DIFF
--- a/samza-shell/src/main/bash/run-class.sh
+++ b/samza-shell/src/main/bash/run-class.sh
@@ -92,7 +92,6 @@ printf "Class-Path: \n $CLASSPATH \n" > manifest.txt
 # Creates a new archive and adds custom manifest information to pathing.jar
 eval "$JAR -cvmf manifest.txt pathing.jar"
 
-
 if [ -z "$JAVA_HOME" ]; then
   JAVA="java"
 else
@@ -152,7 +151,6 @@ fi
 
 # Check if 64 bit is set. If not - try and set it if it's supported
 [[ $JAVA_OPTS != *-d64* ]] && check_and_enable_64_bit_mode
-
 
 # HADOOP_CONF_DIR should be supplied to classpath explicitly for Yarn to parse configs
 echo $JAVA $JAVA_OPTS -cp $HADOOP_CONF_DIR:pathing.jar "$@"

--- a/samza-shell/src/main/bash/run-class.sh
+++ b/samza-shell/src/main/bash/run-class.sh
@@ -38,7 +38,6 @@ fi
 
 HADOOP_YARN_HOME="${HADOOP_YARN_HOME:-$HOME/.samza}"
 HADOOP_CONF_DIR="${HADOOP_CONF_DIR:-$HADOOP_YARN_HOME/conf}"
-CLASSPATH=$HADOOP_CONF_DIR
 GC_LOG_ROTATION_OPTS="-XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=10241024"
 DEFAULT_LOG4J_FILE=$base_dir/lib/log4j.xml
 DEFAULT_LOG4J2_FILE=$base_dir/lib/log4j2.xml
@@ -51,6 +50,7 @@ export JOB_LIB_DIR=$JOB_LIB_DIR
 
 echo JOB_LIB_DIR=$JOB_LIB_DIR
 echo BASE_LIB_DIR=$BASE_LIB_DIR
+CLASSPATH=""
 if [ -d "$JOB_LIB_DIR" ] && [ "$JOB_LIB_DIR" != "$BASE_LIB_DIR" ]; then
   # build a common classpath
   # this class path will contain all the jars from the framework and the job's libs.
@@ -64,7 +64,7 @@ if [ -d "$JOB_LIB_DIR" ] && [ "$JOB_LIB_DIR" != "$BASE_LIB_DIR" ]; then
   all_jars=`for file in $base_jars $job_jars; do echo \`basename $file|sed 's/.*[-]\([0-9]\+\..*\)[jw]ar$/\1/'\` $file; done|sort -t. -k 1,1nr -k 2,2nr -k 3,3nr -k 4,4nr|awk '{print $2}'`
   # generate the class path based on the sorted result, all the jars need to be appended on newlines
   # to ensure java argument length of 72 bytes is not violated
-  for jar in $all_jars; do CLASSPATH=$CLASSPATH"\n $jar "; done
+  for jar in $all_jars; do CLASSPATH=$CLASSPATH" $jar \n"; done
 
   # for debug only
   echo base_jars=$base_jars
@@ -76,15 +76,22 @@ else
   # to ensure line argument length of 72 bytes is not violated
   for file in $BASE_LIB_DIR/*.[jw]ar;
   do
-    CLASSPATH=$CLASSPATH"\n $file "
+    CLASSPATH=$CLASSPATH" $file \n"
   done
   echo generated from BASE_LIB_DIR CLASSPATH=$CLASSPATH
 fi
 
+if [ -z "$JAVA_HOME" ]; then
+  JAR="jar"
+else
+  JAR="$JAVA_HOME/bin/jar"
+fi
+
 # Newlines and spaces are intended to ensure proper parsing of manifest in pathing jar
-printf "Class-Path: \n $CLASSPATH \n\n" > manifest.txt
+printf "Class-Path: \n $CLASSPATH \n" > manifest.txt
 # Creates a new archive and adds custom manifest information to pathing.jar
-jar -cvmf manifest.txt pathing.jar
+eval "$JAR -cvmf manifest.txt pathing.jar"
+
 
 if [ -z "$JAVA_HOME" ]; then
   JAVA="java"
@@ -146,5 +153,7 @@ fi
 # Check if 64 bit is set. If not - try and set it if it's supported
 [[ $JAVA_OPTS != *-d64* ]] && check_and_enable_64_bit_mode
 
-echo $JAVA $JAVA_OPTS -cp pathing.jar "$@"
-exec $JAVA $JAVA_OPTS -cp pathing.jar "$@"
+
+# HADOOP_CONF_DIR should be supplied to classpath explicitly for Yarn to parse configs
+echo $JAVA $JAVA_OPTS -cp $HADOOP_CONF_DIR:pathing.jar "$@"
+exec $JAVA $JAVA_OPTS -cp $HADOOP_CONF_DIR:pathing.jar "$@"

--- a/samza-shell/src/main/bash/run-class.sh
+++ b/samza-shell/src/main/bash/run-class.sh
@@ -78,7 +78,7 @@ else
   do
     CLASSPATH=$CLASSPATH"\n $file "
   done
-  echo generated combined CLASSPATH=$CLASSPATH
+  echo generated from BASE_LIB_DIR CLASSPATH=$CLASSPATH
 fi
 
 # Newlines and spaces are intended to ensure proper parsing of manifest in pathing jar


### PR DESCRIPTION
- To support long classpath with deterministic jar loading we use a concept called pathing jar 
- A new archive called pathing.jar is created with a custom manifest
- This custom manifest file contains the deterministic classpath that we construct

Readings:
- [Adding Classes to the JAR File's Classpath  
](https://docs.oracle.com/javase/tutorial/deployment/jar/downman.html)
- [How to avoid argument line too long with manifest files
](https://stackoverflow.com/questions/3057841/too-long-line-in-manifest-file-while-trying-to-create-jar)
- [Pathing Jar information: (from tools)
](https://stackoverflow.com/questions/201816/how-to-set-a-long-java-classpath-in-windows)  