### PR TITLE
SAMZA-2191: Batch support for table APIs

### DIFF
--- a/docs/learn/documentation/versioned/api/table-api.md
+++ b/docs/learn/documentation/versioned/api/table-api.md
@@ -245,6 +245,8 @@ The table below summarizes table metrics:
 
 | Metrics | Class | Description |
 |---------|-------|-------------|
+|`batch-count`|`AsyncBatchingTable`|Count of batch operations|
+|`batch-duration`|`AsyncBatchingTable`|Timer interval between opening and closing a batch|
 |`get-ns`|`ReadableTable`|Average latency of `get/getAsync()` operations|
 |`getAll-ns`|`ReadableTable`|Average latency of `getAll/getAllAsync()` operations|
 |`num-gets`|`ReadableTable`|Count of `get/getAsync()` operations
@@ -300,6 +302,29 @@ All configuration options of a Remote Table can be found in the
 Couchbase is supported as remote table. See
 [`CouchbaseTableReadFunction`](https://github.com/apache/samza/blob/master/samza-kv-couchbase/src/main/java/org/apache/samza/table/remote/couchbase/CouchbaseTableReadFunction.java) and 
 [`CouchbaseTableWriteFunction`](https://github.com/apache/samza/blob/master/samza-kv-couchbase/src/main/java/org/apache/samza/table/remote/couchbase/CouchbaseTableWriteFunction.java).
+
+### Batching
+
+Remote Table has built-in client-side batching support for its async executions.
+This is useful when a remote data store supports batch processing and is not sophisticated enough
+to handle heavy inbound requests. 
+
+#### Configuration
+
+Batching can be enabled with [`RemoteTableDescriptor`](https://github.com/apache/samza/blob/master/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTableDescriptor.java)
+by providing a [`BatchProvider`](https://github.com/apache/samza/samza-api/src/main/java/org/apache/samza/table/batching/BatchProvider.java)
+The user can choose:
+ 
+1. A [`CompactBatchProvider`](https://github.com/apache/samza/samza-core/src/main/java/org/apache/samza/table/batching/CompactBatchProvider.java) which provides a batch such that
+   the operations are compacted by the key. For update operations, the latter update will override the value of the previous one when they have the same key. For query operations,
+   the operations will be combined as a single operation when they have the same key. 
+2. A [`CompleteBatchProvider`](https://github.com/apache/samza/samza-core/src/main/java/org/apache/samza/table/batching/CompleteBatchProvider.java) which provides a batch such that
+   all the operations will be visible to the remote store regardless of the keys.
+3. A user-defined instance of [`BatchProvider`].
+
+For each [`BatchProvider`], the user can config the following:
+1. Specify the max size the batch can grow before being closed by `withmaxBatchSize(int)`
+2. Specify the max time the batch can last before being closed by `withmaxBatchDelay(Duration)`
 
 ### Rate Limiting
 
@@ -607,6 +632,11 @@ We recommend:
    intent of the current design of Samza Remote Table API is to handle 
    retries at a higher and more abstract Remote Table level, which implies 
    retrying is not a responsibility of I/O functions.
+
+### Batching
+
+Samza Remote Table API can be configured to utilize user-supplied bath providers. 
+You may refer to the [Batching](#batching) section under Remote Table for more details.
 
 ### Caching
 

--- a/docs/learn/documentation/versioned/api/table-api.md
+++ b/docs/learn/documentation/versioned/api/table-api.md
@@ -245,8 +245,8 @@ The table below summarizes table metrics:
 
 | Metrics | Class | Description |
 |---------|-------|-------------|
-|`batch-count`|`AsyncBatchingTable`|Count of batch operations|
-|`batch-duration`|`AsyncBatchingTable`|Timer interval between opening and closing a batch|
+|`num-batches`|`AsyncBatchingTable`|Number of batch operations|
+|`batch-ns`|`AsyncBatchingTable`|Time interval between opening and closing a batch|
 |`get-ns`|`ReadableTable`|Average latency of `get/getAsync()` operations|
 |`getAll-ns`|`ReadableTable`|Average latency of `getAll/getAllAsync()` operations|
 |`num-gets`|`ReadableTable`|Count of `get/getAsync()` operations

--- a/samza-api/src/main/java/org/apache/samza/table/batching/Batch.java
+++ b/samza-api/src/main/java/org/apache/samza/table/batching/Batch.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Manages a sequence of {@link Operation}s, which will be performed as a batch.
+ * A batch can be configured with a {@code maxBatchSize} and/or {@code maxBatchDelay}.
+ * When the number of operations in the batch exceeds the {@code maxBatchSize}
+ * or the time window exceeds the {@code maxBatchDelay}, the batch will be performed.
+ *
+ * @param <K> The type of the key associated with the {@link Operation}
+ * @param <V> The type of the value associated with the {@link Operation}
+ */
+public interface Batch<K, V> {
+  /**
+   * Add an operation to the batch.
+   *
+   * @param operation The operation to be added.
+   * @return A {@link CompletableFuture} that indicate the status of the batch.
+   */
+  CompletableFuture<Void> addOperation(Operation<K, V> operation);
+
+  /**
+   * Close the bach so that it will not accept more operations.
+   */
+  void close();
+
+  /**
+   * @return Whether the bach can accept more operations.
+   */
+  boolean isClosed();
+
+  /**
+   * @return The operations buffered by the batch.
+   */
+  Collection<Operation<K, V>> getOperations();
+
+  /**
+   * @return The batch max delay.
+   */
+  Duration getmaxBatchDelay();
+
+  /**
+   * @return The batch capacity
+   */
+  int getmaxBatchSize();
+
+  /**
+   * Change the batch status to be complete.
+   */
+  void complete();
+
+  /**
+   * Change the batch status to be complete with exception.
+   */
+  void completeExceptionally(Throwable throwable);
+
+  /**
+   * @return The number of operations in the batch.
+   */
+  int size();
+
+  /**
+   * @return True if the batch is empty.
+   */
+  default boolean isEmpty() {
+    return size() == 0;
+  }
+}

--- a/samza-api/src/main/java/org/apache/samza/table/batching/Batch.java
+++ b/samza-api/src/main/java/org/apache/samza/table/batching/Batch.java
@@ -59,12 +59,12 @@ public interface Batch<K, V> {
   /**
    * @return The batch max delay.
    */
-  Duration getmaxBatchDelay();
+  Duration getMaxBatchDelay();
 
   /**
    * @return The batch capacity
    */
-  int getmaxBatchSize();
+  int getMaxBatchSize();
 
   /**
    * Change the batch status to be complete.

--- a/samza-api/src/main/java/org/apache/samza/table/batching/BatchProvider.java
+++ b/samza-api/src/main/java/org/apache/samza/table/batching/BatchProvider.java
@@ -30,12 +30,12 @@ public abstract class BatchProvider<K, V> implements TablePart, Serializable {
   private int maxBatchSize = 100;
   private Duration maxBatchDelay = Duration.ofMillis(100);
 
-  public BatchProvider<K, V> withmaxBatchSize(int maxBatchSize) {
+  public BatchProvider<K, V> withMaxBatchSize(int maxBatchSize) {
     this.maxBatchSize = maxBatchSize;
     return this;
   }
 
-  public BatchProvider<K, V> withmaxBatchDelay(Duration maxBatchDelay) {
+  public BatchProvider<K, V> withMaxBatchDelay(Duration maxBatchDelay) {
     this.maxBatchDelay = maxBatchDelay;
     return this;
   }

--- a/samza-api/src/main/java/org/apache/samza/table/batching/BatchProvider.java
+++ b/samza-api/src/main/java/org/apache/samza/table/batching/BatchProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+import java.io.Serializable;
+import java.time.Duration;
+import org.apache.samza.table.remote.TablePart;
+
+
+public abstract class BatchProvider<K, V> implements TablePart, Serializable {
+  public abstract Batch<K, V> getBatch();
+
+  private int maxBatchSize = 100;
+  private Duration maxBatchDelay = Duration.ofMillis(100);
+
+  public BatchProvider<K, V> withmaxBatchSize(int maxBatchSize) {
+    this.maxBatchSize = maxBatchSize;
+    return this;
+  }
+
+  public BatchProvider<K, V> withmaxBatchDelay(Duration maxBatchDelay) {
+    this.maxBatchDelay = maxBatchDelay;
+    return this;
+  }
+
+  public int getMaxBatchSize() {
+    return maxBatchSize;
+  }
+
+  public Duration getmaxBatchDelay() {
+    return maxBatchDelay;
+  }
+}

--- a/samza-api/src/main/java/org/apache/samza/table/batching/Operation.java
+++ b/samza-api/src/main/java/org/apache/samza/table/batching/Operation.java
@@ -35,4 +35,9 @@ public interface Operation<K, V> {
    * @return The value associated with the operation.
    */
   V getValue();
+
+  /**
+   * @return The extra arguments associated with the operation.
+   */
+  Object[] getArgs();
 }

--- a/samza-api/src/main/java/org/apache/samza/table/batching/Operation.java
+++ b/samza-api/src/main/java/org/apache/samza/table/batching/Operation.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+/**
+ * Interface for operations that can be batched.
+ *
+ * @param <K> The key type associated with the operation.
+ * @param <V> The value type associated with the operation.
+ */
+public interface Operation<K, V> {
+  /**
+   * @return The key associated with the operation.
+   */
+  K getKey();
+
+  /**
+   * @return The value associated with the operation.
+   */
+  V getValue();
+}

--- a/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
+++ b/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
@@ -91,7 +91,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
   // Indicate whether write rate limiter is enabled or not
   private boolean enableWriteRateLimiter = true;
 
-  // Batching support to reduce traffic volume sent to the the remote store.
+  // Batching support to reduce traffic volume sent to the remote store.
   private BatchProvider<K, V> batchProvider;
 
   // Rates for constructing the default rate limiter when they are non-zero

--- a/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
+++ b/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.apache.samza.SamzaException;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.MapConfig;
+import org.apache.samza.table.batching.BatchProvider;
 import org.apache.samza.table.remote.TablePart;
 import org.apache.samza.table.remote.TableRateLimiter;
 import org.apache.samza.table.remote.TableReadFunction;
@@ -74,6 +75,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
   public static final String ASYNC_CALLBACK_POOL_SIZE = "io.async.callback.pool.size";
   public static final String READ_RETRY_POLICY = "io.read.retry.policy";
   public static final String WRITE_RETRY_POLICY = "io.write.retry.policy";
+  public static final String BATCH_PROVIDER = "io.batch.provider";
 
   // Input support for a specific remote store (required)
   private TableReadFunction<K, V> readFn;
@@ -84,11 +86,13 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
   // Rate limiter for client-side throttling; it is set by withRateLimiter()
   private RateLimiter rateLimiter;
 
-  // Indicate whether read rate limiter is enabled or not
   private boolean enableReadRateLimiter = true;
 
   // Indicate whether write rate limiter is enabled or not
   private boolean enableWriteRateLimiter = true;
+
+  // Batching support to reduce traffic volume sent to the the remote store.
+  private BatchProvider<K, V> batchProvider;
 
   // Rates for constructing the default rate limiter when they are non-zero
   private Map<String, Integer> tagCreditsMap = new HashMap<>();
@@ -259,6 +263,11 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
     return this;
   }
 
+  public RemoteTableDescriptor<K, V> withBatchProvider(BatchProvider<K, V> batchProvider) {
+    this.batchProvider = batchProvider;
+    return this;
+  }
+
   @Override
   public String getProviderFactoryClassName() {
     return PROVIDER_FACTORY_CLASS_NAME;
@@ -327,6 +336,10 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
       addTablePartConfig(WRITE_FN, writeFn, jobConfig, tableConfig);
     }
 
+    if (batchProvider != null) {
+      addTableConfig(BATCH_PROVIDER, SerdeUtils.serialize("batch provider", batchProvider), tableConfig);
+      addTablePartConfig(BATCH_PROVIDER, batchProvider, jobConfig, tableConfig);
+    }
     return Collections.unmodifiableMap(tableConfig);
   }
 

--- a/samza-core/src/main/java/org/apache/samza/table/batching/AbstractBatch.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/AbstractBatch.java
@@ -28,6 +28,7 @@ abstract class AbstractBatch<K, V> implements Batch<K, V> {
   protected final Duration maxBatchDelay;
   protected final CompletableFuture<Void> completableFuture;
   protected boolean closed = false;
+  protected static final BatchingNotSupportedException BATCH_NOT_SUPPORTED_EXCEPTION = new BatchingNotSupportedException();
 
   AbstractBatch(int maxBatchSize, Duration maxBatchDelay) {
     // The max number of {@link Operation}s that the batch can hold.
@@ -41,7 +42,7 @@ abstract class AbstractBatch<K, V> implements Batch<K, V> {
    * @return The batch capacity.
    */
   @Override
-  public int getmaxBatchSize() {
+  public int getMaxBatchSize() {
     return maxBatchSize;
   }
 
@@ -49,7 +50,7 @@ abstract class AbstractBatch<K, V> implements Batch<K, V> {
    * @return The batch max delay.
    */
   @Override
-  public Duration getmaxBatchDelay() {
+  public Duration getMaxBatchDelay() {
     return maxBatchDelay;
   }
 

--- a/samza-core/src/main/java/org/apache/samza/table/batching/AbstractBatch.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/AbstractBatch.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+
+abstract class AbstractBatch<K, V> implements Batch<K, V> {
+  protected final int maxBatchSize;
+  protected final Duration maxBatchDelay;
+  protected final CompletableFuture<Void> completableFuture;
+  protected boolean closed = false;
+
+  AbstractBatch(int maxBatchSize, Duration maxBatchDelay) {
+    // The max number of {@link Operation}s that the batch can hold.
+    this.maxBatchSize = maxBatchSize;
+    // The max time that the batch can last before being performed.
+    this.maxBatchDelay = maxBatchDelay;
+    completableFuture = new CompletableFuture<>();
+  }
+
+  /**
+   * @return The batch capacity.
+   */
+  @Override
+  public int getmaxBatchSize() {
+    return maxBatchSize;
+  }
+
+  /**
+   * @return The batch max delay.
+   */
+  @Override
+  public Duration getmaxBatchDelay() {
+    return maxBatchDelay;
+  }
+
+  @Override
+  public void complete() {
+    completableFuture.complete(null);
+  }
+
+  @Override
+  public void completeExceptionally(Throwable throwable) {
+    completableFuture.completeExceptionally(throwable);
+  }
+
+  @Override
+  public void close() {
+    closed = true;
+  }
+
+  @Override
+  public boolean isClosed() {
+    return closed;
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/table/batching/AsyncBatchingTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/AsyncBatchingTable.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import org.apache.samza.SamzaException;
+import org.apache.samza.context.Context;
+import org.apache.samza.storage.kv.Entry;
+import org.apache.samza.table.AsyncReadWriteTable;
+import org.apache.samza.table.utils.TableMetricsUtil;
+
+
+/**
+ * A wrapper of a {@link AsyncReadWriteTable} that supports batch operations.
+ *
+ * This batching table does not guarantee any ordering of different operation types within the batch.
+ * For instance, query(Q) and update(u) operations arrives in the following sequences, Q1, U1, Q2, U2,
+ * it does not mean the the remote data store will receive the messages in the same order. Instead,
+ * the operations will be grouped by type and sent via micro batches. For this sequence, Q1 and Q2 will
+ * be grouped to micro batch B1; U1 and U2 will be grouped to micro batch B2, the implementation class
+ * can decide the order of the micro batches.
+ *
+ * Synchronized table operations (get/put/delete) should be used with caution for the batching feature.
+ * If the table is used by a single thread, there will be at most one operation in the batch, and the
+ * batch will be performed when the TTL of the batch window expires. Batching does not make sense in this scenario.
+ *
+ * Note: The batching feature will ignore the "args" parameter for each API.
+ *
+ * @param <K> The type of the key.
+ * @param <V> The type of the value.
+ */
+public class AsyncBatchingTable<K, V> implements AsyncReadWriteTable<K, V> {
+  private final AsyncReadWriteTable<K, V> table;
+  private final String tableId;
+  private final BatchProvider<K, V> batchProvider;
+  private final ScheduledExecutorService batchTimerExecutorService;
+  private BatchProcessor<K, V> batchProcessor;
+
+  /**
+   * @param tableId The id of the table.
+   * @param table The target table that serves the batch operations.
+   * @param batchProvider Batch provider to create a batch instance.
+   */
+  public AsyncBatchingTable(String tableId, AsyncReadWriteTable table, BatchProvider<K, V> batchProvider,
+      ScheduledExecutorService batchTimerExecutorService) {
+    Preconditions.checkNotNull(tableId);
+    Preconditions.checkNotNull(table);
+    Preconditions.checkNotNull(batchProvider);
+    Preconditions.checkNotNull(batchTimerExecutorService);
+
+    this.tableId = tableId;
+    this.table = table;
+    this.batchProvider = batchProvider;
+    this.batchTimerExecutorService = batchTimerExecutorService;
+  }
+
+  @Override
+  public CompletableFuture<V> getAsync(K key, Object... args) {
+    Preconditions.checkNotNull(key);
+
+    try {
+      return batchProcessor.processQueryOperation(new GetOperation<>(key));
+    } catch (Exception e) {
+      throw new SamzaException(e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<Map<K, V>> getAllAsync(List<K> keys, Object... args) {
+    Preconditions.checkNotNull(keys);
+
+    return table.getAllAsync(keys);
+  }
+
+  @Override
+  public CompletableFuture<Void> putAsync(K key, V value, Object... args) {
+    Preconditions.checkNotNull(key);
+
+    try {
+      return batchProcessor.processUpdateOperation(new PutOperation<>(key, value));
+    } catch (Exception e) {
+      throw new SamzaException(e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<Void> putAllAsync(List<Entry<K, V>> entries, Object... args) {
+    Preconditions.checkNotNull(entries);
+
+    return table.putAllAsync(entries);
+  }
+
+  @Override
+  public CompletableFuture<Void> deleteAsync(K key, Object... args) {
+    Preconditions.checkNotNull(key);
+    try {
+      return batchProcessor.processUpdateOperation(new DeleteOperation<>(key));
+    } catch (Exception e) {
+      throw new SamzaException(e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<Void> deleteAllAsync(List<K> keys, Object... args) {
+    Preconditions.checkNotNull(keys);
+
+    return table.deleteAllAsync(keys);
+  }
+
+  @Override
+  public void init(Context context) {
+    table.init(context);
+    final TableMetricsUtil metricsUtil = new TableMetricsUtil(context, this, tableId);
+    setBatchProcessor(new BatchMetrics(metricsUtil));
+  }
+
+  @Override
+  public void flush() {
+    table.flush();
+  }
+
+  @Override
+  public void close() {
+    batchProcessor.stop();
+    table.close();
+  }
+
+  @VisibleForTesting
+  void setBatchProcessor(BatchMetrics batchMetrics) {
+    batchProcessor = new BatchProcessor<>(batchMetrics, new TableBatchHandler<>(table),
+        batchProvider, batchTimerExecutorService);
+  }
+
+  @VisibleForTesting
+  BatchProcessor<K, V> getBatchProcessor() {
+    return batchProcessor;
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/table/batching/AsyncBatchingTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/AsyncBatchingTable.java
@@ -96,6 +96,11 @@ public class AsyncBatchingTable<K, V> implements AsyncReadWriteTable<K, V> {
   }
 
   @Override
+  public <T> CompletableFuture<T> readAsync(int opId, Object ... args) {
+    return table.readAsync(opId, args);
+  }
+
+  @Override
   public CompletableFuture<Void> putAsync(K key, V value, Object... args) {
     try {
       return batchProcessor.processUpdateOperation(new PutOperation<>(key, value, args));
@@ -134,6 +139,11 @@ public class AsyncBatchingTable<K, V> implements AsyncReadWriteTable<K, V> {
 
     createBatchProcessor(TableMetricsUtil.mayCreateHighResolutionClock(context.getJobContext().getConfig()),
         new BatchMetrics(metricsUtil));
+  }
+
+  @Override
+  public <T> CompletableFuture<T> writeAsync(int opId, Object ... args) {
+    return table.writeAsync(opId, args);
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/table/batching/BatchHandler.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/BatchHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+import java.util.concurrent.CompletableFuture;
+
+
+/**
+ * Define how the batch operations will be handled.
+ *
+ * @param <K> The key type of the operations
+ * @param <V> The value type of the operations.
+ */
+public interface BatchHandler<K, V> {
+  /**
+   *
+   * @param batch The batch to be handled
+   * @return A {@link CompletableFuture} that indicates the status of the handle process.
+   */
+  CompletableFuture<Void> handle(Batch<K, V> batch);
+}

--- a/samza-core/src/main/java/org/apache/samza/table/batching/BatchMetrics.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/BatchMetrics.java
@@ -39,8 +39,8 @@ class BatchMetrics {
   final Timer batchDuration;
 
   public BatchMetrics(TableMetricsUtil metricsUtil) {
-    batchCount = metricsUtil.newCounter("batch-count");
-    batchDuration = metricsUtil.newTimer("batch-duration");
+    batchCount = metricsUtil.newCounter("num-batches");
+    batchDuration = metricsUtil.newTimer("batch-ns");
   }
 
   public void incBatchCount() {

--- a/samza-core/src/main/java/org/apache/samza/table/batching/BatchMetrics.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/BatchMetrics.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+import org.apache.samza.metrics.Counter;
+import org.apache.samza.metrics.Timer;
+import org.apache.samza.table.utils.TableMetricsUtil;
+
+
+/**
+ * Wrapper of batch-related metrics.
+ */
+class BatchMetrics {
+  /**
+   * The number of batches
+   */
+  final Counter batchCount;
+
+  /**
+   * The time duration between opening and closing the batch
+   */
+  final Timer batchDuration;
+
+  public BatchMetrics(TableMetricsUtil metricsUtil) {
+    batchCount = metricsUtil.newCounter("batch-count");
+    batchDuration = metricsUtil.newTimer("batch-duration");
+  }
+
+  public void incBatchCount() {
+    batchCount.inc();
+  }
+
+  public void updateBatchDuration(long d) {
+    batchDuration.update(d);
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/table/batching/BatchNotSupportedException.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/BatchNotSupportedException.java
@@ -19,32 +19,20 @@
 
 package org.apache.samza.table.batching;
 
-import java.io.Serializable;
-import java.time.Duration;
-import org.apache.samza.table.remote.TablePart;
-
-
-public abstract class BatchProvider<K, V> implements TablePart, Serializable {
-  public abstract Batch<K, V> getBatch();
-
-  private int maxBatchSize = 100;
-  private Duration maxBatchDelay = Duration.ofMillis(100);
-
-  public BatchProvider<K, V> withmaxBatchSize(int maxBatchSize) {
-    this.maxBatchSize = maxBatchSize;
-    return this;
+public class BatchNotSupportedException extends RuntimeException {
+  public BatchNotSupportedException() {
+    super();
   }
 
-  public BatchProvider<K, V> withmaxBatchDelay(Duration maxBatchDelay) {
-    this.maxBatchDelay = maxBatchDelay;
-    return this;
+  public BatchNotSupportedException(String message) {
+    super(message);
   }
 
-  public int getMaxBatchSize() {
-    return maxBatchSize;
+  public BatchNotSupportedException(Throwable cause) {
+    super(cause);
   }
 
-  public Duration getMaxBatchDelay() {
-    return maxBatchDelay;
+  public BatchNotSupportedException(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/table/batching/BatchProcessor.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/BatchProcessor.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+
+/**
+ * Place a sequence of operations into a {@link Batch}. When a batch is not allowed to accept more
+ * operations, it will handled by a {@link BatchHandler}. Meanwhile, a new {@link Batch} will be
+ * created and a timer will be set for it.
+ *
+ * @param <K> The type of the key associated with the {@link Operation}
+ * @param <V> The type of the value associated with the {@link Operation}
+ */
+public class BatchProcessor<K, V> {
+  private final ScheduledExecutorService scheduledExecutorService;
+  private final ReentrantLock lock = new ReentrantLock();
+  private final BatchHandler<K, V> batchHandler;
+  private final BatchProvider<K, V> batchProvider;
+  private final BatchMetrics batchMetrics;
+  private Batch<K, V> batch;
+  private ScheduledFuture<?> scheduledFuture;
+  private long batchOpenTimestamp;
+
+  /**
+   * @param batchHandler Defines how each batch will be processed.
+   * @param batchProvider The batch provider to create a batch instance.
+   * @param scheduledExecutorService A scheduled executor service to set timers for the managed batches.
+   */
+  public BatchProcessor(BatchMetrics batchMetrics, BatchHandler<K, V> batchHandler, BatchProvider batchProvider,
+      ScheduledExecutorService scheduledExecutorService) {
+    Preconditions.checkNotNull(batchHandler);
+    Preconditions.checkNotNull(batchProvider);
+    Preconditions.checkNotNull(scheduledExecutorService);
+
+    this.batchHandler = batchHandler;
+    this.batchProvider = batchProvider;
+    this.scheduledExecutorService = scheduledExecutorService;
+    this.batchMetrics = batchMetrics;
+  }
+
+  private CompletableFuture<Void> addOperation(Operation<K, V> operation) {
+    if (batch == null) {
+      startNewBatch();
+    } else if (batch.isClosed()) {
+      processBatch(true);
+    }
+    final CompletableFuture<Void> res = batch.addOperation(operation);
+    if (batch.isClosed()) {
+      processBatch(true);
+    }
+    return res;
+  }
+
+  /**
+   * @param operation The query operation to be added to the batch.
+   * @return A {@link CompletableFuture} to indicate whether the operation is finished.
+   */
+  CompletableFuture<V> processQueryOperation(Operation<K, V> operation) {
+    Preconditions.checkNotNull(operation);
+    Preconditions.checkArgument(operation instanceof GetOperation);
+
+    lock.lock();
+    try {
+      GetOperation<K, V> getOperation = (GetOperation) operation;
+      addOperation(getOperation);
+      return getOperation.getCompletableFuture();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * @param operation The update operation to be added to the batch.
+   * @return A {@link CompletableFuture} to indicate whether the operation is finished.
+   */
+  CompletableFuture<Void> processUpdateOperation(Operation<K, V> operation) {
+    Preconditions.checkNotNull(operation);
+    Preconditions.checkArgument(operation instanceof PutOperation || operation instanceof DeleteOperation);
+
+    lock.lock();
+    try {
+      return addOperation(operation);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void processBatch(boolean cancelTimer) {
+    mayCancelTimer(cancelTimer);
+    closeBatch();
+    batchHandler.handle(batch);
+    startNewBatch();
+  }
+
+  private void startNewBatch() {
+    batch = batchProvider.getBatch();
+    batchOpenTimestamp = System.currentTimeMillis();
+    batchMetrics.incBatchCount();
+    setBatchTimer(batch);
+  }
+
+  private void closeBatch() {
+    batch.close();
+    batchMetrics.updateBatchDuration(System.currentTimeMillis() - batchOpenTimestamp);
+  }
+
+  private void mayCancelTimer(boolean cancelTimer) {
+    if (cancelTimer && scheduledFuture != null) {
+      scheduledFuture.cancel(true);
+    }
+  }
+
+  /**
+   * Set a timer to close the batch when the batch is older than the max delay.
+   */
+  private void setBatchTimer(Batch<K, V> batch) {
+    final long maxDelay = batch.getmaxBatchDelay().toMillis();
+    if (maxDelay != Integer.MAX_VALUE) {
+      scheduledFuture = scheduledExecutorService.schedule(() -> {
+          lock.lock();
+          try {
+            processBatch(false);
+          } finally {
+            lock.unlock();
+          }
+        }, maxDelay, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  /**
+   * Stop the processor and cancel all the pending futures.
+   */
+  void stop() {
+    if (scheduledFuture != null) {
+      scheduledFuture.cancel(true);
+    }
+  }
+
+  /**
+   * Get the current number of operations received.
+   */
+  @VisibleForTesting
+  int size() {
+    return batch == null ? 0 : batch.size();
+  }
+
+  /**
+   * Get the latest update operation for the specified key.
+   */
+  @VisibleForTesting
+  Operation<K, V> getLastUpdate(K key) {
+    final Collection<Operation<K, V>> operations = batch.getOperations();
+    final Iterator<Operation<K, V>> iterator = operations.iterator();
+    Operation<K, V> lastUpdate = null;
+    while (iterator.hasNext()) {
+      final Operation<K, V> operation = iterator.next();
+      if ((operation instanceof PutOperation || operation instanceof DeleteOperation)
+          && operation.getKey().equals(key)) {
+        lastUpdate = operation;
+      }
+    }
+    return lastUpdate;
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/table/batching/BatchProcessor.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/BatchProcessor.java
@@ -68,8 +68,6 @@ public class BatchProcessor<K, V> {
   private CompletableFuture<Void> addOperation(Operation<K, V> operation) {
     if (batch == null) {
       startNewBatch();
-    } else if (batch.isClosed()) {
-      processBatch(true);
     }
     final CompletableFuture<Void> res = batch.addOperation(operation);
     if (batch.isClosed()) {

--- a/samza-core/src/main/java/org/apache/samza/table/batching/BatchingNotSupportedException.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/BatchingNotSupportedException.java
@@ -19,20 +19,24 @@
 
 package org.apache.samza.table.batching;
 
-public class BatchNotSupportedException extends RuntimeException {
-  public BatchNotSupportedException() {
+/**
+ * When adding an {@link Operation} to a {@link Batch}, if the batch implementation class
+ * does not want to batch the operation, it should throw a {@link BatchingNotSupportedException}.
+ */
+public class BatchingNotSupportedException extends UnsupportedOperationException {
+  public BatchingNotSupportedException() {
     super();
   }
 
-  public BatchNotSupportedException(String message) {
+  public BatchingNotSupportedException(String message) {
     super(message);
   }
 
-  public BatchNotSupportedException(Throwable cause) {
+  public BatchingNotSupportedException(Throwable cause) {
     super(cause);
   }
 
-  public BatchNotSupportedException(String message, Throwable cause) {
+  public BatchingNotSupportedException(String message, Throwable cause) {
     super(message, cause);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/table/batching/CompactBatch.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/CompactBatch.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 class CompactBatch<K, V> extends AbstractBatch<K, V> {
   private final Map<K, Operation<K, V>> updates = new LinkedHashMap<>();
   private final Set<Operation<K, V>> queries = new LinkedHashSet<>();
+  private static final BatchNotSupportedException BATCH_NOT_SUPPORTED_EXCEPTION = new BatchNotSupportedException();
 
   public CompactBatch(int maxBatchSize, Duration maxBatchDelay) {
     super(maxBatchSize, maxBatchDelay);
@@ -63,6 +64,10 @@ class CompactBatch<K, V> extends AbstractBatch<K, V> {
   @Override
   public CompletableFuture<Void> addOperation(Operation<K, V> operation) {
     Preconditions.checkNotNull(operation);
+
+    if (operation.getArgs() != null && operation.getArgs().length > 0) {
+      throw BATCH_NOT_SUPPORTED_EXCEPTION;
+    }
 
     if (operation instanceof GetOperation) {
       queries.add(operation);

--- a/samza-core/src/main/java/org/apache/samza/table/batching/CompactBatch.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/CompactBatch.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+import com.google.common.base.Preconditions;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+/**
+ * A newer update operation will override the value of an earlier one.
+ * Consecutive query operations with the same key will be combined as a single query.
+ *
+ * @param <K> The type of the key associated with the {@link Operation}
+ * @param <V> The type of the value associated with the {@link Operation}
+ */
+class CompactBatch<K, V> extends AbstractBatch<K, V> {
+  private final Map<K, Operation<K, V>> updates = new LinkedHashMap<>();
+  private final Set<Operation<K, V>> queries = new LinkedHashSet<>();
+
+  public CompactBatch(int maxBatchSize, Duration maxBatchDelay) {
+    super(maxBatchSize, maxBatchDelay);
+  }
+
+  /**
+   * @return The batch size.
+   */
+  @Override
+  public int size() {
+    return updates.size() + queries.size();
+  }
+
+  /**
+   * When adding a GetOperation to the batch, mark the GetOperation completed immediately if there is
+   * an UpdateOperation for the key, otherwise, adding the operation to a list.
+   * When adding a Put or DeleteOperation, if there is an update operation for the same key, the existing
+   * operation will be replaced by the new one.
+   */
+  @Override
+  public CompletableFuture<Void> addOperation(Operation<K, V> operation) {
+    Preconditions.checkNotNull(operation);
+
+    if (operation instanceof GetOperation) {
+      queries.add(operation);
+    } else {
+      updates.put(operation.getKey(), operation);
+    }
+    if (size() >= maxBatchSize) {
+      close();
+    }
+    return completableFuture;
+  }
+
+  @Override
+  public Collection<Operation<K, V>> getOperations() {
+    return Stream.of(queries, updates.values()).flatMap(Collection::stream).collect(Collectors.toList());
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/table/batching/CompactBatch.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/CompactBatch.java
@@ -23,9 +23,7 @@ import com.google.common.base.Preconditions;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -40,8 +38,7 @@ import java.util.stream.Stream;
  */
 class CompactBatch<K, V> extends AbstractBatch<K, V> {
   private final Map<K, Operation<K, V>> updates = new LinkedHashMap<>();
-  private final Set<Operation<K, V>> queries = new LinkedHashSet<>();
-  private static final BatchNotSupportedException BATCH_NOT_SUPPORTED_EXCEPTION = new BatchNotSupportedException();
+  private final Map<K, Operation<K, V>> queries = new LinkedHashMap<>();
 
   public CompactBatch(int maxBatchSize, Duration maxBatchDelay) {
     super(maxBatchSize, maxBatchDelay);
@@ -70,7 +67,7 @@ class CompactBatch<K, V> extends AbstractBatch<K, V> {
     }
 
     if (operation instanceof GetOperation) {
-      queries.add(operation);
+      queries.putIfAbsent(operation.getKey(), operation);
     } else {
       updates.put(operation.getKey(), operation);
     }
@@ -82,6 +79,6 @@ class CompactBatch<K, V> extends AbstractBatch<K, V> {
 
   @Override
   public Collection<Operation<K, V>> getOperations() {
-    return Stream.of(queries, updates.values()).flatMap(Collection::stream).collect(Collectors.toList());
+    return Stream.of(queries.values(), updates.values()).flatMap(Collection::stream).collect(Collectors.toList());
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/table/batching/CompactBatchProvider.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/CompactBatchProvider.java
@@ -22,6 +22,6 @@ package org.apache.samza.table.batching;
 public class CompactBatchProvider<K, V> extends BatchProvider<K, V> {
   @Override
   public Batch<K, V> getBatch() {
-    return new CompactBatch<>(getMaxBatchSize(), getmaxBatchDelay());
+    return new CompactBatch<>(getMaxBatchSize(), getMaxBatchDelay());
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/table/batching/CompactBatchProvider.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/CompactBatchProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+public class CompactBatchProvider<K, V> extends BatchProvider<K, V> {
+  @Override
+  public Batch<K, V> getBatch() {
+    return new CompactBatch<>(getMaxBatchSize(), getmaxBatchDelay());
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/table/batching/CompleteBatch.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/CompleteBatch.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+import com.google.common.base.Preconditions;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+
+/**
+ * The complete operation sequences are stored in the batch, regardless of whether the keys are the same or not.
+ *
+ * @param <K> The type of the key associated with the {@link Operation}
+ * @param <V> The type of the value associated with the {@link Operation}
+ */
+class CompleteBatch<K, V> extends AbstractBatch<K, V> {
+  private final List<Operation<K, V>> operations = new ArrayList<>();
+
+  public CompleteBatch(int maxBatchSize, Duration maxBatchDelay) {
+    super(maxBatchSize, maxBatchDelay);
+  }
+
+  /**
+   * @return The batch size.
+   */
+  @Override
+  public int size() {
+    return operations.size();
+  }
+
+  /**
+   * All operations will be buffered without any compaction.
+   */
+  @Override
+  public CompletableFuture<Void> addOperation(Operation<K, V> operation) {
+    Preconditions.checkNotNull(operation);
+    operations.add(operation);
+    if (size() >= maxBatchSize) {
+      close();
+    }
+    return completableFuture;
+  }
+
+  @Override
+  public Collection<Operation<K, V>> getOperations() {
+    return operations;
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/table/batching/CompleteBatchProvider.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/CompleteBatchProvider.java
@@ -22,6 +22,6 @@ package org.apache.samza.table.batching;
 public class CompleteBatchProvider<K, V> extends BatchProvider<K, V> {
   @Override
   public Batch<K, V> getBatch() {
-    return new CompleteBatch<>(getMaxBatchSize(), getmaxBatchDelay());
+    return new CompleteBatch<>(getMaxBatchSize(), getMaxBatchDelay());
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/table/batching/CompleteBatchProvider.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/CompleteBatchProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+public class CompleteBatchProvider<K, V> extends BatchProvider<K, V> {
+  @Override
+  public Batch<K, V> getBatch() {
+    return new CompleteBatch<>(getMaxBatchSize(), getmaxBatchDelay());
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/table/batching/DeleteOperation.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/DeleteOperation.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+import com.google.common.base.Preconditions;
+
+
+/**
+ * Delete operation.
+ *
+ * @param <K> The type of the key.
+ */
+public class DeleteOperation<K, V> implements Operation<K, V> {
+  final K key;
+
+  public DeleteOperation(K key) {
+    Preconditions.checkNotNull(key);
+
+    this.key = key;
+  }
+
+  /**
+   * @return The key to be deleted.
+   */
+  @Override
+  public K getKey() {
+    return key;
+  }
+
+  /**
+   * @return null.
+   */
+  @Override
+  public V getValue() {
+    return null;
+  }
+
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+
+    final DeleteOperation<K, V> otherOp = (DeleteOperation) other;
+    return otherOp.getValue() == null && getKey().equals(otherOp.getKey());
+  }
+
+  @Override
+  public int hashCode() {
+    return getKey().hashCode();
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/table/batching/DeleteOperation.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/DeleteOperation.java
@@ -29,11 +29,13 @@ import com.google.common.base.Preconditions;
  */
 public class DeleteOperation<K, V> implements Operation<K, V> {
   final K key;
+  final Object[] args;
 
-  public DeleteOperation(K key) {
+  public DeleteOperation(K key, Object ... args) {
     Preconditions.checkNotNull(key);
 
     this.key = key;
+    this.args = args;
   }
 
   /**
@@ -52,6 +54,13 @@ public class DeleteOperation<K, V> implements Operation<K, V> {
     return null;
   }
 
+  /**
+   * @return The extra arguments associated with the table.
+   */
+  @Override
+  public Object[] getArgs() {
+    return args;
+  }
 
   @Override
   public boolean equals(Object other) {

--- a/samza-core/src/main/java/org/apache/samza/table/batching/DeleteOperation.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/DeleteOperation.java
@@ -61,22 +61,4 @@ public class DeleteOperation<K, V> implements Operation<K, V> {
   public Object[] getArgs() {
     return args;
   }
-
-  @Override
-  public boolean equals(Object other) {
-    if (this == other) {
-      return true;
-    }
-    if (other == null || getClass() != other.getClass()) {
-      return false;
-    }
-
-    final DeleteOperation<K, V> otherOp = (DeleteOperation) other;
-    return otherOp.getValue() == null && getKey().equals(otherOp.getKey());
-  }
-
-  @Override
-  public int hashCode() {
-    return getKey().hashCode();
-  }
 }

--- a/samza-core/src/main/java/org/apache/samza/table/batching/GetOperation.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/GetOperation.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+import com.google.common.base.Preconditions;
+import java.util.concurrent.CompletableFuture;
+
+
+/**
+ * Get operation.
+ *
+ * @param <K> The type of the key.
+ */
+public class GetOperation<K, V> implements Operation<K, V> {
+  final K key;
+  final CompletableFuture<V> completableFuture = new CompletableFuture<>();
+
+  public GetOperation(K key) {
+    Preconditions.checkNotNull(key);
+
+    this.key = key;
+  }
+
+  /**
+   * @return The key of the operation.
+   */
+  @Override
+  public K getKey() {
+    Preconditions.checkNotNull(key);
+
+    return key;
+  }
+
+  /**
+   * @return null.
+   */
+  @Override
+  public V getValue() {
+    return null;
+  }
+
+  CompletableFuture<V> getCompletableFuture() {
+    return completableFuture;
+  }
+
+  void complete(V val) {
+    completableFuture.complete(val);
+  }
+
+  void completeExceptionally(Throwable ex) {
+    completableFuture.completeExceptionally(ex);
+  }
+
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+
+    final GetOperation<K, V> otherOp = (GetOperation) other;
+    return otherOp.getValue() == null && getKey().equals(otherOp.getKey());
+  }
+
+  @Override
+  public int hashCode() {
+    return getKey().hashCode();
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/table/batching/GetOperation.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/GetOperation.java
@@ -30,12 +30,15 @@ import java.util.concurrent.CompletableFuture;
  */
 public class GetOperation<K, V> implements Operation<K, V> {
   final K key;
+  final Object[] args;
   final CompletableFuture<V> completableFuture = new CompletableFuture<>();
 
-  public GetOperation(K key) {
+  public GetOperation(K key, Object ... args) {
     Preconditions.checkNotNull(key);
+    Preconditions.checkNotNull(args);
 
     this.key = key;
+    this.args = args;
   }
 
   /**
@@ -54,6 +57,14 @@ public class GetOperation<K, V> implements Operation<K, V> {
   @Override
   public V getValue() {
     return null;
+  }
+
+  /**
+   * @return The extra arguments associated with the table.
+   */
+  @Override
+  public Object[] getArgs() {
+    return args;
   }
 
   CompletableFuture<V> getCompletableFuture() {

--- a/samza-core/src/main/java/org/apache/samza/table/batching/GetOperation.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/GetOperation.java
@@ -78,23 +78,4 @@ public class GetOperation<K, V> implements Operation<K, V> {
   void completeExceptionally(Throwable ex) {
     completableFuture.completeExceptionally(ex);
   }
-
-
-  @Override
-  public boolean equals(Object other) {
-    if (this == other) {
-      return true;
-    }
-    if (other == null || getClass() != other.getClass()) {
-      return false;
-    }
-
-    final GetOperation<K, V> otherOp = (GetOperation) other;
-    return otherOp.getValue() == null && getKey().equals(otherOp.getKey());
-  }
-
-  @Override
-  public int hashCode() {
-    return getKey().hashCode();
-  }
 }

--- a/samza-core/src/main/java/org/apache/samza/table/batching/PutOperation.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/PutOperation.java
@@ -65,28 +65,4 @@ public class PutOperation<K, V> implements Operation<K, V> {
   public Object[] getArgs() {
     return args;
   }
-
-  @Override
-  public boolean equals(Object other) {
-    if (this == other) {
-      return true;
-    }
-    if (other == null || getClass() != other.getClass()) {
-      return false;
-    }
-
-    final PutOperation<K, V> otherOp = (PutOperation) other;
-
-    // If value for this object is null, should be null for other object as well.
-    if ((getValue() == null) ^ (otherOp.getValue() == null)) {
-      return false;
-    }
-
-    return getKey().equals(otherOp.getKey()) && getValue().equals(otherOp.getValue());
-  }
-
-  @Override
-  public int hashCode() {
-    return getKey().hashCode();
-  }
 }

--- a/samza-core/src/main/java/org/apache/samza/table/batching/PutOperation.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/PutOperation.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+import com.google.common.base.Preconditions;
+
+
+/**
+ * Put operation.
+ *
+ * @param <K> The type of the key.
+ * @param <V> The type of the value
+ */
+public class PutOperation<K, V> implements Operation<K, V> {
+  final private K key;
+  final private V val;
+
+  public PutOperation(K key, V val) {
+    Preconditions.checkNotNull(key);
+
+    this.key = key;
+    this.val = val;
+  }
+
+  /**
+   * @return The key to be put to the table.
+   */
+  @Override
+  public K getKey() {
+    return key;
+  }
+
+  /**
+   * @return The value to be put to the table.
+   */
+  @Override
+  public V getValue() {
+    return val;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+
+    final PutOperation<K, V> otherOp = (PutOperation) other;
+
+    // If value for this object is null, should be null for other object as well.
+    if ((getValue() == null) ^ (otherOp.getValue() == null)) {
+      return false;
+    }
+
+    return getKey().equals(otherOp.getKey()) && getValue().equals(otherOp.getValue());
+  }
+
+  @Override
+  public int hashCode() {
+    return getKey().hashCode();
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/table/batching/PutOperation.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/PutOperation.java
@@ -31,12 +31,15 @@ import com.google.common.base.Preconditions;
 public class PutOperation<K, V> implements Operation<K, V> {
   final private K key;
   final private V val;
+  final private Object[] args;
 
-  public PutOperation(K key, V val) {
+  public PutOperation(K key, V val, Object ... args) {
     Preconditions.checkNotNull(key);
+    Preconditions.checkNotNull(args);
 
     this.key = key;
     this.val = val;
+    this.args = args;
   }
 
   /**
@@ -53,6 +56,14 @@ public class PutOperation<K, V> implements Operation<K, V> {
   @Override
   public V getValue() {
     return val;
+  }
+
+  /**
+   * @return The extra arguments associated with the table.
+   */
+  @Override
+  public Object[] getArgs() {
+    return args;
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/table/batching/TableBatchHandler.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/TableBatchHandler.java
@@ -21,6 +21,7 @@ package org.apache.samza.table.batching;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -55,7 +56,7 @@ public class TableBatchHandler<K, V> implements BatchHandler<K, V> {
     Preconditions.checkNotNull(operations);
     final List<K> gets = getOperationKeys(operations);
     if (gets.isEmpty()) {
-      return CompletableFuture.completedFuture(null);
+      return CompletableFuture.completedFuture(Collections.EMPTY_MAP);
     }
 
     final Object[] args = getOperationArgs(operations);
@@ -88,7 +89,7 @@ public class TableBatchHandler<K, V> implements BatchHandler<K, V> {
         .map(op -> new Entry<>(op.getKey(), op.getValue()))
         .collect(Collectors.toList());
     if (puts.isEmpty()) {
-      return CompletableFuture.completedFuture(null);
+      return CompletableFuture.completedFuture(Collections.EMPTY_MAP);
     }
 
     final Object[] args = getOperationArgs(operations);
@@ -106,7 +107,7 @@ public class TableBatchHandler<K, V> implements BatchHandler<K, V> {
 
     final List<K> deletes = getOperationKeys(operations);
     if (deletes.isEmpty()) {
-      return CompletableFuture.completedFuture(null);
+      return CompletableFuture.completedFuture(Collections.EMPTY_MAP);
     }
     final Object[] args = getOperationArgs(operations);
     return args == null ? table.deleteAllAsync(deletes) : table.deleteAllAsync(deletes, args);

--- a/samza-core/src/main/java/org/apache/samza/table/batching/TableBatchHandler.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/TableBatchHandler.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import com.google.common.base.Preconditions;
+import java.util.stream.Collectors;
+import org.apache.samza.storage.kv.Entry;
+import org.apache.samza.table.AsyncReadWriteTable;
+
+
+/**
+ * Defines how table performs batch operations.
+ *
+ * @param <K> The key type of the operation.
+ * @param <V> The value type of the operation.
+ */
+public class TableBatchHandler<K, V> implements BatchHandler<K, V> {
+  private final AsyncReadWriteTable<K, V> table;
+
+  public TableBatchHandler(AsyncReadWriteTable<K, V> table) {
+    Preconditions.checkNotNull(table);
+
+    this.table = table;
+  }
+
+  /**
+   * Define how batch get should be done.
+   *
+   * @param operations The batch get operations.
+   * @return A CompletableFuture to represent the status of the batch operation.
+   */
+  CompletableFuture<?> handleBatchGet(Collection<Operation<K, V>> operations) {
+    Preconditions.checkNotNull(operations);
+
+    final List<K> gets = new ArrayList<>(operations.size());
+    operations.forEach(operation -> gets.add(operation.getKey()));
+    final CompletableFuture<Map<K, V>> getsFuture = gets.isEmpty() ?
+        CompletableFuture.completedFuture(null) : table.getAllAsync(gets);
+
+    getsFuture.whenComplete((map, throwable) -> {
+        operations.forEach(operation -> {
+            GetOperation<K, V> getOperation = (GetOperation<K, V>) operation;
+            if (throwable != null) {
+              getOperation.completeExceptionally(throwable);
+            } else {
+              getOperation.complete(map.get(operation.getKey()));
+            }
+          });
+      });
+    return getsFuture;
+  }
+
+  /**
+   * Define how batch put should be done.
+   *
+   * @param operations The batch get operations.
+   * @return A CompletableFuture to represent the status of the batch operation.
+   */
+  CompletableFuture<?> handleBatchPut(Collection<Operation<K, V>> operations) {
+    Preconditions.checkNotNull(operations);
+
+    final List<Entry<K, V>> puts = operations.stream()
+        .map(op -> new Entry<>(op.getKey(), op.getValue()))
+        .collect(Collectors.toList());
+
+    return puts.isEmpty() ? CompletableFuture.completedFuture(null) : table.putAllAsync(puts);
+  }
+
+  /**
+   * Define how batch delete should be done.
+   *
+   * @param operations The batch get operations.
+   * @return A CompletableFuture to represent the status of the batch operation.
+   */
+  CompletableFuture<?> handleBatchDelete(Collection<Operation<K, V>> operations) {
+    Preconditions.checkNotNull(operations);
+
+    final List<K> deletes = operations.stream()
+        .map(op -> op.getKey())
+        .collect(Collectors.toList());
+
+    return deletes.isEmpty() ? CompletableFuture.completedFuture(null) : table.deleteAllAsync(deletes);
+  }
+
+  List<Operation<K, V>> getQueryOperations(Batch<K, V> batch) {
+    return batch.getOperations().stream().filter(op -> op instanceof GetOperation)
+        .collect(Collectors.toList());
+  }
+
+  List<Operation<K, V>> getPutOperations(Batch<K, V> batch) {
+    return batch.getOperations().stream().filter(op -> op instanceof PutOperation)
+        .collect(Collectors.toList());
+  }
+
+  List<Operation<K, V>> getDeleteOperations(Batch<K, V> batch) {
+    return batch.getOperations().stream().filter(op -> op instanceof DeleteOperation)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Perform batch operations.
+   */
+  @Override
+  public CompletableFuture<Void> handle(Batch<K, V> batch) {
+    return CompletableFuture.allOf(
+        handleBatchPut(getPutOperations(batch)),
+        handleBatchDelete(getDeleteOperations(batch)),
+        handleBatchGet(getQueryOperations(batch)))
+        .whenComplete((val, throwable) -> {
+            if (throwable != null) {
+              batch.completeExceptionally(throwable);
+            } else {
+              batch.complete();
+            }
+          });
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/table/utils/TableMetricsUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/table/utils/TableMetricsUtil.java
@@ -20,6 +20,8 @@
 package org.apache.samza.table.utils;
 
 import com.google.common.base.Preconditions;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.MetricsConfig;
 import org.apache.samza.context.Context;
 import org.apache.samza.metrics.Counter;
 import org.apache.samza.metrics.Gauge;
@@ -29,6 +31,7 @@ import org.apache.samza.table.Table;
 import org.apache.samza.table.caching.SupplierGauge;
 
 import java.util.function.Supplier;
+import org.apache.samza.util.HighResolutionClock;
 
 
 /**
@@ -103,4 +106,8 @@ public class TableMetricsUtil {
     return String.format("%s-%s", tableId, name);
   }
 
+  public static HighResolutionClock mayCreateHighResolutionClock(Config config) {
+    final MetricsConfig metricsConfig = new MetricsConfig(config);
+    return metricsConfig.getMetricsTimerEnabled() ? System::nanoTime : () -> 0;
+  }
 }

--- a/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchProcessor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchProcessor.java
@@ -156,7 +156,7 @@ public class TestBatchProcessor {
   private static BatchProcessor<Integer, Integer> createBatchProcessor(ReadWriteTable<Integer, Integer> table,
       int maxSize, int maxDelay) {
     final BatchProvider<Integer, Integer> batchProvider = new CompactBatchProvider<Integer, Integer>()
-        .withmaxBatchDelay(Duration.ofMillis(maxDelay)).withmaxBatchSize(maxSize);
+        .withMaxBatchDelay(Duration.ofMillis(maxDelay)).withMaxBatchSize(maxSize);
     final BatchHandler<Integer, Integer> batchHandler = new TableBatchHandler<>(table);
     final BatchMetrics batchMetrics = mock(BatchMetrics.class);
     return new BatchProcessor<>(batchMetrics, batchHandler, batchProvider, () -> 0, Executors.newSingleThreadScheduledExecutor());

--- a/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchProcessor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchProcessor.java
@@ -159,6 +159,6 @@ public class TestBatchProcessor {
         .withmaxBatchDelay(Duration.ofMillis(maxDelay)).withmaxBatchSize(maxSize);
     final BatchHandler<Integer, Integer> batchHandler = new TableBatchHandler<>(table);
     final BatchMetrics batchMetrics = mock(BatchMetrics.class);
-    return new BatchProcessor<>(batchMetrics, batchHandler, batchProvider, Executors.newSingleThreadScheduledExecutor());
+    return new BatchProcessor<>(batchMetrics, batchHandler, batchProvider, () -> 0, Executors.newSingleThreadScheduledExecutor());
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchProcessor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchProcessor.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+import org.apache.samza.table.ReadWriteTable;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+import static java.lang.Thread.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+    TestBatchProcessor.TestCreate.class,
+    TestBatchProcessor.TestUpdatesAndLookup.class,
+    TestBatchProcessor.TestBatchTriggered.class
+  })
+public class TestBatchProcessor {
+  private static final int SLOW_OPERATION_TIME_MS = 500;
+  private static final Supplier<Void> SLOW_UPDATE_SUPPLIER = () -> {
+    try {
+      sleep(SLOW_OPERATION_TIME_MS);
+    } catch (InterruptedException e) {
+      // ignore
+    }
+    return null;
+  };
+
+  public static class TestCreate {
+    @Test
+    public void testCreate() {
+      final ReadWriteTable<Integer, Integer> table = mock(ReadWriteTable.class);
+      final BatchProcessor<Integer, Integer> batchProcessor = createBatchProcessor(table,
+          3, Integer.MAX_VALUE);
+
+      // The batch processor initially has no operation.
+      Assert.assertEquals(0, batchProcessor.size());
+      batchProcessor.processUpdateOperation(new PutOperation<>(1, 1));
+      // The batch processor now has one operation.
+      Assert.assertEquals(1, batchProcessor.size());
+    }
+  }
+
+  public static class TestUpdatesAndLookup {
+    @Test
+    public void testUpdateAndLookup() {
+      final ReadWriteTable<Integer, Integer> table = mock(ReadWriteTable.class);
+      final BatchProcessor<Integer, Integer> batchProcessor =
+          createBatchProcessor(table, Integer.MAX_VALUE, Integer.MAX_VALUE);
+
+      int numberOfPuts = 10;
+      for (int i = 0; i < numberOfPuts; i++) {
+        batchProcessor.processUpdateOperation(new PutOperation<>(i, i));
+      }
+
+      // verify that the number of addBatch operations is correct.
+      Assert.assertEquals(numberOfPuts, batchProcessor.size());
+
+      // Verify that the value is correct for each key.
+      for (int i = 0; i < numberOfPuts; i++) {
+        final Operation<Integer, Integer> operation = batchProcessor.getLastUpdate(i);
+        Assert.assertEquals(i, operation.getKey().intValue());
+        Assert.assertEquals(i, operation.getValue().intValue());
+      }
+    }
+  }
+
+  public static class TestBatchTriggered {
+    @Test
+    public void testBatchOperationTriggeredByBatchSize() {
+      final int maxBatchSize = 3;
+
+      final ReadWriteTable<Integer, Integer> table = mock(ReadWriteTable.class);
+      when(table.putAllAsync(anyList())).thenReturn(CompletableFuture.supplyAsync(SLOW_UPDATE_SUPPLIER));
+
+      final BatchProcessor<Integer, Integer> batchProcessor =
+          createBatchProcessor(table, maxBatchSize, Integer.MAX_VALUE);
+
+      List<CompletableFuture<Void>> futureList = new ArrayList<>();
+      // One batch will be created and sent to the remote table after the for-loop.
+      for (int i = 0; i < maxBatchSize; i++) {
+        futureList.add(batchProcessor.processUpdateOperation(new PutOperation<>(i, i)));
+      }
+
+      for (int i = 0; i < maxBatchSize; i++) {
+        Assert.assertFalse(futureList.get(i).isDone());
+      }
+      Assert.assertEquals(0, batchProcessor.size());
+
+      try {
+        sleep(SLOW_OPERATION_TIME_MS * 2);
+      } catch (InterruptedException e) {
+        // ignore
+      }
+
+      for (int i = 0; i < maxBatchSize; i++) {
+        Assert.assertTrue(futureList.get(i).isDone());
+      }
+    }
+
+    @Test
+    public void testBatchOperationTriggeredByTimer() {
+      final int maxBatchDelayMs = 100;
+      final int putOperationCount = 100;
+
+      final ReadWriteTable<Integer, Integer> table = mock(ReadWriteTable.class);
+      when(table.putAllAsync(any())).thenReturn(CompletableFuture.completedFuture(null));
+      when(table.deleteAllAsync(anyList())).thenReturn(CompletableFuture.completedFuture(null));
+
+      final BatchProcessor<Integer, Integer> batchProcessor =
+          createBatchProcessor(table, Integer.MAX_VALUE, maxBatchDelayMs);
+
+      for (int i = 0; i < putOperationCount; i++) {
+        batchProcessor.processUpdateOperation(new PutOperation<>(i, i));
+      }
+
+      // There's one batch with infinite maximum size, it has 100ms maximum delay.
+      Assert.assertEquals(putOperationCount, batchProcessor.size());
+
+      try {
+        sleep(maxBatchDelayMs * 2);
+      } catch (InterruptedException e) {
+        // ignore
+      }
+
+      // After the timer fired, a new batch will be created.
+      Assert.assertEquals(0, batchProcessor.size());
+    }
+  }
+
+  private static BatchProcessor<Integer, Integer> createBatchProcessor(ReadWriteTable<Integer, Integer> table,
+      int maxSize, int maxDelay) {
+    final BatchProvider<Integer, Integer> batchProvider = new CompactBatchProvider<Integer, Integer>()
+        .withmaxBatchDelay(Duration.ofMillis(maxDelay)).withmaxBatchSize(maxSize);
+    final BatchHandler<Integer, Integer> batchHandler = new TableBatchHandler<>(table);
+    final BatchMetrics batchMetrics = mock(BatchMetrics.class);
+    return new BatchProcessor<>(batchMetrics, batchHandler, batchProvider, Executors.newSingleThreadScheduledExecutor());
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchTable.java
@@ -109,7 +109,7 @@ public class TestBatchTable {
     asyncBatchingTable = new AsyncBatchingTable("id", table, new CompactBatchProvider()
         .withmaxBatchSize(BATCH_SIZE)
         .withmaxBatchDelay(BATCH_DELAY), Executors.newSingleThreadScheduledExecutor());
-    asyncBatchingTable.setBatchProcessor(mock(BatchMetrics.class));
+    asyncBatchingTable.createBatchProcessor(() -> 0, mock(BatchMetrics.class));
 
     doAnswer(putAnswer).when(table).put(anyInt(), anyInt());
     doAnswer(putAsyncAnswer).when(table).putAsync(anyInt(), anyInt());

--- a/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchTable.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import org.apache.samza.storage.kv.Entry;
+import org.apache.samza.table.ReadWriteTable;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+
+import static org.mockito.Mockito.*;
+
+public class TestBatchTable {
+  private static final int BATCH_SIZE = 5;
+  private static final Duration BATCH_DELAY = Duration.ofMillis(Integer.MAX_VALUE);
+
+  private AsyncBatchingTable<Integer, Integer> asyncBatchingTable;
+  private ReadWriteTable<Integer, Integer> table;
+  private Map<Integer, Integer> tableDb;
+
+  @Before
+  public void setup() {
+    final Answer getAnswer = invocation -> {
+      Integer key = invocation.getArgumentAt(0, Integer.class);
+      return tableDb.get(key);
+    };
+
+    final Answer getAsyncAnswer = invocation -> {
+      Integer key = invocation.getArgumentAt(0, Integer.class);
+      return CompletableFuture.completedFuture(tableDb.get(key));
+    };
+
+    final Answer getAllAsyncAnswer = invocation -> {
+      final List<Integer> list = invocation.getArgumentAt(0, List.class);
+      final Map<Integer, Integer> map = new HashMap<>();
+      list.forEach(k -> map.put(k, tableDb.get(k)));
+      return CompletableFuture.completedFuture(map);
+    };
+
+    final Answer putAnswer = invocation -> {
+      Integer key = invocation.getArgumentAt(0, Integer.class);
+      Integer value = invocation.getArgumentAt(1, Integer.class);
+      tableDb.put(key, value);
+      return null;
+    };
+
+    final Answer putAsyncAnswer = invocation -> {
+      final Integer key = invocation.getArgumentAt(0, Integer.class);
+      final Integer value = invocation.getArgumentAt(1, Integer.class);
+      tableDb.put(key, value);
+      return CompletableFuture.completedFuture(null);
+    };
+
+    final Answer putAllAsyncAnswer = invocation -> {
+      final List<Entry<Integer, Integer>> list = invocation.getArgumentAt(0, List.class);
+      list.forEach(entry -> tableDb.put(entry.getKey(), entry.getValue()));
+      return CompletableFuture.completedFuture(null);
+    };
+
+    final Answer deleteAnswer = invocation -> {
+      final Integer key = invocation.getArgumentAt(0, Integer.class);
+      tableDb.remove(key);
+      return null;
+    };
+
+    final Answer deleteAsyncAnswer = invocation -> {
+      final Integer key = invocation.getArgumentAt(0, Integer.class);
+      tableDb.remove(key);
+      return CompletableFuture.completedFuture(null);
+    };
+
+    final Answer deleteAllAsyncAnswer = invocation -> {
+      final List<Integer> list = invocation.getArgumentAt(0, List.class);
+      list.forEach(k -> tableDb.remove(k));
+      return CompletableFuture.completedFuture(null);
+    };
+
+    table = mock(ReadWriteTable.class);
+    final BatchMetrics batchMetrics = mock(BatchMetrics.class);
+    tableDb = new HashMap<>();
+    asyncBatchingTable = new AsyncBatchingTable("id", table, new CompactBatchProvider()
+        .withmaxBatchSize(BATCH_SIZE)
+        .withmaxBatchDelay(BATCH_DELAY), Executors.newSingleThreadScheduledExecutor());
+    asyncBatchingTable.setBatchProcessor(mock(BatchMetrics.class));
+
+    doAnswer(putAnswer).when(table).put(anyInt(), anyInt());
+    doAnswer(putAsyncAnswer).when(table).putAsync(anyInt(), anyInt());
+    doAnswer(putAllAsyncAnswer).when(table).putAllAsync(anyList());
+
+    doAnswer(deleteAnswer).when(table).delete(anyInt());
+    doAnswer(deleteAsyncAnswer).when(table).deleteAsync(anyInt());
+    doAnswer(deleteAllAsyncAnswer).when(table).deleteAllAsync(anyList());
+
+    doAnswer(getAnswer).when(table).get(anyInt());
+    doAnswer(getAsyncAnswer).when(table).getAsync(anyInt());
+    doAnswer(getAllAsyncAnswer).when(table).getAllAsync(anyList());
+  }
+
+  @After
+  public void tearDown() {
+    asyncBatchingTable.close();
+  }
+
+  @Test
+  public void testPutAsync() {
+    final List<CompletableFuture<Void>> futures = new LinkedList<>();
+    for (int i = 0; i < BATCH_SIZE; i++) {
+      futures.add(asyncBatchingTable.putAsync(i, i));
+    }
+    sleep();
+
+    final BatchProcessor<Integer, Integer> batchProcessor = asyncBatchingTable.getBatchProcessor();
+
+    // Verify that all async puts are finished.
+    futures.forEach(future -> Assert.assertTrue(future.isDone()));
+    verify(table, times(1)).putAllAsync(any());
+
+    // There should be no operations in the batch processor.
+    Assert.assertEquals(0, batchProcessor.size());
+
+    asyncBatchingTable.putAsync(BATCH_SIZE, BATCH_SIZE);
+
+    // Now batch size should be 1.
+    Assert.assertEquals(1, batchProcessor.size());
+  }
+
+  @Test
+  public void testPutAllAsync() {
+    final List<Entry<Integer, Integer>> entries = new LinkedList<>();
+
+    for (int i = 0; i < BATCH_SIZE; i++) {
+      entries.add(new Entry<>(i, i));
+    }
+
+    CompletableFuture<Void> future = asyncBatchingTable.putAllAsync(entries);
+    final BatchProcessor<Integer, Integer> batchProcessor = asyncBatchingTable.getBatchProcessor();
+
+    sleep();
+
+    // Verify that putAllAsync is finished.
+    Assert.assertTrue(future.isDone());
+
+    // There should be no pending operations.
+    Assert.assertEquals(0, batchProcessor.size());
+
+    // The addBatchUpdates batch operations propagates to the table.
+    verify(table, times(1)).putAllAsync(anyList());
+
+    // This new addBatchUpdates will make the batch size to be 1.
+    asyncBatchingTable.putAsync(BATCH_SIZE, BATCH_SIZE);
+
+    Assert.assertEquals(1, batchProcessor.size());
+  }
+
+  @Test
+  public void testGetAsync() throws ExecutionException, InterruptedException {
+    for (int i = 0; i < BATCH_SIZE; i++) {
+      asyncBatchingTable.putAsync(i, i);
+    }
+    sleep();
+
+    final List<CompletableFuture<Integer>> futures = new ArrayList<>(BATCH_SIZE);
+    for (int i = 0; i < BATCH_SIZE; i++) {
+      futures.add(asyncBatchingTable.getAsync(i));
+    }
+    sleep();
+
+    for (Integer i = 0; i < BATCH_SIZE; i++) {
+      Assert.assertTrue(futures.get(i).isDone());
+      Assert.assertEquals(i, futures.get(i).get());
+    }
+    verify(table, times(1)).getAllAsync(anyList());
+  }
+
+  @Test
+  public void testGetAllAsync() throws ExecutionException, InterruptedException {
+    for (int i = 0; i < BATCH_SIZE; i++) {
+      asyncBatchingTable.putAsync(i, i);
+    }
+    sleep();
+
+    final List<Integer> keys = new LinkedList<>();
+    for (int i = 0; i < BATCH_SIZE; i++) {
+      keys.add(new Integer(i));
+    }
+
+    CompletableFuture<Map<Integer, Integer>> future = asyncBatchingTable.getAllAsync(keys);
+    sleep();
+
+    Assert.assertTrue(future.isDone());
+    Assert.assertEquals(BATCH_SIZE, future.get().size());
+
+    verify(table, times(1)).getAllAsync(anyList());
+  }
+
+  @Test
+  public void testDeleteAsync() throws Exception {
+    for (int i = 0; i < BATCH_SIZE; i++) {
+      asyncBatchingTable.putAsync(i, i);
+    }
+    sleep();
+
+    // The 1st batch is done.
+    verify(table, times(1)).putAllAsync(anyList());
+
+    final List<CompletableFuture<Void>> completableFutures = new ArrayList<>();
+    for (int i = 0; i < BATCH_SIZE; i++) {
+      completableFutures.add(asyncBatchingTable.deleteAsync(i));
+    }
+    sleep();
+
+    for (int i = 0; i < BATCH_SIZE; i++) {
+      Assert.assertEquals(null, completableFutures.get(i).get());
+    }
+  }
+
+  @Test
+  public void testDeleteAllAsync() throws Exception {
+    for (int i = 0; i < BATCH_SIZE; i++) {
+      asyncBatchingTable.putAsync(i, i);
+    }
+    sleep();
+
+    final List<Integer> keys = new LinkedList<>();
+    for (int i = 0; i < BATCH_SIZE; i++) {
+      keys.add(new Integer(i));
+    }
+
+    final CompletableFuture<Void> future = asyncBatchingTable.deleteAllAsync(keys);
+    sleep();
+    Assert.assertTrue(future.isDone());
+
+    final CompletableFuture<Map<Integer, Integer>> getAllFuture = asyncBatchingTable.getAllAsync(keys);
+    sleep();
+
+    Assert.assertTrue(getAllFuture.isDone());
+    getAllFuture.get().forEach((k, v) -> Assert.assertEquals(null, v));
+  }
+
+  private void sleep() {
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException e) {
+      // ignore
+    }
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchTable.java
@@ -107,8 +107,8 @@ public class TestBatchTable {
     final BatchMetrics batchMetrics = mock(BatchMetrics.class);
     tableDb = new HashMap<>();
     asyncBatchingTable = new AsyncBatchingTable("id", table, new CompactBatchProvider()
-        .withmaxBatchSize(BATCH_SIZE)
-        .withmaxBatchDelay(BATCH_DELAY), Executors.newSingleThreadScheduledExecutor());
+        .withMaxBatchSize(BATCH_SIZE)
+        .withMaxBatchDelay(BATCH_DELAY), Executors.newSingleThreadScheduledExecutor());
     asyncBatchingTable.createBatchProcessor(() -> 0, mock(BatchMetrics.class));
 
     doAnswer(putAnswer).when(table).put(anyInt(), anyInt());

--- a/samza-core/src/test/java/org/apache/samza/table/caching/TestCachingTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/caching/TestCachingTable.java
@@ -286,6 +286,7 @@ public class TestCachingTable {
         tableId + "-remote", readFn, writeFn,
         rateLimitHelper, rateLimitHelper, Executors.newSingleThreadExecutor(),
         null, null, null,
+        null, null,
         Executors.newSingleThreadExecutor());
 
     final CachingTable<String, String> cachingTable = new CachingTable<>(
@@ -407,6 +408,7 @@ public class TestCachingTable {
         tableId, readFn, writeFn,
         rateLimitHelper, rateLimitHelper, Executors.newSingleThreadExecutor(),
         null, null, null,
+        null, null,
         Executors.newSingleThreadExecutor());
 
     final CachingTable<String, String> cachingTable = new CachingTable<>(

--- a/samza-core/src/test/java/org/apache/samza/table/remote/TestRemoteTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/TestRemoteTable.java
@@ -86,7 +86,7 @@ public class TestRemoteTable {
 
     RemoteTable<K, V> table = new RemoteTable(tableId, readFn, writeFn,
         readRateLimiter, writeRateLimiter, rateLimitingExecutor,
-        readPolicy, writePolicy, retryExecutor, cbExecutor);
+        readPolicy, writePolicy, retryExecutor, null, null, cbExecutor);
     table.init(getMockContext());
     verify(readFn, times(1)).init(any(), any());
     if (writeFn != null) {

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableEndToEnd.java
@@ -474,7 +474,7 @@ public class TestRemoteTableEndToEnd extends IntegrationTestHarness {
     RemoteTable<String, String> table = new RemoteTable<>("table1", reader, null,
         rateLimitHelper, null, Executors.newSingleThreadExecutor(),
         null, null, null,
-        null);
+        null, null, null);
     table.init(createMockContext());
     table.get("abc");
   }
@@ -490,7 +490,7 @@ public class TestRemoteTableEndToEnd extends IntegrationTestHarness {
     RemoteTable<String, String> table = new RemoteTable<String, String>("table1", reader, writer,
         rateLimitHelper, rateLimitHelper, Executors.newSingleThreadExecutor(),
         null, null, null,
-        null);
+        null, null, null);
     table.init(createMockContext());
     table.put("abc", "efg");
   }
@@ -502,7 +502,7 @@ public class TestRemoteTableEndToEnd extends IntegrationTestHarness {
     RemoteTable<String, String> table = new RemoteTable<String, String>("table1", reader, null,
         rateLimitHelper, null, Executors.newSingleThreadExecutor(),
         null, null, null,
-        null);
+        null, null, null);
     table.init(createMockContext());
     try {
       table.put("abc", "efg");

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableWithBatchEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableWithBatchEndToEnd.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.test.table;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.samza.application.StreamApplication;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.MapConfig;
+import org.apache.samza.operators.KV;
+import org.apache.samza.runtime.LocalApplicationRunner;
+import org.apache.samza.serializers.NoOpSerde;
+import org.apache.samza.storage.kv.Entry;
+import org.apache.samza.system.descriptors.DelegatingSystemDescriptor;
+import org.apache.samza.system.descriptors.GenericInputDescriptor;
+import org.apache.samza.table.Table;
+import org.apache.samza.table.batching.CompactBatchProvider;
+import org.apache.samza.table.descriptors.RemoteTableDescriptor;
+import org.apache.samza.table.remote.BaseTableFunction;
+import org.apache.samza.table.remote.TableRateLimiter;
+import org.apache.samza.table.remote.TableReadFunction;
+import org.apache.samza.table.remote.TableWriteFunction;
+import org.apache.samza.test.harness.IntegrationTestHarness;
+import org.apache.samza.test.util.Base64Serializer;
+import org.apache.samza.util.RateLimiter;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.samza.test.table.TestTableData.*;
+import static org.mockito.Mockito.*;
+
+
+public class TestRemoteTableWithBatchEndToEnd extends IntegrationTestHarness {
+
+  static Map<String, List<EnrichedPageView>> writtenRecords = new HashMap<>();
+  static Map<String, AtomicInteger> batchWrites = new HashMap<>();
+  static Map<String, AtomicInteger> batchReads = new HashMap<>();
+
+  static class InMemoryReadFunction extends BaseTableFunction
+      implements TableReadFunction<Integer, Profile> {
+    private final String serializedProfiles;
+    private final String testName;
+    private transient Map<Integer, Profile> profileMap;
+    private transient AtomicInteger batchReadCounter;
+
+    private InMemoryReadFunction(String testName, String profiles) {
+      this.testName = testName;
+      this.serializedProfiles = profiles;
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+      in.defaultReadObject();
+      Profile[] profiles = Base64Serializer.deserialize(this.serializedProfiles, Profile[].class);
+      this.profileMap = Arrays.stream(profiles).collect(Collectors.toMap(p -> p.getMemberId(), Function.identity()));
+      batchReadCounter = batchReads.get(testName);
+    }
+
+    @Override
+    public CompletableFuture<Profile> getAsync(Integer key) {
+      return CompletableFuture.completedFuture(profileMap.get(key));
+    }
+
+    @Override
+    public CompletableFuture<Map<Integer, Profile>> getAllAsync(Collection<Integer> keys) {
+      batchReadCounter.incrementAndGet();
+      return TableReadFunction.super.getAllAsync(keys);
+    }
+
+    @Override
+    public boolean isRetriable(Throwable exception) {
+      return false;
+    }
+
+    static InMemoryReadFunction getInMemoryReadFunction(String testName, String serializedProfiles) {
+      return new InMemoryReadFunction(testName, serializedProfiles);
+    }
+  }
+
+  static class InMemoryWriteFunction extends BaseTableFunction
+      implements TableWriteFunction<Integer, EnrichedPageView> {
+    private transient List<EnrichedPageView> records;
+    private transient AtomicInteger batchWritesCounter;
+    private final String testName;
+
+    public InMemoryWriteFunction(String testName) {
+      this.testName = testName;
+    }
+
+    // Verify serializable functionality
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+      in.defaultReadObject();
+
+      // Write to the global list for verification
+      records = writtenRecords.get(testName);
+      batchWritesCounter = batchWrites.get(testName);
+    }
+
+    @Override
+    public CompletableFuture<Void> putAsync(Integer key, EnrichedPageView record) {
+      records.add(record);
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteAsync(Integer key) {
+      records.remove(key);
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> putAllAsync(Collection<Entry<Integer, EnrichedPageView>> records) {
+      batchWritesCounter.incrementAndGet();
+      return TableWriteFunction.super.putAllAsync(records);
+    }
+
+    @Override
+    public boolean isRetriable(Throwable exception) {
+      return false;
+    }
+  }
+
+
+  static class MyReadFunction extends BaseTableFunction
+      implements TableReadFunction {
+    @Override
+    public CompletableFuture getAsync(Object key) {
+      return null;
+    }
+
+    @Override
+    public boolean isRetriable(Throwable exception) {
+      return false;
+    }
+  }
+
+  private void doTestStreamTableJoinRemoteTable(String testName, boolean batchRead, boolean batchWrite) throws Exception {
+    final InMemoryWriteFunction writer = new InMemoryWriteFunction(testName);
+
+    batchReads.put(testName, new AtomicInteger());
+    batchWrites.put(testName, new AtomicInteger());
+    writtenRecords.put(testName, new CopyOnWriteArrayList<>());
+
+    int count = 10;
+    PageView[] pageViews = generatePageViews(count);
+    String profiles = Base64Serializer.serialize(generateProfiles(count));
+
+    int partitionCount = 4;
+    Map<String, String> configs = TestLocalTableEndToEnd.getBaseJobConfig(bootstrapUrl(), zkConnect());
+
+    configs.put("streams.PageView.samza.system", "test");
+    configs.put("streams.PageView.source", Base64Serializer.serialize(pageViews));
+    configs.put("streams.PageView.partitionCount", String.valueOf(partitionCount));
+
+    final RateLimiter readRateLimiter = mock(RateLimiter.class, withSettings().serializable());
+    final RateLimiter writeRateLimiter = mock(RateLimiter.class, withSettings().serializable());
+    final TableRateLimiter.CreditFunction creditFunction = (k, v, args)->1;
+    final StreamApplication app = appDesc -> {
+      RemoteTableDescriptor<Integer, Profile> inputTableDesc = new RemoteTableDescriptor<>("profile-table-1");
+      inputTableDesc
+          .withReadFunction(InMemoryReadFunction.getInMemoryReadFunction(testName, profiles))
+          .withRateLimiter(readRateLimiter, creditFunction, null);
+      if (batchRead) {
+        inputTableDesc.withBatchProvider(new CompactBatchProvider().withmaxBatchDelay(Duration.ofMillis(10)));
+      }
+
+      // dummy reader
+      TableReadFunction readFn = new MyReadFunction();
+
+      RemoteTableDescriptor<Integer, EnrichedPageView> outputTableDesc = new RemoteTableDescriptor<>("enriched-page-view-table-1");
+      outputTableDesc
+          .withReadFunction(readFn)
+          .withWriteFunction(writer)
+          .withRateLimiter(writeRateLimiter, creditFunction, creditFunction);
+      if (batchWrite) {
+        outputTableDesc.withBatchProvider(new CompactBatchProvider().withmaxBatchDelay(Duration.ofMillis(10)));
+      }
+
+      Table<KV<Integer, EnrichedPageView>> outputTable = appDesc.getTable(outputTableDesc);
+
+      Table<KV<Integer, Profile>> inputTable = appDesc.getTable(inputTableDesc);
+
+      DelegatingSystemDescriptor ksd = new DelegatingSystemDescriptor("test");
+      GenericInputDescriptor<PageView> isd = ksd.getInputDescriptor("PageView", new NoOpSerde<>());
+      appDesc.getInputStream(isd)
+          .map(pv -> new KV<>(pv.getMemberId(), pv))
+          .join(inputTable, new PageViewToProfileJoinFunction())
+          .map(m -> new KV(m.getMemberId(), m))
+          .sendTo(outputTable);
+    };
+
+    Config config = new MapConfig(configs);
+    final LocalApplicationRunner runner = new LocalApplicationRunner(app, config);
+    executeRun(runner, config);
+
+    runner.waitForFinish();
+    int numExpected = count * partitionCount;
+    Assert.assertEquals(numExpected, writtenRecords.get(testName).size());
+    Assert.assertTrue(writtenRecords.get(testName).get(0) instanceof EnrichedPageView);
+
+    if (batchRead) {
+      Assert.assertEquals(numExpected, batchReads.get(testName).get());
+    }
+    if (batchWrite) {
+      Assert.assertEquals(numExpected, batchWrites.get(testName).get());
+    }
+  }
+
+  @Test
+  public void testStreamTableJoinRemoteTableBatchingReadWrite() throws Exception {
+    doTestStreamTableJoinRemoteTable("testStreamTableJoinRemoteTableBatchingReadWrite", true, true);
+  }
+
+  @Test
+  public void testStreamTableJoinRemoteTableBatchingRead() throws Exception {
+    doTestStreamTableJoinRemoteTable("testStreamTableJoinRemoteTableBatchingRead", true, false);
+  }
+
+  @Test
+  public void testStreamTableJoinRemoteTableBatchingWrite() throws Exception {
+    doTestStreamTableJoinRemoteTable("testStreamTableJoinRemoteTableBatchingWrite", false, true);
+  }
+}

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableWithBatchEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableWithBatchEndToEnd.java
@@ -191,7 +191,7 @@ public class TestRemoteTableWithBatchEndToEnd extends IntegrationTestHarness {
           .withReadFunction(InMemoryReadFunction.getInMemoryReadFunction(testName, profiles))
           .withRateLimiter(readRateLimiter, creditFunction, null);
       if (batchRead) {
-        inputTableDesc.withBatchProvider(new CompactBatchProvider().withmaxBatchSize(batchSize).withmaxBatchDelay(Duration.ofHours(1)));
+        inputTableDesc.withBatchProvider(new CompactBatchProvider().withMaxBatchSize(batchSize).withMaxBatchDelay(Duration.ofHours(1)));
       }
 
       // dummy reader
@@ -203,7 +203,7 @@ public class TestRemoteTableWithBatchEndToEnd extends IntegrationTestHarness {
           .withWriteFunction(writer)
           .withRateLimiter(writeRateLimiter, creditFunction, creditFunction);
       if (batchWrite) {
-        outputTableDesc.withBatchProvider(new CompactBatchProvider().withmaxBatchSize(batchSize).withmaxBatchDelay(Duration.ofHours(1)));
+        outputTableDesc.withBatchProvider(new CompactBatchProvider().withMaxBatchSize(batchSize).withMaxBatchDelay(Duration.ofHours(1)));
       }
 
       Table<KV<Integer, EnrichedPageView>> outputTable = appDesc.getTable(outputTableDesc);

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestTableData.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestTableData.java
@@ -205,6 +205,16 @@ public class TestTableData {
     return pageviews;
   }
 
+  static public PageView[] generatePageViewsWithDistinctKeys(int count) {
+    Random random = new Random();
+    PageView[] pageviews = new PageView[count];
+    for (int i = 0; i < count; i++) {
+      String pagekey = PAGEKEYS[random.nextInt(PAGEKEYS.length - 1)];
+      pageviews[i] = new PageView(pagekey, i);
+    }
+    return pageviews;
+  }
+
   private static final String[] COMPANIES = {"MSFT", "LKND", "GOOG", "FB", "AMZN", "CSCO"};
 
   static public Profile[] generateProfiles(int count) {


### PR DESCRIPTION
Add a CompactBatch class to allow users to compact and batch
the operations sent to the remote store via table APIs.

@weisong44 Please review.