### PR TITLE
SAMZA-2143: Fix NPE in `CoordinatorStreamMessage#equals` and some clean-up to CoordinatorStreamSystemConsumer

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/coordinator/stream/CoordinatorStreamSystemConsumer.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/stream/CoordinatorStreamSystemConsumer.java
@@ -202,13 +202,11 @@ public class CoordinatorStreamSystemConsumer {
     }
   }
 
-  public Set<CoordinatorStreamMessage> getBoostrappedStream() {
-    log.info("Returning the bootstrapped data from the stream");
-    if (!isBootstrapped)
-      bootstrap();
-    return bootstrappedStreamSet;
-  }
-
+  /**
+   * Returns the set of bootstrapped {@link CoordinatorStreamMessage}s
+   * @param type The type of {@link CoordinatorStreamMessage}s to return.
+   * @return The bootstrapped {@link CoordinatorStreamMessage}s
+   */
   public Set<CoordinatorStreamMessage> getBootstrappedStream(String type) {
     log.debug("Bootstrapping coordinator stream for messages of type {}", type);
     bootstrap();

--- a/samza-core/src/main/java/org/apache/samza/coordinator/stream/messages/CoordinatorStreamMessage.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/stream/messages/CoordinatorStreamMessage.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * </p>
  *
  * <pre>
- * key =&gt; [1, "set-config", "job.name"] 
+ * key =&gt; [1, "set-config", "job.name"]
  *
  * message =&gt; {
  *   "host": "192.168.0.1",
@@ -312,6 +312,8 @@ public class CoordinatorStreamMessage {
     if (messageMap == null) {
       if (other.messageMap != null)
         return false;
+    } else if (getMessageValues() == null) {
+      return other.getMessageValues() == null;
     } else if (!getMessageValues().equals(other.getMessageValues()))
       return false;
     return true;

--- a/samza-core/src/test/java/org/apache/samza/coordinator/stream/TestCoordinatorStreamMessage.java
+++ b/samza-core/src/test/java/org/apache/samza/coordinator/stream/TestCoordinatorStreamMessage.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
+import java.util.HashMap;
 import org.apache.samza.coordinator.stream.messages.CoordinatorStreamMessage;
 import org.apache.samza.coordinator.stream.messages.Delete;
 import org.apache.samza.coordinator.stream.messages.SetConfig;
@@ -79,5 +80,19 @@ public class TestCoordinatorStreamMessage {
     assertEquals(message.hashCode(), message1.hashCode());
     assertEquals(message, message1);
     assertTrue(!message.equals(message2));
+  }
+
+  @Test
+  public void testEqualsNPEonNullValues() {
+    String[] testKeys = {"key1", "key2"};
+    HashMap<String, Object> messageMap = new HashMap<>();
+    messageMap.put("values", new HashMap<String, String>());
+    HashMap<String, Object> messageMapWithNullValues = new HashMap<>();
+    messageMapWithNullValues.put("values", null);
+    CoordinatorStreamMessage message = new CoordinatorStreamMessage(testKeys, messageMap);
+    CoordinatorStreamMessage messageWithNullValue = new CoordinatorStreamMessage(testKeys, messageMapWithNullValues);
+
+    assertFalse("Should not throw NPE and should not be equal to each other.",
+        messageWithNullValue.equals(message));
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/coordinator/stream/TestCoordinatorStreamSystemConsumer.java
+++ b/samza-core/src/test/java/org/apache/samza/coordinator/stream/TestCoordinatorStreamSystemConsumer.java
@@ -120,7 +120,7 @@ public class TestCoordinatorStreamSystemConsumer {
 
     consumer.bootstrap();
 
-    Set<CoordinatorStreamMessage> bootstrappedMessages = consumer.getBoostrappedStream();
+    Set<CoordinatorStreamMessage> bootstrappedMessages = consumer.getBootstrappedStream(SetConfig.TYPE);
 
     assertEquals(2, bootstrappedMessages.size()); // First message should have been removed as a duplicate
     CoordinatorStreamMessage[] coordinatorStreamMessages = bootstrappedMessages.toArray(new CoordinatorStreamMessage[2]);


### PR DESCRIPTION
1) NPE exposed in `CoordinatorStreamMessage#equals` now that the metadata store allows arbitrary messages to be stored in the coordinator stream. See [SAMZA-2143](https://issues.apache.org/jira/browse/SAMZA-2143) for example NPE stack trace.

2) In `CoordinatorStreamSystemConsumer`, remove unused `getBootstrappedStream` overloaded method and unit test the appropriate method that is actually used in non-test code.

@shanthoosh - please take a look when you get a chance.