### PR TITLE
SAMZA-2221: Use the KafkaStreamSpec instead of the StreamSpec 

### DIFF
--- a/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaStreamSpec.java
+++ b/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaStreamSpec.java
@@ -73,7 +73,7 @@ public class KafkaStreamSpec extends StreamSpec {
    * @param originalConfig  The original config to filter
    * @return                The filtered config
    */
-  private static Map<String, String> filterUnsupportedProperties(Map<String, String> originalConfig) {
+  static Map<String, String> filterUnsupportedProperties(Map<String, String> originalConfig) {
     Map<String, String> filteredConfig = new HashMap<>();
     for (Map.Entry<String, String> entry: originalConfig.entrySet()) {
       // Kafka requires replication factor, but not as a property, so we have to filter it out.


### PR DESCRIPTION
When creating a new Kafka topic, currenlty StreamSpec is used other than the
KafkaStreamSpec. KafkaStreamSpec contains more properties, such as "retention.ms",
that StreamSpec is not aware of.

@sborya  @xinyuiscool  @weisong44 