### PR TITLE
Remove scala 2.10 version from documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ After the bootstrap script has completed, the regular gradlew instructions below
 
 #### Scala and YARN
 
-Samza builds with [Scala](http://www.scala-lang.org/) 2.10 or 2.11 and [YARN](http://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/YARN.html) 2.6.1, by default. Use the -PscalaSuffix switches to change Scala versions. Samza supports building Scala with 2.10 and 2.11.
+Samza builds with [Scala](http://www.scala-lang.org/) 2.11 or 2.12 and [YARN](http://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/YARN.html) 2.6.1, by default. Use the -PscalaSuffix switches to change Scala versions. Samza supports building Scala with 2.11 and 2.12.
 
     ./gradlew -PscalaSuffix=2.11 clean build
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -119,7 +119,7 @@ If the VOTE has successfully passed on the release candidate, you can log in to 
 [repository web interface](https://repository.apache.org) (same as above) and "release" 
 the org.apache.samza repository listed under "Staging Repositories".
 
-The instructions above publish the Samza artifacts for scala 2.11. To publish for scala 2.10 and 2.12:
+The instructions above publish the Samza artifacts for scala 2.11. To publish for scala 2.12:
 
 * Set the desired `scalaSuffix` in `gradle.properties`.
 * Run `./gradlew clean uploadArchives` to generate and upload the Samza artifacts.

--- a/docs/contribute/tests.md
+++ b/docs/contribute/tests.md
@@ -41,7 +41,7 @@ Samza's unit tests can also be run against all supported permutations of Scala a
 
 To run the tests against a specific combination:
 
-    ./gradlew -PscalaSuffix=2.10 -PyarnVersion=2.4.0 clean check
+    ./gradlew -PscalaSuffix=2.11 -PyarnVersion=2.4.0 clean check
 
 To run Samza's unit tests against all permutations, run:
 

--- a/docs/learn/tutorials/versioned/remote-debugging-samza.md
+++ b/docs/learn/tutorials/versioned/remote-debugging-samza.md
@@ -47,7 +47,7 @@ cd samza
 Let's also release Samza to Maven's local repository, so hello-samza has access to the JARs that it needs.
 
 {% highlight bash %}
-./gradlew -PscalaSuffix=2.10 clean publishToMavenLocal
+./gradlew -PscalaSuffix=2.11 clean publishToMavenLocal
 {% endhighlight %}
 
 Next, open Eclipse, and import the Samza source code into your workspace: "File" &gt; "Import" &gt; "Existing Projects into Workspace" &gt; "Browse". Select 'samza' folder, and hit 'finish'.


### PR DESCRIPTION
Post 1.0, samza does not support scala 2.10 version. This patch removes the references of the scala 2.10 version from the documentation.