### PR TITLE
Propogating the system messages to the stream.

### DIFF
--- a/samza-sql/src/main/java/org/apache/samza/sql/data/SamzaSqlRelMsgMetadata.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/data/SamzaSqlRelMsgMetadata.java
@@ -20,6 +20,8 @@
 package org.apache.samza.sql.data;
 
 import java.io.Serializable;
+import java.time.Instant;
+import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 
@@ -36,9 +38,16 @@ public class SamzaSqlRelMsgMetadata implements Serializable {
   public boolean isNewInputMessage = true;
 
   /**
-   *
+   * Indicates whether the SamzaSqlMessage is a system message or not.
    */
-  public String operatorBeginProcessingInstant = null;
+  @JsonIgnore
+  private boolean isSystemMessage = false;
+
+  /**
+   * Time at which the join operation started for the message.
+   * If there is no join node in the operator graph, this will be -1.
+   */
+  public long joinStartTimeMs = -1;
 
 
   /**
@@ -93,7 +102,6 @@ public class SamzaSqlRelMsgMetadata implements Serializable {
 
   public boolean hasArrivalTime() { return arrivalTime != null && !arrivalTime.isEmpty(); }
 
-
   @JsonProperty("scanTime")
   public String getscanTime() { return scanTime;}
 
@@ -102,6 +110,16 @@ public class SamzaSqlRelMsgMetadata implements Serializable {
   }
 
   public boolean hasScanTime() { return scanTime != null && !scanTime.isEmpty(); }
+
+  @JsonIgnore
+  public  void setIsSystemMessage(boolean isSystemMessage) {
+    this.isSystemMessage = isSystemMessage;
+  }
+
+  @JsonIgnore
+  public boolean isSystemMessage() {
+    return isSystemMessage;
+  }
 
   @Override
   public String toString() {

--- a/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationConfig.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationConfig.java
@@ -89,6 +89,7 @@ public class SamzaSqlApplicationConfig {
 
   public static final String CFG_METADATA_TOPIC_PREFIX = "samza.sql.metadataTopicPrefix";
   public static final String CFG_GROUPBY_WINDOW_DURATION_MS = "samza.sql.groupby.window.ms";
+  public static final String CFG_SQL_PROCESS_SYSTEM_EVENTS = "samza.sql.processSystemEvents";
 
   public static final String SAMZA_SYSTEM_LOG = "log";
 
@@ -115,6 +116,7 @@ public class SamzaSqlApplicationConfig {
 
   private final String metadataTopicPrefix;
   private final long windowDurationMs;
+  private final boolean processSystemEvents;
 
   public SamzaSqlApplicationConfig(Config staticConfig, List<String> inputSystemStreams,
       List<String> outputSystemStreams) {
@@ -165,6 +167,8 @@ public class SamzaSqlApplicationConfig {
 
     metadataTopicPrefix =
         staticConfig.get(CFG_METADATA_TOPIC_PREFIX, DEFAULT_METADATA_TOPIC_PREFIX);
+
+    processSystemEvents = staticConfig.getBoolean(CFG_SQL_PROCESS_SYSTEM_EVENTS, true);
     windowDurationMs = staticConfig.getLong(CFG_GROUPBY_WINDOW_DURATION_MS, DEFAULT_GROUPBY_WINDOW_DURATION_MS);
   }
 
@@ -323,5 +327,9 @@ public class SamzaSqlApplicationConfig {
 
   public long getWindowDurationMs() {
     return windowDurationMs;
+  }
+
+  public boolean isProcessSystemEvents() {
+    return processSystemEvents;
   }
 }

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/ProjectTranslator.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/ProjectTranslator.java
@@ -193,5 +193,4 @@ class ProjectTranslator {
     context.registerMessageStream(project.getId(), outputStream);
     context.registerRelNode(project.getId(), project);
   }
-
 }

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/ScanTranslator.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/ScanTranslator.java
@@ -1,21 +1,21 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.apache.samza.sql.translator;
 
@@ -36,8 +36,8 @@ import org.apache.samza.operators.MessageStream;
 import org.apache.samza.operators.functions.FilterFunction;
 import org.apache.samza.operators.functions.MapFunction;
 import org.apache.samza.serializers.NoOpSerde;
-import org.apache.samza.sql.SamzaSqlInputTransformer;
 import org.apache.samza.sql.SamzaSqlInputMessage;
+import org.apache.samza.sql.SamzaSqlInputTransformer;
 import org.apache.samza.sql.data.SamzaSqlRelMessage;
 import org.apache.samza.sql.interfaces.SamzaRelConverter;
 import org.apache.samza.sql.interfaces.SqlIOConfig;
@@ -47,6 +47,7 @@ import org.apache.samza.system.descriptors.InputDescriptor;
 import org.apache.samza.system.descriptors.InputTransformer;
 import org.apache.samza.table.descriptors.CachingTableDescriptor;
 import org.apache.samza.table.descriptors.RemoteTableDescriptor;
+
 
 /**
  * Translator to translate the TableScans in relational graph to the corresponding input streams in the StreamGraph
@@ -78,7 +79,7 @@ class ScanTranslator {
 
     @Override
     public boolean apply(SamzaSqlInputMessage samzaSqlInputMessage) {
-      return !relConverter.isSystemMessage(samzaSqlInputMessage.getKeyAndMessageKV());
+      return !samzaSqlInputMessage.getMetadata().isSystemMessage();
     }
   }
 
@@ -147,11 +148,11 @@ class ScanTranslator {
       queryInputEvents.inc();
       processingTime.update(Duration.between(startProcessing, endProcessing).toMillis());
     }
-
   } // ScanMapFunction
 
-  void translate(final TableScan tableScan, final String queryLogicalId, final String logicalOpId, final TranslatorContext context,
-      Map<String, DelegatingSystemDescriptor> systemDescriptors, Map<String, MessageStream<SamzaSqlInputMessage>> inputMsgStreams) {
+  void translate(final TableScan tableScan, final String queryLogicalId, final String logicalOpId,
+      final TranslatorContext context, Map<String, DelegatingSystemDescriptor> systemDescriptors,
+      Map<String, MessageStream<SamzaSqlInputMessage>> inputMsgStreams) {
     StreamApplicationDescriptor streamAppDesc = context.getStreamAppDescriptor();
     List<String> tableNameParts = tableScan.getTable().getQualifiedName();
     String sourceName = SqlIOConfig.getSourceFromSourceParts(tableNameParts);
@@ -162,9 +163,9 @@ class ScanTranslator {
     final String streamId = sqlIOConfig.getStreamId();
     final String source = sqlIOConfig.getSource();
 
-    final boolean isRemoteTable = sqlIOConfig.getTableDescriptor().isPresent() &&
-        (sqlIOConfig.getTableDescriptor().get() instanceof RemoteTableDescriptor ||
-            sqlIOConfig.getTableDescriptor().get() instanceof CachingTableDescriptor);
+    final boolean isRemoteTable = sqlIOConfig.getTableDescriptor().isPresent() && (
+        sqlIOConfig.getTableDescriptor().get() instanceof RemoteTableDescriptor || sqlIOConfig.getTableDescriptor()
+            .get() instanceof CachingTableDescriptor);
 
     // For remote table, we don't have an input stream descriptor. The table descriptor is already defined by the
     // SqlIOResolverFactory.
@@ -181,22 +182,55 @@ class ScanTranslator {
       systemDescriptors.put(systemName, systemDescriptor);
     } else {
       /* in SamzaSQL, there should be no systemDescriptor setup by user, so this branch happens only
-      * in case of Fan-OUT (i.e., same input stream used in multiple sql statements), or when same input
-      * used twice in same sql statement (e.g., select ... from input as i1, input as i2 ...), o.w., throw error */
+       * in case of Fan-OUT (i.e., same input stream used in multiple sql statements), or when same input
+       * used twice in same sql statement (e.g., select ... from input as i1, input as i2 ...), o.w., throw error */
       if (systemDescriptor.getTransformer().isPresent()) {
         InputTransformer existingTransformer = systemDescriptor.getTransformer().get();
         if (!(existingTransformer instanceof SamzaSqlInputTransformer)) {
-          throw new SamzaException("SamzaSQL Exception: existing transformer for " + systemName + " is not SamzaSqlInputTransformer");
+          throw new SamzaException(
+              "SamzaSQL Exception: existing transformer for " + systemName + " is not SamzaSqlInputTransformer");
         }
       }
     }
 
     InputDescriptor inputDescriptor = systemDescriptor.getInputDescriptor(streamId, new NoOpSerde<>());
-    MessageStream<SamzaSqlRelMessage> samzaSqlRelMessageStream =
-        inputMsgStreams.computeIfAbsent(source, v -> streamAppDesc.getInputStream(inputDescriptor))
-            .filter(new FilterSystemMessageFunction(sourceName, queryId))
-            .map(new ScanMapFunction(sourceName, queryId, queryLogicalId, logicalOpId));
+
+    if (!inputMsgStreams.containsKey(source)) {
+      MessageStream<SamzaSqlInputMessage> inputMsgStream = streamAppDesc.getInputStream(inputDescriptor);
+      inputMsgStreams.put(source, inputMsgStream.map(new SystemMessageMapperFunction(source, queryId)));
+    }
+    MessageStream<SamzaSqlRelMessage> samzaSqlRelMessageStream = inputMsgStreams.get(source)
+        .filter(new FilterSystemMessageFunction(sourceName, queryId))
+        .map(new ScanMapFunction(sourceName, queryId, queryLogicalId, logicalOpId));
 
     context.registerMessageStream(tableScan.getId(), samzaSqlRelMessageStream);
+  }
+
+  /**
+   * Function that populates whether the message is a system message.
+   * TODO This should ideally be populated by the InputTransformer in future.
+   */
+  private static class SystemMessageMapperFunction implements MapFunction<SamzaSqlInputMessage, SamzaSqlInputMessage> {
+    private final String source;
+    private final int queryId;
+    private transient SamzaRelConverter relConverter;
+
+    public SystemMessageMapperFunction(String source, int queryId) {
+      this.source = source;
+      this.queryId = queryId;
+    }
+
+    @Override
+    public void init(Context context) {
+      TranslatorContext translatorContext =
+          ((SamzaSqlApplicationContext) context.getApplicationTaskContext()).getTranslatorContexts().get(queryId);
+      relConverter = translatorContext.getMsgConverter(source);
+    }
+
+    @Override
+    public SamzaSqlInputMessage apply(SamzaSqlInputMessage message) {
+      message.getMetadata().setIsSystemMessage(relConverter.isSystemMessage(message.getKeyAndMessageKV()));
+      return message;
+    }
   }
 }

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/TranslatorInputMetricsMapFunction.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/TranslatorInputMetricsMapFunction.java
@@ -19,7 +19,6 @@
 
 package org.apache.samza.sql.translator;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.time.Instant;
 import org.apache.samza.context.ContainerContext;
 import org.apache.samza.context.Context;
@@ -60,7 +59,7 @@ class TranslatorInputMetricsMapFunction implements MapFunction<SamzaSqlRelMessag
   @Override
   public SamzaSqlRelMessage apply(SamzaSqlRelMessage message) {
     inputEvents.inc();
-    message.getSamzaSqlRelMsgMetadata().operatorBeginProcessingInstant = Instant.now().toString();
+    message.getSamzaSqlRelMsgMetadata().joinStartTimeMs = Instant.now().toEpochMilli();
     return message;
   }
 

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/TranslatorOutputMetricsMapFunction.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/TranslatorOutputMetricsMapFunction.java
@@ -63,7 +63,7 @@ class TranslatorOutputMetricsMapFunction implements MapFunction<SamzaSqlRelMessa
   @Override
   public SamzaSqlRelMessage apply(SamzaSqlRelMessage message) {
     Instant endProcessing = Instant.now();
-    Instant beginProcessing = Instant.parse(message.getSamzaSqlRelMsgMetadata().operatorBeginProcessingInstant);
+    Instant beginProcessing = Instant.ofEpochMilli(message.getSamzaSqlRelMsgMetadata().joinStartTimeMs);
     outputEvents.inc();
     processingTime.update(Duration.between(beginProcessing, endProcessing).toMillis());
     return message;

--- a/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
@@ -1,21 +1,21 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
 
 package org.apache.samza.test.samzasql;
 
@@ -120,10 +120,10 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
         String.format(SamzaSqlApplicationConfig.CFG_FMT_SAMZA_REL_CONVERTER_DOMAIN, "avro");
     staticConfigs.put(avroSamzaToRelMsgConverterDomain + SamzaSqlApplicationConfig.CFG_FACTORY,
         SampleRelConverterFactory.class.getName());
-    staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_PROCESS_SYSTEM_EVENTS, "false");
     String sql = "Insert into testavro.simpleOutputTopic select * from testavro.SIMPLE1";
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
+    staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_PROCESS_SYSTEM_EVENTS, "false");
     runApplication(new MapConfig(staticConfigs));
 
     List<Integer> outMessages = TestAvroSystemFactory.messages.stream()
@@ -195,8 +195,7 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     Assert.assertEquals(numMessages * 2, outMessages.size());
     Set<Integer> outMessagesSet = new HashSet<>(outMessages);
     Assert.assertEquals(numMessages, outMessagesSet.size());
-    Assert.assertTrue(
-        IntStream.range(0, numMessages).boxed().collect(Collectors.toList()).equals(new ArrayList<>(outMessagesSet)));
+    Assert.assertTrue(IntStream.range(0, numMessages).boxed().collect(Collectors.toList()).equals(new ArrayList<>(outMessagesSet)));
   }
 
   @Test
@@ -217,8 +216,7 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     Assert.assertEquals(numMessages * 2, outMessages.size());
     Set<Integer> outMessagesSet = new HashSet<>(outMessages);
     Assert.assertEquals(numMessages, outMessagesSet.size());
-    Assert.assertTrue(
-        IntStream.range(0, numMessages).boxed().collect(Collectors.toList()).equals(new ArrayList<>(outMessagesSet)));
+    Assert.assertTrue(IntStream.range(0, numMessages).boxed().collect(Collectors.toList()).equals(new ArrayList<>(outMessagesSet)));
   }
 
   @Test
@@ -238,8 +236,7 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     Assert.assertEquals(numMessages * 2, outMessages.size());
     Set<Integer> outMessagesSet = new HashSet<>(outMessages);
     Assert.assertEquals(numMessages, outMessagesSet.size());
-    Assert.assertTrue(
-        IntStream.range(0, numMessages).boxed().collect(Collectors.toList()).equals(new ArrayList<>(outMessagesSet)));
+    Assert.assertTrue(IntStream.range(0, numMessages).boxed().collect(Collectors.toList()).equals(new ArrayList<>(outMessagesSet)));
   }
 
   @Test
@@ -259,8 +256,7 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     Assert.assertEquals(numMessages * 2, outMessages.size());
     Set<Integer> outMessagesSet = new HashSet<>(outMessages);
     Assert.assertEquals(numMessages, outMessagesSet.size());
-    Assert.assertTrue(
-        IntStream.range(0, numMessages).boxed().collect(Collectors.toList()).equals(new ArrayList<>(outMessagesSet)));
+    Assert.assertTrue(IntStream.range(0, numMessages).boxed().collect(Collectors.toList()).equals(new ArrayList<>(outMessagesSet)));
   }
 
   @Test
@@ -290,9 +286,10 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
 
     LOG.info(" Class Path : " + RelOptUtil.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath());
-    String sql1 = "Insert into testavro.outputTopic(string_value, id, bytes_value, fixed_value, float_value) "
-        + " select Flatten(array_values) as string_value, id, bytes_value, fixed_value, float_value "
-        + " from testavro.COMPLEX1";
+    String sql1 =
+        "Insert into testavro.outputTopic(string_value, id, bytes_value, fixed_value, float_value) "
+            + " select Flatten(array_values) as string_value, id, bytes_value, fixed_value, float_value "
+            + " from testavro.COMPLEX1";
     List<String> sqlStmts = Collections.singletonList(sql1);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
@@ -307,15 +304,17 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     Assert.assertEquals(expectedMessages, outMessages.size());
   }
 
+
   @Test
   public void testEndToEndComplexRecord() {
     int numMessages = 10;
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
 
-    String sql1 = "Insert into testavro.outputTopic"
-        + " select map_values['key0'] as string_value, union_value, array_values[0] as string_value, map_values, id, bytes_value, fixed_value, float_value "
-        + " from testavro.COMPLEX1";
+    String sql1 =
+        "Insert into testavro.outputTopic"
+            + " select map_values['key0'] as string_value, union_value, array_values[0] as string_value, map_values, id, bytes_value, fixed_value, float_value "
+            + " from testavro.COMPLEX1";
     List<String> sqlStmts = Collections.singletonList(sql1);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
@@ -333,7 +332,9 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
 
     String sql1 =
-        "Insert into testavro.outputTopic" + " select `phoneNumbers`[0].`kind`" + " from testavro.PROFILE as p";
+        "Insert into testavro.outputTopic"
+            + " select `phoneNumbers`[0].`kind`"
+            + " from testavro.PROFILE as p";
     List<String> sqlStmts = Collections.singletonList(sql1);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
@@ -417,8 +418,11 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     int numMessages = 20;
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
-    String sql1 = "Insert into testavro.outputTopic(id) " + "select id " + "from testavro.SIMPLE1 "
-        + "where RegexMatch('.*4', name)";
+    String sql1 =
+        "Insert into testavro.outputTopic(id) "
+            + "select id "
+            + "from testavro.SIMPLE1 "
+            + "where RegexMatch('.*4', name)";
     List<String> sqlStmts = Collections.singletonList(sql1);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
@@ -435,19 +439,22 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
     staticConfigs.putAll(configs);
-    String sql = "Insert into testavro.enrichedPageViewTopic "
-        + "select pv.pageKey as __key__, pv.pageKey as pageKey, coalesce(null, 'N/A') as companyName,"
-        + "       p.name as profileName, p.address as profileAddress " + "from testavro.PROFILE.`$table` as p "
-        + "join testavro.PAGEVIEW as pv " + " on p.id = pv.profileId";
+    String sql =
+        "Insert into testavro.enrichedPageViewTopic "
+            + "select pv.pageKey as __key__, pv.pageKey as pageKey, coalesce(null, 'N/A') as companyName,"
+            + "       p.name as profileName, p.address as profileAddress "
+            + "from testavro.PROFILE.`$table` as p "
+            + "join testavro.PAGEVIEW as pv "
+            + " on p.id = pv.profileId";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
 
     List<String> outMessages = TestAvroSystemFactory.messages.stream()
-        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + "," + (
-            ((GenericRecord) x.getMessage()).get("profileName") == null ? "null"
-                : ((GenericRecord) x.getMessage()).get("profileName").toString()))
+        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + ","
+            + (((GenericRecord) x.getMessage()).get("profileName") == null ? "null" :
+            ((GenericRecord) x.getMessage()).get("profileName").toString()))
         .collect(Collectors.toList());
     Assert.assertEquals(numMessages, outMessages.size());
     List<String> expectedOutMessages = TestAvroSystemFactory.getPageKeyProfileNameJoin(numMessages);
@@ -461,19 +468,22 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
     staticConfigs.putAll(configs);
-    String sql = "Insert into testavro.enrichedPageViewTopic "
-        + "select pv.pageKey as __key__, pv.pageKey as pageKey, coalesce(null, 'N/A') as companyName,"
-        + "       p.name as profileName, p.address as profileAddress " + "from testavro.PROFILE.`$table` as p "
-        + "join testavro.PAGEVIEW as pv " + " on p.__key__ = pv.profileId";
+    String sql =
+        "Insert into testavro.enrichedPageViewTopic "
+            + "select pv.pageKey as __key__, pv.pageKey as pageKey, coalesce(null, 'N/A') as companyName,"
+            + "       p.name as profileName, p.address as profileAddress "
+            + "from testavro.PROFILE.`$table` as p "
+            + "join testavro.PAGEVIEW as pv "
+            + " on p.__key__ = pv.profileId";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
 
     List<String> outMessages = TestAvroSystemFactory.messages.stream()
-        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + "," + (
-            ((GenericRecord) x.getMessage()).get("profileName") == null ? "null"
-                : ((GenericRecord) x.getMessage()).get("profileName").toString()))
+        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + ","
+            + (((GenericRecord) x.getMessage()).get("profileName") == null ? "null" :
+            ((GenericRecord) x.getMessage()).get("profileName").toString()))
         .collect(Collectors.toList());
     Assert.assertEquals(numMessages, outMessages.size());
     List<String> expectedOutMessages = TestAvroSystemFactory.getPageKeyProfileNameJoin(numMessages);
@@ -487,19 +497,22 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
     staticConfigs.putAll(configs);
-    String sql = "Insert into testavro.enrichedPageViewTopic "
-        + "select pv.pageKey as __key__, pv.pageKey as pageKey, coalesce(null, 'N/A') as companyName,"
-        + "       p.name as profileName, p.address as profileAddress " + "from testavro.PROFILE.`$table` as p "
-        + "join testavro.PAGEVIEW as pv " + " on MyTest(p.id) = MyTest(pv.profileId)";
+    String sql =
+        "Insert into testavro.enrichedPageViewTopic "
+            + "select pv.pageKey as __key__, pv.pageKey as pageKey, coalesce(null, 'N/A') as companyName,"
+            + "       p.name as profileName, p.address as profileAddress "
+            + "from testavro.PROFILE.`$table` as p "
+            + "join testavro.PAGEVIEW as pv "
+            + " on MyTest(p.id) = MyTest(pv.profileId)";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
 
     List<String> outMessages = TestAvroSystemFactory.messages.stream()
-        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + "," + (
-            ((GenericRecord) x.getMessage()).get("profileName") == null ? "null"
-                : ((GenericRecord) x.getMessage()).get("profileName").toString()))
+        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + ","
+            + (((GenericRecord) x.getMessage()).get("profileName") == null ? "null" :
+            ((GenericRecord) x.getMessage()).get("profileName").toString()))
         .collect(Collectors.toList());
     Assert.assertEquals(numMessages, outMessages.size());
     List<String> expectedOutMessages = TestAvroSystemFactory.getPageKeyProfileNameJoin(numMessages);
@@ -513,23 +526,28 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
     staticConfigs.putAll(configs);
-    String sql = "Insert into testavro.enrichedPageViewTopic "
-        + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
-        + "       p.address as profileAddress " + "from testavro.PROFILE.`$table` as p "
-        + "join testavro.PAGEVIEW as pv " + " on p.id = pv.profileId";
+    String sql =
+        "Insert into testavro.enrichedPageViewTopic "
+            + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
+            + "       p.address as profileAddress "
+            + "from testavro.PROFILE.`$table` as p "
+            + "join testavro.PAGEVIEW as pv "
+            + " on p.id = pv.profileId";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
 
-    List<String> outMessages = TestAvroSystemFactory.messages.stream().map(x -> {
-      GenericRecord profileAddr = (GenericRecord) ((GenericRecord) x.getMessage()).get("profileAddress");
-      GenericRecord streetNum = (GenericRecord) (profileAddr.get("streetnum"));
-      return ((GenericRecord) x.getMessage()).get("pageKey").toString() + "," + (
-          ((GenericRecord) x.getMessage()).get("profileName") == null ? "null"
-              : ((GenericRecord) x.getMessage()).get("profileName").toString()) + "," + profileAddr.get("zip") + ","
-          + streetNum.get("number");
-    }).collect(Collectors.toList());
+    List<String> outMessages = TestAvroSystemFactory.messages.stream()
+        .map(x -> {
+            GenericRecord profileAddr = (GenericRecord) ((GenericRecord) x.getMessage()).get("profileAddress");
+            GenericRecord streetNum = (GenericRecord) (profileAddr.get("streetnum"));
+            return ((GenericRecord) x.getMessage()).get("pageKey").toString() + ","
+                + (((GenericRecord) x.getMessage()).get("profileName") == null ? "null" :
+                ((GenericRecord) x.getMessage()).get("profileName").toString()) + ","
+                + profileAddr.get("zip") + "," + streetNum.get("number");
+          })
+        .collect(Collectors.toList());
     Assert.assertEquals(numMessages, outMessages.size());
     List<String> expectedOutMessages = TestAvroSystemFactory.getPageKeyProfileNameAddressJoin(numMessages);
     Assert.assertEquals(outMessages, expectedOutMessages);
@@ -542,25 +560,30 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
     staticConfigs.putAll(configs);
-    String sql = "Insert into testavro.enrichedPageViewTopic "
-        + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
-        + "       p.address as profileAddress " + "from testavro.PROFILE.`$table` as p "
-        + "join testavro.PAGEVIEW as pv " + " on p.id = pv.profileId " + "where p.name = 'Mike'";
+    String sql =
+        "Insert into testavro.enrichedPageViewTopic "
+            + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
+            + "       p.address as profileAddress "
+            + "from testavro.PROFILE.`$table` as p "
+            + "join testavro.PAGEVIEW as pv "
+            + " on p.id = pv.profileId "
+            + "where p.name = 'Mike'";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
 
     List<String> outMessages = TestAvroSystemFactory.messages.stream()
-        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + "," + (
-            ((GenericRecord) x.getMessage()).get("profileName") == null ? "null"
-                : ((GenericRecord) x.getMessage()).get("profileName").toString()))
+        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + ","
+            + (((GenericRecord) x.getMessage()).get("profileName") == null ? "null" :
+            ((GenericRecord) x.getMessage()).get("profileName").toString()))
         .collect(Collectors.toList());
     Assert.assertEquals(4, outMessages.size());
-    List<String> expectedOutMessages = TestAvroSystemFactory.getPageKeyProfileNameJoin(numMessages)
-        .stream()
-        .filter(msg -> msg.endsWith("Mike"))
-        .collect(Collectors.toList());
+    List<String> expectedOutMessages =
+        TestAvroSystemFactory.getPageKeyProfileNameJoin(numMessages)
+            .stream()
+            .filter(msg -> msg.endsWith("Mike"))
+            .collect(Collectors.toList());
     Assert.assertEquals(expectedOutMessages, outMessages);
   }
 
@@ -570,19 +593,22 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages, true);
-    String sql = "Insert into testavro.enrichedPageViewTopic "
-        + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
-        + "       p.address as profileAddress " + "from testavro.PAGEVIEW as pv "
-        + "join testavro.PROFILE.`$table` as p " + " on pv.profileId = p.id";
+    String sql =
+        "Insert into testavro.enrichedPageViewTopic "
+            + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
+            + "       p.address as profileAddress "
+            + "from testavro.PAGEVIEW as pv "
+            + "join testavro.PROFILE.`$table` as p "
+            + " on pv.profileId = p.id";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
 
     List<String> outMessages = TestAvroSystemFactory.messages.stream()
-        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + "," + (
-            ((GenericRecord) x.getMessage()).get("profileName") == null ? "null"
-                : ((GenericRecord) x.getMessage()).get("profileName").toString()))
+        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + ","
+            + (((GenericRecord) x.getMessage()).get("profileName") == null ? "null" :
+            ((GenericRecord) x.getMessage()).get("profileName").toString()))
         .collect(Collectors.toList());
     // Half the foreign keys are null.
     Assert.assertEquals(numMessages / 2, outMessages.size());
@@ -596,19 +622,22 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages, true);
-    String sql = "Insert into testavro.enrichedPageViewTopic "
-        + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
-        + "       p.address as profileAddress " + "from testavro.PAGEVIEW as pv "
-        + "left join testavro.PROFILE.`$table` as p " + " on pv.profileId = p.id";
+    String sql =
+        "Insert into testavro.enrichedPageViewTopic "
+            + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
+            + "       p.address as profileAddress "
+            + "from testavro.PAGEVIEW as pv "
+            + "left join testavro.PROFILE.`$table` as p "
+            + " on pv.profileId = p.id";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
 
     List<String> outMessages = TestAvroSystemFactory.messages.stream()
-        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + "," + (
-            ((GenericRecord) x.getMessage()).get("profileName") == null ? "null"
-                : ((GenericRecord) x.getMessage()).get("profileName").toString()))
+        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + ","
+            + (((GenericRecord) x.getMessage()).get("profileName") == null ? "null" :
+            ((GenericRecord) x.getMessage()).get("profileName").toString()))
         .collect(Collectors.toList());
     Assert.assertEquals(numMessages, outMessages.size());
     List<String> expectedOutMessages =
@@ -622,19 +651,22 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages, true);
-    String sql = "Insert into testavro.enrichedPageViewTopic "
-        + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
-        + "       p.address as profileAddress " + "from testavro.PROFILE.`$table` as p "
-        + "right join testavro.PAGEVIEW as pv " + " on p.id = pv.profileId";
+    String sql =
+        "Insert into testavro.enrichedPageViewTopic "
+            + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
+            + "       p.address as profileAddress "
+            + "from testavro.PROFILE.`$table` as p "
+            + "right join testavro.PAGEVIEW as pv "
+            + " on p.id = pv.profileId";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
 
     List<String> outMessages = TestAvroSystemFactory.messages.stream()
-        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + "," + (
-            ((GenericRecord) x.getMessage()).get("profileName") == null ? "null"
-                : ((GenericRecord) x.getMessage()).get("profileName").toString()))
+        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + ","
+            + (((GenericRecord) x.getMessage()).get("profileName") == null ? "null" :
+            ((GenericRecord) x.getMessage()).get("profileName").toString()))
         .collect(Collectors.toList());
     Assert.assertEquals(numMessages, outMessages.size());
     List<String> expectedOutMessages =
@@ -648,11 +680,15 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
-    String sql = "Insert into testavro.enrichedPageViewTopic "
-        + "select pv.pageKey as __key__, pv.pageKey as pageKey, c.name as companyName, p.name as profileName,"
-        + "       p.address as profileAddress " + "from testavro.PAGEVIEW as pv "
-        + "join testavro.PROFILE.`$table` as p " + " on MyTest(p.id) = MyTest(pv.profileId) "
-        + " join testavro.COMPANY.`$table` as c " + " on MyTest(p.companyId) = MyTest(c.id)";
+    String sql =
+        "Insert into testavro.enrichedPageViewTopic "
+            + "select pv.pageKey as __key__, pv.pageKey as pageKey, c.name as companyName, p.name as profileName,"
+            + "       p.address as profileAddress "
+            + "from testavro.PAGEVIEW as pv "
+            + "join testavro.PROFILE.`$table` as p "
+            + " on MyTest(p.id) = MyTest(pv.profileId) "
+            + " join testavro.COMPANY.`$table` as c "
+            + " on MyTest(p.companyId) = MyTest(c.id)";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
@@ -674,11 +710,15 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
-    String sql = "Insert into testavro.enrichedPageViewTopic "
-        + "select pv.pageKey as __key__, pv.pageKey as pageKey, c.name as companyName, p.name as profileName,"
-        + "       p.address as profileAddress " + "from testavro.PAGEVIEW as pv "
-        + "join testavro.PROFILE.`$table` as p " + " on MyTest(p.__key__) = MyTest(pv.profileId) "
-        + " join testavro.COMPANY.`$table` as c " + " on MyTest(p.companyId) = MyTest(c.__key__)";
+    String sql =
+        "Insert into testavro.enrichedPageViewTopic "
+            + "select pv.pageKey as __key__, pv.pageKey as pageKey, c.name as companyName, p.name as profileName,"
+            + "       p.address as profileAddress "
+            + "from testavro.PAGEVIEW as pv "
+            + "join testavro.PROFILE.`$table` as p "
+            + " on MyTest(p.__key__) = MyTest(pv.profileId) "
+            + " join testavro.COMPANY.`$table` as c "
+            + " on MyTest(p.companyId) = MyTest(c.__key__)";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
@@ -700,11 +740,15 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
-    String sql = "Insert into testavro.enrichedPageViewTopic "
-        + "select pv.pageKey as __key__, pv.pageKey as pageKey, c.name as companyName, p.name as profileName,"
-        + "       p.address as profileAddress " + "from testavro.PAGEVIEW as pv "
-        + "join testavro.PROFILE.`$table` as p " + " on p.id = pv.profileId " + " join testavro.COMPANY.`$table` as c "
-        + " on p.companyId = c.id AND c.id = pv.profileId";
+    String sql =
+        "Insert into testavro.enrichedPageViewTopic "
+            + "select pv.pageKey as __key__, pv.pageKey as pageKey, c.name as companyName, p.name as profileName,"
+            + "       p.address as profileAddress "
+            + "from testavro.PAGEVIEW as pv "
+            + "join testavro.PROFILE.`$table` as p "
+            + " on p.id = pv.profileId "
+            + " join testavro.COMPANY.`$table` as c "
+            + " on p.companyId = c.id AND c.id = pv.profileId";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
@@ -733,8 +777,10 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
         SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages, false, false, windowDurationMs);
     staticConfigs.putAll(configs);
     String sql =
-        "Insert into testavro.pageViewCountTopic" + " select 'SampleJob' as jobName, pv.pageKey, count(*) as `count`"
-            + " from testavro.PAGEVIEW as pv" + " where pv.pageKey = 'job' or pv.pageKey = 'inbox'"
+        "Insert into testavro.pageViewCountTopic"
+            + " select 'SampleJob' as jobName, pv.pageKey, count(*) as `count`"
+            + " from testavro.PAGEVIEW as pv"
+            + " where pv.pageKey = 'job' or pv.pageKey = 'inbox'"
             + " group by (pv.pageKey)";
 
     List<String> sqlStmts = Arrays.asList(sql);
@@ -743,20 +789,21 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     // Let's capture the list of windows/counts per key.
     HashMap<String, List<String>> pageKeyCountListMap = new HashMap<>();
-    TestAvroSystemFactory.messages.stream().map(x -> {
-      String pageKey = ((GenericRecord) x.getMessage()).get("pageKey").toString();
-      String count = ((GenericRecord) x.getMessage()).get("count").toString();
-      pageKeyCountListMap.computeIfAbsent(pageKey, k -> new ArrayList<>()).add(count);
-      return pageKeyCountListMap;
-    });
+    TestAvroSystemFactory.messages.stream()
+        .map(x -> {
+            String pageKey = ((GenericRecord) x.getMessage()).get("pageKey").toString();
+            String count = ((GenericRecord) x.getMessage()).get("count").toString();
+            pageKeyCountListMap.computeIfAbsent(pageKey, k -> new ArrayList<>()).add(count);
+            return pageKeyCountListMap;
+          });
 
     HashMap<String, Integer> pageKeyCountMap = new HashMap<>();
     pageKeyCountListMap.forEach((key, list) -> {
-      // Check that the number of windows per key is non-zero but less than the number of input messages per key.
-      Assert.assertTrue(list.size() > 1 && list.size() < numMessages / TestAvroSystemFactory.pageKeys.length);
-      // Collapse the count of messages per key
-      pageKeyCountMap.put(key, list.stream().mapToInt(Integer::parseInt).sum());
-    });
+        // Check that the number of windows per key is non-zero but less than the number of input messages per key.
+        Assert.assertTrue(list.size() > 1 && list.size() < numMessages / TestAvroSystemFactory.pageKeys.length);
+        // Collapse the count of messages per key
+        pageKeyCountMap.put(key, list.stream().mapToInt(Integer::parseInt).sum());
+      });
 
     Set<String> pageKeys = new HashSet<>(Arrays.asList("job", "inbox"));
     HashMap<String, Integer> expectedPageKeyCountMap =

--- a/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
@@ -1,21 +1,21 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.apache.samza.test.samzasql;
 
@@ -107,6 +107,29 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
         .map(x -> Integer.valueOf(((GenericRecord) x.getMessage()).get("id").toString()))
         .sorted()
         .collect(Collectors.toList());
+    Assert.assertEquals(numMessages, outMessages.size());
+  }
+
+  @Test
+  public void testEndToEndDisableSystemMessages() {
+    int numMessages = 20;
+
+    TestAvroSystemFactory.messages.clear();
+    Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
+    String avroSamzaToRelMsgConverterDomain =
+        String.format(SamzaSqlApplicationConfig.CFG_FMT_SAMZA_REL_CONVERTER_DOMAIN, "avro");
+    staticConfigs.put(avroSamzaToRelMsgConverterDomain + SamzaSqlApplicationConfig.CFG_FACTORY,
+        SampleRelConverterFactory.class.getName());
+    staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_PROCESS_SYSTEM_EVENTS, "false");
+    String sql = "Insert into testavro.simpleOutputTopic select * from testavro.SIMPLE1";
+    List<String> sqlStmts = Arrays.asList(sql);
+    staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
+    runApplication(new MapConfig(staticConfigs));
+
+    List<Integer> outMessages = TestAvroSystemFactory.messages.stream()
+        .map(x -> Integer.valueOf(((GenericRecord) x.getMessage()).get("id").toString()))
+        .sorted()
+        .collect(Collectors.toList());
     Assert.assertEquals((numMessages + 1) / 2, outMessages.size());
   }
 
@@ -172,9 +195,10 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     Assert.assertEquals(numMessages * 2, outMessages.size());
     Set<Integer> outMessagesSet = new HashSet<>(outMessages);
     Assert.assertEquals(numMessages, outMessagesSet.size());
-    Assert.assertTrue(IntStream.range(0, numMessages).boxed().collect(Collectors.toList()).equals(new ArrayList<>(outMessagesSet)));
+    Assert.assertTrue(
+        IntStream.range(0, numMessages).boxed().collect(Collectors.toList()).equals(new ArrayList<>(outMessagesSet)));
   }
-  
+
   @Test
   public void testEndToEndMultiSqlStmtsWithSameSystemStreamAsInputAndOutput() {
     int numMessages = 20;
@@ -193,7 +217,8 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     Assert.assertEquals(numMessages * 2, outMessages.size());
     Set<Integer> outMessagesSet = new HashSet<>(outMessages);
     Assert.assertEquals(numMessages, outMessagesSet.size());
-    Assert.assertTrue(IntStream.range(0, numMessages).boxed().collect(Collectors.toList()).equals(new ArrayList<>(outMessagesSet)));
+    Assert.assertTrue(
+        IntStream.range(0, numMessages).boxed().collect(Collectors.toList()).equals(new ArrayList<>(outMessagesSet)));
   }
 
   @Test
@@ -213,7 +238,8 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     Assert.assertEquals(numMessages * 2, outMessages.size());
     Set<Integer> outMessagesSet = new HashSet<>(outMessages);
     Assert.assertEquals(numMessages, outMessagesSet.size());
-    Assert.assertTrue(IntStream.range(0, numMessages).boxed().collect(Collectors.toList()).equals(new ArrayList<>(outMessagesSet)));
+    Assert.assertTrue(
+        IntStream.range(0, numMessages).boxed().collect(Collectors.toList()).equals(new ArrayList<>(outMessagesSet)));
   }
 
   @Test
@@ -233,7 +259,8 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     Assert.assertEquals(numMessages * 2, outMessages.size());
     Set<Integer> outMessagesSet = new HashSet<>(outMessages);
     Assert.assertEquals(numMessages, outMessagesSet.size());
-    Assert.assertTrue(IntStream.range(0, numMessages).boxed().collect(Collectors.toList()).equals(new ArrayList<>(outMessagesSet)));
+    Assert.assertTrue(
+        IntStream.range(0, numMessages).boxed().collect(Collectors.toList()).equals(new ArrayList<>(outMessagesSet)));
   }
 
   @Test
@@ -263,10 +290,9 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
 
     LOG.info(" Class Path : " + RelOptUtil.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath());
-    String sql1 =
-        "Insert into testavro.outputTopic(string_value, id, bytes_value, fixed_value, float_value) "
-            + " select Flatten(array_values) as string_value, id, bytes_value, fixed_value, float_value "
-            + " from testavro.COMPLEX1";
+    String sql1 = "Insert into testavro.outputTopic(string_value, id, bytes_value, fixed_value, float_value) "
+        + " select Flatten(array_values) as string_value, id, bytes_value, fixed_value, float_value "
+        + " from testavro.COMPLEX1";
     List<String> sqlStmts = Collections.singletonList(sql1);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
@@ -281,17 +307,15 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     Assert.assertEquals(expectedMessages, outMessages.size());
   }
 
-
   @Test
   public void testEndToEndComplexRecord() {
     int numMessages = 10;
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
 
-    String sql1 =
-        "Insert into testavro.outputTopic"
-            + " select map_values['key0'] as string_value, union_value, array_values[0] as string_value, map_values, id, bytes_value, fixed_value, float_value "
-            + " from testavro.COMPLEX1";
+    String sql1 = "Insert into testavro.outputTopic"
+        + " select map_values['key0'] as string_value, union_value, array_values[0] as string_value, map_values, id, bytes_value, fixed_value, float_value "
+        + " from testavro.COMPLEX1";
     List<String> sqlStmts = Collections.singletonList(sql1);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
@@ -309,9 +333,7 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
 
     String sql1 =
-        "Insert into testavro.outputTopic"
-            + " select `phoneNumbers`[0].`kind`"
-            + " from testavro.PROFILE as p";
+        "Insert into testavro.outputTopic" + " select `phoneNumbers`[0].`kind`" + " from testavro.PROFILE as p";
     List<String> sqlStmts = Collections.singletonList(sql1);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
@@ -395,11 +417,8 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     int numMessages = 20;
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
-    String sql1 =
-        "Insert into testavro.outputTopic(id) "
-            + "select id "
-            + "from testavro.SIMPLE1 "
-            + "where RegexMatch('.*4', name)";
+    String sql1 = "Insert into testavro.outputTopic(id) " + "select id " + "from testavro.SIMPLE1 "
+        + "where RegexMatch('.*4', name)";
     List<String> sqlStmts = Collections.singletonList(sql1);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
@@ -416,22 +435,19 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
     staticConfigs.putAll(configs);
-    String sql =
-        "Insert into testavro.enrichedPageViewTopic "
-            + "select pv.pageKey as __key__, pv.pageKey as pageKey, coalesce(null, 'N/A') as companyName,"
-            + "       p.name as profileName, p.address as profileAddress "
-            + "from testavro.PROFILE.`$table` as p "
-            + "join testavro.PAGEVIEW as pv "
-            + " on p.id = pv.profileId";
+    String sql = "Insert into testavro.enrichedPageViewTopic "
+        + "select pv.pageKey as __key__, pv.pageKey as pageKey, coalesce(null, 'N/A') as companyName,"
+        + "       p.name as profileName, p.address as profileAddress " + "from testavro.PROFILE.`$table` as p "
+        + "join testavro.PAGEVIEW as pv " + " on p.id = pv.profileId";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
 
     List<String> outMessages = TestAvroSystemFactory.messages.stream()
-        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + ","
-            + (((GenericRecord) x.getMessage()).get("profileName") == null ? "null" :
-            ((GenericRecord) x.getMessage()).get("profileName").toString()))
+        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + "," + (
+            ((GenericRecord) x.getMessage()).get("profileName") == null ? "null"
+                : ((GenericRecord) x.getMessage()).get("profileName").toString()))
         .collect(Collectors.toList());
     Assert.assertEquals(numMessages, outMessages.size());
     List<String> expectedOutMessages = TestAvroSystemFactory.getPageKeyProfileNameJoin(numMessages);
@@ -445,22 +461,19 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
     staticConfigs.putAll(configs);
-    String sql =
-        "Insert into testavro.enrichedPageViewTopic "
-            + "select pv.pageKey as __key__, pv.pageKey as pageKey, coalesce(null, 'N/A') as companyName,"
-            + "       p.name as profileName, p.address as profileAddress "
-            + "from testavro.PROFILE.`$table` as p "
-            + "join testavro.PAGEVIEW as pv "
-            + " on p.__key__ = pv.profileId";
+    String sql = "Insert into testavro.enrichedPageViewTopic "
+        + "select pv.pageKey as __key__, pv.pageKey as pageKey, coalesce(null, 'N/A') as companyName,"
+        + "       p.name as profileName, p.address as profileAddress " + "from testavro.PROFILE.`$table` as p "
+        + "join testavro.PAGEVIEW as pv " + " on p.__key__ = pv.profileId";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
 
     List<String> outMessages = TestAvroSystemFactory.messages.stream()
-        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + ","
-            + (((GenericRecord) x.getMessage()).get("profileName") == null ? "null" :
-            ((GenericRecord) x.getMessage()).get("profileName").toString()))
+        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + "," + (
+            ((GenericRecord) x.getMessage()).get("profileName") == null ? "null"
+                : ((GenericRecord) x.getMessage()).get("profileName").toString()))
         .collect(Collectors.toList());
     Assert.assertEquals(numMessages, outMessages.size());
     List<String> expectedOutMessages = TestAvroSystemFactory.getPageKeyProfileNameJoin(numMessages);
@@ -474,22 +487,19 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
     staticConfigs.putAll(configs);
-    String sql =
-        "Insert into testavro.enrichedPageViewTopic "
-            + "select pv.pageKey as __key__, pv.pageKey as pageKey, coalesce(null, 'N/A') as companyName,"
-            + "       p.name as profileName, p.address as profileAddress "
-            + "from testavro.PROFILE.`$table` as p "
-            + "join testavro.PAGEVIEW as pv "
-            + " on MyTest(p.id) = MyTest(pv.profileId)";
+    String sql = "Insert into testavro.enrichedPageViewTopic "
+        + "select pv.pageKey as __key__, pv.pageKey as pageKey, coalesce(null, 'N/A') as companyName,"
+        + "       p.name as profileName, p.address as profileAddress " + "from testavro.PROFILE.`$table` as p "
+        + "join testavro.PAGEVIEW as pv " + " on MyTest(p.id) = MyTest(pv.profileId)";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
 
     List<String> outMessages = TestAvroSystemFactory.messages.stream()
-        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + ","
-            + (((GenericRecord) x.getMessage()).get("profileName") == null ? "null" :
-            ((GenericRecord) x.getMessage()).get("profileName").toString()))
+        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + "," + (
+            ((GenericRecord) x.getMessage()).get("profileName") == null ? "null"
+                : ((GenericRecord) x.getMessage()).get("profileName").toString()))
         .collect(Collectors.toList());
     Assert.assertEquals(numMessages, outMessages.size());
     List<String> expectedOutMessages = TestAvroSystemFactory.getPageKeyProfileNameJoin(numMessages);
@@ -503,28 +513,23 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
     staticConfigs.putAll(configs);
-    String sql =
-        "Insert into testavro.enrichedPageViewTopic "
-            + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
-            + "       p.address as profileAddress "
-            + "from testavro.PROFILE.`$table` as p "
-            + "join testavro.PAGEVIEW as pv "
-            + " on p.id = pv.profileId";
+    String sql = "Insert into testavro.enrichedPageViewTopic "
+        + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
+        + "       p.address as profileAddress " + "from testavro.PROFILE.`$table` as p "
+        + "join testavro.PAGEVIEW as pv " + " on p.id = pv.profileId";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
 
-    List<String> outMessages = TestAvroSystemFactory.messages.stream()
-        .map(x -> {
-            GenericRecord profileAddr = (GenericRecord) ((GenericRecord) x.getMessage()).get("profileAddress");
-            GenericRecord streetNum = (GenericRecord) (profileAddr.get("streetnum"));
-            return ((GenericRecord) x.getMessage()).get("pageKey").toString() + ","
-                + (((GenericRecord) x.getMessage()).get("profileName") == null ? "null" :
-                ((GenericRecord) x.getMessage()).get("profileName").toString()) + ","
-                + profileAddr.get("zip") + "," + streetNum.get("number");
-          })
-        .collect(Collectors.toList());
+    List<String> outMessages = TestAvroSystemFactory.messages.stream().map(x -> {
+      GenericRecord profileAddr = (GenericRecord) ((GenericRecord) x.getMessage()).get("profileAddress");
+      GenericRecord streetNum = (GenericRecord) (profileAddr.get("streetnum"));
+      return ((GenericRecord) x.getMessage()).get("pageKey").toString() + "," + (
+          ((GenericRecord) x.getMessage()).get("profileName") == null ? "null"
+              : ((GenericRecord) x.getMessage()).get("profileName").toString()) + "," + profileAddr.get("zip") + ","
+          + streetNum.get("number");
+    }).collect(Collectors.toList());
     Assert.assertEquals(numMessages, outMessages.size());
     List<String> expectedOutMessages = TestAvroSystemFactory.getPageKeyProfileNameAddressJoin(numMessages);
     Assert.assertEquals(outMessages, expectedOutMessages);
@@ -537,30 +542,25 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
     staticConfigs.putAll(configs);
-    String sql =
-        "Insert into testavro.enrichedPageViewTopic "
-            + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
-            + "       p.address as profileAddress "
-            + "from testavro.PROFILE.`$table` as p "
-            + "join testavro.PAGEVIEW as pv "
-            + " on p.id = pv.profileId "
-            + "where p.name = 'Mike'";
+    String sql = "Insert into testavro.enrichedPageViewTopic "
+        + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
+        + "       p.address as profileAddress " + "from testavro.PROFILE.`$table` as p "
+        + "join testavro.PAGEVIEW as pv " + " on p.id = pv.profileId " + "where p.name = 'Mike'";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
 
     List<String> outMessages = TestAvroSystemFactory.messages.stream()
-        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + ","
-            + (((GenericRecord) x.getMessage()).get("profileName") == null ? "null" :
-            ((GenericRecord) x.getMessage()).get("profileName").toString()))
+        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + "," + (
+            ((GenericRecord) x.getMessage()).get("profileName") == null ? "null"
+                : ((GenericRecord) x.getMessage()).get("profileName").toString()))
         .collect(Collectors.toList());
     Assert.assertEquals(4, outMessages.size());
-    List<String> expectedOutMessages =
-        TestAvroSystemFactory.getPageKeyProfileNameJoin(numMessages)
-            .stream()
-            .filter(msg -> msg.endsWith("Mike"))
-            .collect(Collectors.toList());
+    List<String> expectedOutMessages = TestAvroSystemFactory.getPageKeyProfileNameJoin(numMessages)
+        .stream()
+        .filter(msg -> msg.endsWith("Mike"))
+        .collect(Collectors.toList());
     Assert.assertEquals(expectedOutMessages, outMessages);
   }
 
@@ -570,22 +570,19 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages, true);
-    String sql =
-        "Insert into testavro.enrichedPageViewTopic "
-            + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
-            + "       p.address as profileAddress "
-            + "from testavro.PAGEVIEW as pv "
-            + "join testavro.PROFILE.`$table` as p "
-            + " on pv.profileId = p.id";
+    String sql = "Insert into testavro.enrichedPageViewTopic "
+        + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
+        + "       p.address as profileAddress " + "from testavro.PAGEVIEW as pv "
+        + "join testavro.PROFILE.`$table` as p " + " on pv.profileId = p.id";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
 
     List<String> outMessages = TestAvroSystemFactory.messages.stream()
-        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + ","
-            + (((GenericRecord) x.getMessage()).get("profileName") == null ? "null" :
-            ((GenericRecord) x.getMessage()).get("profileName").toString()))
+        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + "," + (
+            ((GenericRecord) x.getMessage()).get("profileName") == null ? "null"
+                : ((GenericRecord) x.getMessage()).get("profileName").toString()))
         .collect(Collectors.toList());
     // Half the foreign keys are null.
     Assert.assertEquals(numMessages / 2, outMessages.size());
@@ -599,22 +596,19 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages, true);
-    String sql =
-        "Insert into testavro.enrichedPageViewTopic "
-            + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
-            + "       p.address as profileAddress "
-            + "from testavro.PAGEVIEW as pv "
-            + "left join testavro.PROFILE.`$table` as p "
-            + " on pv.profileId = p.id";
+    String sql = "Insert into testavro.enrichedPageViewTopic "
+        + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
+        + "       p.address as profileAddress " + "from testavro.PAGEVIEW as pv "
+        + "left join testavro.PROFILE.`$table` as p " + " on pv.profileId = p.id";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
 
     List<String> outMessages = TestAvroSystemFactory.messages.stream()
-        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + ","
-            + (((GenericRecord) x.getMessage()).get("profileName") == null ? "null" :
-            ((GenericRecord) x.getMessage()).get("profileName").toString()))
+        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + "," + (
+            ((GenericRecord) x.getMessage()).get("profileName") == null ? "null"
+                : ((GenericRecord) x.getMessage()).get("profileName").toString()))
         .collect(Collectors.toList());
     Assert.assertEquals(numMessages, outMessages.size());
     List<String> expectedOutMessages =
@@ -628,22 +622,19 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages, true);
-    String sql =
-        "Insert into testavro.enrichedPageViewTopic "
-            + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
-            + "       p.address as profileAddress "
-            + "from testavro.PROFILE.`$table` as p "
-            + "right join testavro.PAGEVIEW as pv "
-            + " on p.id = pv.profileId";
+    String sql = "Insert into testavro.enrichedPageViewTopic "
+        + "select pv.pageKey as __key__, pv.pageKey as pageKey, p.name as companyName, p.name as profileName,"
+        + "       p.address as profileAddress " + "from testavro.PROFILE.`$table` as p "
+        + "right join testavro.PAGEVIEW as pv " + " on p.id = pv.profileId";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
 
     List<String> outMessages = TestAvroSystemFactory.messages.stream()
-        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + ","
-            + (((GenericRecord) x.getMessage()).get("profileName") == null ? "null" :
-            ((GenericRecord) x.getMessage()).get("profileName").toString()))
+        .map(x -> ((GenericRecord) x.getMessage()).get("pageKey").toString() + "," + (
+            ((GenericRecord) x.getMessage()).get("profileName") == null ? "null"
+                : ((GenericRecord) x.getMessage()).get("profileName").toString()))
         .collect(Collectors.toList());
     Assert.assertEquals(numMessages, outMessages.size());
     List<String> expectedOutMessages =
@@ -657,15 +648,11 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
-    String sql =
-        "Insert into testavro.enrichedPageViewTopic "
-            + "select pv.pageKey as __key__, pv.pageKey as pageKey, c.name as companyName, p.name as profileName,"
-            + "       p.address as profileAddress "
-            + "from testavro.PAGEVIEW as pv "
-            + "join testavro.PROFILE.`$table` as p "
-            + " on MyTest(p.id) = MyTest(pv.profileId) "
-            + " join testavro.COMPANY.`$table` as c "
-            + " on MyTest(p.companyId) = MyTest(c.id)";
+    String sql = "Insert into testavro.enrichedPageViewTopic "
+        + "select pv.pageKey as __key__, pv.pageKey as pageKey, c.name as companyName, p.name as profileName,"
+        + "       p.address as profileAddress " + "from testavro.PAGEVIEW as pv "
+        + "join testavro.PROFILE.`$table` as p " + " on MyTest(p.id) = MyTest(pv.profileId) "
+        + " join testavro.COMPANY.`$table` as c " + " on MyTest(p.companyId) = MyTest(c.id)";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
@@ -687,15 +674,11 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
-    String sql =
-        "Insert into testavro.enrichedPageViewTopic "
-            + "select pv.pageKey as __key__, pv.pageKey as pageKey, c.name as companyName, p.name as profileName,"
-            + "       p.address as profileAddress "
-            + "from testavro.PAGEVIEW as pv "
-            + "join testavro.PROFILE.`$table` as p "
-            + " on MyTest(p.__key__) = MyTest(pv.profileId) "
-            + " join testavro.COMPANY.`$table` as c "
-            + " on MyTest(p.companyId) = MyTest(c.__key__)";
+    String sql = "Insert into testavro.enrichedPageViewTopic "
+        + "select pv.pageKey as __key__, pv.pageKey as pageKey, c.name as companyName, p.name as profileName,"
+        + "       p.address as profileAddress " + "from testavro.PAGEVIEW as pv "
+        + "join testavro.PROFILE.`$table` as p " + " on MyTest(p.__key__) = MyTest(pv.profileId) "
+        + " join testavro.COMPANY.`$table` as c " + " on MyTest(p.companyId) = MyTest(c.__key__)";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
@@ -717,15 +700,11 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
-    String sql =
-        "Insert into testavro.enrichedPageViewTopic "
-            + "select pv.pageKey as __key__, pv.pageKey as pageKey, c.name as companyName, p.name as profileName,"
-            + "       p.address as profileAddress "
-            + "from testavro.PAGEVIEW as pv "
-            + "join testavro.PROFILE.`$table` as p "
-            + " on p.id = pv.profileId "
-            + " join testavro.COMPANY.`$table` as c "
-            + " on p.companyId = c.id AND c.id = pv.profileId";
+    String sql = "Insert into testavro.enrichedPageViewTopic "
+        + "select pv.pageKey as __key__, pv.pageKey as pageKey, c.name as companyName, p.name as profileName,"
+        + "       p.address as profileAddress " + "from testavro.PAGEVIEW as pv "
+        + "join testavro.PROFILE.`$table` as p " + " on p.id = pv.profileId " + " join testavro.COMPANY.`$table` as c "
+        + " on p.companyId = c.id AND c.id = pv.profileId";
 
     List<String> sqlStmts = Arrays.asList(sql);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
@@ -754,10 +733,8 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
         SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages, false, false, windowDurationMs);
     staticConfigs.putAll(configs);
     String sql =
-        "Insert into testavro.pageViewCountTopic"
-            + " select 'SampleJob' as jobName, pv.pageKey, count(*) as `count`"
-            + " from testavro.PAGEVIEW as pv"
-            + " where pv.pageKey = 'job' or pv.pageKey = 'inbox'"
+        "Insert into testavro.pageViewCountTopic" + " select 'SampleJob' as jobName, pv.pageKey, count(*) as `count`"
+            + " from testavro.PAGEVIEW as pv" + " where pv.pageKey = 'job' or pv.pageKey = 'inbox'"
             + " group by (pv.pageKey)";
 
     List<String> sqlStmts = Arrays.asList(sql);
@@ -766,21 +743,20 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     // Let's capture the list of windows/counts per key.
     HashMap<String, List<String>> pageKeyCountListMap = new HashMap<>();
-    TestAvroSystemFactory.messages.stream()
-        .map(x -> {
-            String pageKey = ((GenericRecord) x.getMessage()).get("pageKey").toString();
-            String count = ((GenericRecord) x.getMessage()).get("count").toString();
-            pageKeyCountListMap.computeIfAbsent(pageKey, k -> new ArrayList<>()).add(count);
-            return pageKeyCountListMap;
-          });
+    TestAvroSystemFactory.messages.stream().map(x -> {
+      String pageKey = ((GenericRecord) x.getMessage()).get("pageKey").toString();
+      String count = ((GenericRecord) x.getMessage()).get("count").toString();
+      pageKeyCountListMap.computeIfAbsent(pageKey, k -> new ArrayList<>()).add(count);
+      return pageKeyCountListMap;
+    });
 
     HashMap<String, Integer> pageKeyCountMap = new HashMap<>();
     pageKeyCountListMap.forEach((key, list) -> {
-        // Check that the number of windows per key is non-zero but less than the number of input messages per key.
-        Assert.assertTrue(list.size() > 1 && list.size() < numMessages / TestAvroSystemFactory.pageKeys.length);
-        // Collapse the count of messages per key
-        pageKeyCountMap.put(key, list.stream().mapToInt(Integer::parseInt).sum());
-      });
+      // Check that the number of windows per key is non-zero but less than the number of input messages per key.
+      Assert.assertTrue(list.size() > 1 && list.size() < numMessages / TestAvroSystemFactory.pageKeys.length);
+      // Collapse the count of messages per key
+      pageKeyCountMap.put(key, list.stream().mapToInt(Integer::parseInt).sum());
+    });
 
     Set<String> pageKeys = new HashSet<>(Arrays.asList("job", "inbox"));
     HashMap<String, Integer> expectedPageKeyCountMap =


### PR DESCRIPTION
This method adds the System message metadata to the SamzaSQLRelMessageMetadata and uses the metadata to directly send these system messages to output stream directly bypassing the Samza SQL processing pipeline.

