### PR TITLE
Records with all null values are transformed to null records

### DIFF
--- a/samza-sql/src/test/java/org/apache/samza/sql/avro/TestAvroRelConversion.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/avro/TestAvroRelConversion.java
@@ -62,6 +62,7 @@ import org.apache.samza.sql.planner.RelSchemaConverter;
 import org.apache.samza.sql.schema.SqlSchema;
 import org.apache.samza.system.SystemStream;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -280,6 +281,8 @@ public class TestAvroRelConversion {
     }
   }
 
+  // SAMZA-2110 We need to enable this when we have a true support for Null records
+  @Ignore
   @Test
   public void testRecordConversionWithNullPayload() throws IOException {
     GenericData.Record record = null;

--- a/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
@@ -123,7 +123,8 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     runApplication(new MapConfig(staticConfigs));
 
     List<Integer> outMessages = TestAvroSystemFactory.messages.stream()
-        .map(x -> x.getMessage() == null ? null : Integer.valueOf(((GenericRecord) x.getMessage()).get("id").toString()))
+        .map(x -> x.getMessage() == null || ((GenericRecord) x.getMessage()).get("id") == null ? null
+            : Integer.valueOf(((GenericRecord) x.getMessage()).get("id").toString()))
         .filter(Objects::nonNull)
         .sorted()
         .collect(Collectors.toList());

--- a/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlRemoteTable.java
+++ b/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlRemoteTable.java
@@ -32,6 +32,7 @@ import org.apache.samza.sql.util.JsonUtil;
 import org.apache.samza.sql.util.SamzaSqlTestConfig;
 import org.apache.samza.sql.util.RemoteStoreIOResolverTestFactory;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 
@@ -52,6 +53,8 @@ public class TestSamzaSqlRemoteTable extends SamzaSqlIntegrationTestHarness {
     Assert.assertEquals(numMessages, RemoteStoreIOResolverTestFactory.records.size());
   }
 
+  // SAMZA-2110 We need to enable this when we have a true support for Null records
+  @Ignore
   @Test
   public void testSinkEndToEndWithKeyWithNullRecords() {
     int numMessages = 20;
@@ -212,6 +215,8 @@ public class TestSamzaSqlRemoteTable extends SamzaSqlIntegrationTestHarness {
     Assert.assertEquals(expectedOutMessages, outMessages);
   }
 
+  // SAMZA-2110 We need to enable this when we have a true support for null records.
+  @Ignore
   @Test
   public void testSameJoinTargetSinkEndToEndRightOuterJoin() {
     int numMessages = 21;


### PR DESCRIPTION
Right now Samza SQL AvroRelConverter transforms the records with null values into null records. I think this was added to support `select * from` usecase when the input has null records, But ideally that should be supported through a mechanism where the entire record is passed as null from input to the output rather than add a current hack where we are flattening the record with null values into null record.  