### PR TITLE
 SAMZA-2091: Update ZkClient in samza-standalone to use string serializer

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/zk/ZkBarrierForVersionUpgrade.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkBarrierForVersionUpgrade.java
@@ -92,10 +92,6 @@ public class ZkBarrierForVersionUpgrade {
       this.str = str;
     }
 
-    public String getValue() {
-      return str;
-    }
-
     @Override
     public String toString() {
       return str;
@@ -129,7 +125,7 @@ public class ZkBarrierForVersionUpgrade {
         barrierParticipantsPath,
         barrierStatePath});
     LOG.info("Marking the barrier state: {} as {}.", barrierStatePath, State.NEW);
-    zkUtils.writeData(barrierStatePath, State.NEW.getValue());
+    zkUtils.writeData(barrierStatePath, State.NEW.toString());
 
     LOG.info("Subscribing child changes on the path: {} for barrier version: {}.", barrierParticipantsPath, version);
     zkUtils.subscribeChildChanges(barrierParticipantsPath, new ZkBarrierChangeHandler(version, participants, zkUtils));
@@ -164,7 +160,7 @@ public class ZkBarrierForVersionUpgrade {
     State barrierState = State.valueOf(zkUtils.getZkClient().readData(barrierStatePath));
     if (Objects.equals(barrierState, State.NEW)) {
       LOG.info(String.format("Expiring the barrier version: %s. Marking the barrier state: %s as %s.", version, barrierStatePath, State.TIMED_OUT));
-      zkUtils.writeData(keyBuilder.getBarrierStatePath(version), State.TIMED_OUT.getValue());
+      zkUtils.writeData(keyBuilder.getBarrierStatePath(version), State.TIMED_OUT.toString());
     } else {
       LOG.debug(String.format("Barrier version: %s is at: %s state. Not marking barrier as %s.", version, barrierState, State.TIMED_OUT));
     }
@@ -202,7 +198,7 @@ public class ZkBarrierForVersionUpgrade {
             State barrierState = State.valueOf(zkUtils.getZkClient().readData(barrierStatePath));
             if (Objects.equals(barrierState, State.NEW)) {
               LOG.info(String.format("Expected participants has joined the barrier version: %s. Marking the barrier state: %s as %s.", barrierVersion, barrierStatePath, State.DONE));
-              zkUtils.writeData(barrierStatePath, State.DONE.getValue()); // this will trigger notifications
+              zkUtils.writeData(barrierStatePath, State.DONE.toString()); // this will trigger notifications
             } else {
               LOG.debug(String.format("Barrier version: %s is at: %s state. Not marking barrier as %s.", barrierVersion, barrierState, State.DONE));
             }

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkBarrierForVersionUpgrade.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkBarrierForVersionUpgrade.java
@@ -82,12 +82,18 @@ public class ZkBarrierForVersionUpgrade {
   private final ScheduleAfterDebounceTime debounceTimer;
 
   public enum State {
-    NEW("NEW"), TIMED_OUT("TIMED_OUT"), DONE("DONE");
+    NEW("NEW"),
+    TIMED_OUT("TIMED_OUT"),
+    DONE("DONE");
 
     private String str;
 
     State(String str) {
       this.str = str;
+    }
+
+    public String getValue() {
+      return str;
     }
 
     @Override
@@ -123,7 +129,7 @@ public class ZkBarrierForVersionUpgrade {
         barrierParticipantsPath,
         barrierStatePath});
     LOG.info("Marking the barrier state: {} as {}.", barrierStatePath, State.NEW);
-    zkUtils.writeData(barrierStatePath, State.NEW);
+    zkUtils.writeData(barrierStatePath, State.NEW.getValue());
 
     LOG.info("Subscribing child changes on the path: {} for barrier version: {}.", barrierParticipantsPath, version);
     zkUtils.subscribeChildChanges(barrierParticipantsPath, new ZkBarrierChangeHandler(version, participants, zkUtils));
@@ -155,10 +161,10 @@ public class ZkBarrierForVersionUpgrade {
    */
   public void expire(String version) {
     String barrierStatePath = keyBuilder.getBarrierStatePath(version);
-    State barrierState = zkUtils.getZkClient().readData(barrierStatePath);
+    State barrierState = State.valueOf(zkUtils.getZkClient().readData(barrierStatePath));
     if (Objects.equals(barrierState, State.NEW)) {
       LOG.info(String.format("Expiring the barrier version: %s. Marking the barrier state: %s as %s.", version, barrierStatePath, State.TIMED_OUT));
-      zkUtils.writeData(keyBuilder.getBarrierStatePath(version), State.TIMED_OUT);
+      zkUtils.writeData(keyBuilder.getBarrierStatePath(version), State.TIMED_OUT.getValue());
     } else {
       LOG.debug(String.format("Barrier version: %s is at: %s state. Not marking barrier as %s.", version, barrierState, State.TIMED_OUT));
     }
@@ -193,10 +199,10 @@ public class ZkBarrierForVersionUpgrade {
       if (participantIds.size() == expectedParticipantIds.size() && CollectionUtils.containsAll(participantIds, expectedParticipantIds)) {
         debounceTimer.scheduleAfterDebounceTime(ACTION_NAME, 0, () -> {
             String barrierStatePath = keyBuilder.getBarrierStatePath(barrierVersion);
-            State barrierState = zkUtils.getZkClient().readData(barrierStatePath);
+            State barrierState = State.valueOf(zkUtils.getZkClient().readData(barrierStatePath));
             if (Objects.equals(barrierState, State.NEW)) {
               LOG.info(String.format("Expected participants has joined the barrier version: %s. Marking the barrier state: %s as %s.", barrierVersion, barrierStatePath, State.DONE));
-              zkUtils.writeData(barrierStatePath, State.DONE); // this will trigger notifications
+              zkUtils.writeData(barrierStatePath, State.DONE.getValue()); // this will trigger notifications
             } else {
               LOG.debug(String.format("Barrier version: %s is at: %s state. Not marking barrier as %s.", barrierVersion, barrierState, State.DONE));
             }
@@ -227,12 +233,13 @@ public class ZkBarrierForVersionUpgrade {
     public void doHandleDataChange(String dataPath, Object data) {
       LOG.info(String.format("Received barrierState change notification for barrier version: %s from zkNode: %s with data: %s.", barrierVersion, dataPath, data));
 
-      State barrierState = (State) data;
+      String dataStr = (String) data;
+      State barrierState = State.valueOf(dataStr);
       List<State> expectedBarrierStates = ImmutableList.of(State.DONE, State.TIMED_OUT);
 
-      if (barrierState != null && expectedBarrierStates.contains(barrierState)) {
+      if (expectedBarrierStates.contains(barrierState)) {
         zkUtils.unsubscribeDataChanges(barrierStatePath, this);
-        barrierListenerOptional.ifPresent(zkBarrierListener -> zkBarrierListener.onBarrierStateChanged(barrierVersion, (State) data));
+        barrierListenerOptional.ifPresent(zkBarrierListener -> zkBarrierListener.onBarrierStateChanged(barrierVersion, barrierState));
       } else {
         LOG.debug("Barrier version: {} is at state: {}. Ignoring the barrierState change notification.", barrierVersion, barrierState);
       }

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkCoordinationUtilsFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkCoordinationUtilsFactory.java
@@ -20,7 +20,6 @@ package org.apache.samza.zk;
 
 import com.google.common.base.Strings;
 import org.I0Itec.zkclient.ZkClient;
-import org.I0Itec.zkclient.serialize.SerializableSerializer;
 import org.apache.samza.SamzaException;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.ZkConfig;
@@ -56,7 +55,7 @@ public class ZkCoordinationUtilsFactory implements CoordinationUtilsFactory {
   public static ZkClient createZkClient(String connectString, int sessionTimeoutMS, int connectionTimeoutMs) {
     ZkClient zkClient;
     try {
-      zkClient = new ZkClient(connectString, sessionTimeoutMS, connectionTimeoutMs, new SerializableSerializer(), connectionTimeoutMs);
+      zkClient = new ZkClient(connectString, sessionTimeoutMS, connectionTimeoutMs, new ZkStringSerializer(), connectionTimeoutMs);
     } catch (Exception e) {
       // ZkClient constructor may throw a variety of different exceptions, not all of them Zk based.
       throw new SamzaException("zkClient failed to connect to ZK at :" + connectString, e);
@@ -88,4 +87,5 @@ public class ZkCoordinationUtilsFactory implements CoordinationUtilsFactory {
       throw new SamzaException("Zookeeper namespace: " + path + " does not exist for zk at " + zkConnect);
     }
   }
+
 }

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinatorFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinatorFactory.java
@@ -33,8 +33,9 @@ import org.slf4j.LoggerFactory;
 public class ZkJobCoordinatorFactory implements JobCoordinatorFactory {
 
   private static final Logger LOG = LoggerFactory.getLogger(ZkJobCoordinatorFactory.class);
-  private static final String JOB_COORDINATOR_ZK_PATH_FORMAT = "%s/%s-%s-coordinationData";
+  private static final String JOB_COORDINATOR_ZK_PATH_FORMAT = "%s/%s-%s-%s-coordinationData";
   private static final String DEFAULT_JOB_NAME = "defaultJob";
+  private static final String PROTOCOL_VERSION = "1.0";
 
   /**
    * Instantiates an {@link ZkJobCoordinator} using the {@link Config}.
@@ -67,6 +68,6 @@ public class ZkJobCoordinatorFactory implements JobCoordinatorFactory {
         : DEFAULT_JOB_NAME;
     String jobId = jobConfig.getJobId();
 
-    return String.format(JOB_COORDINATOR_ZK_PATH_FORMAT, appId, jobName, jobId);
+    return String.format(JOB_COORDINATOR_ZK_PATH_FORMAT, appId, jobName, jobId, PROTOCOL_VERSION);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkStringSerializer.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkStringSerializer.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.zk;
+
+import java.io.UnsupportedEncodingException;
+import org.I0Itec.zkclient.exception.ZkMarshallingError;
+import org.I0Itec.zkclient.serialize.ZkSerializer;
+
+
+public class ZkStringSerializer implements ZkSerializer {
+
+  private static final String UTF_8 = "UTF-8";
+
+  @Override
+  public byte[] serialize(Object data) throws ZkMarshallingError {
+    if (data != null) {
+      try {
+        return ((String) data).getBytes(UTF_8);
+      } catch (UnsupportedEncodingException e) {
+        throw new ZkMarshallingError(e);
+      }
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public Object deserialize(byte[] bytes) throws ZkMarshallingError {
+    if (bytes != null) {
+      try {
+        return new String(bytes, 0, bytes.length, UTF_8);
+      } catch (UnsupportedEncodingException e) {
+        throw new ZkMarshallingError(e);
+      }
+    } else {
+      return null;
+    }
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkBarrierForVersionUpgrade.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkBarrierForVersionUpgrade.java
@@ -55,9 +55,9 @@ public class TestZkBarrierForVersionUpgrade {
 
   @Before
   public void testSetup() {
-    ZkClient zkClient = new ZkClient(testZkConnectionString, ZkConfig.DEFAULT_SESSION_TIMEOUT_MS, ZkConfig.DEFAULT_CONNECTION_TIMEOUT_MS);
+    ZkClient zkClient = new ZkClient(testZkConnectionString, ZkConfig.DEFAULT_SESSION_TIMEOUT_MS, ZkConfig.DEFAULT_CONNECTION_TIMEOUT_MS, new ZkStringSerializer());
     this.zkUtils = new ZkUtils(new ZkKeyBuilder("group1"), zkClient, ZkConfig.DEFAULT_CONNECTION_TIMEOUT_MS, ZkConfig.DEFAULT_SESSION_TIMEOUT_MS, new NoOpMetricsRegistry());
-    ZkClient zkClient1 = new ZkClient(testZkConnectionString, ZkConfig.DEFAULT_SESSION_TIMEOUT_MS, ZkConfig.DEFAULT_CONNECTION_TIMEOUT_MS);
+    ZkClient zkClient1 = new ZkClient(testZkConnectionString, ZkConfig.DEFAULT_SESSION_TIMEOUT_MS, ZkConfig.DEFAULT_CONNECTION_TIMEOUT_MS, new ZkStringSerializer());
     this.zkUtils1 = new ZkUtils(new ZkKeyBuilder("group1"), zkClient1, ZkConfig.DEFAULT_CONNECTION_TIMEOUT_MS, ZkConfig.DEFAULT_SESSION_TIMEOUT_MS, new NoOpMetricsRegistry());
   }
 
@@ -110,8 +110,8 @@ public class TestZkBarrierForVersionUpgrade {
 
     processor1Barrier.create(BARRIER_VERSION, processors);
 
-    State barrierState = zkUtils.getZkClient().readData(barrierId + "/barrier_1/barrier_state");
-    assertEquals(State.NEW, barrierState);
+    String barrierState = zkUtils.getZkClient().readData(barrierId + "/barrier_1/barrier_state");
+    assertEquals(State.NEW, State.valueOf(barrierState));
 
     processor1Barrier.join(BARRIER_VERSION, "p1");
     processor2Barrier.join(BARRIER_VERSION, "p2");
@@ -126,7 +126,7 @@ public class TestZkBarrierForVersionUpgrade {
 
     List<String> children = zkUtils.getZkClient().getChildren(barrierId + "/barrier_1/barrier_participants");
     barrierState = zkUtils.getZkClient().readData(barrierId + "/barrier_1/barrier_state");
-    assertEquals(State.DONE, barrierState);
+    assertEquals(State.DONE, State.valueOf(barrierState));
     assertNotNull(children);
     assertEquals("Unexpected barrier state. Didn't find two processors.", 2, children.size());
     assertEquals("Unexpected barrier state. Didn't find the expected members.", processors, children);
@@ -158,8 +158,8 @@ public class TestZkBarrierForVersionUpgrade {
     assertTrue("Barrier Timeout test failed to complete within test timeout.", result);
 
     List<String> children = zkUtils.getZkClient().getChildren(barrierId + "/barrier_1/barrier_participants");
-    State barrierState = zkUtils.getZkClient().readData(barrierId + "/barrier_1/barrier_state");
-    assertEquals(State.TIMED_OUT, barrierState);
+    String barrierState = zkUtils.getZkClient().readData(barrierId + "/barrier_1/barrier_state");
+    assertEquals(State.TIMED_OUT, State.valueOf(barrierState));
     assertNotNull(children);
     assertEquals("Unexpected barrier state. Didn't find two processors.", 2, children.size());
     assertEquals("Unexpected barrier state. Didn't find the expected members.", ImmutableList.of("p1", "p2"), children);
@@ -190,8 +190,8 @@ public class TestZkBarrierForVersionUpgrade {
 
     processor1Barrier.expire(BARRIER_VERSION);
 
-    State barrierState = zkUtils.getZkClient().readData(barrierId + "/barrier_1/barrier_state");
-    assertEquals(State.DONE, barrierState);
+    String barrierState = zkUtils.getZkClient().readData(barrierId + "/barrier_1/barrier_state");
+    assertEquals(State.DONE, State.valueOf(barrierState));
   }
 
   @Test
@@ -222,7 +222,7 @@ public class TestZkBarrierForVersionUpgrade {
 
     processor1Barrier.join(BARRIER_VERSION, "p3");
 
-    State barrierState = zkUtils.getZkClient().readData(barrierId + "/barrier_1/barrier_state");
-    assertEquals(State.TIMED_OUT, barrierState);
+    String barrierState = zkUtils.getZkClient().readData(barrierId + "/barrier_1/barrier_state");
+    assertEquals(State.TIMED_OUT, State.valueOf(barrierState));
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkStringSerializer.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkStringSerializer.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.zk;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class TestZkStringSerializer {
+
+  @Test
+  public void testStringSerialization() throws Exception {
+    ZkStringSerializer serde = new ZkStringSerializer();
+    Assert.assertEquals(null, serde.serialize(null));
+    Assert.assertEquals(null, serde.deserialize(null));
+
+    String fooBar = "37";
+    byte[] fooBarBytes = serde.serialize(fooBar);
+    Assert.assertArrayEquals(fooBar.getBytes("UTF-8"), fooBarBytes);
+    Assert.assertEquals(fooBar, serde.deserialize(fooBarBytes));
+  }
+}

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
@@ -66,6 +66,7 @@ import org.apache.samza.test.StandaloneIntegrationTestHarness;
 import org.apache.samza.test.StandaloneTestUtils;
 import org.apache.samza.util.NoOpMetricsRegistry;
 import org.apache.samza.util.Util;
+import org.apache.samza.zk.ZkStringSerializer;
 import org.apache.samza.zk.ZkJobCoordinatorFactory;
 import org.apache.samza.zk.ZkKeyBuilder;
 import org.apache.samza.zk.ZkUtils;
@@ -143,7 +144,7 @@ public class TestZkLocalApplicationRunner extends StandaloneIntegrationTestHarne
     configMap.put(JobConfig.PROCESSOR_ID(), PROCESSOR_IDS[2]);
     applicationConfig3 = new ApplicationConfig(new MapConfig(configMap));
 
-    ZkClient zkClient = new ZkClient(zkConnect());
+    ZkClient zkClient = new ZkClient(zkConnect(), ZK_CONNECTION_TIMEOUT_MS, ZK_CONNECTION_TIMEOUT_MS, new ZkStringSerializer());
     ZkKeyBuilder zkKeyBuilder = new ZkKeyBuilder(ZkJobCoordinatorFactory.getJobCoordinationZkPath(applicationConfig1));
     zkUtils = new ZkUtils(zkKeyBuilder, zkClient, ZK_CONNECTION_TIMEOUT_MS, ZK_SESSION_TIMEOUT_MS, new NoOpMetricsRegistry());
     zkUtils.connect();


### PR DESCRIPTION
This patch is comprised of the following changes: 

1. Switch from using SerializableSerializer to ZkStringSerializer in the zkClient for standalone.
  ZkClient uses pluggable serde to serialize/deserialize user-defined types to bytes before it's written to zookeeper. In the current implementation, the predefined SerializableSerializer(which uses the java native serialization) provided as default by the ZkClient library is used by samza-standalone. SerializableSerializer augments special characters  on top of the serialized data as auxiliary data. The presence of these special characters makes the parsing of zookeeper data impossible  when building custom tools in languages(such as python) that does not have java native serializer. To solve this problem, this patch introduces string serializer to serialize/deserialize data before it's written to zookeeper.
2. Adds a new string serializer which implements the ZkSerializer serialization abstraction provided by the ZkClient.
3. Add protocol version to the zookeeper base path  to enable us to make data format changes easily in the future. 
4. Fix the usages where there're direct type conversion are done.

**Testing:**

1. Added unit tests for the newly introduced serializer.
2. Tested this patch  with the sample standalone test jobs from the samza-hello-samza repository.