### PR TITLE
SAMZA-2178: Utils to directly inject custom IME to InMemorySystem streams via TestRunner

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/system/inmemory/InMemoryManager.java
+++ b/samza-core/src/main/java/org/apache/samza/system/inmemory/InMemoryManager.java
@@ -76,6 +76,19 @@ class InMemoryManager {
   }
 
   /**
+   * Handles produce request from {@link InMemorySystemProducer} for case where a job has a custom IME and
+   * populates the underlying message queue with the IME.
+   *
+   * @param ssp
+   * @param envelope
+   */
+  void put(SystemStreamPartition ssp, IncomingMessageEnvelope envelope) {
+    List<IncomingMessageEnvelope> messages = bufferedMessages.get(ssp);
+    bufferedMessages.get(ssp).add(envelope);
+  }
+
+
+  /**
    * Handles the poll request from {@link InMemorySystemConsumer}. It uses the input offset as the starting offset for
    * each {@link SystemStreamPartition}.
    *

--- a/samza-core/src/main/java/org/apache/samza/system/inmemory/InMemoryManager.java
+++ b/samza-core/src/main/java/org/apache/samza/system/inmemory/InMemoryManager.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.apache.samza.Partition;
+import org.apache.samza.SamzaException;
 import org.apache.samza.system.EndOfStreamMessage;
 import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.system.StreamSpec;
@@ -78,12 +79,19 @@ class InMemoryManager {
   /**
    * Handles produce request from {@link InMemorySystemProducer} for case where a job has a custom IME and
    * populates the underlying message queue with the IME.
+   * Note: Offset in the envelope needs to be in the increasing order for envelopes in the same ssp and needs to
+   * start at 0 for the first envelope, otherwise poll logic will be impacted
    *
-   * @param ssp
-   * @param envelope
+   * @param ssp system stream partition
+   * @param envelope incoming message envelope
    */
   void put(SystemStreamPartition ssp, IncomingMessageEnvelope envelope) {
     List<IncomingMessageEnvelope> messages = bufferedMessages.get(ssp);
+    String offset = String.valueOf(messages.size());
+    if (envelope.getOffset().equals(offset)) {
+      throw new SamzaException(
+          String.format("Offset mismatch for ssp %s, expected %s found %s, please set the correct offset", ssp, offset, envelope.getOffset()));
+    }
     bufferedMessages.get(ssp).add(envelope);
   }
 

--- a/samza-core/src/main/java/org/apache/samza/system/inmemory/InMemorySystemProducer.java
+++ b/samza-core/src/main/java/org/apache/samza/system/inmemory/InMemorySystemProducer.java
@@ -21,6 +21,7 @@ package org.apache.samza.system.inmemory;
 
 import com.google.common.base.Preconditions;
 import org.apache.samza.Partition;
+import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.system.OutgoingMessageEnvelope;
 import org.apache.samza.system.SystemProducer;
 import org.apache.samza.system.SystemStreamPartition;
@@ -93,6 +94,15 @@ public class InMemorySystemProducer implements SystemProducer {
 
     SystemStreamPartition ssp = new SystemStreamPartition(envelope.getSystemStream(), new Partition(partition));
     memoryManager.put(ssp, key, message);
+  }
+
+  /**
+   * Populates the IME to the ssp configured, this gives user more control to set up Test environment
+   *
+   * @param envelope
+   */
+  public void send(IncomingMessageEnvelope envelope) {
+    memoryManager.put(envelope.getSystemStreamPartition(), envelope);
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/system/inmemory/InMemorySystemProducer.java
+++ b/samza-core/src/main/java/org/apache/samza/system/inmemory/InMemorySystemProducer.java
@@ -97,9 +97,13 @@ public class InMemorySystemProducer implements SystemProducer {
   }
 
   /**
-   * Populates the IME to the ssp configured, this gives user more control to set up Test environment
+   * Populates the IME to the ssp configured, this gives user more control to set up Test environment partition.
+   * The offset in the envelope needs to adhere to a rule that for messages in the same system stream partition the
+   * offset needs to start at 0 for the first and be monotonically increasing for the following messages.
+   * If not the {@link InMemoryManager#put(SystemStreamPartition, IncomingMessageEnvelope)} will fail.
    *
-   * @param envelope
+   * Note: Please DO NOT use this in production use cases, this is only meant to set-up more flexible tests
+   * @param envelope incoming message envelope
    */
   public void send(IncomingMessageEnvelope envelope) {
     memoryManager.put(envelope.getSystemStreamPartition(), envelope);

--- a/samza-core/src/main/java/org/apache/samza/system/inmemory/InMemorySystemProducer.java
+++ b/samza-core/src/main/java/org/apache/samza/system/inmemory/InMemorySystemProducer.java
@@ -102,7 +102,8 @@ public class InMemorySystemProducer implements SystemProducer {
    * offset needs to start at 0 for the first and be monotonically increasing for the following messages.
    * If not the {@link InMemoryManager#put(SystemStreamPartition, IncomingMessageEnvelope)} will fail.
    *
-   * Note: Please DO NOT use this in production use cases, this is only meant to set-up more flexible tests
+   * Note: Please DO NOT use this in production use cases, this is only meant to set-up more flexible tests.
+   * This function is not thread safe.
    * @param envelope incoming message envelope
    */
   public void send(IncomingMessageEnvelope envelope) {

--- a/samza-test/src/test/java/org/apache/samza/test/framework/StreamTaskIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/framework/StreamTaskIntegrationTest.java
@@ -197,7 +197,7 @@ public class StreamTaskIntegrationTest {
   }
 
   @Test
-  public void testSyncTaskWithMultiplePartitionMultithreadedWithCutomIME() throws Exception {
+  public void testSyncTaskWithMultiplePartitionMultithreadedWithCustomIME() throws Exception {
     Map<Integer, List<KV>> inputPartitionData = new HashMap<>();
     Map<Integer, List<KV>> inputPartitionIME = new HashMap<>();
     Map<Integer, List<Integer>> expectedOutputPartitionData = new HashMap<>();

--- a/samza-test/src/test/java/org/apache/samza/test/framework/StreamTaskIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/framework/StreamTaskIntegrationTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.samza.Partition;
 import org.apache.samza.SamzaException;
 import org.apache.samza.application.TaskApplication;
 import org.apache.samza.context.Context;
@@ -40,6 +41,7 @@ import org.apache.samza.storage.kv.inmemory.descriptors.InMemoryTableDescriptor;
 import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.system.OutgoingMessageEnvelope;
 import org.apache.samza.system.SystemStream;
+import org.apache.samza.system.SystemStreamPartition;
 import org.apache.samza.system.kafka.descriptors.KafkaInputDescriptor;
 import org.apache.samza.system.kafka.descriptors.KafkaOutputDescriptor;
 import org.apache.samza.system.kafka.descriptors.KafkaSystemDescriptor;
@@ -191,6 +193,32 @@ public class StreamTaskIntegrationTest {
     Map<Integer, List<KV>> inputPartitionData = new HashMap<>();
     Map<Integer, List<Integer>> expectedOutputPartitionData = new HashMap<>();
     genData(inputPartitionData, expectedOutputPartitionData);
+    syncTaskWithMultiplePartitionMultithreadedHelper(inputPartitionData, expectedOutputPartitionData);
+  }
+
+  @Test
+  public void testSyncTaskWithMultiplePartitionMultithreadedWithCutomIME() throws Exception {
+    Map<Integer, List<KV>> inputPartitionData = new HashMap<>();
+    Map<Integer, List<KV>> inputPartitionIME = new HashMap<>();
+    Map<Integer, List<Integer>> expectedOutputPartitionData = new HashMap<>();
+    genData(inputPartitionData, expectedOutputPartitionData);
+
+    for (Map.Entry<Integer, List<KV>> entry: inputPartitionData.entrySet()) {
+      Integer partitionId = entry.getKey();
+      List<KV> messages = entry.getValue();
+      SystemStreamPartition ssp = new SystemStreamPartition("test", "input", new Partition(partitionId));
+      inputPartitionIME.put(partitionId, new ArrayList<>());
+      int offset = 0;
+      for (KV message: messages) {
+        IncomingMessageEnvelope ime = new IncomingMessageEnvelope(ssp, String.valueOf(offset++), message.key, message.getValue());
+        inputPartitionIME.get(partitionId).add(KV.of(message.key, ime));
+      }
+    }
+    syncTaskWithMultiplePartitionMultithreadedHelper(inputPartitionData, expectedOutputPartitionData);
+  }
+
+  void syncTaskWithMultiplePartitionMultithreadedHelper(Map<Integer, List<KV>> inputPartitionData,
+      Map<Integer, List<Integer>> expectedOutputPartitionData) throws Exception {
 
     InMemorySystemDescriptor isd = new InMemorySystemDescriptor("test");
 


### PR DESCRIPTION
Please read the jira tagged for description: https://issues.apache.org/jira/browse/SAMZA-2178

Use cases where this is helpful: 
Systems like Brooklin at LinkedIn where they have a custom BrooklinIncomingMessageEnvelope (BIMEs), this helps to directly feed BIMEs to InMemorySystem for Testing 

@bharathkk @prateekm please have a look when you have time!