### PR TITLE
SAMZA-2009: Add ability to disable table metrics

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/container/SamzaContainerContext.java
+++ b/samza-api/src/main/java/org/apache/samza/container/SamzaContainerContext.java
@@ -52,4 +52,8 @@ public class SamzaContainerContext {
     this.taskNames = Collections.unmodifiableCollection(taskNames);
     this.metricsRegistry = metricsRegistry;
   }
+
+  public MetricsRegistry getMetricsRegistry() {
+    return metricsRegistry;
+  }
 }

--- a/samza-core/src/main/java/org/apache/samza/table/utils/TableMetricsUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/table/utils/TableMetricsUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.utils;
+
+import org.apache.samza.metrics.Counter;
+import org.apache.samza.metrics.Timer;
+
+
+public class TableMetricsUtil {
+
+  public static void incCounter(Counter counter) {
+    if (counter != null) {
+      counter.inc();
+    }
+  }
+
+  public static void updateTimer(Timer timer, long duration) {
+    if (timer != null) {
+      timer.update(duration);
+    }
+  }
+
+}


### PR DESCRIPTION
This is to back port SAMZA-2004 to 0.14.1, due to the extend of changed made in Samza 1.0, the back port is actually done manually.

More details can be found here
https://github.com/apache/samza/pull/822

