### PR TITLE
Fix ZkLocalApplicationRunner regression introduced by PR #951

### DIFF
--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
@@ -153,10 +153,16 @@ public class TestZkLocalApplicationRunner extends IntegrationTestHarness {
     zkUtils = new ZkUtils(zkKeyBuilder, zkClient, ZK_CONNECTION_TIMEOUT_MS, ZK_SESSION_TIMEOUT_MS, new NoOpMetricsRegistry());
     zkUtils.connect();
 
+    ImmutableMap<String, Integer> topicToPartitionCount = ImmutableMap.of(
+        inputSinglePartitionKafkaTopic, 1,
+        outputSinglePartitionKafkaTopic, 1,
+        inputKafkaTopic, 5,
+        outputKafkaTopic, 5);
+
     List<NewTopic> newTopics =
         ImmutableList.of(inputKafkaTopic, outputKafkaTopic, inputSinglePartitionKafkaTopic, outputSinglePartitionKafkaTopic)
             .stream()
-            .map(topic -> new NewTopic(topic, 5, (short) 1))
+            .map(topic -> new NewTopic(topic, topicToPartitionCount.get(topic), (short) 1))
             .collect(Collectors.toList());
 
     assertTrue("Encountered errors during test setup. Failed to create topics.", createTopics(newTopics));


### PR DESCRIPTION
https://github.com/apache/samza/pull/951 introduced a regression in TestZkLocalApplicationRunner by creating topics with 5 partitions instead of 1.
