### PR TITLE
Minor: Disable outdated sonar-scanner in .travis.yml file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jdk:
 script:
   ## travis_wait increases build idle-wait time from 10 minutes to 30 minutes.
   - travis_wait 30 ./gradlew clean build
-  - type sonar-scanner &>/dev/null; if [ $? -eq 0 ]; then sonar-scanner; else echo "Not running sonar"; fi
+#  - type sonar-scanner &>/dev/null; if [ $? -eq 0 ]; then sonar-scanner; else echo "Not running sonar"; fi
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
Causing Travis-CI builds to appear broken on master.