### PR TITLE
processorCount AtomicInt Metrics fixes

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/metrics/ContainerProcessManagerMetrics.scala
+++ b/samza-core/src/main/scala/org/apache/samza/metrics/ContainerProcessManagerMetrics.scala
@@ -38,7 +38,7 @@ class ContainerProcessManagerMetrics(val config: Config,
   val mCompletedContainers = newGauge("completed-containers", () => state.completedProcessors.get())
   val mFailedContainers = newGauge("failed-containers", () => state.failedContainers.get())
   val mReleasedContainers = newGauge("released-containers", () => state.releasedContainers.get())
-  val mContainers = newGauge("container-count", () => state.processorCount)
+  val mContainers = newGauge("container-count", () => state.processorCount.get())
   val mRedundantNotifications = newGauge("redundant-notifications", () => state.redundantNotifications.get())
   val mJobHealthy = newGauge("job-healthy", () => if (state.jobHealthy.get()) 1 else 0)
   val mPreferredHostRequests = newGauge("preferred-host-requests", () => state.preferredHostRequests.get())

--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/SamzaAppMasterMetrics.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/SamzaAppMasterMetrics.scala
@@ -52,7 +52,7 @@ class SamzaAppMasterMetrics(
     val mCompletedContainers = newGauge("completed-containers", () => state.completedProcessors.get())
     val mFailedContainers = newGauge("failed-containers", () => state.failedContainers.get())
     val mReleasedContainers = newGauge("released-containers", () => state.releasedContainers.get())
-    val mContainers = newGauge("container-count", () => state.processorCount)
+    val mContainers = newGauge("container-count", () => state.processorCount.get())
     val mJobHealthy = newGauge("job-healthy", () => if (state.jobHealthy.get()) 1 else 0)
 
     reporters.values.foreach(_.start)


### PR DESCRIPTION
Returning the AtomicInteger instances directly for `processorCount` was causing issues with our InfluxDB reporter. I added the `.get()` to match all the others.