### PR TITLE
SAMZA-2051: bump checkstyle version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,4 +23,4 @@ gradleVersion=2.8
 org.gradle.jvmargs="-XX:MaxPermSize=512m"
 
 systemProp.file.encoding=utf-8
-checkstyleVersion=5.9
+checkstyleVersion=6.11

--- a/samza-api/src/main/java/org/apache/samza/table/utils/SerdeUtils.java
+++ b/samza-api/src/main/java/org/apache/samza/table/utils/SerdeUtils.java
@@ -57,7 +57,7 @@ public final class SerdeUtils {
   @SuppressWarnings("unchecked")
   public static <T> T deserialize(String name, String strObject) {
     try {
-      byte [] bytes = Base64.getDecoder().decode(strObject);
+      byte[] bytes = Base64.getDecoder().decode(strObject);
       return (T) new ObjectInputStream(new ByteArrayInputStream(bytes)).readObject();
     } catch (Exception e) {
       String errMsg = "Failed to deserialize " + name;

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerProcessManager.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerProcessManager.java
@@ -168,8 +168,8 @@ public class ContainerProcessManager implements ClusterResourceManager.Callback 
   }
 
   public boolean shouldShutdown() {
-    log.debug(" TaskManager state: Completed containers: {}, Configured containers: {}, Is there too many FailedContainers: {}, Is AllocatorThread alive: {} "
-      , new Object[]{state.completedContainers.get(), state.containerCount, tooManyFailedContainers ? "yes" : "no", allocatorThread.isAlive() ? "yes" : "no"});
+    log.debug(" TaskManager state: Completed containers: {}, Configured containers: {}, Is there too many FailedContainers: {}, Is AllocatorThread alive: {} ",
+      state.completedContainers.get(), state.containerCount, tooManyFailedContainers ? "yes" : "no", allocatorThread.isAlive() ? "yes" : "no");
 
     if (exceptionOccurred != null) {
       log.error("Exception in ContainerProcessManager", exceptionOccurred);

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/HostAwareContainerAllocator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/HostAwareContainerAllocator.java
@@ -45,7 +45,7 @@ public class HostAwareContainerAllocator extends AbstractContainerAllocator {
    */
   private final int requestTimeout;
 
-  public HostAwareContainerAllocator(ClusterResourceManager manager ,
+  public HostAwareContainerAllocator(ClusterResourceManager manager,
                                      int timeout, Config config, SamzaApplicationState state) {
     super(manager, new ResourceRequestState(true, manager), config, state);
     this.requestTimeout = timeout;

--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -39,7 +39,7 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
    * @return the first line of the output.
    * @throws IOException
    */
-  private String getCommandOutput(String [] cmdArray) throws IOException {
+  private String getCommandOutput(String[] cmdArray) throws IOException {
     Process executable = Runtime.getRuntime().exec(cmdArray);
     BufferedReader processReader = null;
     String psOutput = null;

--- a/samza-core/src/main/java/org/apache/samza/execution/LocalJobPlanner.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/LocalJobPlanner.java
@@ -45,7 +45,7 @@ public class LocalJobPlanner extends JobPlanner {
   private static final Logger LOG = LoggerFactory.getLogger(LocalJobPlanner.class);
   private static final String APPLICATION_RUNNER_PATH_SUFFIX = "/ApplicationRunnerData";
 
-  private final String uid = UUID.randomUUID().toString();;
+  private final String uid = UUID.randomUUID().toString();
 
   public LocalJobPlanner(ApplicationDescriptorImpl<? extends ApplicationDescriptor> descriptor) {
     super(descriptor);

--- a/samza-core/src/main/java/org/apache/samza/serializers/IntermediateMessageSerde.java
+++ b/samza-core/src/main/java/org/apache/samza/serializers/IntermediateMessageSerde.java
@@ -68,7 +68,7 @@ public class IntermediateMessageSerde implements Serde<Object> {
     try {
       final Object object;
       final MessageType type = MessageType.values()[bytes[0]];
-      final byte [] data = Arrays.copyOfRange(bytes, 1, bytes.length);
+      final byte[] data = Arrays.copyOfRange(bytes, 1, bytes.length);
       switch (type) {
         case USER_MESSAGE:
           object = userMessageSerde.fromBytes(data);
@@ -103,7 +103,7 @@ public class IntermediateMessageSerde implements Serde<Object> {
 
   @Override
   public byte[] toBytes(Object object) {
-    final byte [] data;
+    final byte[] data;
     final MessageType type = MessageType.of(object);
     switch (type) {
       case USER_MESSAGE:
@@ -119,7 +119,7 @@ public class IntermediateMessageSerde implements Serde<Object> {
         throw new SamzaException("Unknown message type: " + type.name());
     }
 
-    final byte [] bytes = new byte[data.length + 1];
+    final byte[] bytes = new byte[data.length + 1];
     bytes[0] = (byte) type.ordinal();
     System.arraycopy(data, 0, bytes, 1, data.length);
 

--- a/samza-core/src/test/java/org/apache/samza/coordinator/TestJobModelManager.java
+++ b/samza-core/src/test/java/org/apache/samza/coordinator/TestJobModelManager.java
@@ -125,7 +125,7 @@ public class TestJobModelManager {
     Map<String, LocationId> containerLocality = ImmutableMap.of("0", new LocationId("abc-affinity"));
     this.jobModelManager = JobModelManagerTestUtil.getJobModelManagerUsingReadModel(config, mockStreamMetadataCache, server, mockLocalityManager, containerLocality);
 
-    assertEquals(jobModelManager.jobModel().getAllContainerLocality(), new HashMap<String, String>() { { this.put("0", "abc-affinity"); } });
+    assertEquals(jobModelManager.jobModel().getAllContainerLocality(), ImmutableMap.of("0", "abc-affinity"));
   }
 
   @Test
@@ -157,7 +157,7 @@ public class TestJobModelManager {
 
     this.jobModelManager = JobModelManagerTestUtil.getJobModelManagerUsingReadModel(config, mockStreamMetadataCache, server, mockLocalityManager, containerLocality);
 
-    assertEquals(jobModelManager.jobModel().getAllContainerLocality(), new HashMap<String, String>() { { this.put("0", null); } });
+    assertEquals(jobModelManager.jobModel().getAllContainerLocality(), Collections.singletonMap("0", null));
   }
 
   @Test

--- a/samza-core/src/test/java/org/apache/samza/execution/TestExecutionPlanner.java
+++ b/samza-core/src/test/java/org/apache/samza/execution/TestExecutionPlanner.java
@@ -840,8 +840,7 @@ public class TestExecutionPlanner {
           intermediateStreams.remove(edge.getStreamSpec().getId());
         }
       });
-    assertEquals(new HashSet<String>() { { this.add(intermediateStream1); this.add(intermediateBroadcast); } }.toArray(),
-        intermediateStreams.toArray());
+    assertEquals(new HashSet<>(Arrays.asList(intermediateStream1, intermediateBroadcast)), intermediateStreams);
   }
 
   @Test

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImplGraph.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImplGraph.java
@@ -20,7 +20,6 @@
 package org.apache.samza.operators.impl;
 
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import org.apache.samza.Partition;
 import org.apache.samza.application.descriptors.StreamApplicationDescriptorImpl;
@@ -674,7 +673,7 @@ public class TestOperatorImplGraph {
       }
 
       if (perTaskCloseList.get(this.taskName) == null) {
-        perTaskCloseList.put(taskName, Collections.singletonList(opId));
+        perTaskCloseList.put(taskName, new ArrayList<>(Collections.singletonList(opId)));
       } else {
         perTaskCloseList.get(taskName).add(opId);
       }
@@ -686,7 +685,7 @@ public class TestOperatorImplGraph {
     public void init(Context context) {
       TaskName taskName = context.getTaskContext().getTaskModel().getTaskName();
       if (perTaskFunctionMap.get(taskName) == null) {
-        perTaskFunctionMap.put(taskName, ImmutableMap.of(opId, BaseTestFunction.this));
+        perTaskFunctionMap.put(taskName, new HashMap<>(Collections.singletonMap(opId, BaseTestFunction.this)));
       } else {
         if (perTaskFunctionMap.get(taskName).containsKey(opId)) {
           throw new IllegalStateException(String.format("Multiple init called for op %s in the same task instance %s", opId, this.taskName.getTaskName()));
@@ -694,7 +693,7 @@ public class TestOperatorImplGraph {
         perTaskFunctionMap.get(taskName).put(opId, this);
       }
       if (perTaskInitList.get(taskName) == null) {
-        perTaskInitList.put(taskName, Collections.singletonList(opId));
+        perTaskInitList.put(taskName, new ArrayList<>(Collections.singletonList(opId)));
       } else {
         perTaskInitList.get(taskName).add(opId);
       }

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImplGraph.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImplGraph.java
@@ -20,6 +20,7 @@
 package org.apache.samza.operators.impl;
 
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import org.apache.samza.Partition;
 import org.apache.samza.application.descriptors.StreamApplicationDescriptorImpl;
@@ -673,7 +674,7 @@ public class TestOperatorImplGraph {
       }
 
       if (perTaskCloseList.get(this.taskName) == null) {
-        perTaskCloseList.put(taskName, new ArrayList<String>() { { this.add(opId); } });
+        perTaskCloseList.put(taskName, Collections.singletonList(opId));
       } else {
         perTaskCloseList.get(taskName).add(opId);
       }
@@ -685,7 +686,7 @@ public class TestOperatorImplGraph {
     public void init(Context context) {
       TaskName taskName = context.getTaskContext().getTaskModel().getTaskName();
       if (perTaskFunctionMap.get(taskName) == null) {
-        perTaskFunctionMap.put(taskName, new HashMap<String, BaseTestFunction>() { { this.put(opId, BaseTestFunction.this); } });
+        perTaskFunctionMap.put(taskName, ImmutableMap.of(opId, BaseTestFunction.this));
       } else {
         if (perTaskFunctionMap.get(taskName).containsKey(opId)) {
           throw new IllegalStateException(String.format("Multiple init called for op %s in the same task instance %s", opId, this.taskName.getTaskName()));
@@ -693,7 +694,7 @@ public class TestOperatorImplGraph {
         perTaskFunctionMap.get(taskName).put(opId, this);
       }
       if (perTaskInitList.get(taskName) == null) {
-        perTaskInitList.put(taskName, new ArrayList<String>() { { this.add(opId); } });
+        perTaskInitList.put(taskName, Collections.singletonList(opId));
       } else {
         perTaskInitList.get(taskName).add(opId);
       }

--- a/samza-core/src/test/java/org/apache/samza/storage/TestStorageRecovery.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/TestStorageRecovery.java
@@ -20,6 +20,7 @@
 package org.apache.samza.storage;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.samza.Partition;
@@ -92,8 +93,8 @@ public class TestStorageRecovery {
   }
 
   private void putMetadata() {
-    MockSystemFactory.MSG_QUEUES.put(new SystemStreamPartition("mockSystem", SYSTEM_STREAM_NAME, new Partition(0)), new ArrayList<IncomingMessageEnvelope>() { { this.add(msg); } });
-    MockSystemFactory.MSG_QUEUES.put(new SystemStreamPartition("mockSystem", SYSTEM_STREAM_NAME, new Partition(1)), new ArrayList<IncomingMessageEnvelope>() { { this.add(msg); } });
+    MockSystemFactory.MSG_QUEUES.put(new SystemStreamPartition("mockSystem", SYSTEM_STREAM_NAME, new Partition(0)), Collections.singletonList(msg));
+    MockSystemFactory.MSG_QUEUES.put(new SystemStreamPartition("mockSystem", SYSTEM_STREAM_NAME, new Partition(1)), Collections.singletonList(msg));
     MockSystemFactory.MSG_QUEUES.put(new SystemStreamPartition("mockSystem", INPUT_STREAM, new Partition(0)), new ArrayList<>());
     MockSystemFactory.MSG_QUEUES.put(new SystemStreamPartition("mockSystem", INPUT_STREAM, new Partition(1)), new ArrayList<>());
   }

--- a/samza-core/src/test/java/org/apache/samza/table/remote/TestRemoteTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/TestRemoteTable.java
@@ -102,7 +102,7 @@ public class TestRemoteTable {
       if (!retry) {
         doReturn(future).when(readFn).getAsync(anyString());
       } else {
-        final int [] times = new int[] {0};
+        final int[] times = new int[] {0};
         doAnswer(args -> times[0]++ == 0 ? future : CompletableFuture.completedFuture("bar"))
             .when(readFn).getAsync(anyString());
       }
@@ -181,7 +181,7 @@ public class TestRemoteTable {
       }
     } else {
       doReturn(true).when(writeFn).isRetriable(any());
-      final int [] times = new int[] {0};
+      final int[] times = new int[] {0};
       if (isDelete) {
         doAnswer(args -> times[0]++ == 0 ? failureFuture : successFuture).when(writeFn).deleteAsync(any());
       } else {

--- a/samza-core/src/test/java/org/apache/samza/table/retry/TestRetriableTableFunctions.java
+++ b/samza-core/src/test/java/org/apache/samza/table/retry/TestRetriableTableFunctions.java
@@ -85,7 +85,7 @@ public class TestRetriableTableFunctions {
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
     doReturn(true).when(readFn).isRetriable(any());
 
-    int [] times = new int[] {0};
+    int[] times = {0};
     Map<String, String> map = new HashMap<>();
     map.put("foo1", "bar1");
     map.put("foo2", "bar2");
@@ -193,7 +193,7 @@ public class TestRetriableTableFunctions {
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).putAllAsync(any());
     doReturn(true).when(writeFn).isRetriable(any());
 
-    int [] times = new int[] {0};
+    int[] times = new int[] {0};
     List<Entry<String, String>> records = new ArrayList<>();
     records.add(new Entry<>("foo1", "bar1"));
     records.add(new Entry<>("foo2", "bar2"));
@@ -288,7 +288,7 @@ public class TestRetriableTableFunctions {
     // Table fn classification only retries on IllegalArgumentException
     doAnswer(arg -> arg.getArgumentAt(0, Throwable.class) instanceof IllegalArgumentException).when(readFn).isRetriable(any());
 
-    int [] times = new int[1];
+    int[] times = new int[1];
     doAnswer(arg -> {
         if (times[0]++ == 0) {
           CompletableFuture<String> future = new CompletableFuture();

--- a/samza-core/src/test/java/org/apache/samza/task/TestAsyncRunLoop.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestAsyncRunLoop.java
@@ -600,7 +600,7 @@ public class TestAsyncRunLoop {
     tasks.put(taskName0, t0);
     tasks.put(taskName1, t1);
     int maxMessagesInFlight = 1;
-    AsyncRunLoop runLoop = new AsyncRunLoop(tasks, executor, consumerMultiplexer, maxMessagesInFlight , windowMs, commitMs,
+    AsyncRunLoop runLoop = new AsyncRunLoop(tasks, executor, consumerMultiplexer, maxMessagesInFlight, windowMs, commitMs,
                                             callbackTimeoutMs, maxThrottlingDelayMs, maxIdleMs, containerMetrics, () -> 0L, false);
     when(consumerMultiplexer.choose(false)).thenReturn(envelope0).thenReturn(envelope1).thenReturn(null).thenReturn(ssp0EndOfStream).thenReturn(ssp1EndOfStream).thenReturn(null);
 

--- a/samza-test/src/test/java/org/apache/samza/test/framework/StreamApplicationIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/framework/StreamApplicationIntegrationTest.java
@@ -161,7 +161,7 @@ public class StreamApplicationIntegrationTest {
 
       OutputStream<TestTableData.EnrichedPageView> outputStream = appDescriptor.getOutputStream(enrichedPageViewOSD);
       appDescriptor.getInputStream(pageViewISD)
-          .partitionBy(pv -> pv.getValue().getMemberId() ,  pv -> pv.getValue(), KVSerde.of(new IntegerSerde(), new JsonSerdeV2<>(TestTableData.PageView.class)), "p1")
+          .partitionBy(pv -> pv.getValue().getMemberId(),  pv -> pv.getValue(), KVSerde.of(new IntegerSerde(), new JsonSerdeV2<>(TestTableData.PageView.class)), "p1")
           .join(table, new PageViewToProfileJoinFunction())
           .sendTo(outputStream);
     }

--- a/samza-test/src/test/java/org/apache/samza/test/processor/IdentityStreamTask.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/IdentityStreamTask.java
@@ -30,7 +30,7 @@ import org.apache.samza.task.StreamTask;
 import org.apache.samza.task.TaskCoordinator;
 
 
-public class IdentityStreamTask implements StreamTask , InitableTask  {
+public class IdentityStreamTask implements StreamTask, InitableTask  {
   private int processedMessageCount = 0;
   private int expectedMessageCount;
   private String outputTopic;


### PR DESCRIPTION
Checkstyle version upgrade 5.9 -> 6.11 and fixes to pass checks

**Why this version (6.11) but not latest (8.17)?**
In version [6.11.1](http://checkstyle.sourceforge.net/releasenotes.html#Release_6.11.1) lambda indentation support was added, and it reports tremendous amount of errors in project. I found no option to change indent policy for lambdas therefore set version without this check.