### PR TITLE
SAMZA-2083: Adds the register(SystemStreamPartition, startpoint) API to the SystemConsumer.

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/system/SystemConsumer.java
+++ b/samza-api/src/main/java/org/apache/samza/system/SystemConsumer.java
@@ -148,7 +148,7 @@ public interface SystemConsumer {
    */
   @InterfaceStability.Evolving
   default void register(SystemStreamPartition systemStreamPartition, Startpoint startpoint) {
-    throw new UnsupportedOperationException("This operation is not supported.");
+    throw new UnsupportedOperationException(String.format("Registering the ssp: %s with startpoint: %s is not supported.", systemStreamPartition, startpoint));
   }
 
   /**

--- a/samza-core/src/main/scala/org/apache/samza/config/JobConfig.scala
+++ b/samza-core/src/main/scala/org/apache/samza/config/JobConfig.scala
@@ -258,7 +258,7 @@ class JobConfig(config: Config) extends ScalaMapConfig(config) with Logging {
 
   def getMetadataStoreFactory = getOption(JobConfig.METADATA_STORE_FACTORY).getOrElse(classOf[CoordinatorStreamMetadataStoreFactory].getCanonicalName)
 
-  def getStartpointMetadataStoreFactory = getOption(JobConfig.STARTPOINT_METADATA_STORE_FACTORY).getOrElse(getMetadataStoreFactory)
+  def getStartpointMetadataStoreFactory = getOption(JobConfig.STARTPOINT_METADATA_STORE_FACTORY).getOrElse(null)
 
   def getDiagnosticsEnabled = { getBoolean(JobConfig.JOB_DIAGNOSTICS_ENABLED, false) }
 

--- a/samza-core/src/main/scala/org/apache/samza/system/SystemConsumers.scala
+++ b/samza-core/src/main/scala/org/apache/samza/system/SystemConsumers.scala
@@ -21,19 +21,19 @@ package org.apache.samza.system
 
 
 import java.util
+import java.util.ArrayDeque
 import java.util.concurrent.TimeUnit
+import java.util.Collections
+import java.util.HashMap
+import java.util.HashSet
+import java.util.Queue
+import java.util.Set
 import scala.collection.JavaConverters._
 import org.apache.samza.serializers.SerdeManager
 import org.apache.samza.util.{Logging, TimerUtil}
-import org.apache.samza.startpoint.{Startpoint, StartpointVisitor}
+import org.apache.samza.startpoint.Startpoint
 import org.apache.samza.system.chooser.MessageChooser
 import org.apache.samza.SamzaException
-import java.util.ArrayDeque
-import java.util.Collections
-import java.util.HashSet
-import java.util.HashMap
-import java.util.Queue
-import java.util.Set
 
 
 object SystemConsumers {
@@ -205,8 +205,8 @@ class SystemConsumers (
 
     try {
       val consumer = consumers(systemStreamPartition.getSystem)
-      if (startpoint != null && consumer.isInstanceOf[StartpointVisitor]) {
-        startpoint.apply(systemStreamPartition, consumer.asInstanceOf[StartpointVisitor])
+      if (startpoint != null) {
+        consumer.register(systemStreamPartition, startpoint)
       } else {
         consumer.register(systemStreamPartition, offset)
       }

--- a/samza-core/src/test/scala/org/apache/samza/storage/TestTaskStorageManager.scala
+++ b/samza-core/src/test/scala/org/apache/samza/storage/TestTaskStorageManager.scala
@@ -616,7 +616,7 @@ class TestTaskStorageManager extends MockitoSugar {
     })
 
     val mockSystemConsumer = mock[SystemConsumer]
-    when(mockSystemConsumer.register(any(), any())).thenAnswer(new Answer[Unit] {
+    when(mockSystemConsumer.register(any(classOf[SystemStreamPartition]), any(classOf[String]))).thenAnswer(new Answer[Unit] {
       override def answer(invocation: InvocationOnMock): Unit = {
         val args = invocation.getArguments
         if (ssp.equals(args.apply(0).asInstanceOf[SystemStreamPartition])) {

--- a/samza-core/src/test/scala/org/apache/samza/system/TestSystemConsumers.scala
+++ b/samza-core/src/test/scala/org/apache/samza/system/TestSystemConsumers.scala
@@ -31,6 +31,7 @@ import org.apache.samza.system.chooser.MessageChooser
 import org.apache.samza.system.chooser.DefaultChooser
 import org.apache.samza.system.chooser.MockMessageChooser
 import org.apache.samza.util.BlockingEnvelopeMap
+import org.mockito.Mockito
 
 import scala.collection.JavaConverters._
 
@@ -340,39 +341,22 @@ class TestSystemConsumers {
     assertTrue(consumer.lastPoll.contains(systemStreamPartition1))
   }
 
-  @Test(expected = classOf[UnsupportedOperationException])
-  def testSystemConsumersAndStartpointVisitor {
+  @Test
+  def testSystemConsumersRegistration {
     val system = "test-system"
     val stream = "some-stream"
     val systemStreamPartition1 = new SystemStreamPartition(system, stream, new Partition(1))
     val systemStreamPartition2 = new SystemStreamPartition(system, stream, new Partition(2))
 
-    val consumer = new TestStartpointConsumer
+    val consumer = Mockito.mock(classOf[SystemConsumer])
+    val startpoint = Mockito.mock(classOf[Startpoint])
     val consumers = new SystemConsumers(new MockMessageChooser, Map(system -> consumer),
       new SerdeManager, new SystemConsumersMetrics,
       SystemConsumers.DEFAULT_NO_NEW_MESSAGES_TIMEOUT,
       SystemConsumers.DEFAULT_DROP_SERIALIZATION_ERROR,
       SystemConsumers.DEFAULT_POLL_INTERVAL_MS, clock = () => 0)
 
-    consumers.register(systemStreamPartition1, "0", null)
-    assertNull(consumer.getVisitedStartpoint(systemStreamPartition1))
-
-    val startpointSpecific = new StartpointSpecific("1")
-    consumers.register(systemStreamPartition2, "0", startpointSpecific)
-    assertEquals(startpointSpecific, consumer.getVisitedStartpoint(systemStreamPartition2))
-
-    val startpointTimestamp = new StartpointTimestamp(123456L)
-    consumers.register(systemStreamPartition2, "0", startpointTimestamp)
-    assertEquals(startpointTimestamp, consumer.getVisitedStartpoint(systemStreamPartition2))
-
-    val startpointOldest = new StartpointOldest
-    consumers.register(systemStreamPartition2, "0", startpointOldest)
-    assertEquals(startpointOldest, consumer.getVisitedStartpoint(systemStreamPartition2))
-
-    val startpointUpcoming = new StartpointUpcoming
-    consumers.register(systemStreamPartition2, "0", startpointUpcoming)
-    assertEquals(startpointUpcoming, consumer.getVisitedStartpoint(systemStreamPartition2))
-
+    consumers.register(systemStreamPartition1, "0", startpoint)
   }
 
   /**
@@ -419,30 +403,6 @@ class TestSystemConsumers {
     def start {}
     def stop {}
     def register { super.register(systemStreamPartition, "0") }
-  }
-
-  private class TestStartpointConsumer extends SerializingConsumer with StartpointVisitor {
-    var startpoints: Map[SystemStreamPartition, Startpoint] = Map()
-
-    override def visit(systemStreamPartition: SystemStreamPartition, startpointSpecific: StartpointSpecific) {
-      startpoints += systemStreamPartition -> startpointSpecific
-    }
-
-    override def visit(systemStreamPartition: SystemStreamPartition, startpointTimestamp: StartpointTimestamp) {
-      startpoints += systemStreamPartition -> startpointTimestamp
-    }
-
-    override def visit(systemStreamPartition: SystemStreamPartition, startpointUpcoming: StartpointUpcoming) {
-      startpoints += systemStreamPartition -> startpointUpcoming
-    }
-
-    override def visit(systemStreamPartition: SystemStreamPartition, startpointOldest: StartpointOldest) {
-      startpoints += systemStreamPartition -> startpointOldest
-    }
-
-    def getVisitedStartpoint(systemStreamPartition: SystemStreamPartition) : Startpoint = {
-      startpoints.getOrElse(systemStreamPartition, null)
-    }
   }
 }
 

--- a/samza-core/src/test/scala/org/apache/samza/system/TestSystemConsumers.scala
+++ b/samza-core/src/test/scala/org/apache/samza/system/TestSystemConsumers.scala
@@ -340,7 +340,7 @@ class TestSystemConsumers {
     assertTrue(consumer.lastPoll.contains(systemStreamPartition1))
   }
 
-  @Test(expected = classOf[Exception])
+  @Test(expected = classOf[UnsupportedOperationException])
   def testSystemConsumersAndStartpointVisitor {
     val system = "test-system"
     val stream = "some-stream"

--- a/samza-core/src/test/scala/org/apache/samza/system/TestSystemConsumers.scala
+++ b/samza-core/src/test/scala/org/apache/samza/system/TestSystemConsumers.scala
@@ -340,7 +340,7 @@ class TestSystemConsumers {
     assertTrue(consumer.lastPoll.contains(systemStreamPartition1))
   }
 
-  @Test
+  @Test(expected = classOf[Exception])
   def testSystemConsumersAndStartpointVisitor {
     val system = "test-system"
     val stream = "some-stream"


### PR DESCRIPTION
This is a followup PR to address the comments from #869. It is comprised of the following changes:
1. SAMZA-1985 introduced startpoint abstraction, a comprehensive mechanism to define starting positions for a input SystemStreamPartition in samza. This patch merely adds the register(SystemStreamPartition, Startpoint) API to SystemConsumer. 
2. Removes the default metadata store defined for startpoints. This is helpful in not creating the unnecessary metastore connections as a part of container initialization before the startpoint feature is fully completed.

Follow-ups:

1. In a follow-up PR,  new register API and start-point visitors will be implemented for different I/O connectors.
2. Usages of SystemConsumer#register(SystemStreamPartition, offset) is very wide-spread in samza codebase. After the above step is completed, will deprecate SystemConsumer#register(SystemStreamPartition, offset) after moving all it's usages to SystemConsumer#register(SystemStreamPartition, StartpointSpecific). 

