### PR TITLE
SAMZA-2132: Flatten startpoint key when serialized.

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/startpoint/StartpointKey.java
+++ b/samza-core/src/main/java/org/apache/samza/startpoint/StartpointKey.java
@@ -22,11 +22,11 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import org.apache.samza.container.TaskName;
 import org.apache.samza.system.SystemStreamPartition;
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
 
 
-final class StartpointKey {
+@JsonSerialize(using = StartpointKeySerializer.class)
+class StartpointKey {
   private final SystemStreamPartition systemStreamPartition;
   private final TaskName taskName;
 
@@ -41,29 +41,12 @@ final class StartpointKey {
     this.taskName = taskName;
   }
 
-  @JsonIgnore
   SystemStreamPartition getSystemStreamPartition() {
     return systemStreamPartition;
   }
 
-  @JsonProperty("system")
-  String getSystem() {
-    return systemStreamPartition.getSystem();
-  }
-
-  @JsonProperty("stream")
-  String getStream() {
-    return systemStreamPartition.getStream();
-  }
-
-  @JsonProperty("partition")
-  Integer getPartition() {
-    return systemStreamPartition.getPartition().getPartitionId();
-  }
-
-  @JsonProperty("taskName")
-  String getTaskName() {
-    return taskName != null ? taskName.getTaskName() : null;
+  TaskName getTaskName() {
+    return taskName;
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/startpoint/StartpointKey.java
+++ b/samza-core/src/main/java/org/apache/samza/startpoint/StartpointKey.java
@@ -22,11 +22,11 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import org.apache.samza.container.TaskName;
 import org.apache.samza.system.SystemStreamPartition;
-import org.codehaus.jackson.annotate.JsonAutoDetect;
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.annotate.JsonProperty;
 
 
-@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-class StartpointKey {
+final class StartpointKey {
   private final SystemStreamPartition systemStreamPartition;
   private final TaskName taskName;
 
@@ -41,12 +41,29 @@ class StartpointKey {
     this.taskName = taskName;
   }
 
+  @JsonIgnore
   SystemStreamPartition getSystemStreamPartition() {
     return systemStreamPartition;
   }
 
-  TaskName getTaskName() {
-    return taskName;
+  @JsonProperty("system")
+  String getSystem() {
+    return systemStreamPartition.getSystem();
+  }
+
+  @JsonProperty("stream")
+  String getStream() {
+    return systemStreamPartition.getStream();
+  }
+
+  @JsonProperty("partition")
+  Integer getPartition() {
+    return systemStreamPartition.getPartition().getPartitionId();
+  }
+
+  @JsonProperty("taskName")
+  String getTaskName() {
+    return taskName != null ? taskName.getTaskName() : null;
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/startpoint/StartpointKeySerializer.java
+++ b/samza-core/src/main/java/org/apache/samza/startpoint/StartpointKeySerializer.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *//*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *//*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.startpoint;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.samza.container.TaskName;
+import org.apache.samza.system.SystemStreamPartition;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.map.JsonSerializer;
+import org.codehaus.jackson.map.SerializerProvider;
+
+
+final class StartpointKeySerializer extends JsonSerializer<StartpointKey> {
+  @Override
+  public void serialize(StartpointKey startpointKey, JsonGenerator jsonGenerator, SerializerProvider provider) throws
+                                                                                                               IOException {
+    Map<String, Object> systemStreamPartitionMap = new HashMap<>();
+    SystemStreamPartition systemStreamPartition = startpointKey.getSystemStreamPartition();
+    TaskName taskName = startpointKey.getTaskName();
+    systemStreamPartitionMap.put("system", systemStreamPartition.getSystem());
+    systemStreamPartitionMap.put("stream", systemStreamPartition.getStream());
+    systemStreamPartitionMap.put("partition", systemStreamPartition.getPartition().getPartitionId());
+    if (taskName != null) {
+      systemStreamPartitionMap.put("taskName", taskName.getTaskName());
+    }
+    jsonGenerator.writeObject(systemStreamPartitionMap);
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/startpoint/TestStartpointKey.java
+++ b/samza-core/src/test/java/org/apache/samza/startpoint/TestStartpointKey.java
@@ -18,15 +18,19 @@
  */
 package org.apache.samza.startpoint;
 
+import java.io.IOException;
+import java.util.LinkedHashMap;
 import org.apache.samza.Partition;
 import org.apache.samza.container.TaskName;
 import org.apache.samza.serializers.JsonSerdeV2;
 import org.apache.samza.system.SystemStreamPartition;
+import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
 
 
 public class TestStartpointKey {
+
   @Test
   public void testStartpointKey() {
     SystemStreamPartition ssp1 = new SystemStreamPartition("system", "stream", new Partition(2));
@@ -60,5 +64,20 @@ public class TestStartpointKey {
     Assert.assertNotEquals(startpointKeyWithTask1, startpointKeyWithDifferentTask);
     Assert.assertNotEquals(new String(new JsonSerdeV2<>().toBytes(startpointKeyWithTask1)),
         new String(new JsonSerdeV2<>().toBytes(startpointKeyWithDifferentTask)));
+  }
+
+  @Test
+  public void testStartpointKeyFormat() throws IOException {
+    SystemStreamPartition ssp = new SystemStreamPartition("system1", "stream1", new Partition(2));
+    StartpointKey startpointKeyWithTask = new StartpointKey(ssp, new TaskName("t1"));
+    ObjectMapper objectMapper = new ObjectMapper();
+    byte[] jsonBytes = new JsonSerdeV2<>().toBytes(startpointKeyWithTask);
+    LinkedHashMap<String, String> deserialized = objectMapper.readValue(jsonBytes, LinkedHashMap.class);
+
+    Assert.assertEquals(4, deserialized.size());
+    Assert.assertEquals("system1", deserialized.get("system"));
+    Assert.assertEquals("stream1", deserialized.get("stream"));
+    Assert.assertEquals(2, deserialized.get("partition"));
+    Assert.assertEquals("t1", deserialized.get("taskName"));
   }
 }


### PR DESCRIPTION
StartpointKey has unnecessary redundancies when serialized. Example: 
```
"{\"systemStreamPartition\":{\"system\":\"test\",\"stream\":\"test\",\"partition\":{\"partitionId\":2},\"systemStream\":{\"system\":\"test\",\"stream\":\"test\"}},\"taskName\":{\"taskName\":\"Partition 2\"}}"
```
The serialized key should should be flattened to 4 elements: system, stream, partition ID and taskName.

@shanthoosh please take a look.