### PR TITLE
SAMZA-2173: Fix NullPointerException in SetConfig MessageFormat when configurations are deleted.

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/coordinator/stream/messages/CoordinatorStreamMessage.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/stream/messages/CoordinatorStreamMessage.java
@@ -191,7 +191,11 @@ public class CoordinatorStreamMessage {
   }
 
   protected String getMessageValue(String key) {
-    return getMessageValues().get(key);
+    if (isDelete) {
+      return null;
+    } else {
+      return getMessageValues().get(key);
+    }
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/coordinator/stream/messages/SetConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/stream/messages/SetConfig.java
@@ -54,6 +54,13 @@ public class SetConfig extends CoordinatorStreamMessage {
    * @return the configuration as a string
    */
   public String getConfigValue() {
-    return getMessageValue(CONFIG_VALUE_KEY);
+    // Unlike other CoordinatorStreamMessage, SetConfig message(configurations) are deleted with a seperate DELETE CoordinatorStreamMessage.
+    // For deleted configuration messages, the message value map in DELETE message is null. This isDelete check saves us
+    // from dereferencing a null map.
+    if (isDelete()) {
+      return null;
+    } else {
+      return getMessageValue(CONFIG_VALUE_KEY);
+    }
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/coordinator/stream/messages/SetConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/stream/messages/SetConfig.java
@@ -54,13 +54,6 @@ public class SetConfig extends CoordinatorStreamMessage {
    * @return the configuration as a string
    */
   public String getConfigValue() {
-    // Unlike other CoordinatorStreamMessage, SetConfig message(configurations) are deleted with a seperate DELETE CoordinatorStreamMessage.
-    // For deleted configuration messages, the message value map in DELETE message is null. This isDelete check saves us
-    // from dereferencing a null map.
-    if (isDelete()) {
-      return null;
-    } else {
-      return getMessageValue(CONFIG_VALUE_KEY);
-    }
+    return getMessageValue(CONFIG_VALUE_KEY);
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/coordinator/stream/TestCoordinatorStreamMessage.java
+++ b/samza-core/src/test/java/org/apache/samza/coordinator/stream/TestCoordinatorStreamMessage.java
@@ -62,6 +62,14 @@ public class TestCoordinatorStreamMessage {
   }
 
   @Test
+  public void testGetConfigValueShouldReturnNullForDeletedConfigs() {
+    // Null in passed in the message map to indicate that the message has been deleted.
+    CoordinatorStreamMessage message = new CoordinatorStreamMessage(new Object[] {Integer.valueOf(0), SetConfig.TYPE, "random-key"}, null);
+    SetConfig setConfig = new SetConfig(message);
+    assertEquals(null, setConfig.getConfigValue());
+  }
+
+  @Test
   public void testDelete() {
     Delete delete = new Delete("source2", "key", "delete-type");
     assertEquals("delete-type", delete.getType());


### PR DESCRIPTION
Currently the configurations in the coordinator stream are deleted by sending a  Delete message with  message-map set as null and type set as `SetConfig.TYPE`. 

To read configurations from the coordinator stream, there should be a check at the caller API to find if configuration message has been deleted or not. Otherwise it results in a NPE. 

This patch encapsulates the isDelete check into the CoordinatorStreamMessage class and returns null if the configuration key has been deleted.