### PR TITLE
Fix minor issue with operator spec graph traversal

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/execution/OperatorSpecGraphAnalyzer.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/OperatorSpecGraphAnalyzer.java
@@ -22,6 +22,7 @@ package org.apache.samza.execution;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -84,10 +85,7 @@ import org.apache.samza.operators.spec.StreamTableJoinOperatorSpec;
    */
   private static void traverse(OperatorSpec startOpSpec, Consumer<OperatorSpec> visitor,
       Function<OperatorSpec, Iterable<OperatorSpec>> getNextOpSpecs) {
-    visitor.accept(startOpSpec);
-    for (OperatorSpec nextOpSpec : getNextOpSpecs.apply(startOpSpec)) {
-      traverseHelper(startOpSpec, visitor, getNextOpSpecs, new HashSet<>());
-    }
+    traverseHelper(startOpSpec, visitor, getNextOpSpecs, new HashSet<>(Arrays.asList(startOpSpec)));
   }
 
   private static void traverseHelper(OperatorSpec startOpSpec, Consumer<OperatorSpec> visitor,


### PR DESCRIPTION
Remove redundant traversal loop added by mistake during conflict merge.