### PR TITLE
SAMZA-2172: Make High Level applications respect job.container.thread.pool.size

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/task/StreamOperatorTaskFactory.java
+++ b/samza-api/src/main/java/org/apache/samza/task/StreamOperatorTaskFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.task;
+
+import org.apache.samza.annotation.InterfaceStability;
+
+
+/**
+ * Build {@link AsyncStreamTask} instances.
+ * <p>
+ * Implementations should return a new instance of {@link AsyncStreamTask} for each {@link #createInstance()} invocation.
+ */
+@InterfaceStability.Evolving
+public interface StreamOperatorTaskFactory extends TaskFactory<AsyncStreamTask> {
+}

--- a/samza-core/src/main/java/org/apache/samza/task/StreamOperatorTask.java
+++ b/samza-core/src/main/java/org/apache/samza/task/StreamOperatorTask.java
@@ -95,9 +95,9 @@ public class StreamOperatorTask implements AsyncStreamTask, InitableTask, Window
 
   /**
    * Passes the incoming message envelopes along to the {@link InputOperatorImpl} node
-   * for the input {@link SystemStream}. It is non-blocking and dispatches the message to an internally managed thread
+   * for the input {@link SystemStream}. It is non-blocking and dispatches the message to the container thread
    * pool. The thread pool size is configured through job.container.thread.pool.size. In the absence of the config,
-   * the task defaults to a single thread executor.
+   * the task executes the DAG on the run loop thread.
    * <p>
    * From then on, each {@link org.apache.samza.operators.impl.OperatorImpl} propagates its transformed output to
    * its chained {@link org.apache.samza.operators.impl.OperatorImpl}s itself.

--- a/samza-core/src/main/java/org/apache/samza/task/StreamOperatorTaskFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/task/StreamOperatorTaskFactory.java
@@ -18,14 +18,13 @@
  */
 package org.apache.samza.task;
 
-import org.apache.samza.annotation.InterfaceStability;
-
 
 /**
- * Build {@link AsyncStreamTask} instances.
+ * Build {@link StreamOperatorTask} instances.
  * <p>
- * Implementations should return a new instance of {@link AsyncStreamTask} for each {@link #createInstance()} invocation.
+ * Implementations should return a new instance of {@link StreamOperatorTask} for each {@link #createInstance()} invocation.
+ * Note: It is not part of samza-api as it is a temporary hack introduced for SAMZA-2172. It will eventually
+ * go away with SAMZA-2203
  */
-@InterfaceStability.Evolving
-public interface StreamOperatorTaskFactory extends TaskFactory<AsyncStreamTask> {
+interface StreamOperatorTaskFactory extends TaskFactory<AsyncStreamTask> {
 }

--- a/samza-core/src/main/java/org/apache/samza/task/TaskFactoryUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/task/TaskFactoryUtil.java
@@ -122,7 +122,7 @@ public class TaskFactoryUtil {
      * Refer to SAMZA-2203 for more details.
      */
     if (isStreamOperatorTaskClass) {
-      log.info("Adapting StreamOperatorTask to AsyncStreamTaskAdapter");
+      log.info("Adapting StreamOperatorTaskFactory to inject container thread pool");
       return (AsyncStreamTaskFactory) () -> {
         StreamOperatorTask operatorTask = (StreamOperatorTask) factory.createInstance();
         operatorTask.setTaskThreadPool(taskThreadPool);

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -43,7 +43,6 @@ import org.apache.samza.container.disk.{DiskQuotaPolicyFactory, DiskSpaceMonitor
 import org.apache.samza.container.host.{StatisticsMonitorImpl, SystemMemoryStatistics, SystemStatisticsMonitor}
 import org.apache.samza.context._
 import org.apache.samza.job.model.{ContainerModel, JobModel, TaskMode}
-import org.apache.samza.metadatastore.MetadataStoreFactory
 import org.apache.samza.metrics.{JmxServer, JvmMetrics, MetricsRegistryMap, MetricsReporter}
 import org.apache.samza.serializers._
 import org.apache.samza.serializers.model.SamzaObjectMapper

--- a/samza-core/src/test/java/org/apache/samza/task/TestStreamOperatorTask.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestStreamOperatorTask.java
@@ -19,21 +19,21 @@
 
 package org.apache.samza.task;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.apache.samza.context.Context;
 import org.apache.samza.context.JobContext;
 import org.apache.samza.operators.OperatorSpecGraph;
 import org.apache.samza.operators.impl.OperatorImplGraph;
+import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.util.Clock;
 import org.junit.Test;
 
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 
 public class TestStreamOperatorTask {
-
   public static OperatorImplGraph getOperatorImplGraph(StreamOperatorTask task) {
     return task.getOperatorImplGraph();
   }
@@ -53,5 +53,23 @@ public class TestStreamOperatorTask {
       }
     }
     operatorTask.close();
+  }
+
+  /**
+   * Pass an invalid IME to processAsync. Any exceptions in processAsync should still get propagated through the
+   * task callback.
+   */
+  @Test
+  public void testExceptionsInProcessInvokesTaskCallback() {
+    ExecutorService taskThreadPool = Executors.newFixedThreadPool(2);
+    TaskCallback mockTaskCallback = mock(TaskCallback.class);
+    MessageCollector mockMessageCollector = mock(MessageCollector.class);
+    TaskCoordinator mockTaskCoordinator = mock(TaskCoordinator.class);
+    StreamOperatorTask operatorTask = new StreamOperatorTask(mock(OperatorSpecGraph.class));
+    operatorTask.setTaskThreadPool(taskThreadPool);
+
+    operatorTask.processAsync(mock(IncomingMessageEnvelope.class), mockMessageCollector,
+        mockTaskCoordinator, mockTaskCallback);
+    verify(mockTaskCallback, times(1)).failure(any());
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/task/TestTaskFactoryUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestTaskFactoryUtil.java
@@ -93,6 +93,7 @@ public class TestTaskFactoryUtil {
     assertEquals(retFactory, mockAsyncStreamFactory);
   }
 
+  @Test
   public void testFinalizeTaskFactoryForStreamOperatorTask() {
     TaskFactory mockFactory = mock(StreamOperatorTaskFactory.class);
     StreamOperatorTask mockStreamOperatorTask = mock(StreamOperatorTask.class);
@@ -100,7 +101,8 @@ public class TestTaskFactoryUtil {
         .thenReturn(mockStreamOperatorTask);
 
     ExecutorService mockThreadPool = mock(ExecutorService.class);
-    TaskFactoryUtil.finalizeTaskFactory(mockFactory, mockThreadPool);
+    TaskFactory finalizedFactory = TaskFactoryUtil.finalizeTaskFactory(mockFactory, mockThreadPool);
+    finalizedFactory.createInstance();
     verify(mockStreamOperatorTask, times(1)).setTaskThreadPool(eq(mockThreadPool));
   }
 

--- a/samza-core/src/test/java/org/apache/samza/task/TestTaskFactoryUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestTaskFactoryUtil.java
@@ -31,9 +31,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 
 /**
@@ -93,6 +91,17 @@ public class TestTaskFactoryUtil {
     AsyncStreamTaskFactory mockAsyncStreamFactory = mock(AsyncStreamTaskFactory.class);
     retFactory = TaskFactoryUtil.finalizeTaskFactory(mockAsyncStreamFactory, null);
     assertEquals(retFactory, mockAsyncStreamFactory);
+  }
+  
+  public void testFinalizeTaskFactoryForStreamOperatorTask() {
+    TaskFactory mockFactory = mock(StreamOperatorTaskFactory.class);
+    StreamOperatorTask mockStreamOperatorTask = mock(StreamOperatorTask.class);
+    when(mockFactory.createInstance())
+        .thenReturn(mockStreamOperatorTask);
+
+    ExecutorService mockThreadPool = mock(ExecutorService.class);
+    TaskFactoryUtil.finalizeTaskFactory(mockFactory, mockThreadPool);
+    verify(mockStreamOperatorTask, times(1)).setTaskThreadPool(eq(mockThreadPool));
   }
 
   // test getTaskFactory with StreamApplicationDescriptor

--- a/samza-core/src/test/java/org/apache/samza/task/TestTaskFactoryUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestTaskFactoryUtil.java
@@ -92,7 +92,7 @@ public class TestTaskFactoryUtil {
     retFactory = TaskFactoryUtil.finalizeTaskFactory(mockAsyncStreamFactory, null);
     assertEquals(retFactory, mockAsyncStreamFactory);
   }
-  
+
   public void testFinalizeTaskFactoryForStreamOperatorTask() {
     TaskFactory mockFactory = mock(StreamOperatorTaskFactory.class);
     StreamOperatorTask mockStreamOperatorTask = mock(StreamOperatorTask.class);
@@ -111,8 +111,8 @@ public class TestTaskFactoryUtil {
     OperatorSpecGraph mockSpecGraph = mock(OperatorSpecGraph.class);
     when(mockStreamApp.getOperatorSpecGraph()).thenReturn(mockSpecGraph);
     TaskFactory streamTaskFactory = TaskFactoryUtil.getTaskFactory(mockStreamApp);
-    assertTrue(streamTaskFactory instanceof AsyncStreamTaskFactory);
-    AsyncStreamTask streamTask = ((AsyncStreamTaskFactory) streamTaskFactory).createInstance();
+    assertTrue(streamTaskFactory instanceof StreamOperatorTaskFactory);
+    AsyncStreamTask streamTask = ((StreamOperatorTaskFactory) streamTaskFactory).createInstance();
     assertTrue(streamTask instanceof StreamOperatorTask);
     verify(mockSpecGraph).clone();
   }


### PR DESCRIPTION
Refer https://issues.apache.org/jira/browse/SAMZA-2172 for more details.

`2019-04-25 14:41:17.132 [Samza Container Thread-2] WikipediaAsyncApplication [INFO] Executing blocking filter on the thread Samza Container Thread-2
2019-04-25 14:41:17.133 [Samza Container Thread-2] WikipediaAsyncApplication [INFO] Finished executing blocking filter on the thread Samza Container Thread-2
2019-04-25 14:41:17.442 [Samza Container Thread-3] WikipediaAsyncApplication [INFO] Executing blocking filter on the thread Samza Container Thread-3
2019-04-25 14:41:17.442 [Samza Container Thread-3] WikipediaAsyncApplication [INFO] Finished executing blocking filter on the thread Samza Container Thread-3
2019-04-25 14:41:17.487 [Samza Container Thread-0] WikipediaAsyncApplication [INFO] Executing blocking filter on the thread Samza Container Thread-0
`