### PR TITLE
SAMZA-2138: Incorrect logging when task to container mapping is written.

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/coordinator/JobModelManager.scala
+++ b/samza-core/src/main/scala/org/apache/samza/coordinator/JobModelManager.scala
@@ -232,7 +232,7 @@ object JobModelManager extends Logging {
 
     for (container <- jobModel.getContainers.values()) {
       for ((taskName, taskModel) <- container.getTasks) {
-        info ("Storing ssp: %s and task: %s into metadata store" format(taskName.getTaskName, container.getId))
+        info ("Storing task: %s and container ID: %s into metadata store" format(taskName.getTaskName, container.getId))
         taskAssignmentManager.writeTaskContainerMapping(taskName.getTaskName, container.getId, container.getTasks.get(taskName).getTaskMode)
         for (partition <- taskModel.getSystemStreamPartitions) {
           if (!sspToTaskNameMap.containsKey(partition)) {


### PR DESCRIPTION
Example before this fix:
```
2019-03-21 08:36:34.810 [main] JobModelManager$ [INFO] Storing ssp: Partition 1 and task: 0 into metadata store
```