### PR TITLE
SAMZA-2129: Move the offset comparison check to choose the lowest offset to SystemConsumers.

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/system/SystemAdmins.java
+++ b/samza-core/src/main/java/org/apache/samza/system/SystemAdmins.java
@@ -38,6 +38,10 @@ public class SystemAdmins {
     this.systemAdminMap = systemConfig.getSystemAdmins();
   }
 
+  public SystemAdmins(Map<String, SystemAdmin> systemAdminMap) {
+    this.systemAdminMap = systemAdminMap;
+  }
+
   /**
    * Creates a new instance of {@link SystemAdmins} with an empty admin mapping.
    * @return New empty instance of {@link SystemAdmins}

--- a/samza-core/src/main/java/org/apache/samza/system/SystemAdmins.java
+++ b/samza-core/src/main/java/org/apache/samza/system/SystemAdmins.java
@@ -38,10 +38,6 @@ public class SystemAdmins {
     this.systemAdminMap = systemConfig.getSystemAdmins();
   }
 
-  public SystemAdmins(Map<String, SystemAdmin> systemAdminMap) {
-    this.systemAdminMap = systemAdminMap;
-  }
-
   /**
    * Creates a new instance of {@link SystemAdmins} with an empty admin mapping.
    * @return New empty instance of {@link SystemAdmins}

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -464,6 +464,7 @@ object SamzaContainer extends Logging {
     val consumerMultiplexer = new SystemConsumers(
       chooser = chooser,
       consumers = consumers,
+      systemAdmins = systemAdmins,
       serdeManager = serdeManager,
       metrics = systemConsumersMetrics,
       dropDeserializationError = dropDeserializationError,

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -237,7 +237,7 @@ public class ContainerStorageManager {
           sideInputSystemConsumersMetrics.registry(), systemAdmins);
 
       sideInputSystemConsumers =
-          new SystemConsumers(chooser, ScalaJavaUtil.toScalaMap(this.sideInputConsumers), serdeManager,
+          new SystemConsumers(chooser, ScalaJavaUtil.toScalaMap(this.sideInputConsumers), systemAdmins, serdeManager,
               sideInputSystemConsumersMetrics, SystemConsumers.DEFAULT_NO_NEW_MESSAGES_TIMEOUT(), SystemConsumers.DEFAULT_DROP_SERIALIZATION_ERROR(),
               SystemConsumers.DEFAULT_POLL_INTERVAL_MS(), ScalaJavaUtil.toScalaFunction(() -> System.nanoTime()));
     }

--- a/samza-core/src/test/java/org/apache/samza/task/TestAsyncRunLoop.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestAsyncRunLoop.java
@@ -19,6 +19,7 @@
 
 package org.apache.samza.task;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -41,6 +42,8 @@ import org.apache.samza.context.JobContext;
 import org.apache.samza.job.model.TaskModel;
 import org.apache.samza.metrics.MetricsRegistryMap;
 import org.apache.samza.system.IncomingMessageEnvelope;
+import org.apache.samza.system.SystemAdmin;
+import org.apache.samza.system.SystemAdmins;
 import org.apache.samza.system.SystemConsumer;
 import org.apache.samza.system.SystemConsumers;
 import org.apache.samza.system.SystemStreamPartition;
@@ -48,6 +51,7 @@ import org.apache.samza.system.TestSystemConsumers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+import org.mockito.Mockito;
 import scala.Option;
 import scala.collection.JavaConverters;
 
@@ -638,7 +642,9 @@ public class TestAsyncRunLoop {
 
     HashMap<String, SystemConsumer> systemConsumerMap = new HashMap<>();
     systemConsumerMap.put("system1", mockConsumer);
-    SystemConsumers consumers = TestSystemConsumers.getSystemConsumers(systemConsumerMap);
+    SystemAdmins systemAdmins = new SystemAdmins(ImmutableMap.of("testSystem", Mockito.mock(SystemAdmin.class), "system1", Mockito.mock(SystemAdmin.class)));
+
+    SystemConsumers consumers = TestSystemConsumers.getSystemConsumers(systemConsumerMap, systemAdmins);
 
     TaskName taskName1 = new TaskName("task1");
     TaskName taskName2 = new TaskName("task2");

--- a/samza-core/src/test/java/org/apache/samza/task/TestAsyncRunLoop.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestAsyncRunLoop.java
@@ -19,7 +19,6 @@
 
 package org.apache.samza.task;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/samza-core/src/test/java/org/apache/samza/task/TestAsyncRunLoop.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestAsyncRunLoop.java
@@ -640,9 +640,12 @@ public class TestAsyncRunLoop {
     SystemConsumer mockConsumer = mock(SystemConsumer.class);
     when(mockConsumer.poll(anyObject(), anyLong())).thenReturn(sspMap);
 
+    SystemAdmins systemAdmins = Mockito.mock(SystemAdmins.class);
+    Mockito.when(systemAdmins.getSystemAdmin("system1")).thenReturn(Mockito.mock(SystemAdmin.class));
+    Mockito.when(systemAdmins.getSystemAdmin("testSystem")).thenReturn(Mockito.mock(SystemAdmin.class));
+
     HashMap<String, SystemConsumer> systemConsumerMap = new HashMap<>();
     systemConsumerMap.put("system1", mockConsumer);
-    SystemAdmins systemAdmins = new SystemAdmins(ImmutableMap.of("testSystem", Mockito.mock(SystemAdmin.class), "system1", Mockito.mock(SystemAdmin.class)));
 
     SystemConsumers consumers = TestSystemConsumers.getSystemConsumers(systemConsumerMap, systemAdmins);
 

--- a/samza-core/src/test/scala/org/apache/samza/processor/StreamProcessorTestUtils.scala
+++ b/samza-core/src/test/scala/org/apache/samza/processor/StreamProcessorTestUtils.scala
@@ -41,7 +41,7 @@ object StreamProcessorTestUtils {
     val adminMultiplexer = new SystemAdmins(config)
     val consumerMultiplexer = new SystemConsumers(
       new RoundRobinChooser,
-      Map[String, SystemConsumer]())
+      Map[String, SystemConsumer](), SystemAdmins.empty())
     val producerMultiplexer = new SystemProducers(
       Map[String, SystemProducer](),
       new SerdeManager)

--- a/samza-core/src/test/scala/org/apache/samza/system/TestSystemConsumers.scala
+++ b/samza-core/src/test/scala/org/apache/samza/system/TestSystemConsumers.scala
@@ -22,6 +22,7 @@ package org.apache.samza.system
 import java.util
 import java.util.Collections
 
+import com.google.common.collect.ImmutableMap
 import org.junit.Assert._
 import org.junit.Test
 import org.apache.samza.Partition
@@ -44,7 +45,9 @@ class TestSystemConsumers {
     val envelope = new IncomingMessageEnvelope(systemStreamPartition0, "1", "k", "v")
     val consumer = new CustomPollResponseSystemConsumer(envelope)
     var now = 0L
-    val consumers = new SystemConsumers(new MockMessageChooser, Map(system -> consumer),
+    val systemNameToSystemAdminMap = ImmutableMap.of(system, Mockito.mock(classOf[SystemAdmin]))
+
+    val consumers = new SystemConsumers(new MockMessageChooser, Map(system -> consumer), new SystemAdmins(systemNameToSystemAdminMap),
                                         new SerdeManager, new SystemConsumersMetrics,
                                         SystemConsumers.DEFAULT_NO_NEW_MESSAGES_TIMEOUT,
                                         SystemConsumers.DEFAULT_DROP_SERIALIZATION_ERROR,
@@ -106,7 +109,9 @@ class TestSystemConsumers {
     val envelope = new IncomingMessageEnvelope(systemStreamPartition, "1", "k", "v")
     val consumer = new CustomPollResponseSystemConsumer(envelope)
     var now = 0
-    val consumers = new SystemConsumers(new MockMessageChooser, Map(system -> consumer),
+    val systemNameToSystemAdminMap = ImmutableMap.of(system, Mockito.mock(classOf[SystemAdmin]))
+
+    val consumers = new SystemConsumers(new MockMessageChooser, Map(system -> consumer), new SystemAdmins(systemNameToSystemAdminMap),
                                         new SerdeManager, new SystemConsumersMetrics,
                                         SystemConsumers.DEFAULT_NO_NEW_MESSAGES_TIMEOUT,
                                         SystemConsumers.DEFAULT_DROP_SERIALIZATION_ERROR,
@@ -167,13 +172,15 @@ class TestSystemConsumers {
       def poll(systemStreamPartitions: java.util.Set[SystemStreamPartition], timeout: Long) = Map[SystemStreamPartition, java.util.List[IncomingMessageEnvelope]]().asJava
     })
 
+    val systemNameToSystemAdminMap = ImmutableMap.of(system, Mockito.mock(classOf[SystemAdmin]))
+
     val consumers = new SystemConsumers(new MessageChooser {
       def update(envelope: IncomingMessageEnvelope) = Unit
       def choose = null
       def start = chooserStarted += 1
       def stop = chooserStopped += 1
       def register(systemStreamPartition: SystemStreamPartition, offset: String) = chooserRegistered += systemStreamPartition -> offset
-    }, consumer, null)
+    }, consumer, new SystemAdmins(systemNameToSystemAdminMap))
 
     consumers.register(systemStreamPartition, "0", null)
     consumers.start
@@ -231,15 +238,16 @@ class TestSystemConsumers {
     val systemStreamPartition = new SystemStreamPartition(system, "some-stream", new Partition(1))
     val msgChooser = new DefaultChooser
     val consumer = Map(system -> new SerializingConsumer)
-    val systemMessageSerdes = Map(system -> (new StringSerde("UTF-8")).asInstanceOf[Serde[Object]]);
+    val systemMessageSerdes = Map(system -> (new StringSerde("UTF-8")).asInstanceOf[Serde[Object]])
     val serdeManager = new SerdeManager(systemMessageSerdes = systemMessageSerdes)
+    val systemNameToSystemAdminMap = ImmutableMap.of(system, Mockito.mock(classOf[SystemAdmin]))
 
     // throw exceptions when the deserialization has error
-    val consumers = new SystemConsumers(msgChooser, consumer, serdeManager, dropDeserializationError = false)
+    val consumers = new SystemConsumers(msgChooser, consumer, new SystemAdmins(systemNameToSystemAdminMap), serdeManager, dropDeserializationError = false)
     consumers.register(systemStreamPartition, "0", null)
-    consumer(system).putBytesMessage
-    consumer(system).putStringMessage
     consumers.start
+    consumer(system).putStringMessage
+    consumer(system).putBytesMessage
 
     var caughtRightException = false
     try {
@@ -248,16 +256,16 @@ class TestSystemConsumers {
       case e: SystemConsumersException => caughtRightException = true
       case _: Throwable => caughtRightException = false
     }
-    assertTrue("suppose to throw SystemConsumersException", caughtRightException);
+    assertTrue("suppose to throw SystemConsumersException", caughtRightException)
     consumers.stop
 
     // it should not throw exceptions when deserializaion fails if dropDeserializationError is set to true
-    val consumers2 = new SystemConsumers(msgChooser, consumer, serdeManager, dropDeserializationError = true)
+    val consumers2 = new SystemConsumers(msgChooser, consumer, new SystemAdmins(systemNameToSystemAdminMap), serdeManager, dropDeserializationError = true)
     consumers2.register(systemStreamPartition, "0", null)
+    consumers2.start
     consumer(system).putBytesMessage
     consumer(system).putStringMessage
     consumer(system).putBytesMessage
-    consumers2.start
 
     var notThrowException = true;
     try {
@@ -299,8 +307,9 @@ class TestSystemConsumers {
     val normalEnvelope = new IncomingMessageEnvelope(systemStreamPartition1, "1", "k", "v")
     val endOfStreamEnvelope = IncomingMessageEnvelope.buildEndOfStreamEnvelope(systemStreamPartition2)
     val consumer = new CustomPollResponseSystemConsumer(normalEnvelope)
+    val systemNameToSystemAdminMap = ImmutableMap.of(system, Mockito.mock(classOf[SystemAdmin]))
     val consumers = new SystemConsumers(new MockMessageChooser, Map(system -> consumer),
-      new SerdeManager, new SystemConsumersMetrics,
+      new SystemAdmins(systemNameToSystemAdminMap), new SerdeManager, new SystemConsumersMetrics,
       SystemConsumers.DEFAULT_NO_NEW_MESSAGES_TIMEOUT,
       SystemConsumers.DEFAULT_DROP_SERIALIZATION_ERROR,
       SystemConsumers.DEFAULT_POLL_INTERVAL_MS, clock = () => 0)
@@ -350,8 +359,10 @@ class TestSystemConsumers {
 
     val consumer = Mockito.mock(classOf[SystemConsumer])
     val startpoint = Mockito.mock(classOf[Startpoint])
+    val systemNameToAdminMap = ImmutableMap.of("system", Mockito.mock(classOf[SystemAdmin]))
+
     val consumers = new SystemConsumers(new MockMessageChooser, Map(system -> consumer),
-      new SerdeManager, new SystemConsumersMetrics,
+      new SystemAdmins(systemNameToAdminMap), new SerdeManager, new SystemConsumersMetrics,
       SystemConsumers.DEFAULT_NO_NEW_MESSAGES_TIMEOUT,
       SystemConsumers.DEFAULT_DROP_SERIALIZATION_ERROR,
       SystemConsumers.DEFAULT_POLL_INTERVAL_MS, clock = () => 0)
@@ -394,20 +405,28 @@ class TestSystemConsumers {
    */
   private class SerializingConsumer extends BlockingEnvelopeMap {
     val systemStreamPartition = new SystemStreamPartition("test-system", "some-stream", new Partition(1))
-    def putBytesMessage {
+    def putBytesMessage() {
       put(systemStreamPartition, new IncomingMessageEnvelope(systemStreamPartition, "0", "0", "test".getBytes()))
     }
-    def putStringMessage {
+    def putStringMessage() {
       put(systemStreamPartition, new IncomingMessageEnvelope(systemStreamPartition, "0", "1", "test"))
     }
-    def start {}
-    def stop {}
-    def register { super.register(systemStreamPartition, "0") }
+    def start() {}
+    def stop() {}
+
+    override def register(systemStreamPartition: SystemStreamPartition, offset: String): Unit = {
+       super[BlockingEnvelopeMap].register(systemStreamPartition, offset)
+    }
+
+    override def register(systemStreamPartition: SystemStreamPartition, startpoint: Startpoint): Unit = {
+      super[BlockingEnvelopeMap].register(systemStreamPartition, startpoint)
+    }
+
   }
 }
 
 object TestSystemConsumers {
-  def getSystemConsumers(consumers: java.util.Map[String, SystemConsumer]) : SystemConsumers = {
-    new SystemConsumers(new DefaultChooser, consumers.asScala.toMap)
+  def getSystemConsumers(consumers: java.util.Map[String, SystemConsumer], systemAdmins: SystemAdmins = SystemAdmins.empty()) : SystemConsumers = {
+    new SystemConsumers(new DefaultChooser, consumers.asScala.toMap, systemAdmins)
   }
 }

--- a/samza-core/src/test/scala/org/apache/samza/system/TestSystemConsumers.scala
+++ b/samza-core/src/test/scala/org/apache/samza/system/TestSystemConsumers.scala
@@ -22,7 +22,6 @@ package org.apache.samza.system
 import java.util
 import java.util.Collections
 
-import com.google.common.collect.ImmutableMap
 import org.junit.Assert._
 import org.junit.Test
 import org.apache.samza.Partition


### PR DESCRIPTION
This patch is comprised of the following changes:

* Moves the offset comparison check to SystemConsumers
 
     * Currently the offset comparator check to find a lowest for a `SystemStreamPartition` is duplicated in some implementations of  SystemConsumer API.
     * Some `SystemConsumer` implementations do not perform this offset comparator check
in the implementation of register method.
     * Moving this one level up from `SystemConsumer.register(SystemStreamPartition, offset)` API implementation to  `SystemConsumers.register(SystemStreamPartition, offset)` API implementation removes unnecessary duplication and ensures functional correctness.

* Fixes to the test-cases in `TestSystemConsumer`.

There should be no functional breakages introduced by moving the offset-comparator check to `SystemConsumers` layer. Here's why. Metadata and I/O topics currently use SystemConsumer API to read data. 
* Checkpoint topic: This is a stream with one partition and is log-compacted. Samza-container reads from the beginning of this stream. There's no offset comparisons required for this topic.
* ChangeLog topic: To read change-log topic-partition, SamzaContainer uses `StorageManagerUtil.getStartingOffset` to read from the change-log topic and the offset comparator check to choose the lowest offset is currently performed within it.
* Coordinator topic: This is a stream with one partition and is log-compacted. SamzaContainer/ApplicationMaster is currently reads from the beginning of this stream to get the entire state.
*  I/O topics: `SamzaContainer` currently reads  data from input and output topics through `SystemConsumers` API. Moving this offset comparator check should not affect the existing functionality.