### PR TITLE
Bugfix : Passing localityManager to JobModel when created from JobModelManager

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/coordinator/JobModelManager.scala
+++ b/samza-core/src/main/scala/org/apache/samza/coordinator/JobModelManager.scala
@@ -74,6 +74,7 @@ object JobModelManager extends Logging {
       val grouperMetadata: GrouperMetadata = getGrouperMetadata(config, localityManager, taskAssignmentManager)
 
       val jobModel: JobModel = readJobModel(config, changelogPartitionMapping, streamMetadataCache, grouperMetadata)
+      // setting the localityManager explicitly
       jobModelRef.set(new JobModel(jobModel.getConfig, jobModel.getContainers, localityManager))
 
       updateTaskAssignments(jobModel, taskAssignmentManager, grouperMetadata)
@@ -81,7 +82,7 @@ object JobModelManager extends Logging {
       val server = new HttpServer
       server.addServlet("/", new JobServlet(jobModelRef))
 
-      currentJobModelManager = new JobModelManager(jobModel, server, localityManager)
+      currentJobModelManager = new JobModelManager(jobModelRef.get(), server, localityManager)
       currentJobModelManager
     } finally {
       taskAssignmentManager.close()

--- a/samza-core/src/main/scala/org/apache/samza/coordinator/JobModelManager.scala
+++ b/samza-core/src/main/scala/org/apache/samza/coordinator/JobModelManager.scala
@@ -74,7 +74,6 @@ object JobModelManager extends Logging {
       val grouperMetadata: GrouperMetadata = getGrouperMetadata(config, localityManager, taskAssignmentManager)
 
       val jobModel: JobModel = readJobModel(config, changelogPartitionMapping, streamMetadataCache, grouperMetadata)
-      // setting the localityManager explicitly
       jobModelRef.set(new JobModel(jobModel.getConfig, jobModel.getContainers, localityManager))
 
       updateTaskAssignments(jobModel, taskAssignmentManager, grouperMetadata)


### PR DESCRIPTION
Samza Standalone required JobModel refactoring, due to which jobModelRef (and localityManager) is set explicitly in JobModelManager: https://github.com/apache/samza/pull/790.

However the JobModel instances with the localityManager (jobModelRef) was not being used when apply() was being called on the JobModelManager by the ClusterBasedJC.
Due to which host-locality was not being read, causing host affinity to break in YARN.