### PR TITLE
SAMZA-2161: Move ChangelogPartitionManager and CoordinatorStream ConfigReader to MetadataStore.

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterBasedJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterBasedJobCoordinator.java
@@ -217,7 +217,7 @@ public class ClusterBasedJobCoordinator {
 
     try {
       //initialize JobCoordinator state
-      LOG.info("Starting Cluster Based Job Coordinator");
+      LOG.info("Starting cluster based job coordinator");
 
       //create necessary checkpoint and changelog streams, if not created
       JobModel jobModel = jobModelManager.jobModel();
@@ -252,12 +252,12 @@ public class ClusterBasedJobCoordinator {
           Thread.sleep(jobCoordinatorSleepInterval);
         } catch (InterruptedException e) {
           isInterrupted = true;
-          LOG.error("Interrupted in job coordinator loop {} ", e);
+          LOG.error("Interrupted in job coordinator loop", e);
           Thread.currentThread().interrupt();
         }
       }
     } catch (Throwable e) {
-      LOG.error("Exception thrown in the JobCoordinator loop {} ", e);
+      LOG.error("Exception thrown in the JobCoordinator loop", e);
       throw new SamzaException(e);
     } finally {
       onShutDown();
@@ -283,16 +283,16 @@ public class ClusterBasedJobCoordinator {
       containerProcessManager.stop();
       coordinatorStreamStore.close();
     } catch (Throwable e) {
-      LOG.error("Exception while stopping task manager {}", e);
+      LOG.error("Exception while stopping cluster based job coordinator", e);
     }
-    LOG.info("Stopped task manager");
+    LOG.info("Stopped cluster based job coordinator");
 
     if (jmxServer != null) {
       try {
         jmxServer.stop();
         LOG.info("Stopped Jmx Server");
       } catch (Throwable e) {
-        LOG.error("Exception while stopping jmx server {}", e);
+        LOG.error("Exception while stopping jmx server", e);
       }
     }
   }
@@ -356,8 +356,8 @@ public class ClusterBasedJobCoordinator {
           public void onInputStreamsChanged(Set<SystemStream> initialInputSet, Set<SystemStream> newInputStreams,
               Map<String, Pattern> regexesMonitored) {
             if (hasDurableStores) {
-              LOG.error("New input system-streams discovered. Failing the job. New input streams: {}", newInputStreams,
-                  " Existing input streams:", inputStreamsToMonitor);
+              LOG.error("New input system-streams discovered. Failing the job. New input streams: {}" +
+                  " Existing input streams: {}", newInputStreams, inputStreamsToMonitor);
               state.status = SamzaApplicationState.SamzaAppStatus.FAILED;
             }
             coordinatorException = new InputStreamsDiscoveredException("New input streams discovered: " + newInputStreams);
@@ -392,7 +392,7 @@ public class ClusterBasedJobCoordinator {
           new MapConfig(SamzaObjectMapper.getObjectMapper().readValue(coordinatorSystemEnv, Config.class));
       LOG.info("Using the coordinator system config: {}.", coordinatorSystemConfig);
     } catch (IOException e) {
-      LOG.error("Exception while reading coordinator stream config {}", e);
+      LOG.error("Exception while reading coordinator stream config", e);
       throw new SamzaException(e);
     }
     ClusterBasedJobCoordinator jc = new ClusterBasedJobCoordinator(coordinatorSystemConfig);

--- a/samza-core/src/main/java/org/apache/samza/coordinator/metadatastore/CoordinatorStreamStore.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/metadatastore/CoordinatorStreamStore.java
@@ -185,6 +185,7 @@ public class CoordinatorStreamStore implements MetadataStore {
       systemProducer.flush(SOURCE);
     } catch (Exception e) {
       LOG.error("Exception occurred when flushing the metadata store:", e);
+      throw new SamzaException("Exception occurred when flushing the metadata store:", e);
     }
   }
 

--- a/samza-core/src/main/java/org/apache/samza/coordinator/stream/CoordinatorStreamValueSerde.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/stream/CoordinatorStreamValueSerde.java
@@ -59,7 +59,7 @@ public class CoordinatorStreamValueSerde implements Serde<String> {
       return setTaskContainerMapping.getTaskAssignment();
     } else if (type.equalsIgnoreCase(SetChangelogMapping.TYPE)) {
       SetChangelogMapping changelogMapping = new SetChangelogMapping(message);
-      return String.valueOf(changelogMapping.getPartition());
+      return (changelogMapping.getPartition() != null) ? String.valueOf(changelogMapping.getPartition()) : null;
     } else if (type.equalsIgnoreCase(SetConfig.TYPE)) {
       SetConfig setConfig = new SetConfig(message);
       return setConfig.getConfigValue();

--- a/samza-core/src/main/java/org/apache/samza/coordinator/stream/messages/SetChangelogMapping.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/stream/messages/SetChangelogMapping.java
@@ -58,7 +58,8 @@ public class SetChangelogMapping extends CoordinatorStreamMessage {
     return getKey();
   }
 
-  public int getPartition() {
-    return Integer.parseInt(getMessageValue(CHANGELOG_VALUE_KEY));
+  public Integer getPartition() {
+    String changelogPartition = getMessageValue(CHANGELOG_VALUE_KEY);
+    return (changelogPartition != null) ? Integer.parseInt(changelogPartition) : null;
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/coordinator/stream/messages/SetChangelogMapping.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/stream/messages/SetChangelogMapping.java
@@ -19,6 +19,8 @@
 
 package org.apache.samza.coordinator.stream.messages;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * The {@link SetChangelogMapping} message is used to store the changelog partition information for a particular task.
  * The structure looks like:
@@ -60,6 +62,6 @@ public class SetChangelogMapping extends CoordinatorStreamMessage {
 
   public Integer getPartition() {
     String changelogPartition = getMessageValue(CHANGELOG_VALUE_KEY);
-    return (changelogPartition != null) ? Integer.parseInt(changelogPartition) : null;
+    return StringUtils.isNotBlank(changelogPartition) ? Integer.parseInt(changelogPartition) : null;
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/storage/ChangelogStreamManager.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/ChangelogStreamManager.java
@@ -75,7 +75,7 @@ public class ChangelogStreamManager {
     metadataStore.all().forEach((taskName, partitionIdAsBytes) -> {
         String partitionId = valueSerde.fromBytes(partitionIdAsBytes);
         LOG.debug("TaskName: {} is mapped to {}", taskName, partitionId);
-        if (partitionId != null) {
+        if (StringUtils.isNotBlank(partitionId)) {
           changelogMapping.put(new TaskName(taskName), Integer.valueOf(partitionId));
         }
       });

--- a/samza-core/src/main/java/org/apache/samza/storage/ChangelogStreamManager.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/ChangelogStreamManager.java
@@ -19,6 +19,7 @@
 
 package org.apache.samza.storage;
 
+import com.google.common.base.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -28,9 +29,9 @@ import org.apache.samza.config.Config;
 import org.apache.samza.config.JavaStorageConfig;
 import org.apache.samza.config.SystemConfig;
 import org.apache.samza.container.TaskName;
-import org.apache.samza.coordinator.stream.messages.CoordinatorStreamMessage;
+import org.apache.samza.coordinator.stream.CoordinatorStreamValueSerde;
 import org.apache.samza.coordinator.stream.messages.SetChangelogMapping;
-import org.apache.samza.coordinator.stream.CoordinatorStreamManager;
+import org.apache.samza.metadatastore.MetadataStore;
 import org.apache.samza.system.StreamSpec;
 import org.apache.samza.system.SystemAdmin;
 import org.apache.samza.system.SystemStream;
@@ -38,58 +39,73 @@ import org.apache.samza.util.StreamUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
- * The Changelog manager creates the changelog stream. If a coordinator stream manager is provided,
- * it can be used to read, write and update the changelog stream partition-to-task mapping.
+ * Responsible for creating the changelog stream. Used for reading, writing
+ * and updating the task to changelog stream partition association in metadata store.
  */
 public class ChangelogStreamManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(ChangelogStreamManager.class);
-  // This is legacy for changelog. Need to investigate what happens if you use a different source name
-  private static final String SOURCE = "JobModelManager";
 
-  private final CoordinatorStreamManager coordinatorStreamManager;
+  private final MetadataStore metadataStore;
+  private final CoordinatorStreamValueSerde valueSerde;
 
   /**
-   * Construct changelog manager with a bootstrapped coordinator stream.
+   * Builds the ChangelogStreamManager based upon the provided {@link MetadataStore} that is instantiated.
+   * Setting up a metadata store instance is expensive which requires opening multiple connections
+   * and reading tons of information. Fully instantiated metadata store is taken as a constructor argument
+   * to reuse it across different utility classes. Uses the {@link CoordinatorStreamValueSerde} to serialize
+   * messages before reading/writing into metadata store.
    *
-   * @param coordinatorStreamManager Coordinator stream manager.
+   * @param metadataStore an instance of {@link MetadataStore} to read/write the container locality.
    */
-  public ChangelogStreamManager(CoordinatorStreamManager coordinatorStreamManager) {
-    this.coordinatorStreamManager = coordinatorStreamManager;
+  public ChangelogStreamManager(MetadataStore metadataStore) {
+    this.metadataStore = metadataStore;
+    this.valueSerde = new CoordinatorStreamValueSerde(SetChangelogMapping.TYPE);
   }
 
   /**
-   * Read the taskName to partition mapping that is being maintained by this ChangelogManager
+   * Reads the taskName to changelog partition assignments from the {@link MetadataStore}.
+   *
    * @return TaskName to change LOG partition mapping, or an empty map if there were no messages.
    */
   public Map<TaskName, Integer> readPartitionMapping() {
     LOG.debug("Reading changelog partition information");
-    final HashMap<TaskName, Integer> changelogMapping = new HashMap<>();
-    for (CoordinatorStreamMessage coordinatorStreamMessage : coordinatorStreamManager.getBootstrappedStream(SetChangelogMapping.TYPE)) {
-      SetChangelogMapping changelogMapEntry = new SetChangelogMapping(coordinatorStreamMessage);
-      changelogMapping.put(new TaskName(changelogMapEntry.getTaskName()), changelogMapEntry.getPartition());
-      LOG.debug("TaskName: {} is mapped to {}", changelogMapEntry.getTaskName(), changelogMapEntry.getPartition());
-    }
+    final Map<TaskName, Integer> changelogMapping = new HashMap<>();
+    metadataStore.all().forEach((taskName, partitionIdAsBytes) -> {
+        String partitionId = valueSerde.fromBytes(partitionIdAsBytes);
+        LOG.debug("TaskName: {} is mapped to {}", taskName, partitionId);
+        if (partitionId != null) {
+          changelogMapping.put(new TaskName(taskName), Integer.valueOf(partitionId));
+        }
+      });
     return changelogMapping;
   }
 
   /**
-   * Write the taskName to partition mapping.
-   * @param changelogEntries The entries that needs to be written to the coordinator stream, the map takes the taskName
-   *                         and it's corresponding changelog partition.
+   * Writes the taskName to changelog partition assignments to the {@link MetadataStore}.
+   * @param changelogEntries a map of the taskName to the changelog partition to be written to
+   *                         metadata store.
    */
   public void writePartitionMapping(Map<TaskName, Integer> changelogEntries) {
     LOG.debug("Updating changelog information with: ");
     for (Map.Entry<TaskName, Integer> entry : changelogEntries.entrySet()) {
-      LOG.debug("TaskName: {} to Partition: {}", entry.getKey().getTaskName(), entry.getValue());
-      coordinatorStreamManager.send(new SetChangelogMapping(SOURCE, entry.getKey().getTaskName(), entry.getValue()));
+      Preconditions.checkNotNull(entry.getKey());
+      String taskName = entry.getKey().getTaskName();
+      if (entry.getValue() != null) {
+        String changeLogPartitionId = String.valueOf(entry.getValue());
+        LOG.debug("TaskName: {} to Partition: {}", taskName, entry.getValue());
+        metadataStore.put(taskName, valueSerde.toBytes(changeLogPartitionId));
+      } else {
+        LOG.debug("Deleting the TaskName: {}", taskName);
+        metadataStore.delete(taskName);
+      }
     }
   }
 
   /**
-   * Merge previous and new taskName to partition mapping and write it.
+   * Merges the previous and the new taskName to changelog partition mapping.
+   * Writes the merged taskName to partition mapping to {@link MetadataStore}.
    * @param prevChangelogEntries The previous map of taskName to changelog partition.
    * @param newChangelogEntries The new map of taskName to changelog partition.
    */
@@ -101,10 +117,10 @@ public class ChangelogStreamManager {
   }
 
   /**
-   * Utility method to create and validate changelog streams. The method is static because it does not require an
-   * instance of the {@link CoordinatorStreamManager}
-   * @param config Config with changelog info
-   * @param maxChangeLogStreamPartitions Maximum changelog stream partitions to create
+   * Creates and validates the changelog streams of a samza job.
+   *
+   * @param config the configuration with changelog info.
+   * @param maxChangeLogStreamPartitions the maximum number of changelog stream partitions to create.
    */
   public static void createChangelogStreams(Config config, int maxChangeLogStreamPartitions) {
     // Get changelog store config

--- a/samza-core/src/main/scala/org/apache/samza/checkpoint/CheckpointTool.scala
+++ b/samza-core/src/main/scala/org/apache/samza/checkpoint/CheckpointTool.scala
@@ -29,16 +29,17 @@ import org.apache.samza.checkpoint.CheckpointTool.TaskNameToCheckpointMap
 import org.apache.samza.config.TaskConfig.Config2Task
 import org.apache.samza.config._
 import org.apache.samza.container.TaskName
-import org.apache.samza.job.JobRunner.{info, warn, _}
+import org.apache.samza.job.JobRunner.info
 import org.apache.samza.metrics.MetricsRegistryMap
 import org.apache.samza.system.SystemStreamPartition
-import org.apache.samza.util.{CommandLine, Logging, Util}
+import org.apache.samza.util.{CommandLine, CoordinatorStreamUtil, Logging, Util}
 import org.apache.samza.Partition
 import org.apache.samza.SamzaException
 
 import scala.collection.JavaConverters._
 import org.apache.samza.coordinator.JobModelManager
-import org.apache.samza.coordinator.stream.CoordinatorStreamManager
+import org.apache.samza.coordinator.metadatastore.{CoordinatorStreamStore, NamespaceAwareCoordinatorStreamStore}
+import org.apache.samza.coordinator.stream.messages.SetChangelogMapping
 import org.apache.samza.execution.JobPlanner
 import org.apache.samza.storage.ChangelogStreamManager
 
@@ -126,8 +127,9 @@ object CheckpointTool {
   }
 
   def apply(config: Config, offsets: TaskNameToCheckpointMap): CheckpointTool = {
-    val coordinatorStreamManager = new CoordinatorStreamManager(config, new MetricsRegistryMap())
-    new CheckpointTool(offsets, coordinatorStreamManager)
+    val metadataStore: CoordinatorStreamStore = new CoordinatorStreamStore(config, new MetricsRegistryMap())
+    metadataStore.init()
+    new CheckpointTool(offsets, metadataStore, config)
   }
 
   def rewriteConfig(config: JobConfig): Config = {
@@ -158,61 +160,70 @@ object CheckpointTool {
   }
 }
 
-class CheckpointTool(newOffsets: TaskNameToCheckpointMap, coordinatorStreamManager: CoordinatorStreamManager) extends Logging {
+class CheckpointTool(newOffsets: TaskNameToCheckpointMap, coordinatorStreamStore: CoordinatorStreamStore, userDefinedConfig: Config) extends Logging {
 
   def run() {
-    // Read the configuration stored in the coordinator stream.
-    coordinatorStreamManager.register(getClass.getSimpleName)
-    coordinatorStreamManager.start()
-    coordinatorStreamManager.bootstrap()
-    val configFromCoordinatorStream: Config = coordinatorStreamManager.getConfig
+    val configFromCoordinatorStream: Config = getConfigFromCoordinatorStream(coordinatorStreamStore)
+
+    println("Configuration read from the coordinator stream")
+    println(configFromCoordinatorStream)
+
+    val combinedConfigMap: util.Map[String, String] = new util.HashMap[String, String]()
+    combinedConfigMap.putAll(configFromCoordinatorStream)
+    combinedConfigMap.putAll(userDefinedConfig)
+    val combinedConfig: Config = new MapConfig(combinedConfigMap)
 
     // Instantiate the checkpoint manager with coordinator stream configuration.
-    val checkpointManager: CheckpointManager = configFromCoordinatorStream.getCheckpointManagerFactory() match {
+    val checkpointManager: CheckpointManager = combinedConfig.getCheckpointManagerFactory() match {
       case Some(className) =>
         Util.getObj(className, classOf[CheckpointManagerFactory])
-          .getCheckpointManager(configFromCoordinatorStream, new MetricsRegistryMap)
+          .getCheckpointManager(combinedConfig, new MetricsRegistryMap)
       case _ =>
         throw new SamzaException("Configuration: task.checkpoint.factory is not defined.")
     }
+    try {
+      // Find all the TaskNames that would be generated for this job config
+      val changelogManager = new ChangelogStreamManager(new NamespaceAwareCoordinatorStreamStore(coordinatorStreamStore, SetChangelogMapping.TYPE))
+      val jobModelManager = JobModelManager(combinedConfig, changelogManager.readPartitionMapping(), coordinatorStreamStore, new MetricsRegistryMap())
+      val taskNames = jobModelManager
+        .jobModel
+        .getContainers
+        .values
+        .asScala
+        .flatMap(_.getTasks.asScala.keys)
+        .toSet
 
-    // Find all the TaskNames that would be generated for this job config
-    val changelogManager = new ChangelogStreamManager(coordinatorStreamManager)
-    val jobModelManager = JobModelManager(configFromCoordinatorStream, changelogManager.readPartitionMapping())
-    val taskNames = jobModelManager
-      .jobModel
-      .getContainers
-      .values
-      .asScala
-      .flatMap(_.getTasks.asScala.keys)
-      .toSet
+      taskNames.foreach(checkpointManager.register)
+      checkpointManager.start()
 
-    taskNames.foreach(checkpointManager.register)
-    checkpointManager.start()
+      val lastCheckpoints = taskNames.map(taskName => {
+        taskName -> Option(checkpointManager.readLastCheckpoint(taskName))
+          .getOrElse(new Checkpoint(new java.util.HashMap[SystemStreamPartition, String]()))
+          .getOffsets
+          .asScala
+          .toMap
+      }).toMap
 
-    val lastCheckpoints = taskNames.map(taskName => {
-      taskName -> Option(checkpointManager.readLastCheckpoint(taskName))
-                                          .getOrElse(new Checkpoint(new java.util.HashMap[SystemStreamPartition, String]()))
-                                          .getOffsets
-                                          .asScala
-                                          .toMap
-    }).toMap
+      lastCheckpoints.foreach(lcp => logCheckpoint(lcp._1, lcp._2, "Current checkpoint for task: "+ lcp._1))
 
-    lastCheckpoints.foreach(lcp => logCheckpoint(lcp._1, lcp._2, "Current checkpoint for task: "+ lcp._1))
-
-    if (newOffsets != null) {
-      newOffsets.foreach {
-        case (taskName: TaskName, offsets: Map[SystemStreamPartition, String]) => {
-          logCheckpoint(taskName, offsets, "New offset to be written for task: " + taskName)
-          val checkpoint = new Checkpoint(offsets.asJava)
-          checkpointManager.writeCheckpoint(taskName, checkpoint)
-          info(s"Updated the checkpoint of the task: $taskName to: $offsets")
+      if (newOffsets != null) {
+        newOffsets.foreach {
+          case (taskName: TaskName, offsets: Map[SystemStreamPartition, String]) => {
+            logCheckpoint(taskName, offsets, "New offset to be written for task: " + taskName)
+            val checkpoint = new Checkpoint(offsets.asJava)
+            checkpointManager.writeCheckpoint(taskName, checkpoint)
+            info(s"Updated the checkpoint of the task: $taskName to: $offsets")
+          }
         }
       }
-    }
+    } finally {
+      checkpointManager.stop()
+      coordinatorStreamStore.close()
+   }
+  }
 
-    checkpointManager.stop()
-    coordinatorStreamManager.stop()
+  def getConfigFromCoordinatorStream(coordinatorStreamStore: CoordinatorStreamStore): Config = {
+    return CoordinatorStreamUtil.readConfigFromCoordinatorStream(coordinatorStreamStore)
   }
 
   def logCheckpoint(tn: TaskName, checkpoint: Map[SystemStreamPartition, String], prefix: String) {

--- a/samza-core/src/main/scala/org/apache/samza/coordinator/JobModelManager.scala
+++ b/samza-core/src/main/scala/org/apache/samza/coordinator/JobModelManager.scala
@@ -30,24 +30,16 @@ import org.apache.samza.config.Config
 import org.apache.samza.container.grouper.stream.SSPGrouperProxy
 import org.apache.samza.container.grouper.stream.SystemStreamPartitionGrouperFactory
 import org.apache.samza.container.grouper.task._
-import org.apache.samza.container.LocalityManager
-import org.apache.samza.container.TaskName
-import org.apache.samza.coordinator.metadatastore.CoordinatorStreamMetadataStoreFactory
 import org.apache.samza.coordinator.metadatastore.NamespaceAwareCoordinatorStreamStore
-import org.apache.samza.coordinator.server.HttpServer
-import org.apache.samza.coordinator.server.JobServlet
-import org.apache.samza.coordinator.stream.messages.SetContainerHostMapping
 import org.apache.samza.coordinator.stream.messages.SetTaskContainerMapping
 import org.apache.samza.coordinator.stream.messages.SetTaskModeMapping
 import org.apache.samza.coordinator.stream.messages.SetTaskPartitionMapping
-import org.apache.samza.job.model.ContainerModel
-import org.apache.samza.job.model.JobModel
-import org.apache.samza.job.model.TaskMode
-import org.apache.samza.job.model.TaskModel
-import org.apache.samza.metadatastore.MetadataStore
-import org.apache.samza.metadatastore.MetadataStoreFactory
-import org.apache.samza.metrics.MetricsRegistry
-import org.apache.samza.metrics.MetricsRegistryMap
+import org.apache.samza.container.{LocalityManager, TaskName}
+import org.apache.samza.coordinator.metadatastore.CoordinatorStreamStore
+import org.apache.samza.coordinator.server.{HttpServer, JobServlet}
+import org.apache.samza.coordinator.stream.messages.SetContainerHostMapping
+import org.apache.samza.job.model.{ContainerModel, JobModel, TaskMode, TaskModel}
+import org.apache.samza.metrics.{MetricsRegistry, MetricsRegistryMap}
 import org.apache.samza.runtime.LocationId
 import org.apache.samza.system._
 import org.apache.samza.util.Logging
@@ -81,10 +73,9 @@ object JobModelManager extends Logging {
    * @param metricsRegistry the registry for reporting metrics.
    * @return the instantiated {@see JobModelManager}.
    */
-  def apply(config: Config, changelogPartitionMapping: util.Map[TaskName, Integer], metricsRegistry: MetricsRegistry = new MetricsRegistryMap()): JobModelManager = {
-    val coordinatorStreamStoreFactory: MetadataStoreFactory = new CoordinatorStreamMetadataStoreFactory()
-    val coordinatorStreamStore: MetadataStore = coordinatorStreamStoreFactory.getMetadataStore(SOURCE, config, metricsRegistry)
-    coordinatorStreamStore.init()
+  def apply(config: Config, changelogPartitionMapping: util.Map[TaskName, Integer],
+            coordinatorStreamStore: CoordinatorStreamStore,
+            metricsRegistry: MetricsRegistry = new MetricsRegistryMap()): JobModelManager = {
 
     // Instantiate the respective metadata store util classes which uses the same coordinator metadata store.
     val localityManager = new LocalityManager(new NamespaceAwareCoordinatorStreamStore(coordinatorStreamStore, SetContainerHostMapping.TYPE))

--- a/samza-core/src/main/scala/org/apache/samza/coordinator/JobModelManager.scala
+++ b/samza-core/src/main/scala/org/apache/samza/coordinator/JobModelManager.scala
@@ -34,12 +34,18 @@ import org.apache.samza.coordinator.metadatastore.NamespaceAwareCoordinatorStrea
 import org.apache.samza.coordinator.stream.messages.SetTaskContainerMapping
 import org.apache.samza.coordinator.stream.messages.SetTaskModeMapping
 import org.apache.samza.coordinator.stream.messages.SetTaskPartitionMapping
-import org.apache.samza.container.{LocalityManager, TaskName}
+import org.apache.samza.container.LocalityManager
+import org.apache.samza.container.TaskName
 import org.apache.samza.coordinator.metadatastore.CoordinatorStreamStore
-import org.apache.samza.coordinator.server.{HttpServer, JobServlet}
+import org.apache.samza.coordinator.server.HttpServer
+import org.apache.samza.coordinator.server.JobServlet
 import org.apache.samza.coordinator.stream.messages.SetContainerHostMapping
-import org.apache.samza.job.model.{ContainerModel, JobModel, TaskMode, TaskModel}
-import org.apache.samza.metrics.{MetricsRegistry, MetricsRegistryMap}
+import org.apache.samza.job.model.ContainerModel
+import org.apache.samza.job.model.JobModel
+import org.apache.samza.job.model.TaskMode
+import org.apache.samza.job.model.TaskModel
+import org.apache.samza.metrics.MetricsRegistry
+import org.apache.samza.metrics.MetricsRegistryMap
 import org.apache.samza.runtime.LocationId
 import org.apache.samza.system._
 import org.apache.samza.util.Logging

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestClusterBasedJobCoordinator.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestClusterBasedJobCoordinator.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.samza.Partition;
 import org.apache.samza.config.Config;
+import org.apache.samza.config.JobConfig;
 import org.apache.samza.config.MapConfig;
 import org.apache.samza.coordinator.StreamPartitionCountMonitor;
 import org.apache.samza.coordinator.stream.CoordinatorStreamSystemProducer;
@@ -55,7 +56,7 @@ public class TestClusterBasedJobCoordinator {
   Map<String, String> configMap;
 
   @Before
-  public void setUp() throws NoSuchFieldException, NoSuchMethodException {
+  public void setUp() {
     configMap = new HashMap<>();
     configMap.put("job.name", "test-job");
     configMap.put("job.coordinator.system", "kafka");
@@ -81,6 +82,8 @@ public class TestClusterBasedJobCoordinator {
   @Test
   public void testPartitionCountMonitorWithDurableStates() {
     configMap.put("stores.mystore.changelog", "mychangelog");
+    configMap.put(JobConfig.JOB_CONTAINER_COUNT(), "1");
+    when(CoordinatorStreamUtil.readConfigFromCoordinatorStream(anyObject())).thenReturn(new MapConfig(configMap));
     Config config = new MapConfig(configMap);
 
     // mimic job runner code to write the config to coordinator stream
@@ -99,6 +102,8 @@ public class TestClusterBasedJobCoordinator {
 
   @Test
   public void testPartitionCountMonitorWithoutDurableStates() {
+    configMap.put(JobConfig.JOB_CONTAINER_COUNT(), "1");
+    when(CoordinatorStreamUtil.readConfigFromCoordinatorStream(anyObject())).thenReturn(new MapConfig(configMap));
     Config config = new MapConfig(configMap);
 
     // mimic job runner code to write the config to coordinator stream

--- a/samza-core/src/test/java/org/apache/samza/coordinator/metadatastore/CoordinatorStreamStoreTestUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/coordinator/metadatastore/CoordinatorStreamStoreTestUtil.java
@@ -40,12 +40,16 @@ public class CoordinatorStreamStoreTestUtil {
   private final Config config;
 
   public CoordinatorStreamStoreTestUtil(Config config) {
+    this(config, "test-kafka");
+  }
+
+  public CoordinatorStreamStoreTestUtil(Config config, String systemName) {
     this.config = config;
     this.systemFactory = new MockCoordinatorStreamSystemFactory();
     MockCoordinatorStreamSystemFactory.enableMockConsumerCache();
-    SystemConsumer systemConsumer = systemFactory.getConsumer("test-kafka", config, new NoOpMetricsRegistry());
-    SystemProducer systemProducer = systemFactory.getProducer("test-kafka", config, new NoOpMetricsRegistry());
-    SystemAdmin systemAdmin = systemFactory.getAdmin("test-kafka", config);
+    SystemConsumer systemConsumer = systemFactory.getConsumer(systemName, config, new NoOpMetricsRegistry());
+    SystemProducer systemProducer = systemFactory.getProducer(systemName, config, new NoOpMetricsRegistry());
+    SystemAdmin systemAdmin = systemFactory.getAdmin(systemName, config);
     this.coordinatorStreamStore = new CoordinatorStreamStore(config, systemProducer, systemConsumer, systemAdmin);
     this.coordinatorStreamStore.init();
   }

--- a/samza-core/src/test/java/org/apache/samza/coordinator/stream/MockCoordinatorStreamSystemFactory.java
+++ b/samza-core/src/test/java/org/apache/samza/coordinator/stream/MockCoordinatorStreamSystemFactory.java
@@ -95,6 +95,7 @@ public class MockCoordinatorStreamSystemFactory implements SystemFactory {
     String streamName = CoordinatorStreamUtil.getCoordinatorStreamName(jobName, jobId);
     SystemStreamPartition systemStreamPartition = new SystemStreamPartition(systemName, streamName, new Partition(0));
     mockConsumer = new MockCoordinatorStreamWrappedConsumer(systemStreamPartition, config);
+    mockConsumer.register(systemStreamPartition, "0");
     return mockConsumer;
   }
 

--- a/samza-core/src/test/java/org/apache/samza/coordinator/stream/MockCoordinatorStreamWrappedConsumer.java
+++ b/samza-core/src/test/java/org/apache/samza/coordinator/stream/MockCoordinatorStreamWrappedConsumer.java
@@ -65,10 +65,6 @@ public class MockCoordinatorStreamWrappedConsumer extends BlockingEnvelopeMap {
     convertConfigToCoordinatorMessage(config);
   }
 
-  public void addMoreMessages(Config config) {
-    convertConfigToCoordinatorMessage(config);
-  }
-
   public void addMessageEnvelope(IncomingMessageEnvelope envelope) throws IOException, InterruptedException {
     put(systemStreamPartition, envelope);
     setIsAtHead(systemStreamPartition, true);
@@ -77,8 +73,8 @@ public class MockCoordinatorStreamWrappedConsumer extends BlockingEnvelopeMap {
   private void convertConfigToCoordinatorMessage(Config config) {
     try {
       for (Map.Entry<String, String> configPair : config.entrySet()) {
-        byte[] keyBytes = null;
-        byte[] messgeBytes = null;
+        byte[] keyBytes;
+        byte[] messgeBytes;
         if (configPair.getKey().startsWith(CHANGELOGPREFIX)) {
           String[] changelogInfo = configPair.getKey().split(":");
           String changeLogPartition = configPair.getValue();
@@ -110,12 +106,6 @@ public class MockCoordinatorStreamWrappedConsumer extends BlockingEnvelopeMap {
 
     return super.poll(systemStreamPartitions, timeout);
   }
-
-  public CountDownLatch blockPool() {
-    blockpollFlag = true;
-    return blockConsumerPoll;
-  }
-
 
   public void stop() {}
 }


### PR DESCRIPTION
Currently the metadata of a samza job is stored into a kafka topic named coordinator stream.

In samza-yarn `ApplicationMaster`, the same coordinator stream is read twice as a part of the `ApplicationMaster` startup sequence. This duplicate read unnecessarily prolongs the startup time of the application master and makes the container allocation take longer than usual. This inadvertently incurs a substantial increase in input stream processing delay depending upon the size of the coordinator stream. 

To mitigate this problem, the two util classes in samza viz `ChangelogPartitionManager`, `Config` should be moved to use the MetadataStore abstraction.
