### PR TITLE
[SAMZA-2114] Samza-Sql Diagnostics: SamzaSqlInputTransformer to check presence of event and arrival time in ime

### DIFF
--- a/samza-sql/src/main/java/org/apache/samza/sql/SamzaSqlInputTransformer.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/SamzaSqlInputTransformer.java
@@ -40,8 +40,9 @@ public class SamzaSqlInputTransformer implements InputTransformer {
   public Object apply(IncomingMessageEnvelope ime) {
     Assert.notNull(ime, "ime is null");
     KV<Object, Object> keyAndMessageKV = KV.of(ime.getKey(), ime.getMessage());
-    SamzaSqlRelMsgMetadata metadata = new SamzaSqlRelMsgMetadata(Instant.ofEpochMilli(ime.getEventTime()).toString(),
-        Instant.ofEpochMilli(ime.getArrivalTime()).toString(), null);
+    SamzaSqlRelMsgMetadata metadata = new SamzaSqlRelMsgMetadata(
+        (ime.getEventTime() == 0) ? "" : Instant.ofEpochMilli(ime.getEventTime()).toString(),
+        (ime.getArrivalTime() == 0) ? "" : Instant.ofEpochMilli(ime.getArrivalTime()).toString(), null);
     SamzaSqlInputMessage samzaMsg = SamzaSqlInputMessage.of(keyAndMessageKV, metadata);
     return  samzaMsg;
   }


### PR DESCRIPTION
IncomingMessageEnvelope uses 0L for non-present event/arrival times. 
The SamzaSqlInputTransformer should check for that and assign the SamzaSqlRelMsgMetadata corresponding fields accordingly. This PR fixes this.