### PR TITLE
SAMZA-2022: Integrate startpoints with SystemConsumers

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
@@ -163,10 +163,10 @@ class TaskInstance(
 
   def registerConsumers {
     debug("Registering consumers for taskName: %s" format taskName)
-
     systemStreamPartitions.foreach(systemStreamPartition => {
       val startingOffset = getStartingOffset(systemStreamPartition)
-      consumerMultiplexer.register(systemStreamPartition, startingOffset)
+      val startpoint = offsetManager.getStartpoint(taskName, systemStreamPartition).getOrElse(null)
+      consumerMultiplexer.register(systemStreamPartition, startingOffset, startpoint)
       metrics.addOffsetGauge(systemStreamPartition, () =>
         if (sideInputSSPs.contains(systemStreamPartition)) {
           sideInputStorageManager.getLastProcessedOffset(systemStreamPartition)

--- a/samza-core/src/main/scala/org/apache/samza/system/SystemConsumers.scala
+++ b/samza-core/src/main/scala/org/apache/samza/system/SystemConsumers.scala
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit
 import scala.collection.JavaConverters._
 import org.apache.samza.serializers.SerdeManager
 import org.apache.samza.util.{Logging, TimerUtil}
+import org.apache.samza.startpoint.{Startpoint, StartpointVisitor}
 import org.apache.samza.system.chooser.MessageChooser
 import org.apache.samza.SamzaException
 import java.util.ArrayDeque
@@ -33,6 +34,7 @@ import java.util.HashSet
 import java.util.HashMap
 import java.util.Queue
 import java.util.Set
+
 
 object SystemConsumers {
   val DEFAULT_POLL_INTERVAL_MS = 50
@@ -181,7 +183,7 @@ class SystemConsumers (
   }
 
 
-  def register(systemStreamPartition: SystemStreamPartition, offset: String) {
+  def register(systemStreamPartition: SystemStreamPartition, offset: String, startpoint: Startpoint) {
     debug("Registering stream: %s, %s" format (systemStreamPartition, offset))
 
     if (IncomingMessageEnvelope.END_OF_STREAM_OFFSET.equals(offset)) {
@@ -192,10 +194,22 @@ class SystemConsumers (
 
     metrics.registerSystemStreamPartition(systemStreamPartition)
     unprocessedMessagesBySSP.put(systemStreamPartition, new ArrayDeque[IncomingMessageEnvelope]())
+
+    // Note regarding Startpoints and MessageChooser:
+    // Even if there is a startpoint for this SSP, passing in the checkpoint offset should not have any side-effects.
+    // Basically, the offset in the chooser is used in the special scenario where an SSP is both a broadcast and bootstrap stream
+    // and needs to decide what's the lowest starting offset for an SSP that spans across multiple tasks so it knows
+    // to keep the highest priority on the SSP starting from the lowest starting offset until the SSP is fully
+    // bootstrapped to the UPCOMING offset. The offset here is ignored otherwise.
     chooser.register(systemStreamPartition, offset)
 
     try {
-      consumers(systemStreamPartition.getSystem).register(systemStreamPartition, offset)
+      val consumer = consumers(systemStreamPartition.getSystem)
+      if (startpoint != null && consumer.isInstanceOf[StartpointVisitor]) {
+        startpoint.apply(systemStreamPartition, consumer.asInstanceOf[StartpointVisitor])
+      } else {
+        consumer.register(systemStreamPartition, offset)
+      }
     } catch {
       case e: NoSuchElementException => throw new SystemConsumersException("can't register " + systemStreamPartition.getSystem + "'s consumer.", e)
     }

--- a/samza-core/src/test/java/org/apache/samza/task/TestAsyncRunLoop.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestAsyncRunLoop.java
@@ -652,6 +652,7 @@ public class TestAsyncRunLoop {
     when(offsetManager.getLastProcessedOffset(taskName2, ssp2)).thenReturn(Option.apply("0"));
     when(offsetManager.getStartingOffset(taskName1, ssp1)).thenReturn(Option.apply(IncomingMessageEnvelope.END_OF_STREAM_OFFSET));
     when(offsetManager.getStartingOffset(taskName2, ssp2)).thenReturn(Option.apply("1"));
+    when(offsetManager.getStartpoint(anyObject(), anyObject())).thenReturn(Option.empty());
 
     TaskInstance taskInstance1 = createTaskInstance(mockStreamTask1, taskName1, ssp1, offsetManager, consumers);
     TaskInstance taskInstance2 = createTaskInstance(mockStreamTask2, taskName2, ssp2, offsetManager, consumers);


### PR DESCRIPTION
This PR integrates the `Startpoint` with the `SystemConsumers` multiplexer class. The general logic is if there is a `Startpoint` for an SSP in a task and the `SystemConsumer` implements the `StartpointVisitor` interface, it will apply the visitor method via `Startpoint#apply(SystemStreamPartition, StartpointVisitor)`. Otherwise, the `SystemConsumer#register(SystemStreamPartition, checkpointOffset:String)` method is called as it currently does.

@shanthoosh @cameronlee314 @prateekm - Please take a look... after the break is fine. If I don't respond to comments within 24-48 hours during my leave, please feel free to hijack this PR into another PR. 