### PR TITLE
SAMZA-2014: Samza-sql: Support table as both source (for join) and destination in the same application

### DIFF
--- a/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationConfig.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationConfig.java
@@ -127,11 +127,14 @@ public class SamzaSqlApplicationConfig {
     Set<String> inputSystemStreamSet = new HashSet<>(inputSystemStreams);
     Set<String> outputSystemStreamSet = new HashSet<>(outputSystemStreams);
 
-    inputSystemStreamConfigBySource = inputSystemStreamSet.stream()
-         .collect(Collectors.toMap(Function.identity(), src -> ioResolver.fetchSourceInfo(src)));
-
+    // Let's get the output system stream configs before input system stream configs. This is to account for
+    // table descriptor that could be both input and output. Please note that there could be only one
+    // instance of table descriptor and writable table is a readable table but vice versa is not true.
     outputSystemStreamConfigsBySource = outputSystemStreamSet.stream()
          .collect(Collectors.toMap(Function.identity(), x -> ioResolver.fetchSinkInfo(x)));
+
+    inputSystemStreamConfigBySource = inputSystemStreamSet.stream()
+        .collect(Collectors.toMap(Function.identity(), src -> ioResolver.fetchSourceInfo(src)));
 
     Map<String, SqlIOConfig> systemStreamConfigsBySource = new HashMap<>(inputSystemStreamConfigBySource);
     systemStreamConfigsBySource.putAll(outputSystemStreamConfigsBySource);


### PR DESCRIPTION
While parsing queries in an application, with in SamzaSqlApplicationConfig, we collect all input sources and output sources from all queries and create descriptors for input sources first followed by output sources. But there could be only one table descriptor instance per table. Writable table is a readable table but vice versa is not true. If we go through input sources, we will end up creating readable table descriptor and would not be able to create writable table descriptor again when we go through output sources (the code will be ugly if we have to achieve this). There are couple of ways to solve this:
- Always make a table readable and writable
- Go through output sources first followed by input sources.

Choosing option 2 as making a table always read-writable does not make sense.