### PR TITLE
SAMZA-2118: Improve the shutdown sequence of AsyncRunLoop.

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/task/AsyncRunLoop.java
+++ b/samza-core/src/main/java/org/apache/samza/task/AsyncRunLoop.java
@@ -193,6 +193,7 @@ public class AsyncRunLoop implements Runnable, Throttleable {
 
   public void shutdown() {
     shutdownNow = true;
+    resume();
   }
 
   /**
@@ -220,15 +221,17 @@ public class AsyncRunLoop implements Runnable, Throttleable {
    * Insert the envelope into the task pending queues and run all the tasks
    */
   private void runTasks(IncomingMessageEnvelope envelope) {
-    if (envelope != null) {
-      PendingEnvelope pendingEnvelope = new PendingEnvelope(envelope);
-      for (AsyncTaskWorker worker : sspToTaskWorkerMapping.get(envelope.getSystemStreamPartition())) {
-        worker.state.insertEnvelope(pendingEnvelope);
+    if (!shutdownNow) {
+      if (envelope != null) {
+        PendingEnvelope pendingEnvelope = new PendingEnvelope(envelope);
+        for (AsyncTaskWorker worker : sspToTaskWorkerMapping.get(envelope.getSystemStreamPartition())) {
+          worker.state.insertEnvelope(pendingEnvelope);
+        }
       }
-    }
 
-    for (AsyncTaskWorker worker: taskWorkers) {
-      worker.run();
+      for (AsyncTaskWorker worker: taskWorkers) {
+        worker.run();
+      }
     }
   }
 

--- a/samza-core/src/main/java/org/apache/samza/task/AsyncRunLoop.java
+++ b/samza-core/src/main/java/org/apache/samza/task/AsyncRunLoop.java
@@ -283,7 +283,10 @@ public class AsyncRunLoop implements Runnable, Throttleable {
   }
 
   /**
-   * Resume the runloop thread. It is triggered once a task becomes ready again or has failure.
+   * Resume the runloop thread. This API is triggered in the following scenarios:
+   * A. A task becomes ready to process a message.
+   * B. A task has failed when processing a message.
+   * C. User thread shuts down the run loop.
    */
   private void resume() {
     log.trace("Resume loop thread");

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestTaskApplication.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestTaskApplication.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.test.processor;
+
+import java.util.concurrent.CountDownLatch;
+import org.apache.samza.application.TaskApplication;
+import org.apache.samza.application.descriptors.TaskApplicationDescriptor;
+import org.apache.samza.serializers.NoOpSerde;
+import org.apache.samza.system.IncomingMessageEnvelope;
+import org.apache.samza.system.kafka.descriptors.KafkaInputDescriptor;
+import org.apache.samza.system.kafka.descriptors.KafkaOutputDescriptor;
+import org.apache.samza.system.kafka.descriptors.KafkaSystemDescriptor;
+import org.apache.samza.task.AsyncStreamTask;
+import org.apache.samza.task.AsyncStreamTaskFactory;
+import org.apache.samza.task.ClosableTask;
+import org.apache.samza.task.MessageCollector;
+import org.apache.samza.task.TaskCallback;
+import org.apache.samza.task.TaskCoordinator;
+import org.apache.samza.test.table.TestTableData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestTaskApplication implements TaskApplication {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestTaskApplication.class);
+
+  private final String systemName;
+  private final String inputTopic;
+  private final String outputTopic;
+  private final CountDownLatch shutdownLatch;
+  private final CountDownLatch processedMessageLatch;
+
+  public TestTaskApplication(String systemName, String inputTopic, String outputTopic,
+      CountDownLatch processedMessageLatch, CountDownLatch shutdownLatch) {
+    this.systemName = systemName;
+    this.inputTopic = inputTopic;
+    this.outputTopic = outputTopic;
+    this.processedMessageLatch = processedMessageLatch;
+    this.shutdownLatch = shutdownLatch;
+  }
+
+  private class TestTaskImpl implements AsyncStreamTask, ClosableTask {
+
+    @Override
+    public void processAsync(IncomingMessageEnvelope envelope, MessageCollector collector, TaskCoordinator coordinator, TaskCallback callback) {
+      processedMessageLatch.countDown();
+      // Implementation does not invokes callback.complete to block the AsyncRunLoop.process() after it exhausts the
+      // `task.max.concurrency` defined per task.
+    }
+
+    @Override
+    public void close() {
+      LOG.info("Task instance is shutting down.");
+      shutdownLatch.countDown();
+    }
+  }
+
+  @Override
+  public void describe(TaskApplicationDescriptor appDescriptor) {
+    KafkaSystemDescriptor ksd = new KafkaSystemDescriptor(systemName);
+    KafkaInputDescriptor<TestTableData.Profile> inputDescriptor = ksd.getInputDescriptor(inputTopic, new NoOpSerde<>());
+    KafkaOutputDescriptor<TestTableData.EnrichedPageView> outputDescriptor = ksd.getOutputDescriptor(outputTopic, new NoOpSerde<>());
+    appDescriptor.withInputStream(inputDescriptor)
+                 .withOutputStream(outputDescriptor)
+                 .withTaskFactory((AsyncStreamTaskFactory) () -> new TestTaskImpl());
+  }
+}

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
@@ -958,15 +958,17 @@ public class TestZkLocalApplicationRunner extends StandaloneIntegrationTestHarne
     // Run the application.
     executeRun(appRunner, applicationConfig1);
 
-    // wait for the task to receive at least one dispatched message.
+    // Wait for the task to receive at least one dispatched message.
     processedMessagesLatch1.await();
 
     // Kill the application when none of the dispatched messages is acknowledged as completed by the task.
     appRunner.kill();
     appRunner.waitForFinish();
+
     // Expect the shutdown latch to be triggered.
     shutdownLatch.await();
 
+    // Assert that the shutdown was successful.
     Assert.assertEquals(ApplicationStatus.SuccessfulFinish, appRunner.status());
   }
 


### PR DESCRIPTION
A samza container is comprised of multiple tasks and event-loop. Event loop is the main orchestration layer between the different stages of a task(process, commit, window) and delivers messages to task by polling them from different consumers. 

Currently in samza, the event loop dispatches messages to the tasks as per user-defined configuration `task.max.concurrency`. After dispatching messages with count equal to `task.max.concurrency` to the tasks,  the event loop is blocked until the processing of at-least a single dispatched message finishes(aka the task implementation invokes `taskCallBack.complete()` for at-least a dispatched message). 

When the event loop is blocked by this, the user thread would sometimes try to shutdown the event loop. This shutdown intent marked by the user-thread will take effect only when the processing of a single message completes. In some-cases, when the task implementation does retry on failure for a message, this could prolong the shutdown of the samza event loop.

This introduces tight coupling between the task processing time and the event loop shutdown time.

This behavior was observed predominantly in standalone applications where the samza container is shutdown as a part of the re-balancing phase and task processing time was significantly larger.

To alleviate this problem, as a part of this patch, we wake-up the samza event-loop thread when the user-thread marks the intent to shutdown the event-loop.
