### PR TITLE
DOCS: Fix release tab

### DIFF
--- a/docs/_menu/index.html
+++ b/docs/_menu/index.html
@@ -12,6 +12,8 @@ items:
     items_attributes: 'data-documentation="/learn/documentation/version/"'
   - menu_title: Releases
     items:
+      - menu_title: 1.1.0
+        url: '/releases/1.1.0'
       - menu_title: 1.0.0
         url: '/releases/1.0.0'
       - menu_title: 0.14

--- a/docs/_releases/1.1.0.md
+++ b/docs/_releases/1.1.0.md
@@ -1,12 +1,9 @@
 ---
-layout: blog
-title: Announcing the release of Apache Samza 1.1.0
-icon: git-pull-request
-authors:
-    - name: Shanthoosh Venkataraman
-      website:
-      image:
-excerpt_separator: <!--more-->
+version: '1.1'
+order: 11
+layout: page
+menu_title: '1.1'
+title: Apache Samza 1.1 <a href="/learn/documentation/1.1.0/">      [Docs] </a> 
 ---
 <!--
    Licensed to the Apache Software Foundation (ASF) under one or more
@@ -24,10 +21,6 @@ excerpt_separator: <!--more-->
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-# **Announcing the release of Apache Samza 1.1.0**
-
-
-<!--more-->
 
 
 We’re thrilled to announce to the release of Apache Samza 1.1.0.


### PR DESCRIPTION
@jmakes @jagadish-v0 @shanthoosh 

Added 1.1.0 version to release tab.

![image](https://user-images.githubusercontent.com/29577458/55036760-cf3e2f00-4fd8-11e9-88a0-a6728e354626.png)
