### PR TITLE
SAMZA-2153: Implement to Config for TableRetryPolicy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,6 +144,7 @@ project(':samza-api') {
     compile "org.apache.commons:commons-lang3:$commonsLang3Version"
     compile "org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion"
     compile "com.google.guava:guava:$guavaVersion"
+    compile "com.google.code.gson:gson:$gsonVersion"
     compile "org.slf4j:slf4j-api:$slf4jVersion"
     compile "io.dropwizard.metrics:metrics-core:3.1.2"
     testCompile "junit:junit:$junitVersion"

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -26,6 +26,7 @@
   commonsHttpClientVersion = "3.1"
   commonsLang3Version = "3.4"
   elasticsearchVersion = "2.2.0"
+  gsonVersion = "2.8.5"
   guavaVersion = "23.0"
   hamcrestVersion = "1.3"
   httpClientVersion = "4.4.1"

--- a/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
+++ b/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
@@ -112,6 +112,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
   public RemoteTableDescriptor<K, V> withReadFunction(TableReadFunction<K, V> readFn) {
     Preconditions.checkNotNull(readFn, "null read function");
     this.readFn = readFn;
+    this.readFn.setTableId(String.format("%s.%s", tableId, READ_FN));
     return this;
   }
 
@@ -123,6 +124,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
   public RemoteTableDescriptor<K, V> withWriteFunction(TableWriteFunction<K, V> writeFn) {
     Preconditions.checkNotNull(writeFn, "null write function");
     this.writeFn = writeFn;
+    this.writeFn.setTableId(String.format("%s.%s", tableId, WRITE_FN));
     return this;
   }
 
@@ -135,6 +137,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
     Preconditions.checkNotNull(readFn, "null read function");
     Preconditions.checkNotNull(retryPolicy, "null retry policy");
     this.readRetryPolicy = retryPolicy;
+    this.readRetryPolicy.setTableId(String.format("%s.%s", tableId, READ_RETRY_POLICY));
     return this;
   }
 
@@ -147,6 +150,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
     Preconditions.checkNotNull(writeFn, "null write function");
     Preconditions.checkNotNull(retryPolicy, "null retry policy");
     this.writeRetryPolicy = retryPolicy;
+    this.writeRetryPolicy.setTableId(String.format("%s.%s", tableId, WRITE_RETRY_POLICY));
     return this;
   }
 
@@ -170,6 +174,12 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
     this.rateLimiter = rateLimiter;
     this.readCreditFn = readCreditFn;
     this.writeCreditFn = writeCreditFn;
+    if (this.readCreditFn != null) {
+      this.readCreditFn.setTableId(String.format("%s.%s", tableId, READ_CREDIT_FN));
+    }
+    if (this.writeCreditFn != null) {
+      this.writeCreditFn.setTableId(String.format("%s.%s", tableId, WRITE_CREDIT_FN));
+    }
     return this;
   }
 

--- a/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
+++ b/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
@@ -165,7 +165,8 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
    * @return this table descriptor instance
    */
   public RemoteTableDescriptor<K, V> withRateLimiter(RateLimiter rateLimiter,
-      TableRateLimiter.CreditFunction<K, V> readCreditFn, TableRateLimiter.CreditFunction<K, V> writeCreditFn) {
+      TableRateLimiter.CreditFunction<K, V> readCreditFn,
+      TableRateLimiter.CreditFunction<K, V> writeCreditFn) {
     Preconditions.checkNotNull(rateLimiter, "null read rate limiter");
     this.rateLimiter = rateLimiter;
     this.readCreditFn = readCreditFn;
@@ -232,8 +233,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
       RateLimiter defaultRateLimiter;
       try {
         @SuppressWarnings("unchecked")
-        Class<? extends RateLimiter> clazz =
-            (Class<? extends RateLimiter>) Class.forName(DEFAULT_RATE_LIMITER_CLASS_NAME);
+        Class<? extends RateLimiter> clazz = (Class<? extends RateLimiter>) Class.forName(DEFAULT_RATE_LIMITER_CLASS_NAME);
         Constructor<? extends RateLimiter> ctor = clazz.getConstructor(Map.class);
         defaultRateLimiter = ctor.newInstance(tagCreditsMap);
       } catch (Exception ex) {
@@ -295,20 +295,20 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
     Preconditions.checkArgument(rateLimiter == null || tagCreditsMap.isEmpty(),
         "Only one of rateLimiter instance or read/write limits can be specified");
     // Assume callback executor pool should have no more than 20 threads
-    Preconditions.checkArgument(asyncCallbackPoolSize <= 20, "too many threads for async callback executor.");
+    Preconditions.checkArgument(asyncCallbackPoolSize <= 20,
+        "too many threads for async callback executor.");
   }
 
   /**
    * Helper method to add table part config items to table configuration
+   * @param tablePartKey key of the table part
    * @param tablePart table part
    * @param jobConfig job configuration
    * @param tableConfig table configuration
    */
   protected void addTablePartConfig(String tablePartKey, TablePart tablePart, Config jobConfig,
       Map<String, String> tableConfig) {
-    Map<String, String> tablePartConfig = tablePart.toConfig(jobConfig, new MapConfig(tableConfig));
-    for (String configKey : tablePartConfig.keySet()) {
-      addTableConfig(String.format("%s.%s", tablePartKey, configKey), tablePartConfig.get(configKey), tableConfig);
-    }
+    tablePart.toConfig(jobConfig, new MapConfig(tableConfig))
+        .forEach((k, v) -> addTableConfig(String.format("%s.%s", tablePartKey, k), v, tableConfig));
   }
 }

--- a/samza-api/src/main/java/org/apache/samza/table/remote/TablePart.java
+++ b/samza-api/src/main/java/org/apache/samza/table/remote/TablePart.java
@@ -43,19 +43,4 @@ public interface TablePart {
   default Map<String, String> toConfig(Config jobConfig, Config tableConfig) {
     return Collections.emptyMap();
   }
-
-  /**
-   * Set tableId for this table part. This method can be called by sub-classes of
-   * {@link org.apache.samza.table.descriptors.BaseTableDescriptor}, where tableId is available.
-   * @param tableId table id
-   */
-  default void setTableId(String tableId) {
-  }
-
-  /**
-   * Return the tableId that has been set. Return empty string by default.
-   */
-  default String getTableId() {
-    return "";
-  }
 }

--- a/samza-api/src/main/java/org/apache/samza/table/remote/TablePart.java
+++ b/samza-api/src/main/java/org/apache/samza/table/remote/TablePart.java
@@ -44,4 +44,18 @@ public interface TablePart {
     return Collections.emptyMap();
   }
 
+  /**
+   * Set tableId for this table part. This method can be called by sub-classes of
+   * {@link org.apache.samza.table.descriptors.BaseTableDescriptor}, where tableId is available.
+   * @param tableId table id
+   */
+  default void setTableId(String tableId) {
+  }
+
+  /**
+   * Return the tableId that has been set. Return empty string by default.
+   */
+  default String getTableId() {
+    return "";
+  }
 }

--- a/samza-api/src/main/java/org/apache/samza/table/retry/TableRetryPolicy.java
+++ b/samza-api/src/main/java/org/apache/samza/table/retry/TableRetryPolicy.java
@@ -19,10 +19,7 @@
 
 package org.apache.samza.table.retry;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import java.io.Serializable;
-import java.lang.reflect.Modifier;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
@@ -31,6 +28,7 @@ import java.util.function.Predicate;
 import com.google.common.base.Preconditions;
 import org.apache.samza.config.Config;
 import org.apache.samza.table.remote.TablePart;
+import org.apache.samza.table.utils.SerdeUtils;
 
 
 /**
@@ -268,7 +266,6 @@ public class TableRetryPolicy implements TablePart, Serializable {
    */
   @Override
   public Map<String, String> toConfig(Config jobConfig, Config tableConfig) {
-    final Gson gson = new GsonBuilder().excludeFieldsWithModifiers(Modifier.TRANSIENT, Modifier.STATIC).create();
-    return Collections.singletonMap(this.getClass().getSimpleName(), gson.toJson(this));
+    return Collections.singletonMap(this.getClass().getSimpleName(), SerdeUtils.toJson("table retry policy", this));
   }
 }

--- a/samza-api/src/main/java/org/apache/samza/table/retry/TableRetryPolicy.java
+++ b/samza-api/src/main/java/org/apache/samza/table/retry/TableRetryPolicy.java
@@ -30,7 +30,6 @@ import java.util.function.Predicate;
 
 import com.google.common.base.Preconditions;
 import org.apache.samza.config.Config;
-import org.apache.samza.config.JavaTableConfig;
 import org.apache.samza.table.remote.TablePart;
 
 
@@ -81,9 +80,6 @@ public class TableRetryPolicy implements TablePart, Serializable {
 
   // By default no backoff during retries
   private BackoffType backoffType = BackoffType.NONE;
-
-  // The tableId of this table part
-  private String tableId;
 
   /**
    * Serializable adapter interface for {@link java.util.function.Predicate}.
@@ -273,23 +269,6 @@ public class TableRetryPolicy implements TablePart, Serializable {
   @Override
   public Map<String, String> toConfig(Config jobConfig, Config tableConfig) {
     final Gson gson = new GsonBuilder().excludeFieldsWithModifiers(Modifier.TRANSIENT, Modifier.STATIC).create();
-    return Collections.singletonMap(JavaTableConfig.buildKey(tableId, this.getClass().getCanonicalName()),
-        gson.toJson(this));
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public void setTableId(String tableId) {
-    this.tableId = tableId;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public String getTableId() {
-    return tableId;
+    return Collections.singletonMap(this.getClass().getSimpleName(), gson.toJson(this));
   }
 }

--- a/samza-api/src/main/java/org/apache/samza/table/retry/TableRetryPolicy.java
+++ b/samza-api/src/main/java/org/apache/samza/table/retry/TableRetryPolicy.java
@@ -19,11 +19,17 @@
 
 package org.apache.samza.table.retry;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import java.io.Serializable;
+import java.lang.reflect.Modifier;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import com.google.common.base.Preconditions;
+import org.apache.samza.config.Config;
 import org.apache.samza.table.remote.TablePart;
 
 
@@ -74,6 +80,9 @@ public class TableRetryPolicy implements TablePart, Serializable {
 
   // By default no backoff during retries
   private BackoffType backoffType = BackoffType.NONE;
+
+  // The tableId of this table part
+  private String tableId;
 
   /**
    * Serializable adapter interface for {@link java.util.function.Predicate}.
@@ -255,5 +264,31 @@ public class TableRetryPolicy implements TablePart, Serializable {
    */
   public RetryPredicate getRetryPredicate() {
     return retryPredicate;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Map<String, String> toConfig(Config jobConfig, Config tableConfig) {
+    final Gson gson = new GsonBuilder().excludeFieldsWithModifiers(Modifier.TRANSIENT, Modifier.STATIC).create();
+    return Collections.singletonMap(String.format("%s.%s", getTableId(), this.getClass().getCanonicalName()),
+        gson.toJson(this));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void setTableId(String tableId) {
+    this.tableId = tableId;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getTableId() {
+    return tableId;
   }
 }

--- a/samza-api/src/main/java/org/apache/samza/table/retry/TableRetryPolicy.java
+++ b/samza-api/src/main/java/org/apache/samza/table/retry/TableRetryPolicy.java
@@ -30,6 +30,7 @@ import java.util.function.Predicate;
 
 import com.google.common.base.Preconditions;
 import org.apache.samza.config.Config;
+import org.apache.samza.config.JavaTableConfig;
 import org.apache.samza.table.remote.TablePart;
 
 
@@ -272,7 +273,7 @@ public class TableRetryPolicy implements TablePart, Serializable {
   @Override
   public Map<String, String> toConfig(Config jobConfig, Config tableConfig) {
     final Gson gson = new GsonBuilder().excludeFieldsWithModifiers(Modifier.TRANSIENT, Modifier.STATIC).create();
-    return Collections.singletonMap(String.format("%s.%s", getTableId(), this.getClass().getCanonicalName()),
+    return Collections.singletonMap(JavaTableConfig.buildKey(tableId, this.getClass().getCanonicalName()),
         gson.toJson(this));
   }
 

--- a/samza-api/src/main/java/org/apache/samza/table/utils/SerdeUtils.java
+++ b/samza-api/src/main/java/org/apache/samza/table/utils/SerdeUtils.java
@@ -19,11 +19,17 @@
 
 package org.apache.samza.table.utils;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.lang.reflect.Modifier;
 import java.util.Base64;
 
 import org.apache.samza.SamzaException;
@@ -62,6 +68,36 @@ public final class SerdeUtils {
     } catch (Exception e) {
       String errMsg = "Failed to deserialize " + name;
       throw new SamzaException(errMsg, e);
+    }
+  }
+
+  /**
+   * Helper method to serialize Java objects as json strings
+   * @param object object to be serialized
+   * @return Json representation of the object
+   */
+  public static String toJson(String name, Object object) {
+    final Gson gson = new GsonBuilder().excludeFieldsWithModifiers(Modifier.TRANSIENT, Modifier.STATIC)
+        // Tells Gson how to serialize fields with type of Class.
+        .registerTypeHierarchyAdapter(Class.class, new TypeAdapter<Class>() {
+          @Override
+          public void write(JsonWriter out, Class value) throws IOException {
+            if (value == null) {
+              out.nullValue();
+            } else {
+              out.value(value.getName());
+            }
+          }
+
+          @Override
+          public Class read(JsonReader in) {
+            throw new SamzaException("Deserialization from json is not supported.");
+          }
+        }).create();
+    try {
+      return gson.toJson(object);
+    } catch (Exception e) {
+      throw new SamzaException(String.format("Failed to serialize %s to json", name), e);
     }
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
@@ -76,8 +76,7 @@ public class TestRemoteTableDescriptor {
 
   private void doTestSerialize(RateLimiter rateLimiter, CreditFunction readCredFn, CreditFunction writeCredFn) {
     String tableId = "1";
-    RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId)
-        .withReadFunction(createMockTableReadFunction())
+    RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId).withReadFunction(createMockTableReadFunction())
         .withWriteFunction(createMockTableWriteFunction());
     if (rateLimiter != null) {
       desc.withRateLimiter(rateLimiter, readCredFn, writeCredFn);
@@ -121,8 +120,7 @@ public class TestRemoteTableDescriptor {
   @Test
   public void testSerializeNullWriteFunction() {
     String tableId = "1";
-    RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId)
-        .withReadFunction(createMockTableReadFunction());
+    RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId).withReadFunction(createMockTableReadFunction());
     Map<String, String> tableConfig = desc.toConfig(new MapConfig());
     assertExists(RemoteTableDescriptor.READ_FN, tableId, tableConfig);
     assertEquals(null, RemoteTableDescriptor.WRITE_FN, tableId, tableConfig);
@@ -148,10 +146,8 @@ public class TestRemoteTableDescriptor {
   public void testTablePartToConfigDefault() {
     TableReadFunction readFn = createMockTableReadFunction();
     when(readFn.toConfig(any(), any())).thenReturn(createConfigPair(1));
-    Map<String, String> tableConfig = new RemoteTableDescriptor("1")
-        .withReadFunction(readFn)
-        .withReadRateLimit(100)
-        .toConfig(new MapConfig());
+    Map<String, String> tableConfig =
+        new RemoteTableDescriptor("1").withReadFunction(readFn).withReadRateLimit(100).toConfig(new MapConfig());
     verify(readFn, times(1)).toConfig(any(), any());
     Assert.assertEquals("v1", tableConfig.get("k1"));
   }
@@ -182,8 +178,7 @@ public class TestRemoteTableDescriptor {
     TableRetryPolicy writeRetryPolicy = createMockTableRetryPolicy();
     when(writeRetryPolicy.toConfig(any(), any())).thenReturn(createConfigPair(keys++));
 
-    Map<String, String> tableConfig = new RemoteTableDescriptor("1")
-        .withReadFunction(readFn)
+    Map<String, String> tableConfig = new RemoteTableDescriptor("1").withReadFunction(readFn)
         .withWriteFunction(writeFn)
         .withRateLimiter(rateLimiter, readCredFn, writeCredFn)
         .withReadRetryPolicy(readRetryPolicy)
@@ -198,9 +193,19 @@ public class TestRemoteTableDescriptor {
     verify(readRetryPolicy, times(1)).toConfig(any(), any());
     verify(writeRetryPolicy, times(1)).toConfig(any(), any());
 
+    System.out.println(tableConfig);
     for (int n = 0; n < keys; n++) {
       Assert.assertEquals("v" + n, tableConfig.get("k" + n));
     }
+  }
+
+  @Test
+  public void testTableRetryPolicyToConfig() {
+    Map<String, String> tableConfig = new RemoteTableDescriptor("1").withReadFunction(createMockTableReadFunction())
+        .withReadRetryPolicy(new TableRetryPolicy())
+        .toConfig(new MapConfig());
+    Assert.assertEquals(tableConfig.get("1.io.read.retry.policy.org.apache.samza.table.retry.TableRetryPolicy"),
+        "{\"exponentialFactor\":0.0,\"backoffType\":\"NONE\",\"tableId\":\"1.io.read.retry.policy\",\"retryPredicate\":{}}");
   }
 
   private Context createMockContext(TableDescriptor tableDescriptor) {
@@ -241,6 +246,7 @@ public class TestRemoteTableDescriptor {
 
   static class CountingCreditFunction<K, V> implements CreditFunction<K, V> {
     int numCalls = 0;
+
     @Override
     public int getCredits(K key, V value) {
       numCalls++;
@@ -303,7 +309,6 @@ public class TestRemoteTableDescriptor {
 
     ThreadPoolExecutor callbackExecutor = TestUtils.getFieldValue(rwTable, "callbackExecutor");
     Assert.assertEquals(10, callbackExecutor.getCorePoolSize());
-
   }
 
   @Test

--- a/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
@@ -76,7 +76,8 @@ public class TestRemoteTableDescriptor {
 
   private void doTestSerialize(RateLimiter rateLimiter, CreditFunction readCredFn, CreditFunction writeCredFn) {
     String tableId = "1";
-    RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId).withReadFunction(createMockTableReadFunction())
+    RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId)
+        .withReadFunction(createMockTableReadFunction())
         .withWriteFunction(createMockTableWriteFunction());
     if (rateLimiter != null) {
       desc.withRateLimiter(rateLimiter, readCredFn, writeCredFn);
@@ -120,7 +121,8 @@ public class TestRemoteTableDescriptor {
   @Test
   public void testSerializeNullWriteFunction() {
     String tableId = "1";
-    RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId).withReadFunction(createMockTableReadFunction());
+    RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId)
+        .withReadFunction(createMockTableReadFunction());
     Map<String, String> tableConfig = desc.toConfig(new MapConfig());
     assertExists(RemoteTableDescriptor.READ_FN, tableId, tableConfig);
     assertEquals(null, RemoteTableDescriptor.WRITE_FN, tableId, tableConfig);
@@ -146,8 +148,10 @@ public class TestRemoteTableDescriptor {
   public void testTablePartToConfigDefault() {
     TableReadFunction readFn = createMockTableReadFunction();
     when(readFn.toConfig(any(), any())).thenReturn(createConfigPair(1));
-    Map<String, String> tableConfig =
-        new RemoteTableDescriptor("1").withReadFunction(readFn).withReadRateLimit(100).toConfig(new MapConfig());
+    Map<String, String> tableConfig = new RemoteTableDescriptor("1")
+        .withReadFunction(readFn)
+        .withReadRateLimit(100)
+        .toConfig(new MapConfig());
     verify(readFn, times(1)).toConfig(any(), any());
     Assert.assertEquals("v1", tableConfig.get("tables.1.io.read.func.k1"));
   }
@@ -259,11 +263,11 @@ public class TestRemoteTableDescriptor {
 
   private void doTestDeserializeReadFunctionAndLimiter(boolean rateOnly, boolean rlGets, boolean rlPuts) {
     int numRateLimitOps = (rlGets ? 1 : 0) + (rlPuts ? 1 : 0);
-    RemoteTableDescriptor<String, String> desc =
-        new RemoteTableDescriptor("1").withReadFunction(createMockTableReadFunction())
-            .withReadRetryPolicy(new TableRetryPolicy().withRetryPredicate((ex) -> false))
-            .withWriteFunction(createMockTableWriteFunction())
-            .withAsyncCallbackExecutorPoolSize(10);
+    RemoteTableDescriptor<String, String> desc = new RemoteTableDescriptor("1")
+        .withReadFunction(createMockTableReadFunction())
+        .withReadRetryPolicy(new TableRetryPolicy().withRetryPredicate((ex) -> false))
+        .withWriteFunction(createMockTableWriteFunction())
+        .withAsyncCallbackExecutorPoolSize(10);
 
     if (rateOnly) {
       if (rlGets) {

--- a/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
@@ -204,8 +204,21 @@ public class TestRemoteTableDescriptor {
     Map<String, String> tableConfig = new RemoteTableDescriptor("1").withReadFunction(createMockTableReadFunction())
         .withReadRetryPolicy(new TableRetryPolicy())
         .toConfig(new MapConfig());
-    Assert.assertEquals(tableConfig.get("1.io.read.retry.policy.org.apache.samza.table.retry.TableRetryPolicy"),
+    Assert.assertEquals(tableConfig.get("tables.1.io.read.retry.policy.org.apache.samza.table.retry.TableRetryPolicy"),
         "{\"exponentialFactor\":0.0,\"backoffType\":\"NONE\",\"tableId\":\"1.io.read.retry.policy\",\"retryPredicate\":{}}");
+  }
+
+  @Test
+  public void testTableRetryPolicySameInstanceToConfig() {
+    TableRetryPolicy retryPolicy = new TableRetryPolicy();
+    Map<String, String> tableConfig = new RemoteTableDescriptor("1")
+        .withReadFunction(createMockTableReadFunction())
+        .withWriteFunction(createMockTableWriteFunction())
+        .withReadRetryPolicy(retryPolicy)
+        .withWriteRetryPolicy(retryPolicy)
+        .toConfig(new MapConfig());
+    Assert.assertEquals(tableConfig.get("tables.1.io.read.and.write.retry.policy.org.apache.samza.table.retry.TableRetryPolicy"),
+        "{\"exponentialFactor\":0.0,\"backoffType\":\"NONE\",\"tableId\":\"1.io.read.and.write.retry.policy\",\"retryPredicate\":{}}");
   }
 
   private Context createMockContext(TableDescriptor tableDescriptor) {

--- a/samza-core/src/test/java/org/apache/samza/table/retry/TestTableRetryPolicy.java
+++ b/samza-core/src/test/java/org/apache/samza/table/retry/TestTableRetryPolicy.java
@@ -46,6 +46,9 @@ public class TestTableRetryPolicy {
     Assert.assertEquals(100, fsRetry.getJitter().toMillis());
     Assert.assertEquals(4, fsRetry.getMaxRetries());
     Assert.assertNotNull(retryPolicy.getRetryPredicate());
+    Assert.assertEquals("{\"sleepTime\":{\"seconds\":1,\"nanos\":0},\"exponentialFactor\":0.0,"
+        + "\"jitter\":{\"seconds\":0,\"nanos\":100000000},\"maxAttempts\":4,\"backoffType\":\"FIXED\","
+        + "\"retryPredicate\":{}}", retryPolicy.toConfig(null, null).get("TableRetryPolicy"));
   }
 
   @Test
@@ -57,6 +60,9 @@ public class TestTableRetryPolicy {
     RetryPolicy fsRetry = FailsafeAdapter.valueOf(retryPolicy);
     Assert.assertEquals(1000, fsRetry.getDelayMin().toMillis());
     Assert.assertEquals(2000, fsRetry.getDelayMax().toMillis());
+    Assert.assertEquals("{\"randomMin\":{\"seconds\":1,\"nanos\":0},\"randomMax\":{\"seconds\":2,\"nanos\":0},"
+            + "\"exponentialFactor\":0.0,\"backoffType\":\"RANDOM\",\"retryPredicate\":{}}",
+        retryPolicy.toConfig(null, null).get("TableRetryPolicy"));
   }
 
   @Test
@@ -70,6 +76,10 @@ public class TestTableRetryPolicy {
     Assert.assertEquals(2000, fsRetry.getMaxDelay().toMillis());
     Assert.assertEquals(1.5, fsRetry.getDelayFactor(), 0.001);
     Assert.assertEquals(100, fsRetry.getJitter().toMillis());
+    Assert.assertEquals("{\"sleepTime\":{\"seconds\":1,\"nanos\":0},\"exponentialFactor\":1.5,"
+            + "\"exponentialMaxSleep\":{\"seconds\":2,\"nanos\":0},\"jitter\":{\"seconds\":0,\"nanos\":100000000},"
+            + "\"backoffType\":\"EXPONENTIAL\",\"retryPredicate\":{}}",
+        retryPolicy.toConfig(null, null).get("TableRetryPolicy"));
   }
 
   @Test
@@ -78,5 +88,7 @@ public class TestTableRetryPolicy {
     retryPolicy.withRetryPredicate((e) -> e instanceof IllegalArgumentException);
     Assert.assertTrue(retryPolicy.getRetryPredicate().test(new IllegalArgumentException()));
     Assert.assertFalse(retryPolicy.getRetryPredicate().test(new NullPointerException()));
+    Assert.assertEquals("{\"exponentialFactor\":0.0,\"backoffType\":\"NONE\",\"retryPredicate\":{}}",
+        retryPolicy.toConfig(null, null).get("TableRetryPolicy"));
   }
 }


### PR DESCRIPTION
Added setTableId and getTableId to TablePart interface.
Implemented toConfig method in TableRetryPolicy to serialize the class to json format so that it can be visible in container log.
Tested with TestRemoteTableDescriptor.