### PR TITLE
SAMZA-2189: Integrate startpoint resolution workflow with SamzaContainer startup sequence.

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -667,7 +667,7 @@ public class ContainerStorageManager {
       }
 
       // register startingOffset with the sysConsumer and register a metric for it
-      sideInputSystemConsumers.register(ssp, startingOffset, null);
+      sideInputSystemConsumers.register(ssp, startingOffset);
       taskInstanceMetrics.get(sideInputStorageManagers.get(ssp).getTaskName()).addOffsetGauge(
           ssp, ScalaJavaUtil.toScalaFunction(() -> sideInputStorageManagers.get(ssp).getLastProcessedOffset(ssp)));
 

--- a/samza-core/src/main/scala/org/apache/samza/system/SystemConsumers.scala
+++ b/samza-core/src/main/scala/org/apache/samza/system/SystemConsumers.scala
@@ -31,7 +31,6 @@ import java.util.Set
 import scala.collection.JavaConverters._
 import org.apache.samza.serializers.SerdeManager
 import org.apache.samza.util.{Logging, TimerUtil}
-import org.apache.samza.startpoint.Startpoint
 import org.apache.samza.system.chooser.MessageChooser
 import org.apache.samza.SamzaException
 
@@ -197,7 +196,7 @@ class SystemConsumers (
   }
 
 
-  def register(systemStreamPartition: SystemStreamPartition, offset: String, startpoint: Startpoint) {
+  def register(systemStreamPartition: SystemStreamPartition, offset: String) {
     debug("Registering stream: %s, %s" format (systemStreamPartition, offset))
 
     if (IncomingMessageEnvelope.END_OF_STREAM_OFFSET.equals(offset)) {
@@ -209,12 +208,6 @@ class SystemConsumers (
     metrics.registerSystemStreamPartition(systemStreamPartition)
     unprocessedMessagesBySSP.put(systemStreamPartition, new ArrayDeque[IncomingMessageEnvelope]())
 
-    // Note regarding Startpoints and MessageChooser:
-    // Even if there is a startpoint for this SSP, passing in the checkpoint offset should not have any side-effects.
-    // Basically, the offset in the chooser is used in the special scenario where an SSP is both a broadcast and bootstrap stream
-    // and needs to decide what's the lowest starting offset for an SSP that spans across multiple tasks so it knows
-    // to keep the highest priority on the SSP starting from the lowest starting offset until the SSP is fully
-    // bootstrapped to the UPCOMING offset. The offset here is ignored otherwise.
     chooser.register(systemStreamPartition, offset)
 
     try {

--- a/samza-core/src/test/scala/org/apache/samza/container/TestTaskInstance.scala
+++ b/samza-core/src/test/scala/org/apache/samza/container/TestTaskInstance.scala
@@ -19,7 +19,7 @@
 
 package org.apache.samza.container
 
-import java.util.{Collections, Optional}
+import java.util.Collections
 
 import org.apache.samza.Partition
 import org.apache.samza.checkpoint.{Checkpoint, OffsetManager}

--- a/samza-core/src/test/scala/org/apache/samza/system/TestSystemConsumers.scala
+++ b/samza-core/src/test/scala/org/apache/samza/system/TestSystemConsumers.scala
@@ -53,8 +53,8 @@ class TestSystemConsumers {
                                         SystemConsumers.DEFAULT_DROP_SERIALIZATION_ERROR,
                                         SystemConsumers.DEFAULT_POLL_INTERVAL_MS, clock = () => now)
 
-    consumers.register(systemStreamPartition0, "0", null)
-    consumers.register(systemStreamPartition1, "1234", null)
+    consumers.register(systemStreamPartition0, "0")
+    consumers.register(systemStreamPartition1, "1234")
     consumers.start
 
     // Tell the consumer to respond with 1000 messages for SSP0, and no
@@ -118,7 +118,7 @@ class TestSystemConsumers {
                                         SystemConsumers.DEFAULT_DROP_SERIALIZATION_ERROR,
                                         SystemConsumers.DEFAULT_POLL_INTERVAL_MS, clock = () => now)
 
-    consumers.register(systemStreamPartition, "0", null)
+    consumers.register(systemStreamPartition, "0")
     consumers.start
 
     // Start should trigger a poll to the consumer.
@@ -184,7 +184,7 @@ class TestSystemConsumers {
       def register(systemStreamPartition: SystemStreamPartition, offset: String) = chooserRegistered += systemStreamPartition -> offset
     }, consumer, systemAdmins)
 
-    consumers.register(systemStreamPartition, "0", null)
+    consumers.register(systemStreamPartition, "0")
     consumers.start
     consumers.stop
 
@@ -226,7 +226,7 @@ class TestSystemConsumers {
     // it should throw a SystemConsumersException because system2 does not have a consumer
     var caughtRightException = false
     try {
-      consumers.register(systemStreamPartition2, "0", null)
+      consumers.register(systemStreamPartition2, "0")
     } catch {
       case e: SystemConsumersException => caughtRightException = true
       case _: Throwable => caughtRightException = false
@@ -247,7 +247,7 @@ class TestSystemConsumers {
 
     // throw exceptions when the deserialization has error
     val consumers = new SystemConsumers(msgChooser, consumer, systemAdmins, serdeManager, dropDeserializationError = false)
-    consumers.register(systemStreamPartition, "0", null)
+    consumers.register(systemStreamPartition, "0")
     consumers.start
     consumer(system).putStringMessage
     consumer(system).putBytesMessage
@@ -264,7 +264,7 @@ class TestSystemConsumers {
 
     // it should not throw exceptions when deserializaion fails if dropDeserializationError is set to true
     val consumers2 = new SystemConsumers(msgChooser, consumer, systemAdmins, serdeManager, dropDeserializationError = true)
-    consumers2.register(systemStreamPartition, "0", null)
+    consumers2.register(systemStreamPartition, "0")
     consumers2.start
     consumer(system).putBytesMessage
     consumer(system).putStringMessage
@@ -318,8 +318,8 @@ class TestSystemConsumers {
       SystemConsumers.DEFAULT_DROP_SERIALIZATION_ERROR,
       SystemConsumers.DEFAULT_POLL_INTERVAL_MS, clock = () => 0)
 
-    consumers.register(systemStreamPartition1, "0", null)
-    consumers.register(systemStreamPartition2, "0", null)
+    consumers.register(systemStreamPartition1, "0")
+    consumers.register(systemStreamPartition2, "0")
     consumers.start
 
     // Start should trigger a poll to the consumer.
@@ -362,7 +362,6 @@ class TestSystemConsumers {
     val systemStreamPartition2 = new SystemStreamPartition(system, stream, new Partition(2))
 
     val consumer = Mockito.mock(classOf[SystemConsumer])
-    val startpoint = Mockito.mock(classOf[Startpoint])
     val systemAdmins = Mockito.mock(classOf[SystemAdmins])
     Mockito.when(systemAdmins.getSystemAdmin(system)).thenReturn(Mockito.mock(classOf[SystemAdmin]))
 
@@ -372,7 +371,7 @@ class TestSystemConsumers {
       SystemConsumers.DEFAULT_DROP_SERIALIZATION_ERROR,
       SystemConsumers.DEFAULT_POLL_INTERVAL_MS, clock = () => 0)
 
-    consumers.register(systemStreamPartition1, "0", startpoint)
+    consumers.register(systemStreamPartition1, "0")
   }
 
   /**


### PR DESCRIPTION
This patch is comprised of the following changes:

* Integrates the resolving startpoints to offset workflow to container startup sequence.
* Either if the startpoint does not exist for a (taskname, system-stream-partition) or the startpoint resolution fails, then the checkpointed offset is used as starting offset 
* Added unit-tests to validate the altered starting offset computation flow for a partition. 