### PR TITLE
SAMZA-2072: Update guava to 23.0

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -26,7 +26,7 @@
   commonsHttpClientVersion = "3.1"
   commonsLang3Version = "3.4"
   elasticsearchVersion = "2.2.0"
-  guavaVersion = "17.0"
+  guavaVersion = "23.0"
   hamcrestVersion = "1.3"
   httpClientVersion = "4.4.1"
   jacksonVersion = "1.9.13"

--- a/samza-api/src/main/java/org/apache/samza/startpoint/Startpoint.java
+++ b/samza-api/src/main/java/org/apache/samza/startpoint/Startpoint.java
@@ -18,6 +18,7 @@
  */
 package org.apache.samza.startpoint;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import java.time.Instant;
 import org.apache.samza.annotation.InterfaceStability;
@@ -58,7 +59,7 @@ public abstract class Startpoint {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).toString();
+    return MoreObjects.toStringHelper(this).toString();
   }
 
   @Override

--- a/samza-api/src/main/java/org/apache/samza/startpoint/StartpointOldest.java
+++ b/samza-api/src/main/java/org/apache/samza/startpoint/StartpointOldest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.samza.startpoint;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import org.apache.samza.system.SystemStreamPartition;
 
 
@@ -41,6 +41,6 @@ public final class StartpointOldest extends Startpoint {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).toString();
+    return MoreObjects.toStringHelper(this).toString();
   }
 }

--- a/samza-api/src/main/java/org/apache/samza/startpoint/StartpointSpecific.java
+++ b/samza-api/src/main/java/org/apache/samza/startpoint/StartpointSpecific.java
@@ -18,6 +18,7 @@
  */
 package org.apache.samza.startpoint;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import org.apache.samza.system.SystemStreamPartition;
 
@@ -58,7 +59,7 @@ public final class StartpointSpecific extends Startpoint {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("specificOffset", specificOffset).toString();
+    return MoreObjects.toStringHelper(this).add("specificOffset", specificOffset).toString();
   }
 
   @Override

--- a/samza-api/src/main/java/org/apache/samza/startpoint/StartpointTimestamp.java
+++ b/samza-api/src/main/java/org/apache/samza/startpoint/StartpointTimestamp.java
@@ -18,6 +18,7 @@
  */
 package org.apache.samza.startpoint;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import org.apache.samza.system.SystemStreamPartition;
 
@@ -58,7 +59,7 @@ public final class StartpointTimestamp extends Startpoint {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).add("timestampOffset", timestampOffset).toString();
+    return MoreObjects.toStringHelper(this).add("timestampOffset", timestampOffset).toString();
   }
 
   @Override

--- a/samza-api/src/main/java/org/apache/samza/startpoint/StartpointUpcoming.java
+++ b/samza-api/src/main/java/org/apache/samza/startpoint/StartpointUpcoming.java
@@ -18,7 +18,7 @@
  */
 package org.apache.samza.startpoint;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import org.apache.samza.system.SystemStreamPartition;
 
 
@@ -41,6 +41,6 @@ public final class StartpointUpcoming extends Startpoint {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).toString();
+    return MoreObjects.toStringHelper(this).toString();
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/startpoint/StartpointKey.java
+++ b/samza-core/src/main/java/org/apache/samza/startpoint/StartpointKey.java
@@ -18,6 +18,7 @@
  */
 package org.apache.samza.startpoint;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import org.apache.samza.container.TaskName;
 import org.apache.samza.system.SystemStreamPartition;
@@ -50,7 +51,7 @@ class StartpointKey {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this).toString();
+    return MoreObjects.toStringHelper(this).toString();
   }
 
   @Override


### PR DESCRIPTION
Startpoint is relying on an old version of guava, which should be updated to 23.0 for the newer api.