### PR TITLE
SAMZA-2120: Enable custom handling of ConsumerRecords consumed by Kafka 

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/task/AsyncRunLoop.java
+++ b/samza-core/src/main/java/org/apache/samza/task/AsyncRunLoop.java
@@ -611,10 +611,12 @@ public class AsyncRunLoop implements Runnable, Throttleable {
             List<TaskCallbackImpl> callbacksToUpdate = callbackManager.updateCallback(callbackImpl);
             for (TaskCallbackImpl callbackToUpdate : callbacksToUpdate) {
               IncomingMessageEnvelope envelope = callbackToUpdate.envelope;
-              log.trace("Update offset for ssp {}, offset {}", envelope.getSystemStreamPartition(), envelope.getOffset());
+              log.trace("Update offset for ssp {}, checkpoint offset {}", envelope.getSystemStreamPartition(),
+                  envelope.getCheckpointOffset());
 
               // update offset
-              task.offsetManager().update(task.taskName(), envelope.getSystemStreamPartition(), envelope.getOffset());
+              task.offsetManager()
+                  .update(task.taskName(), envelope.getSystemStreamPartition(), envelope.getCheckpointOffset());
 
               // update coordinator
               coordinatorRequests.update(callbackToUpdate.coordinator);

--- a/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
@@ -153,7 +153,7 @@ class TaskInstance(
       val startpoint = offsetManager.getStartpoint(taskName, systemStreamPartition).getOrElse(null)
       consumerMultiplexer.register(systemStreamPartition, startingOffset, startpoint)
       metrics.addOffsetGauge(systemStreamPartition, () =>
-          offsetManager.getLastProcessedOffset(taskName, systemStreamPartition).orNull
+          offsetManager.getCheckpointOffset(taskName, systemStreamPartition).orNull
         )
     })
   }
@@ -185,10 +185,10 @@ class TaskInstance(
           task.asInstanceOf[StreamTask].process(envelope, collector, coordinator)
         }
 
-        trace("Updating offset map for taskName, SSP and offset: %s, %s, %s"
-          format(taskName, incomingMessageSsp, envelope.getOffset))
+        trace("Updating offset map for taskName, SSP and checkpoint offset: %s, %s, %s"
+          format (taskName, incomingMessageSsp, envelope.getCheckpointOffset))
 
-        offsetManager.update(taskName, incomingMessageSsp, envelope.getOffset)
+        offsetManager.update(taskName, incomingMessageSsp, envelope.getCheckpointOffset)
       }
 
     }

--- a/samza-core/src/main/scala/org/apache/samza/serializers/SerdeManager.scala
+++ b/samza-core/src/main/scala/org/apache/samza/serializers/SerdeManager.scala
@@ -147,6 +147,7 @@ class SerdeManager(
       new IncomingMessageEnvelope(
         envelope.getSystemStreamPartition,
         envelope.getOffset,
+        envelope.getCheckpointOffset,
         key,
         message,
         envelope.getSize,

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -661,7 +661,7 @@ public class ContainerStorageManager {
       // register startingOffset with the sysConsumer and register a metric for it
       sideInputSystemConsumers.register(ssp, startingOffset, null);
       taskInstanceMetrics.get(sideInputStorageManagers.get(ssp).getTaskName()).addOffsetGauge(
-          ssp, ScalaJavaUtil.toScalaFunction(() -> sideInputStorageManagers.get(ssp).getLastProcessedOffset(ssp)));
+          ssp, ScalaJavaUtil.toScalaFunction(() -> sideInputStorageManagers.get(ssp).getCheckpointOffset(ssp)));
 
       SystemStreamMetadata systemStreamMetadata = streamMetadataCache.getSystemStreamMetadata(ssp.getSystemStream(), false);
       SystemStreamMetadata.SystemStreamPartitionMetadata sspMetadata =

--- a/samza-core/src/test/scala/org/apache/samza/checkpoint/TestOffsetManager.scala
+++ b/samza-core/src/test/scala/org/apache/samza/checkpoint/TestOffsetManager.scala
@@ -54,7 +54,7 @@ class TestOffsetManager {
     val offsetManager = OffsetManager(systemStreamMetadata, config)
     offsetManager.register(taskName, Set(systemStreamPartition))
     offsetManager.start
-    assertFalse(offsetManager.getLastProcessedOffset(taskName, systemStreamPartition).isDefined)
+    assertFalse(offsetManager.getCheckpointOffset(taskName, systemStreamPartition).isDefined)
     assertTrue(offsetManager.getStartingOffset(taskName, systemStreamPartition).isDefined)
     assertEquals("0", offsetManager.getStartingOffset(taskName, systemStreamPartition).get)
   }
@@ -83,11 +83,11 @@ class TestOffsetManager {
     assertEquals(checkpointManager.checkpoints.head._2, checkpointManager.readLastCheckpoint(taskName))
     // Should get offset 45 back from the checkpoint manager, which is last processed, and system admin should return 46 as starting offset.
     assertEquals("46", offsetManager.getStartingOffset(taskName, systemStreamPartition).get)
-    assertEquals("45", offsetManager.getLastProcessedOffset(taskName, systemStreamPartition).get)
+    assertEquals("45", offsetManager.getCheckpointOffset(taskName, systemStreamPartition).get)
     offsetManager.update(taskName, systemStreamPartition, "46")
-    assertEquals("46", offsetManager.getLastProcessedOffset(taskName, systemStreamPartition).get)
+    assertEquals("46", offsetManager.getCheckpointOffset(taskName, systemStreamPartition).get)
     offsetManager.update(taskName, systemStreamPartition, "47")
-    assertEquals("47", offsetManager.getLastProcessedOffset(taskName, systemStreamPartition).get)
+    assertEquals("47", offsetManager.getCheckpointOffset(taskName, systemStreamPartition).get)
     // Should never update starting offset.
     assertEquals("46", offsetManager.getStartingOffset(taskName, systemStreamPartition).get)
     // Should not update null offset
@@ -283,7 +283,7 @@ class TestOffsetManager {
     offsetManager.start
     assertTrue(checkpointManager.isStarted)
     assertEquals(1, checkpointManager.registered.size)
-    assertNull(offsetManager.getLastProcessedOffset(taskName, systemStreamPartition1).getOrElse(null))
+    assertNull(offsetManager.getCheckpointOffset(taskName, systemStreamPartition1).getOrElse(null))
   }
 
   @Test
@@ -404,14 +404,14 @@ class TestOffsetManager {
     offsetManager.update(taskName, systemStreamPartition, "47") // Offset updated before checkpoint
     offsetManager.writeCheckpoint(taskName, checkpoint46)
     assertNotNull(startpointManager.readStartpoint(systemStreamPartition, taskName)) // Startpoint should only be deleted at first checkpoint
-    assertEquals(Some("47"), offsetManager.getLastProcessedOffset(taskName, systemStreamPartition))
+    assertEquals(Some("47"), offsetManager.getCheckpointOffset(taskName, systemStreamPartition))
     assertEquals("46", offsetManager.offsetManagerMetrics.checkpointedOffsets.get(systemStreamPartition).getValue)
 
     // Now write the checkpoint for the latest offset
     val checkpoint47 = offsetManager.buildCheckpoint(taskName)
     offsetManager.writeCheckpoint(taskName, checkpoint47)
     assertNotNull(startpointManager.readStartpoint(systemStreamPartition, taskName)) // Startpoint should only be deleted at first checkpoint
-    assertEquals(Some("47"), offsetManager.getLastProcessedOffset(taskName, systemStreamPartition))
+    assertEquals(Some("47"), offsetManager.getCheckpointOffset(taskName, systemStreamPartition))
     assertEquals("47", offsetManager.offsetManagerMetrics.checkpointedOffsets.get(systemStreamPartition).getValue)
   }
 

--- a/samza-core/src/test/scala/org/apache/samza/container/TestTaskInstance.scala
+++ b/samza-core/src/test/scala/org/apache/samza/container/TestTaskInstance.scala
@@ -154,9 +154,9 @@ class TestTaskInstance extends AssertionsForJUnit with MockitoSugar {
     when(this.metrics.processes).thenReturn(mock[Counter])
     when(this.metrics.messagesActuallyProcessed).thenReturn(mock[Counter])
     when(this.offsetManager.getStartingOffset(TASK_NAME, SYSTEM_STREAM_PARTITION)).thenReturn(Some("2"))
-    this.taskInstance.process(new IncomingMessageEnvelope(SYSTEM_STREAM_PARTITION, "4", null, null),
+    this.taskInstance.process(new IncomingMessageEnvelope(SYSTEM_STREAM_PARTITION, "4", "checkpoint4", null, null, 0, 0, 0),
       mock[ReadableCoordinator])
-    verify(this.offsetManager).update(TASK_NAME, SYSTEM_STREAM_PARTITION, "4")
+    verify(this.offsetManager).update(TASK_NAME, SYSTEM_STREAM_PARTITION, "checkpoint4")
   }
 
   /**

--- a/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaSystemConsumer.java
+++ b/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaSystemConsumer.java
@@ -79,14 +79,15 @@ public class KafkaSystemConsumer<K, V> extends BlockingEnvelopeMap implements Sy
    * Create a KafkaSystemConsumer for the provided {@code systemName}
    * @param kafkaConsumer kafka Consumer object to be used by this system consumer
    * @param systemName system name for which we create the consumer
+   * @param consumerRecordHandler {@link ConsumerRecordHandler} for new Kafka records
    * @param config application config
    * @param clientId clientId from the kafka consumer to be used in the KafkaConsumerProxy
    * @param metrics metrics for this KafkaSystemConsumer
    * @param clock system clock
    */
-  public KafkaSystemConsumer(Consumer<K, V> kafkaConsumer, String systemName, Config config, String clientId,
+  public KafkaSystemConsumer(Consumer<K, V> kafkaConsumer, String systemName,
+      ConsumerRecordHandler consumerRecordHandler, Config config, String clientId,
       KafkaSystemConsumerMetrics metrics, Clock clock) {
-
     super(metrics.registry(), clock, metrics.getClass().getName());
 
     this.kafkaConsumer = kafkaConsumer;
@@ -102,7 +103,8 @@ public class KafkaSystemConsumer<K, V> extends BlockingEnvelopeMap implements Sy
 
     // Create the proxy to do the actual message reading.
     String metricName = String.format("%s-%s", systemName, clientId);
-    proxy = new KafkaConsumerProxy(kafkaConsumer, systemName, clientId, messageSink, metrics, metricName);
+    proxy = new KafkaConsumerProxy<>(kafkaConsumer, systemName, clientId, messageSink, consumerRecordHandler, metrics,
+        metricName);
     LOG.info("{}: Created KafkaConsumerProxy {} ", this, proxy);
   }
 

--- a/samza-kafka/src/main/scala/org/apache/samza/system/kafka/BasicConsumerRecordHandler.java
+++ b/samza-kafka/src/main/scala/org/apache/samza/system/kafka/BasicConsumerRecordHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.system.kafka;
+
+import java.time.Instant;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.samza.system.IncomingMessageEnvelope;
+import org.apache.samza.system.SystemStreamPartition;
+import org.apache.samza.util.Clock;
+import org.apache.samza.util.KafkaUtilJava;
+
+
+/**
+ * Basic implementation of {@link ConsumerRecordHandler} which mostly just does passthrough of fields from
+ * {@link ConsumerRecord} to {@link IncomingMessageEnvelope}.
+ */
+public class BasicConsumerRecordHandler implements ConsumerRecordHandler {
+  private final Clock clock;
+
+  public BasicConsumerRecordHandler(Clock clock) {
+    this.clock = clock;
+  }
+
+  @Override
+  public IncomingMessageEnvelope onNewRecord(ConsumerRecord<?, ?> consumerRecord,
+      SystemStreamPartition systemStreamPartition) {
+    return new IncomingMessageEnvelope(systemStreamPartition, String.valueOf(consumerRecord.offset()),
+        consumerRecord.key(), consumerRecord.value(), KafkaUtilJava.getRecordSize(consumerRecord),
+        consumerRecord.timestamp(), Instant.now().toEpochMilli());
+  }
+}

--- a/samza-kafka/src/main/scala/org/apache/samza/system/kafka/ConsumerRecordHandler.java
+++ b/samza-kafka/src/main/scala/org/apache/samza/system/kafka/ConsumerRecordHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.system.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.samza.system.IncomingMessageEnvelope;
+import org.apache.samza.system.SystemStreamPartition;
+
+
+public interface ConsumerRecordHandler {
+  /**
+   * Handle a new incoming {@link ConsumerRecord} and convert it into an {@link IncomingMessageEnvelope} for Samza.
+   * @param consumerRecord new incoming {@link ConsumerRecord}
+   * @param systemStreamPartition {@link SystemStreamPartition} from which the {@code consumerRecord} was consumed
+   * @return {@link IncomingMessageEnvelope} corresponding to the {@code consumerRecord}
+   */
+  IncomingMessageEnvelope onNewRecord(ConsumerRecord<?, ?> consumerRecord, SystemStreamPartition systemStreamPartition);
+}

--- a/samza-kafka/src/main/scala/org/apache/samza/system/kafka/KafkaSystemFactory.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/system/kafka/KafkaSystemFactory.scala
@@ -57,8 +57,10 @@ class KafkaSystemFactory extends SystemFactory with Logging {
     val kafkaConsumer = KafkaSystemConsumer.createKafkaConsumerImpl[Array[Byte], Array[Byte]](systemName, kafkaConsumerConfig)
     info("Created kafka consumer for system %s, clientId %s: %s" format (systemName, clientId, kafkaConsumer))
 
-    val kafkaSystemConsumer = new KafkaSystemConsumer(kafkaConsumer, systemName, config, clientId, metrics,
-      new SystemClock)
+    val consumerRecordHandler = new BasicConsumerRecordHandler(SystemClock.instance)
+
+    val kafkaSystemConsumer = new KafkaSystemConsumer(kafkaConsumer, systemName, consumerRecordHandler, config,
+      clientId, metrics, new SystemClock)
     info("Created samza system consumer for system %s, config %s: %s" format(systemName, config, kafkaSystemConsumer))
 
     kafkaSystemConsumer

--- a/samza-kafka/src/main/scala/org/apache/samza/util/KafkaUtilJava.java
+++ b/samza-kafka/src/main/scala/org/apache/samza/util/KafkaUtilJava.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.util;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+
+public class KafkaUtilJava {
+  public static int getRecordSize(ConsumerRecord<?, ?> consumerRecord) {
+    int keySize = (consumerRecord.key() == null) ? 0 : consumerRecord.serializedKeySize();
+    int valueSize = (consumerRecord.value() == null) ? 0 : consumerRecord.serializedValueSize();
+    return keySize + valueSize;
+  }
+}

--- a/samza-kafka/src/test/java/org/apache/samza/system/kafka/TestBasicConsumerRecordHandler.java
+++ b/samza-kafka/src/test/java/org/apache/samza/system/kafka/TestBasicConsumerRecordHandler.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.system.kafka;
+
+import java.time.Instant;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.samza.Partition;
+import org.apache.samza.system.IncomingMessageEnvelope;
+import org.apache.samza.system.SystemStreamPartition;
+import org.apache.samza.util.Clock;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+
+public class TestBasicConsumerRecordHandler {
+  private static final TopicPartition TOPIC_PARTITION = new TopicPartition("topic", 1);
+  private static final long PLAIN_OFFSET = 123;
+  private static final String KEY = "key";
+  private static final String VALUE = "value";
+  private static final Instant RECORD_TIMESTAMP = Instant.ofEpochMilli(10000);
+  private static final Instant NOW = Instant.ofEpochMilli(10001);
+  private static final SystemStreamPartition SSP =
+      new SystemStreamPartition("system", TOPIC_PARTITION.topic(), new Partition(TOPIC_PARTITION.partition()));
+
+  @Mock
+  private Clock clock;
+  @Mock
+  private ConsumerRecord<String, String> consumerRecord;
+
+  private BasicConsumerRecordHandler basicConsumerRecordHandler;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+
+    when(this.clock.currentTimeMillis()).thenReturn(NOW.toEpochMilli());
+
+    when(this.consumerRecord.partition()).thenReturn(TOPIC_PARTITION.partition());
+    when(this.consumerRecord.topic()).thenReturn(TOPIC_PARTITION.topic());
+    when(this.consumerRecord.offset()).thenReturn(PLAIN_OFFSET);
+    when(this.consumerRecord.key()).thenReturn(KEY);
+    when(this.consumerRecord.value()).thenReturn(VALUE);
+    when(this.consumerRecord.serializedKeySize()).thenReturn(KEY.length());
+    when(this.consumerRecord.serializedValueSize()).thenReturn(VALUE.length());
+    when(this.consumerRecord.timestamp()).thenReturn(RECORD_TIMESTAMP.toEpochMilli());
+
+    this.basicConsumerRecordHandler = new BasicConsumerRecordHandler(this.clock);
+  }
+
+  @Test
+  public void testOnNewRecord() {
+    IncomingMessageEnvelope expected =
+        new IncomingMessageEnvelope(SSP, Long.toString(PLAIN_OFFSET), KEY, VALUE, KEY.length() + VALUE.length(),
+            RECORD_TIMESTAMP.toEpochMilli(), NOW.toEpochMilli());
+    assertEquals(this.basicConsumerRecordHandler.onNewRecord(this.consumerRecord, SSP), expected);
+  }
+}

--- a/samza-kafka/src/test/java/org/apache/samza/system/kafka/TestKafkaSystemConsumer.java
+++ b/samza-kafka/src/test/java/org/apache/samza/system/kafka/TestKafkaSystemConsumer.java
@@ -41,6 +41,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
 
 
 public class TestKafkaSystemConsumer {
@@ -71,8 +72,9 @@ public class TestKafkaSystemConsumer {
     final KafkaConsumer<byte[], byte[]> kafkaConsumer = new MockKafkaConsumer(consumerConfig);
 
     MockKafkaSystemConsumer newKafkaSystemConsumer =
-        new MockKafkaSystemConsumer(kafkaConsumer, TEST_SYSTEM, config, TEST_PREFIX_ID,
-            new KafkaSystemConsumerMetrics(TEST_SYSTEM, new NoOpMetricsRegistry()), System::currentTimeMillis);
+        new MockKafkaSystemConsumer(kafkaConsumer, TEST_SYSTEM, mock(ConsumerRecordHandler.class), config,
+            TEST_PREFIX_ID, new KafkaSystemConsumerMetrics(TEST_SYSTEM, new NoOpMetricsRegistry()),
+            System::currentTimeMillis);
 
     return newKafkaSystemConsumer;
   }
@@ -213,9 +215,10 @@ public class TestKafkaSystemConsumer {
   }
 
   static class MockKafkaSystemConsumer extends KafkaSystemConsumer {
-    public MockKafkaSystemConsumer(Consumer kafkaConsumer, String systemName, Config config, String clientId,
-        KafkaSystemConsumerMetrics metrics, Clock clock) {
-      super(kafkaConsumer, systemName, config, clientId, metrics, clock);
+    public MockKafkaSystemConsumer(Consumer kafkaConsumer, String systemName,
+        ConsumerRecordHandler consumerRecordHandler, Config config, String clientId, KafkaSystemConsumerMetrics metrics,
+        Clock clock) {
+      super(kafkaConsumer, systemName, consumerRecordHandler, config, clientId, metrics, clock);
     }
 
     @Override

--- a/samza-kafka/src/test/java/org/apache/samza/util/TestKafkaUtilJava.java
+++ b/samza-kafka/src/test/java/org/apache/samza/util/TestKafkaUtilJava.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.util;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class TestKafkaUtilJava {
+  @Test
+  public void testGetRecordSize() {
+    String key = "key";
+    String value = "value";
+    ConsumerRecord<String, String> consumerRecord = mock(ConsumerRecord.class);
+
+    // null key and value
+    when(consumerRecord.key()).thenReturn(null);
+    when(consumerRecord.value()).thenReturn(null);
+    assertEquals(0, KafkaUtilJava.getRecordSize(consumerRecord));
+
+    // null key, non-null value
+    when(consumerRecord.key()).thenReturn(null);
+    when(consumerRecord.value()).thenReturn(value);
+    when(consumerRecord.serializedValueSize()).thenReturn(value.length());
+    assertEquals(value.length(), KafkaUtilJava.getRecordSize(consumerRecord));
+
+    // non-null key, null value (this case seems odd, but the ConsumerRecord API seems to allow it)
+    when(consumerRecord.key()).thenReturn(key);
+    when(consumerRecord.serializedKeySize()).thenReturn(key.length());
+    when(consumerRecord.value()).thenReturn(null);
+    assertEquals(key.length(), KafkaUtilJava.getRecordSize(consumerRecord));
+
+    // non-null key, non-null value
+    when(consumerRecord.key()).thenReturn(key);
+    when(consumerRecord.serializedKeySize()).thenReturn(key.length());
+    when(consumerRecord.value()).thenReturn(value);
+    when(consumerRecord.serializedValueSize()).thenReturn(value.length());
+    assertEquals(key.length() + value.length(), KafkaUtilJava.getRecordSize(consumerRecord));
+  }
+}


### PR DESCRIPTION
This includes the code from https://github.com/apache/samza/pull/940.
For this PR, it would be practical to just look at commit https://github.com/apache/samza/commit/e09f03022802b0757146915647a20a56478a7e4e.