### PR TITLE
Minor: properly close KafkaCheckpointManager in TestKafkaCheckpointManager

### DIFF
--- a/samza-kafka/src/test/scala/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.scala
+++ b/samza-kafka/src/test/scala/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.scala
@@ -233,6 +233,7 @@ class TestKafkaCheckpointManager extends KafkaServerTestHarness {
     kcm.register(taskName)
     kcm.start
     kcm.writeCheckpoint(taskName, checkpoint)
+    kcm.stop
   }
 
   private def createTopic(cpTopic: String, partNum: Int, props: Properties) = {


### PR DESCRIPTION
Higher versions of KafkaServerTestHarness will validate that certain threads are no longer alive when the test class exits. Eventually, when kafka is upgraded, that validation would fail.