### PR TITLE
SAMZA-2144: In TaskInstance, bypass "SSP caught-up" check if offset is set by a startpoint

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
@@ -334,7 +334,8 @@ class TaskInstance(
         // Mark ssp to be caught up if the starting offset is already the
         // upcoming offset, meaning the task has consumed all the messages
         // in this partition before and waiting for the future incoming messages.
-        if(Objects.equals(upcomingOffset, startingOffset)) {
+        // Also mark ssp as caught up if starting offset is defined by a startpoint.
+        if (Objects.equals(upcomingOffset, startingOffset) || offsetManager.getStartpoint(taskName, ssp).isDefined) {
           ssp2CaughtupMapping(ssp) = true
         }
       })


### PR DESCRIPTION
TaskInstance maintains a "SSP caught-up map" to ensure that all tasks for the same SSP have caught up to he same checkpoint offset before processing any messages. However, this does not apply to startpoints since it expects to begin processing messages starting from the startpoint's offset position.

@shanthoosh please take a look.