### PR TITLE
SAMZA-2134:Enable table rate limiter by default.

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
+++ b/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
@@ -188,9 +188,9 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
    *
    * @return this table descriptor instance.
    */
-  public RemoteTableDescriptor<K, V> withDisableRateLimiter() {
-    withDisableReadRateLimiter();
-    withDisableWriteRateLimiter();
+  public RemoteTableDescriptor<K, V> withRateLimiterDisabled() {
+    withReadRateLimiterDisabled();
+    withWriteRateLimiterDisabled();
     return this;
   }
 
@@ -199,7 +199,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
    *
    * @return this table descriptor instance.
    */
-  public RemoteTableDescriptor<K, V> withDisableReadRateLimiter() {
+  public RemoteTableDescriptor<K, V> withReadRateLimiterDisabled() {
     this.enableReadRateLimiter = false;
     return this;
   }
@@ -209,7 +209,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
    *
    * @return this table descriptor instance.
    */
-  public RemoteTableDescriptor<K, V> withDisableWriteRateLimiter() {
+  public RemoteTableDescriptor<K, V> withWriteRateLimiterDisabled() {
     this.enableWriteRateLimiter = false;
     return this;
   }

--- a/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
@@ -82,10 +82,10 @@ public class TestRemoteTableDescriptor {
     if (rateLimiter != null) {
       desc.withRateLimiter(rateLimiter, readCredFn, writeCredFn);
       if (readCredFn == null) {
-        desc.withDisableReadRateLimiter();
+        desc.withReadRateLimiterDisabled();
       }
       if (writeCredFn == null) {
-        desc.withDisableWriteRateLimiter();
+        desc.withWriteRateLimiterDisabled();
       }
     } else {
       desc.withReadRateLimit(100);
@@ -129,7 +129,7 @@ public class TestRemoteTableDescriptor {
     String tableId = "1";
     RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId)
         .withReadFunction(createMockTableReadFunction())
-        .withDisableRateLimiter();
+        .withRateLimiterDisabled();
     Map<String, String> tableConfig = desc.toConfig(new MapConfig());
     assertExists(RemoteTableDescriptor.READ_FN, tableId, tableConfig);
     assertEquals(null, RemoteTableDescriptor.WRITE_FN, tableId, tableConfig);
@@ -267,12 +267,12 @@ public class TestRemoteTableDescriptor {
       if (rlGets) {
         desc.withReadRateLimit(1000);
       } else {
-        desc.withDisableReadRateLimiter();
+        desc.withReadRateLimiterDisabled();
       }
       if (rlPuts) {
         desc.withWriteRateLimit(2000);
       } else {
-        desc.withDisableWriteRateLimiter();
+        desc.withWriteRateLimiterDisabled();
       }
     } else {
       if (numRateLimitOps > 0) {
@@ -280,19 +280,19 @@ public class TestRemoteTableDescriptor {
         if (rlGets) {
           tagCredits.put(RemoteTableDescriptor.RL_READ_TAG, 1000);
         } else {
-          desc.withDisableReadRateLimiter();
+          desc.withReadRateLimiterDisabled();
         }
         if (rlPuts) {
           tagCredits.put(RemoteTableDescriptor.RL_WRITE_TAG, 2000);
         } else {
-          desc.withDisableWriteRateLimiter();
+          desc.withWriteRateLimiterDisabled();
         }
 
         // Spy the rate limiter to verify call count
         RateLimiter rateLimiter = spy(new EmbeddedTaggedRateLimiter(tagCredits));
         desc.withRateLimiter(rateLimiter, new CountingCreditFunction(), new CountingCreditFunction());
       } else {
-        desc.withDisableRateLimiter();
+        desc.withRateLimiterDisabled();
       }
     }
 

--- a/samza-sql/src/test/java/org/apache/samza/sql/util/RemoteStoreIOResolverTestFactory.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/util/RemoteStoreIOResolverTestFactory.java
@@ -112,10 +112,12 @@ public class RemoteStoreIOResolverTestFactory implements SqlIOResolverFactory {
           if (isSink) {
             tableDescriptor = new RemoteTableDescriptor<>(TEST_TABLE_ID + "-" + ioName.replace(".", "-").replace("$", "-"))
                 .withReadFunction(new InMemoryReadFunction())
-                .withWriteFunction(new InMemoryWriteFunction());
+                .withWriteFunction(new InMemoryWriteFunction())
+                .withDisableRateLimiter();
           } else if (sourceComponents[systemIdx].equals(TEST_REMOTE_STORE_SYSTEM)) {
             tableDescriptor = new RemoteTableDescriptor<>(TEST_TABLE_ID + "-" + ioName.replace(".", "-").replace("$", "-"))
-                .withReadFunction(new InMemoryReadFunction());
+                .withReadFunction(new InMemoryReadFunction())
+                .withDisableRateLimiter();
           } else {
             // A local table
             String tableId = changeLogStorePrefix + "InputTable-" + ioName.replace(".", "-").replace("$", "-");

--- a/samza-sql/src/test/java/org/apache/samza/sql/util/RemoteStoreIOResolverTestFactory.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/util/RemoteStoreIOResolverTestFactory.java
@@ -113,11 +113,11 @@ public class RemoteStoreIOResolverTestFactory implements SqlIOResolverFactory {
             tableDescriptor = new RemoteTableDescriptor<>(TEST_TABLE_ID + "-" + ioName.replace(".", "-").replace("$", "-"))
                 .withReadFunction(new InMemoryReadFunction())
                 .withWriteFunction(new InMemoryWriteFunction())
-                .withDisableRateLimiter();
+                .withRateLimiterDisabled();
           } else if (sourceComponents[systemIdx].equals(TEST_REMOTE_STORE_SYSTEM)) {
             tableDescriptor = new RemoteTableDescriptor<>(TEST_TABLE_ID + "-" + ioName.replace(".", "-").replace("$", "-"))
                 .withReadFunction(new InMemoryReadFunction())
-                .withDisableRateLimiter();
+                .withRateLimiterDisabled();
           } else {
             // A local table
             String tableId = changeLogStorePrefix + "InputTable-" + ioName.replace(".", "-").replace("$", "-");

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableEndToEnd.java
@@ -191,11 +191,12 @@ public class TestRemoteTableEndToEnd extends AbstractIntegrationTestHarness {
 
     final RateLimiter readRateLimiter = mock(RateLimiter.class, withSettings().serializable());
     final RateLimiter writeRateLimiter = mock(RateLimiter.class, withSettings().serializable());
+    final TableRateLimiter.CreditFunction creditFunction = (k, v)->1;
     final StreamApplication app = appDesc -> {
       RemoteTableDescriptor<Integer, TestTableData.Profile> inputTableDesc = new RemoteTableDescriptor<>("profile-table-1");
       inputTableDesc
           .withReadFunction(InMemoryReadFunction.getInMemoryReadFunction(profiles))
-          .withRateLimiter(readRateLimiter, null, null);
+          .withRateLimiter(readRateLimiter, creditFunction, null);
 
       // dummy reader
       TableReadFunction readFn = new MyReadFunction();
@@ -204,7 +205,7 @@ public class TestRemoteTableEndToEnd extends AbstractIntegrationTestHarness {
       outputTableDesc
           .withReadFunction(readFn)
           .withWriteFunction(writer)
-          .withRateLimiter(writeRateLimiter, null, null);
+          .withRateLimiter(writeRateLimiter, creditFunction, creditFunction);
 
       Table<KV<Integer, EnrichedPageView>> outputTable = withCache
           ? getCachingTable(outputTableDesc, defaultCache, "output", appDesc)


### PR DESCRIPTION
By default rate limiter will be enabled. The user need to provide a rate limiter for the
table descriptor or disable read/write rate limiter explicitly.