### PR TITLE
SAMZA-2126: Bug fixes for batch-mode generated stream specs

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/execution/StreamEdge.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/StreamEdge.java
@@ -75,9 +75,12 @@ public class StreamEdge {
     StreamSpec spec = (partitions == PARTITIONS_UNKNOWN) ?
         streamSpec : streamSpec.copyWithPartitionCount(partitions);
 
-    // Append unique id to the batch intermediate streams
-    // Check the physical stream name is already generated first
+    // For intermediate stream that physical name is the same as id,
+    // meaning the physical name is auto-generated, and not overrided
+    // by user or batch processing.
     if (isIntermediate && spec.getId().equals(spec.getPhysicalName())) {
+      // Append unique id to the batch intermediate streams
+      // Note this will only happen for batch processing
       String physicalName = StreamManager.createUniqueNameForBatch(spec.getPhysicalName(), config);
       if (!physicalName.equals(spec.getPhysicalName())) {
         spec = spec.copyWithPhysicalName(physicalName);

--- a/samza-core/src/main/java/org/apache/samza/execution/StreamEdge.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/StreamEdge.java
@@ -75,7 +75,9 @@ public class StreamEdge {
     StreamSpec spec = (partitions == PARTITIONS_UNKNOWN) ?
         streamSpec : streamSpec.copyWithPartitionCount(partitions);
 
-    if (isIntermediate) {
+    // Append unique id to the batch intermediate streams
+    // Check the physical stream name is already generated first
+    if (isIntermediate && spec.getId().equals(spec.getPhysicalName())) {
       String physicalName = StreamManager.createUniqueNameForBatch(spec.getPhysicalName(), config);
       if (!physicalName.equals(spec.getPhysicalName())) {
         spec = spec.copyWithPhysicalName(physicalName);

--- a/samza-core/src/test/java/org/apache/samza/execution/TestStreamEdge.java
+++ b/samza-core/src/test/java/org/apache/samza/execution/TestStreamEdge.java
@@ -50,9 +50,15 @@ public class TestStreamEdge {
     Map<String, String> config = new HashMap<>();
     config.put(ApplicationConfig.APP_MODE, ApplicationConfig.ApplicationMode.BATCH.name());
     config.put(ApplicationConfig.APP_RUN_ID, "123");
+
+    // For batch, if the physical name hasn't been generated, it should append the unique id
     StreamSpec batchSpec = new StreamSpec("stream-1", "stream-1", "system-1");
     StreamEdge edge = new StreamEdge(batchSpec, true, false, new MapConfig(config));
     assertEquals(edge.getStreamSpec().getPhysicalName(), batchSpec.getPhysicalName() + "-123");
+
+    // if the physical name has already been geneated somehow, then don't change
+    edge = new StreamEdge(spec, true, false, new MapConfig(config));
+    assertEquals(edge.getStreamSpec().getPhysicalName(), spec.getPhysicalName());
   }
 
   @Test

--- a/samza-core/src/test/java/org/apache/samza/execution/TestStreamEdge.java
+++ b/samza-core/src/test/java/org/apache/samza/execution/TestStreamEdge.java
@@ -50,8 +50,9 @@ public class TestStreamEdge {
     Map<String, String> config = new HashMap<>();
     config.put(ApplicationConfig.APP_MODE, ApplicationConfig.ApplicationMode.BATCH.name());
     config.put(ApplicationConfig.APP_RUN_ID, "123");
-    StreamEdge edge = new StreamEdge(spec, true, false, new MapConfig(config));
-    assertEquals(edge.getStreamSpec().getPhysicalName(), spec.getPhysicalName() + "-123");
+    StreamSpec batchSpec = new StreamSpec("stream-1", "stream-1", "system-1");
+    StreamEdge edge = new StreamEdge(batchSpec, true, false, new MapConfig(config));
+    assertEquals(edge.getStreamSpec().getPhysicalName(), batchSpec.getPhysicalName() + "-123");
   }
 
   @Test

--- a/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaSystemAdmin.java
+++ b/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaSystemAdmin.java
@@ -582,7 +582,9 @@ public class KafkaSystemAdmin implements SystemAdmin {
               coordinatorStreamProperties);
     } else if (intermediateStreamProperties.containsKey(spec.getId())) {
       kafkaSpec = KafkaStreamSpec.fromSpec(spec);
-      kafkaSpec.getProperties().putAll(intermediateStreamProperties.get(spec.getId()));
+      Properties properties = kafkaSpec.getProperties();
+      properties.putAll(intermediateStreamProperties.get(spec.getId()));
+      kafkaSpec = kafkaSpec.copyWithProperties(properties);
     } else {
       kafkaSpec = KafkaStreamSpec.fromSpec(spec);
     }

--- a/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaSystemAdmin.java
+++ b/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaSystemAdmin.java
@@ -581,7 +581,8 @@ public class KafkaSystemAdmin implements SystemAdmin {
           new KafkaStreamSpec(spec.getId(), spec.getPhysicalName(), systemName, 1, coordinatorStreamReplicationFactor,
               coordinatorStreamProperties);
     } else if (intermediateStreamProperties.containsKey(spec.getId())) {
-      kafkaSpec = KafkaStreamSpec.fromSpec(spec).copyWithProperties(intermediateStreamProperties.get(spec.getId()));
+      kafkaSpec = KafkaStreamSpec.fromSpec(spec);
+      kafkaSpec.getProperties().putAll(intermediateStreamProperties.get(spec.getId()));
     } else {
       kafkaSpec = KafkaStreamSpec.fromSpec(spec);
     }

--- a/samza-kafka/src/main/scala/org/apache/samza/system/kafka/KafkaSystemFactory.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/system/kafka/KafkaSystemFactory.scala
@@ -107,7 +107,6 @@ class KafkaSystemFactory extends SystemFactory with Logging {
       val streamConfig = new StreamConfig(config)
       streamConfig.getStreamIds().filter(streamConfig.getIsIntermediateStream(_)).map(streamId => {
         val properties = new Properties()
-        properties.putAll(streamConfig.getStreamProperties(streamId))
         properties.putIfAbsent("retention.ms", String.valueOf(KafkaConfig.DEFAULT_RETENTION_MS_FOR_BATCH))
         (streamId, properties)
       }).toMap

--- a/samza-kafka/src/main/scala/org/apache/samza/system/kafka/KafkaSystemFactory.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/system/kafka/KafkaSystemFactory.scala
@@ -106,6 +106,7 @@ class KafkaSystemFactory extends SystemFactory with Logging {
     if (appConfig.getAppMode == ApplicationMode.BATCH) {
       val streamConfig = new StreamConfig(config)
       streamConfig.getStreamIds().filter(streamConfig.getIsIntermediateStream(_)).map(streamId => {
+        // only the override here
         val properties = new Properties()
         properties.putIfAbsent("retention.ms", String.valueOf(KafkaConfig.DEFAULT_RETENTION_MS_FOR_BATCH))
         (streamId, properties)

--- a/samza-kafka/src/main/scala/org/apache/samza/system/kafka_deprecated/KafkaSystemAdmin.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/system/kafka_deprecated/KafkaSystemAdmin.scala
@@ -428,7 +428,9 @@ class KafkaSystemAdmin(
       new KafkaStreamSpec(spec.getId, spec.getPhysicalName, systemName, 1, coordinatorStreamReplicationFactor,
         coordinatorStreamProperties)
     } else if (intermediateStreamProperties.contains(spec.getId)) {
-      KafkaStreamSpec.fromSpec(spec).copyWithProperties(intermediateStreamProperties(spec.getId))
+      val kafkaSpec = KafkaStreamSpec.fromSpec(spec)
+      kafkaSpec.getProperties.putAll(intermediateStreamProperties(spec.getId))
+      kafkaSpec
     } else {
       KafkaStreamSpec.fromSpec(spec)
     }

--- a/samza-kafka/src/main/scala/org/apache/samza/system/kafka_deprecated/KafkaSystemAdmin.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/system/kafka_deprecated/KafkaSystemAdmin.scala
@@ -429,8 +429,9 @@ class KafkaSystemAdmin(
         coordinatorStreamProperties)
     } else if (intermediateStreamProperties.contains(spec.getId)) {
       val kafkaSpec = KafkaStreamSpec.fromSpec(spec)
-      kafkaSpec.getProperties.putAll(intermediateStreamProperties(spec.getId))
-      kafkaSpec
+      val properties = kafkaSpec.getProperties
+      properties.putAll(intermediateStreamProperties(spec.getId))
+      kafkaSpec.copyWithProperties(properties)
     } else {
       KafkaStreamSpec.fromSpec(spec)
     }

--- a/samza-kafka/src/main/scala/org/apache/samza/system/kafka_deprecated/KafkaSystemFactory.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/system/kafka_deprecated/KafkaSystemFactory.scala
@@ -158,7 +158,6 @@ class KafkaSystemFactory extends SystemFactory with Logging {
       val streamConfig = new StreamConfig(config)
       streamConfig.getStreamIds().filter(streamConfig.getIsIntermediateStream(_)).map(streamId => {
         val properties = new Properties()
-        properties.putAll(streamConfig.getStreamProperties(streamId))
         properties.putIfAbsent("retention.ms", String.valueOf(KafkaConfig.DEFAULT_RETENTION_MS_FOR_BATCH))
         (streamId, properties)
       }).toMap

--- a/samza-kafka/src/test/java/org/apache/samza/system/kafka/TestKafkaSystemFactoryJava.java
+++ b/samza-kafka/src/test/java/org/apache/samza/system/kafka/TestKafkaSystemFactoryJava.java
@@ -22,6 +22,7 @@ package org.apache.samza.system.kafka;
 import org.apache.samza.config.ApplicationConfig;
 import org.apache.samza.config.KafkaConfig;
 import org.apache.samza.config.MapConfig;
+import org.apache.samza.system.StreamSpec;
 import org.junit.Test;
 import scala.collection.JavaConversions;
 
@@ -32,7 +33,7 @@ import java.util.Properties;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class TestKafkaSystemFactoryJava {
+public class TestKafkaSystemFactoryJava extends TestKafkaSystemAdmin {
 
   @Test
   public void testGetIntermediateStreamProperties() {
@@ -45,15 +46,13 @@ public class TestKafkaSystemFactoryJava {
     // no properties for stream
     config.put("streams.test.samza.intermediate", "true");
     config.put("streams.test.compression.type", "lz4"); //some random config
-    properties = JavaConversions.mapAsJavaMap(
-        factory.getIntermediateStreamProperties(new MapConfig(config)));
-    assertTrue(properties.isEmpty());
-
     config.put(ApplicationConfig.APP_MODE, ApplicationConfig.ApplicationMode.BATCH.name());
-    properties = JavaConversions.mapAsJavaMap(
-        factory.getIntermediateStreamProperties(new MapConfig(config)));
-    assertTrue(!properties.isEmpty());
-    Properties prop = properties.get("test");
+
+    KafkaSystemAdmin admin = createSystemAdmin(SYSTEM(), config);
+    StreamSpec spec = new StreamSpec("test", "test", SYSTEM(), config);
+    KafkaStreamSpec kspec = admin.toKafkaSpec(spec);
+
+    Properties prop = kspec.getProperties();
     assertEquals(prop.getProperty("retention.ms"), String.valueOf(KafkaConfig.DEFAULT_RETENTION_MS_FOR_BATCH()));
     assertEquals(prop.getProperty("compression.type"), "lz4");
   }


### PR DESCRIPTION
- Kafka properties doesn't support replication.factor when creating topic, so change the way to override intermediate stream properties. 
- Due to planner created twice, we need to check the physical stream name has been created for intermediate streams to avoid the run.id got appended twice.