### PR TITLE
SAMZA-2087: Use separate thread pools for AsyncStreamTaskAdapter and AsyncRunLoop

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/task/AsyncRunLoop.java
+++ b/samza-core/src/main/java/org/apache/samza/task/AsyncRunLoop.java
@@ -177,7 +177,14 @@ public class AsyncRunLoop implements Runnable, Throttleable {
     } finally {
       workerTimer.shutdown();
       callbackExecutor.shutdown();
-      if (callbackTimer != null) callbackTimer.shutdown();
+
+      if (threadPool != null) {
+        threadPool.shutdown();
+      }
+
+      if (callbackTimer != null) {
+        callbackTimer.shutdown();
+      }
     }
   }
 

--- a/samza-core/src/test/java/org/apache/samza/task/TestAsyncStreamAdapter.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestAsyncStreamAdapter.java
@@ -91,7 +91,7 @@ public class TestAsyncStreamAdapter {
 
   @Test
   public void testAdapterWithoutThreadPool() throws Exception {
-    taskAdaptor = new AsyncStreamTaskAdapter(task, null);
+    taskAdaptor = new AsyncStreamTaskAdapter(task, null, 0);
     TestCallbackListener listener = new TestCallbackListener();
     TaskCallback callback = new TaskCallbackImpl(listener, null, envelope, null, 0L, 0L);
 
@@ -122,7 +122,7 @@ public class TestAsyncStreamAdapter {
     TaskCallback callback2 = new TaskCallbackImpl(listener2, null, envelope, null, 1L, 0L);
 
     ExecutorService executor = Executors.newFixedThreadPool(2);
-    taskAdaptor = new AsyncStreamTaskAdapter(task, executor);
+    taskAdaptor = new AsyncStreamTaskAdapter(task, executor, 1);
     taskAdaptor.processAsync(null, null, null, callback1);
     taskAdaptor.processAsync(null, null, null, callback2);
 

--- a/samza-core/src/test/java/org/apache/samza/task/TestTaskFactoryUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestTaskFactoryUtil.java
@@ -18,8 +18,6 @@
  */
 package org.apache.samza.task;
 
-import java.lang.reflect.Field;
-import java.util.concurrent.ExecutorService;
 import org.apache.samza.SamzaException;
 import org.apache.samza.application.descriptors.ApplicationDescriptorImpl;
 import org.apache.samza.application.descriptors.StreamApplicationDescriptorImpl;
@@ -73,34 +71,24 @@ public class TestTaskFactoryUtil {
   public void testFinalizeTaskFactory() throws NoSuchFieldException, IllegalAccessException {
     TaskFactory mockFactory = mock(TaskFactory.class);
     try {
-      TaskFactoryUtil.finalizeTaskFactory(mockFactory, true, null);
+      TaskFactoryUtil.finalizeTaskFactory(mockFactory, true, 0, 0);
       fail("Should have failed with validation");
     } catch (SamzaException se) {
       // expected
     }
     StreamTaskFactory mockStreamFactory = mock(StreamTaskFactory.class);
-    Object retFactory = TaskFactoryUtil.finalizeTaskFactory(mockStreamFactory, true, null);
+    Object retFactory = TaskFactoryUtil.finalizeTaskFactory(mockStreamFactory, true, 0, 0);
     assertEquals(retFactory, mockStreamFactory);
-
-    ExecutorService mockThreadPool = mock(ExecutorService.class);
-    retFactory = TaskFactoryUtil.finalizeTaskFactory(mockStreamFactory, false, mockThreadPool);
-    assertTrue(retFactory instanceof AsyncStreamTaskFactory);
-    assertTrue(((AsyncStreamTaskFactory) retFactory).createInstance() instanceof AsyncStreamTaskAdapter);
-    AsyncStreamTaskAdapter taskAdapter = (AsyncStreamTaskAdapter) ((AsyncStreamTaskFactory) retFactory).createInstance();
-    Field executorSrvFld = AsyncStreamTaskAdapter.class.getDeclaredField("executor");
-    executorSrvFld.setAccessible(true);
-    ExecutorService executor = (ExecutorService) executorSrvFld.get(taskAdapter);
-    assertEquals(executor, mockThreadPool);
 
     AsyncStreamTaskFactory mockAsyncStreamFactory = mock(AsyncStreamTaskFactory.class);
     try {
-      TaskFactoryUtil.finalizeTaskFactory(mockAsyncStreamFactory, true, null);
+      TaskFactoryUtil.finalizeTaskFactory(mockAsyncStreamFactory, true, 0, 0);
       fail("Should have failed");
     } catch (SamzaException se) {
       // expected
     }
 
-    retFactory = TaskFactoryUtil.finalizeTaskFactory(mockAsyncStreamFactory, false, null);
+    retFactory = TaskFactoryUtil.finalizeTaskFactory(mockAsyncStreamFactory, false, 0, 0);
     assertEquals(retFactory, mockAsyncStreamFactory);
   }
 

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestStreamProcessor.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestStreamProcessor.java
@@ -115,18 +115,19 @@ public class TestStreamProcessor extends StandaloneIntegrationTestHarness {
     final String testSystem = "test-system";
     final String inputTopic = "numbers3";
     final String outputTopic = "output3";
+    final long taskShutdownMs = 100000;
     final int messageCount = 20;
 
     final Config configs = new MapConfig(createConfigs("1", testSystem, inputTopic, outputTopic, messageCount));
     final ExecutorService executorService = Executors.newSingleThreadExecutor();
     createTopics(inputTopic, outputTopic);
-    final AsyncStreamTaskFactory stf = () -> new AsyncStreamTaskAdapter(new IdentityStreamTask(), executorService);
+    final AsyncStreamTaskFactory stf =
+        () -> new AsyncStreamTaskAdapter(new IdentityStreamTask(), executorService, taskShutdownMs);
     final TestStubs stubs = new TestStubs(configs, stf, bootstrapServers());
 
     produceMessages(stubs.producer, inputTopic, messageCount);
     run(stubs.processor, stubs.shutdownLatch);
     verifyNumMessages(stubs.consumer, outputTopic, messageCount);
-    executorService.shutdownNow();
   }
 
   /**


### PR DESCRIPTION
Currently, AsyncStreamTaskAdapter and AsyncRunLoop share thread pools and the thread pool size is governed by `job.container.thread.pool.size`. This introduces disparity in the semantics of `task.max.concurrency` between async stream task vs adapted async stream task.

In this PR, we separate the thread pools used by the adapter and the runloop to bring parity between variants of async stream tasks.

