### PR TITLE
SAMZA-2108: Check for host affinity config before resolving preferred host matching

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/clustermanager/AbstractContainerAllocator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/AbstractContainerAllocator.java
@@ -55,6 +55,8 @@ public abstract class AbstractContainerAllocator implements Runnable {
    */
   private final TaskConfig taskConfig;
 
+  private final ClusterManagerConfig clusterManagerConfig;
+
   private final Config config;
 
   /**
@@ -92,6 +94,7 @@ public abstract class AbstractContainerAllocator implements Runnable {
     this.containerMemoryMb = clusterManagerConfig.getContainerMemoryMb();
     this.containerNumCpuCores = clusterManagerConfig.getNumCores();
     this.taskConfig = new TaskConfig(config);
+    this.clusterManagerConfig = new ClusterManagerConfig(config);
     this.state = state;
     this.config = config;
   }
@@ -171,7 +174,7 @@ public abstract class AbstractContainerAllocator implements Runnable {
     for (Map.Entry<String, String> entry : resourceToHostMappings.entrySet()) {
       String containerId = entry.getKey();
       String preferredHost = entry.getValue();
-      if (preferredHost == null)
+      if (preferredHost == null || !clusterManagerConfig.getHostAffinityEnabled())
         preferredHost = ResourceRequestState.ANY_HOST;
 
       requestResource(containerId, preferredHost);

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/AbstractContainerAllocator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/AbstractContainerAllocator.java
@@ -164,22 +164,13 @@ public abstract class AbstractContainerAllocator implements Runnable {
   /**
    * Called during initial request for resources
    *
-   * @param resourceToHostMappings A Map of [containerId, hostName] containerId is the ID of the container process
+   * @param resourceToHostMapping A Map of [containerId, hostName] containerId is the ID of the container process
    *                               to run on the resource. hostName is the host on which the resource must be allocated.
    *                                The hostName value is null, either
-   *                                - when host-affinity is not enabled, or
+   *                                - when host-affinity has never been enabled, or
    *                                - when host-affinity is enabled and job is run for the first time
    */
-  public void requestResources(Map<String, String> resourceToHostMappings) {
-    for (Map.Entry<String, String> entry : resourceToHostMappings.entrySet()) {
-      String containerId = entry.getKey();
-      String preferredHost = entry.getValue();
-      if (preferredHost == null || !clusterManagerConfig.getHostAffinityEnabled())
-        preferredHost = ResourceRequestState.ANY_HOST;
-
-      requestResource(containerId, preferredHost);
-    }
-  }
+  public abstract void requestResources(Map<String, String> resourceToHostMapping);
 
   /**
    * Checks if this allocator has a pending resource request.

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/AbstractContainerAllocator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/AbstractContainerAllocator.java
@@ -55,8 +55,6 @@ public abstract class AbstractContainerAllocator implements Runnable {
    */
   private final TaskConfig taskConfig;
 
-  private final ClusterManagerConfig clusterManagerConfig;
-
   private final Config config;
 
   /**
@@ -94,7 +92,6 @@ public abstract class AbstractContainerAllocator implements Runnable {
     this.containerMemoryMb = clusterManagerConfig.getContainerMemoryMb();
     this.containerNumCpuCores = clusterManagerConfig.getNumCores();
     this.taskConfig = new TaskConfig(config);
-    this.clusterManagerConfig = new ClusterManagerConfig(config);
     this.state = state;
     this.config = config;
   }

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerAllocator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerAllocator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.samza.clustermanager;
 
+import java.util.Map;
 import org.apache.samza.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,4 +53,21 @@ public class ContainerAllocator extends AbstractContainerAllocator {
       runStreamProcessor(request, ResourceRequestState.ANY_HOST);
     }
   }
+
+  /**
+   * Since host-affinity is not enabled, the container id to host mappings will be ignored and all resources will be
+   * matched to any available host.
+   *
+   * @param resourceToHostMapping A Map of [containerId, hostName] containerId is the ID of the container process
+   *                               to run on the resource. The hostName will be ignored and each container process will
+   *                               be matched to any available host.
+   */
+  @Override
+  public void requestResources(Map<String, String> resourceToHostMapping)  {
+    for (Map.Entry<String, String> entry : resourceToHostMapping.entrySet()) {
+      String containerId = entry.getKey();
+      requestResource(containerId, ResourceRequestState.ANY_HOST);
+    }
+  }
+
 }

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/HostAwareContainerAllocator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/HostAwareContainerAllocator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.samza.clustermanager;
 
+import java.util.Map;
 import org.apache.samza.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,6 +95,28 @@ public class HostAwareContainerAllocator extends AbstractContainerAllocator {
           break;
         }
       }
+    }
+  }
+
+  /**
+   * Since host-affinity is enabled, all container processes will be requested on their preferred host. If the job is
+   * run for the first time, it will get matched to any available host.
+   *
+   * @param resourceToHostMapping A Map of [containerId, hostName] containerId is the ID of the container process
+   *                               to run on the resource. hostName is the host on which the resource must be allocated.
+   *                                The hostName value is null when host-affinity is enabled and job is run for the
+   *                                first time
+   */
+  @Override
+  public void requestResources(Map<String, String> resourceToHostMapping) {
+    for (Map.Entry<String, String> entry : resourceToHostMapping.entrySet()) {
+      String containerId = entry.getKey();
+      String preferredHost = entry.getValue();
+      if (preferredHost == null) {
+        log.info("Preferred host not found for container id: {}", containerId);
+        preferredHost = ResourceRequestState.ANY_HOST;
+      }
+      requestResource(containerId, preferredHost);
     }
   }
 

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocator.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocator.java
@@ -139,6 +139,39 @@ public class TestContainerAllocator {
   }
 
   /**
+   * Test requestContainers with containerToHostMapping with host.affinity disabled
+   */
+  @Test
+  public void testRequestContainersWithExistingHosts() throws Exception {
+    Map<String, String> containersToHostMapping = new HashMap<String, String>() {
+      {
+        put("0", "prev_host");
+        put("1", "prev_host");
+        put("2", "prev_host");
+        put("3", "prev_host");
+      }
+    };
+
+    allocatorThread.start();
+
+    containerAllocator.requestResources(containersToHostMapping);
+
+    assertEquals(4, manager.resourceRequests.size());
+
+    assertNotNull(requestState);
+
+    assertEquals(requestState.numPendingRequests(), 4);
+
+    // If host-affinty is not enabled, it doesn't update the requestMap
+    assertNotNull(requestState.getRequestsToCountMap());
+    assertEquals(requestState.getRequestsToCountMap().keySet().size(), 0);
+
+    assertNotNull(state);
+    assertEquals(state.anyHostRequests.get(), 4);
+    assertEquals(state.preferredHostRequests.get(), 0);
+  }
+
+  /**
    * Test request containers with no containerToHostMapping makes the right number of requests
    */
   @Test


### PR DESCRIPTION
@vjagadish @rmatharu  Added check in the AbstractContainerAllocator to check the host-affinity config before using the preferred host mapping