### PR TITLE
Flaky test fix

### DIFF
--- a/samza-core/src/test/java/org/apache/samza/storage/MockStorageEngine.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/MockStorageEngine.java
@@ -21,8 +21,10 @@ package org.apache.samza.storage;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 
+import java.util.List;
 import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.system.SystemStreamPartition;
 
@@ -35,7 +37,7 @@ public class MockStorageEngine implements StorageEngine {
   public static String storeName;
   public static File storeDir;
   public static SystemStreamPartition ssp;
-  public static ArrayList<IncomingMessageEnvelope> incomingMessageEnvelopes = new ArrayList<IncomingMessageEnvelope>();
+  public static List<IncomingMessageEnvelope> incomingMessageEnvelopes = Collections.synchronizedList(new ArrayList<>());
   public static StoreProperties storeProperties;
 
   public MockStorageEngine(String storeName, File storeDir, SystemStreamPartition changeLogSystemStreamPartition, StoreProperties properties) {

--- a/samza-core/src/test/java/org/apache/samza/storage/MockStorageEngine.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/MockStorageEngine.java
@@ -21,8 +21,10 @@ package org.apache.samza.storage;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 
+import java.util.List;
 import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.system.SystemStreamPartition;
 
@@ -37,7 +39,7 @@ public class MockStorageEngine implements StorageEngine {
   public static SystemStreamPartition ssp;
 
   // Thread-safe list is required because the list is shared across StorageEngine instances
-  public static ArrayList<IncomingMessageEnvelope> incomingMessageEnvelopes = new ArrayList<IncomingMessageEnvelope>();
+  public static List<IncomingMessageEnvelope> incomingMessageEnvelopes = Collections.synchronizedList(new ArrayList<>());
   public static StoreProperties storeProperties;
 
   public MockStorageEngine(String storeName, File storeDir, SystemStreamPartition changeLogSystemStreamPartition, StoreProperties properties) {

--- a/samza-core/src/test/java/org/apache/samza/storage/MockStorageEngine.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/MockStorageEngine.java
@@ -21,10 +21,8 @@ package org.apache.samza.storage;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 
-import java.util.List;
 import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.system.SystemStreamPartition;
 
@@ -37,7 +35,9 @@ public class MockStorageEngine implements StorageEngine {
   public static String storeName;
   public static File storeDir;
   public static SystemStreamPartition ssp;
-  public static List<IncomingMessageEnvelope> incomingMessageEnvelopes = Collections.synchronizedList(new ArrayList<>());
+
+  // Thread-safe list is required because the list is shared across StorageEngine instances
+  public static ArrayList<IncomingMessageEnvelope> incomingMessageEnvelopes = new ArrayList<IncomingMessageEnvelope>();
   public static StoreProperties storeProperties;
 
   public MockStorageEngine(String storeName, File storeDir, SystemStreamPartition changeLogSystemStreamPartition, StoreProperties properties) {


### PR DESCRIPTION
MockStorageEngine has a static list of incomingMessageEnvelopes, which was a non thread-safe ArrayList. 
However in case of parallel restore (recent change), this needs to be a thread-safe list.

This causes a StorageRecoveryTool test to be flaky.