### PR TITLE
SAMZA-2110 : Support for deleting records from a table

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/sql/SamzaSqlRelRecord.java
+++ b/samza-api/src/main/java/org/apache/samza/sql/SamzaSqlRelRecord.java
@@ -120,4 +120,8 @@ public class SamzaSqlRelRecord implements Serializable {
     String valueStr = Joiner.on(",").useForNull("null").join(fieldValues);
     return "[Names:{" + nameStr + "} Values:{" + valueStr + "}]";
   }
+
+  public boolean containsField(String name) {
+    return fieldNames.indexOf(name) != -1;
+  }
 }

--- a/samza-api/src/main/java/org/apache/samza/sql/schema/SqlSchema.java
+++ b/samza-api/src/main/java/org/apache/samza/sql/schema/SqlSchema.java
@@ -84,6 +84,10 @@ public class SqlSchema {
         .collect(Collectors.toList());
   }
 
+  public boolean containsField(String keyName) {
+    return fields.stream().anyMatch(x -> x.getFieldName().equals(keyName));
+  }
+
   public List<SqlField> getFields() {
     return fields;
   }

--- a/samza-sql/src/main/java/org/apache/samza/sql/data/SamzaSqlRelMessage.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/data/SamzaSqlRelMessage.java
@@ -38,6 +38,10 @@ public class SamzaSqlRelMessage implements Serializable {
 
   public static final String KEY_NAME = "__key__";
 
+  public static final String OP_NAME = "__op__";
+
+  public static final String DELETE_OP = "DELETE";
+
   // key could be a record in itself.
   private final Object key;
 

--- a/samza-sql/src/main/java/org/apache/samza/sql/planner/RelSchemaConverter.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/planner/RelSchemaConverter.java
@@ -61,7 +61,7 @@ public class RelSchemaConverter extends SqlTypeFactoryImpl {
 
     for (SqlSchema.SqlField field : fields) {
       String fieldName = field.getFieldName();
-      int fieldPos = field.getPosition() + 1;
+      int fieldPos = field.getPosition();
       RelDataType dataType = getRelDataType(field.getFieldSchema());
       relFields.add(new RelDataTypeFieldImpl(fieldName, fieldPos, dataType));
     }

--- a/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlRemoteTable.java
+++ b/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlRemoteTable.java
@@ -32,7 +32,6 @@ import org.apache.samza.sql.util.JsonUtil;
 import org.apache.samza.sql.util.SamzaSqlTestConfig;
 import org.apache.samza.sql.util.RemoteStoreIOResolverTestFactory;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 
@@ -53,8 +52,6 @@ public class TestSamzaSqlRemoteTable extends SamzaSqlIntegrationTestHarness {
     Assert.assertEquals(numMessages, RemoteStoreIOResolverTestFactory.records.size());
   }
 
-  // SAMZA-2110 We need to enable this when we have a true support for Null records
-  @Ignore
   @Test
   public void testSinkEndToEndWithKeyWithNullRecords() {
     int numMessages = 20;
@@ -65,8 +62,10 @@ public class TestSamzaSqlRemoteTable extends SamzaSqlIntegrationTestHarness {
     Map<String, String> staticConfigs =
         SamzaSqlTestConfig.fetchStaticConfigsWithFactories(props, numMessages, false, true);
 
-    String sql = "Insert into testRemoteStore.testTable.`$table` select __key__, id, name from testavro.SIMPLE1";
-    List<String> sqlStmts = Arrays.asList(sql);
+    String sql1 = "Insert into testRemoteStore.testTable.`$table` select __key__, id, name from testavro.SIMPLE1";
+    String sql2 = "Insert into testRemoteStore.testTable.`$table` select __key__, 'DELETE' as __op__ from testavro.SIMPLE1 WHERE name IS NULL";
+
+    List<String> sqlStmts = Arrays.asList(sql1, sql2);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));
 
@@ -215,8 +214,6 @@ public class TestSamzaSqlRemoteTable extends SamzaSqlIntegrationTestHarness {
     Assert.assertEquals(expectedOutMessages, outMessages);
   }
 
-  // SAMZA-2110 We need to enable this when we have a true support for null records.
-  @Ignore
   @Test
   public void testSameJoinTargetSinkEndToEndRightOuterJoin() {
     int numMessages = 21;
@@ -233,7 +230,7 @@ public class TestSamzaSqlRemoteTable extends SamzaSqlIntegrationTestHarness {
     // redundant here, keeping it just for testing purpose.
     String sql =
         "Insert into testRemoteStore.Profile.`$table` "
-            + "select p.__key__ as __key__ "
+            + "select p.__key__ as __key__, 'DELETE' as __op__ "
             + "from testRemoteStore.Profile.`$table` as p "
             + "join testavro.PAGEVIEW as pv "
             + " on p.__key__ = pv.profileId ";


### PR DESCRIPTION
1. Commit adds support for deleting records from table by adding a special __op__ field. SQL users can use this field to say whether the row needs to be deleted in the output table. This is a stop mechanism till we support DELETE operation in SQL. 
2. Adds support for pluggable RelProviders to add the special fields __key__. This is useful if the relProvider knows the type of __key__ and wants to set it explicitly.
3. Removes the hack where field positions are incremented by 1 in RelSchemaConverter to support the special field __key__. With this change the knowledge of the special fields exists only in queryTranslator. In future we could consider moving this logic to RelSchemaProvider.   