### PR TITLE
SAMZA-2193: Fix unit-test failure after making rate limiter as a required config

### DIFF
--- a/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
@@ -217,6 +217,7 @@ public class TestRemoteTableDescriptor {
   public void testTableRetryPolicyToConfig() {
     Map<String, String> tableConfig = new RemoteTableDescriptor("1").withReadFunction(createMockTableReadFunction())
         .withReadRetryPolicy(new TableRetryPolicy())
+        .withRateLimiterDisabled()
         .toConfig(new MapConfig());
     Assert.assertEquals(tableConfig.get("tables.1.io.read.retry.policy.TableRetryPolicy"),
         "{\"exponentialFactor\":0.0,\"backoffType\":\"NONE\",\"retryPredicate\":{}}");

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestCouchbaseRemoteTableEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestCouchbaseRemoteTableEndToEnd.java
@@ -143,11 +143,13 @@ public class TestCouchbaseRemoteTableEndToEnd extends IntegrationTestHarness {
               .withBootstrapHttpDirectPort(couchbaseMock.getHttpPort());
 
       RemoteTableDescriptor<String, String> inputTableDesc = new RemoteTableDescriptor<>("input-table");
-      inputTableDesc.withReadFunction(readFunction);
+      inputTableDesc.withReadFunction(readFunction).withRateLimiterDisabled();
       Table<KV<String, String>> inputTable = appDesc.getTable(inputTableDesc);
 
       RemoteTableDescriptor<String, JsonObject> outputTableDesc = new RemoteTableDescriptor<>("output-table");
-      outputTableDesc.withReadFunction(new DummyReadFunction<>()).withWriteFunction(writeFunction);
+      outputTableDesc.withReadFunction(new DummyReadFunction<>())
+          .withWriteFunction(writeFunction)
+          .withRateLimiterDisabled();
       Table<KV<String, JsonObject>> outputTable = appDesc.getTable(outputTableDesc);
 
       appDesc.getInputStream(inputDescriptor)


### PR DESCRIPTION


A recent code merge makes rate limiter as a required config. It break some
new tests that are added after that PR is created and checked in before that PR is commited.