### PR TITLE
SAMZA-2234: Passing context to Samza SQL UDFs

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/sql/udfs/ScalarUdf.java
+++ b/samza-api/src/main/java/org/apache/samza/sql/udfs/ScalarUdf.java
@@ -20,6 +20,7 @@
 package org.apache.samza.sql.udfs;
 
 import org.apache.samza.config.Config;
+import org.apache.samza.context.Context;
 
 
 /**
@@ -34,6 +35,7 @@ public interface ScalarUdf {
   /**
    * Udfs can implement this method to perform any initialization that they may need.
    * @param udfConfig Config specific to the udf.
+   * @param context Samza application and framework context
    */
-  void init(Config udfConfig);
+  void init(Config udfConfig, Context context);
 }

--- a/samza-sql/src/main/java/org/apache/samza/sql/data/Expression.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/data/Expression.java
@@ -30,8 +30,9 @@ import org.apache.samza.context.Context;
 public interface Expression {
   /**
    * This method is used to implement the expressions that takes in columns as input and returns multiple values.
-   * @param context SamzaSqlExecution context
-   * @param root the root
+   * @param sqlContext SamzaSqlExecution context
+   * @param context Samza context that contains both framework and application specific context.
+   * @param root Calcite DataContext
    * @param inputValues All the relational columns for the particular row
    * @param results the results Result values after executing the java code corresponding to the relational expression.
    */

--- a/samza-sql/src/main/java/org/apache/samza/sql/data/Expression.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/data/Expression.java
@@ -20,6 +20,7 @@
 package org.apache.samza.sql.data;
 
 import org.apache.calcite.DataContext;
+import org.apache.samza.context.Context;
 
 
 /**
@@ -29,10 +30,10 @@ import org.apache.calcite.DataContext;
 public interface Expression {
   /**
    * This method is used to implement the expressions that takes in columns as input and returns multiple values.
-   * @param context the context
+   * @param context SamzaSqlExecution context
    * @param root the root
    * @param inputValues All the relational columns for the particular row
    * @param results the results Result values after executing the java code corresponding to the relational expression.
    */
-  void execute(SamzaSqlExecutionContext context, DataContext root, Object[] inputValues, Object[] results);
+  void execute(SamzaSqlExecutionContext sqlContext, Context context, DataContext root, Object[] inputValues, Object[] results);
 }

--- a/samza-sql/src/main/java/org/apache/samza/sql/data/SamzaSqlExecutionContext.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/data/SamzaSqlExecutionContext.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import org.apache.samza.SamzaException;
 import org.apache.samza.config.Config;
+import org.apache.samza.context.Context;
 import org.apache.samza.sql.interfaces.UdfMetadata;
 import org.apache.samza.sql.runner.SamzaSqlApplicationConfig;
 import org.apache.samza.sql.udfs.ScalarUdf;
@@ -62,15 +63,15 @@ public class SamzaSqlExecutionContext implements Cloneable {
     }
   }
 
-  public ScalarUdf getOrCreateUdf(String clazz, String udfName) {
-    return udfInstances.computeIfAbsent(udfName, s -> createInstance(clazz, udfName));
+  public ScalarUdf getOrCreateUdf(String clazz, String udfName, Context context) {
+    return udfInstances.computeIfAbsent(udfName, s -> createInstance(clazz, udfName, context));
   }
 
-  public ScalarUdf createInstance(String clazz, String udfName) {
+  public ScalarUdf createInstance(String clazz, String udfName, Context context) {
     // Configs should be same for all the UDF methods within a UDF. Hence taking the first one.
     Config udfConfig = udfMetadata.get(udfName).get(0).getUdfConfig();
     ScalarUdf scalarUdf = ReflectionUtil.getObj(getClass().getClassLoader(), clazz, ScalarUdf.class);
-    scalarUdf.init(udfConfig);
+    scalarUdf.init(udfConfig, context);
     return scalarUdf;
   }
 

--- a/samza-sql/src/main/java/org/apache/samza/sql/fn/BuildOutputRecordUdf.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/fn/BuildOutputRecordUdf.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang.Validate;
 import org.apache.samza.config.Config;
+import org.apache.samza.context.Context;
 import org.apache.samza.sql.SamzaSqlRelRecord;
 import org.apache.samza.sql.udfs.SamzaSqlUdf;
 import org.apache.samza.sql.udfs.SamzaSqlUdfMethod;
@@ -64,7 +65,7 @@ import org.apache.samza.sql.udfs.ScalarUdf;
 @SamzaSqlUdf(name = "BuildOutputRecord", description = "Creates an Output record.")
 public class BuildOutputRecordUdf implements ScalarUdf {
   @Override
-  public void init(Config udfConfig) {
+  public void init(Config udfConfig, Context context) {
   }
 
   @SamzaSqlUdfMethod(disableArgumentCheck = true)

--- a/samza-sql/src/main/java/org/apache/samza/sql/fn/ConvertToStringUdf.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/fn/ConvertToStringUdf.java
@@ -20,6 +20,7 @@
 package org.apache.samza.sql.fn;
 
 import org.apache.samza.config.Config;
+import org.apache.samza.context.Context;
 import org.apache.samza.sql.schema.SamzaSqlFieldType;
 import org.apache.samza.sql.udfs.SamzaSqlUdf;
 import org.apache.samza.sql.udfs.SamzaSqlUdfMethod;
@@ -32,7 +33,7 @@ import org.apache.samza.sql.udfs.ScalarUdf;
 @SamzaSqlUdf(name = "convertToString", description = "Converts the object to string.")
 public class ConvertToStringUdf implements ScalarUdf {
   @Override
-  public void init(Config udfConfig) {
+  public void init(Config udfConfig, Context context) {
   }
 
   @SamzaSqlUdfMethod(params = SamzaSqlFieldType.ANY)

--- a/samza-sql/src/main/java/org/apache/samza/sql/fn/FlattenUdf.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/fn/FlattenUdf.java
@@ -21,6 +21,7 @@ package org.apache.samza.sql.fn;
 
 import java.util.List;
 import org.apache.samza.config.Config;
+import org.apache.samza.context.Context;
 import org.apache.samza.sql.schema.SamzaSqlFieldType;
 import org.apache.samza.sql.udfs.SamzaSqlUdf;
 import org.apache.samza.sql.udfs.SamzaSqlUdfMethod;
@@ -30,7 +31,7 @@ import org.apache.samza.sql.udfs.ScalarUdf;
 @SamzaSqlUdf(name = "Flatten", description = "Flattens the array.")
 public class FlattenUdf implements ScalarUdf {
   @Override
-  public void init(Config udfConfig) {
+  public void init(Config udfConfig, Context context) {
   }
 
   @SamzaSqlUdfMethod(params = SamzaSqlFieldType.ARRAY)

--- a/samza-sql/src/main/java/org/apache/samza/sql/fn/GetSqlFieldUdf.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/fn/GetSqlFieldUdf.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang.Validate;
 import org.apache.samza.config.Config;
+import org.apache.samza.context.Context;
 import org.apache.samza.sql.SamzaSqlRelRecord;
 import org.apache.samza.sql.schema.SamzaSqlFieldType;
 import org.apache.samza.sql.udfs.SamzaSqlUdf;
@@ -55,7 +56,7 @@ import org.apache.samza.sql.udfs.ScalarUdf;
 @SamzaSqlUdf(name = "GetSqlField", description = "Get an element from complex Sql field as a String.")
 public class GetSqlFieldUdf implements ScalarUdf {
   @Override
-  public void init(Config udfConfig) {
+  public void init(Config udfConfig, Context context) {
   }
 
   @SamzaSqlUdfMethod(params = {SamzaSqlFieldType.ANY, SamzaSqlFieldType.STRING})

--- a/samza-sql/src/main/java/org/apache/samza/sql/fn/RegexMatchUdf.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/fn/RegexMatchUdf.java
@@ -21,6 +21,7 @@ package org.apache.samza.sql.fn;
 
 import java.util.regex.Pattern;
 import org.apache.samza.config.Config;
+import org.apache.samza.context.Context;
 import org.apache.samza.sql.schema.SamzaSqlFieldType;
 import org.apache.samza.sql.udfs.SamzaSqlUdf;
 import org.apache.samza.sql.udfs.SamzaSqlUdfMethod;
@@ -33,7 +34,7 @@ import org.apache.samza.sql.udfs.ScalarUdf;
 @SamzaSqlUdf(name="RegexMatch", description = "Function to perform the regex match.")
 public class RegexMatchUdf implements ScalarUdf {
   @Override
-  public void init(Config config) {
+  public void init(Config config, Context context) {
 
   }
 

--- a/samza-sql/src/main/java/org/apache/samza/sql/planner/SamzaSqlScalarFunctionImpl.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/planner/SamzaSqlScalarFunctionImpl.java
@@ -77,9 +77,10 @@ public class SamzaSqlScalarFunctionImpl implements ScalarFunction, Implementable
   @Override
   public CallImplementor getImplementor() {
     return RexImpTable.createImplementor((translator, call, translatedOperands) -> {
-      final Expression context = Expressions.parameter(SamzaSqlExecutionContext.class, "context");
-      final Expression getUdfInstance = Expressions.call(ScalarUdf.class, context, getUdfMethod,
-          Expressions.constant(udfMethod.getDeclaringClass().getName()), Expressions.constant(udfName));
+      final Expression sqlContext = Expressions.parameter(SamzaSqlExecutionContext.class, "sqlContext");
+      final Expression samzaContext = Expressions.parameter(SamzaSqlExecutionContext.class, "context");
+      final Expression getUdfInstance = Expressions.call(ScalarUdf.class, sqlContext, getUdfMethod,
+          Expressions.constant(udfMethod.getDeclaringClass().getName()), Expressions.constant(udfName), samzaContext);
       final Expression callExpression = Expressions.call(Expressions.convert_(getUdfInstance, udfMethod.getDeclaringClass()), udfMethod,
           translatedOperands);
       return callExpression;

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/FilterTranslator.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/FilterTranslator.java
@@ -69,6 +69,7 @@ class FilterTranslator {
     private final int queryId;
     private final int filterId;
     private final String logicalOpId;
+    private Context context;
 
     FilterTranslatorFunction(int filterId, int queryId, String logicalOpId) {
       this.filterId = filterId;
@@ -78,6 +79,7 @@ class FilterTranslator {
 
     @Override
     public void init(Context context) {
+      this.context = context;
       this.translatorContext = ((SamzaSqlApplicationContext) context.getApplicationTaskContext()).getTranslatorContexts().get(queryId);
       this.filter = (LogicalFilter) this.translatorContext.getRelNode(filterId);
       this.expr = this.translatorContext.getExpressionCompiler().compile(filter.getInputs(), Collections.singletonList(filter.getCondition()));
@@ -96,7 +98,7 @@ class FilterTranslator {
     public boolean apply(SamzaSqlRelMessage message) {
       Instant startProcessing = Instant.now();
       Object[] result = new Object[1];
-      expr.execute(translatorContext.getExecutionContext(), translatorContext.getDataContext(),
+      expr.execute(translatorContext.getExecutionContext(), context, translatorContext.getDataContext(),
           message.getSamzaSqlRelRecord().getFieldValues().toArray(), result);
       if (result.length > 0 && result[0] instanceof Boolean) {
         boolean retVal = (Boolean) result[0];

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/ProjectTranslator.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/ProjectTranslator.java
@@ -77,6 +77,7 @@ class ProjectTranslator {
     private final int queryId;
     private final int projectId;
     private final String logicalOpId;
+    private Context context;
 
     ProjectMapFunction(int projectId, int queryId, String logicalOpId) {
       this.projectId = projectId;
@@ -90,6 +91,7 @@ class ProjectTranslator {
      */
     @Override
     public void init(Context context) {
+      this.context = context;
       this.translatorContext = ((SamzaSqlApplicationContext) context.getApplicationTaskContext()).getTranslatorContexts().get(queryId);
       this.project = (Project) this.translatorContext.getRelNode(projectId);
       this.expr = this.translatorContext.getExpressionCompiler().compile(project.getInputs(), project.getProjects());
@@ -112,7 +114,7 @@ class ProjectTranslator {
       Instant arrivalTime = Instant.now();
       RelDataType type = project.getRowType();
       Object[] output = new Object[type.getFieldCount()];
-      expr.execute(translatorContext.getExecutionContext(), translatorContext.getDataContext(),
+      expr.execute(translatorContext.getExecutionContext(), context, translatorContext.getDataContext(),
           message.getSamzaSqlRelRecord().getFieldValues().toArray(), output);
       List<String> names = new ArrayList<>();
       for (int index = 0; index < output.length; index++) {

--- a/samza-sql/src/test/java/org/apache/samza/sql/translator/TestFilterTranslator.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/translator/TestFilterTranslator.java
@@ -128,24 +128,23 @@ public class TestFilterTranslator extends TranslatorTestBase {
         new SamzaSqlRelMsgMetadata("", "", ""));
     SamzaSqlExecutionContext executionContext = mock(SamzaSqlExecutionContext.class);
     DataContext dataContext = mock(DataContext.class);
-    Context context = mock(Context.class);
     when(mockTranslatorContext.getExecutionContext()).thenReturn(executionContext);
     when(mockTranslatorContext.getDataContext()).thenReturn(dataContext);
     Object[] result = new Object[1];
 
     doAnswer( invocation -> {
-      Object[] retValue = invocation.getArgumentAt(3, Object[].class);
+      Object[] retValue = invocation.getArgumentAt(4, Object[].class);
       retValue[0] = new Boolean(true);
       return null;
-    }).when(mockExpr).execute(eq(executionContext), eq(context), eq(dataContext),
+    }).when(mockExpr).execute(eq(executionContext), eq(mockContext), eq(dataContext),
         eq(mockInputMsg.getSamzaSqlRelRecord().getFieldValues().toArray()), eq(result));
     assertTrue(filterFn.apply(mockInputMsg));
 
     doAnswer( invocation -> {
-      Object[] retValue = invocation.getArgumentAt(3, Object[].class);
+      Object[] retValue = invocation.getArgumentAt(4, Object[].class);
       retValue[0] = new Boolean(false);
       return null;
-    }).when(mockExpr).execute(eq(executionContext), eq(context), eq(dataContext),
+    }).when(mockExpr).execute(eq(executionContext), eq(mockContext), eq(dataContext),
         eq(mockInputMsg.getSamzaSqlRelRecord().getFieldValues().toArray()), eq(result));
     assertFalse(filterFn.apply(mockInputMsg));
 

--- a/samza-sql/src/test/java/org/apache/samza/sql/translator/TestFilterTranslator.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/translator/TestFilterTranslator.java
@@ -128,6 +128,7 @@ public class TestFilterTranslator extends TranslatorTestBase {
         new SamzaSqlRelMsgMetadata("", "", ""));
     SamzaSqlExecutionContext executionContext = mock(SamzaSqlExecutionContext.class);
     DataContext dataContext = mock(DataContext.class);
+    Context context = mock(Context.class);
     when(mockTranslatorContext.getExecutionContext()).thenReturn(executionContext);
     when(mockTranslatorContext.getDataContext()).thenReturn(dataContext);
     Object[] result = new Object[1];
@@ -136,7 +137,7 @@ public class TestFilterTranslator extends TranslatorTestBase {
       Object[] retValue = invocation.getArgumentAt(3, Object[].class);
       retValue[0] = new Boolean(true);
       return null;
-    }).when(mockExpr).execute(eq(executionContext), eq(dataContext),
+    }).when(mockExpr).execute(eq(executionContext), eq(context), eq(dataContext),
         eq(mockInputMsg.getSamzaSqlRelRecord().getFieldValues().toArray()), eq(result));
     assertTrue(filterFn.apply(mockInputMsg));
 
@@ -144,7 +145,7 @@ public class TestFilterTranslator extends TranslatorTestBase {
       Object[] retValue = invocation.getArgumentAt(3, Object[].class);
       retValue[0] = new Boolean(false);
       return null;
-    }).when(mockExpr).execute(eq(executionContext), eq(dataContext),
+    }).when(mockExpr).execute(eq(executionContext), eq(context), eq(dataContext),
         eq(mockInputMsg.getSamzaSqlRelRecord().getFieldValues().toArray()), eq(result));
     assertFalse(filterFn.apply(mockInputMsg));
 

--- a/samza-sql/src/test/java/org/apache/samza/sql/translator/TestProjectTranslator.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/translator/TestProjectTranslator.java
@@ -52,6 +52,7 @@ import org.apache.samza.sql.runner.SamzaSqlApplicationContext;
 import org.apache.samza.sql.util.TestMetricsRegistryImpl;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.internal.matchers.Any;
 import org.mockito.internal.util.reflection.Whitebox;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -73,6 +74,7 @@ import static org.mockito.Mockito.when;
 @PrepareForTest(LogicalProject.class)
 public class TestProjectTranslator extends TranslatorTestBase {
   final private String LOGICAL_OP_ID = "sql0_project_0";
+
   @Test
   public void testTranslate() throws IOException, ClassNotFoundException {
     // setup mock values to the constructor of FilterTranslator
@@ -143,7 +145,6 @@ public class TestProjectTranslator extends TranslatorTestBase {
     SamzaSqlRelMessage mockInputMsg = new SamzaSqlRelMessage(new ArrayList<>(), new ArrayList<>(),
         new SamzaSqlRelMsgMetadata("", "", ""));
     SamzaSqlExecutionContext executionContext = mock(SamzaSqlExecutionContext.class);
-    Context context = mock(Context.class);
     DataContext dataContext = mock(DataContext.class);
     when(mockTranslatorContext.getExecutionContext()).thenReturn(executionContext);
     when(mockTranslatorContext.getDataContext()).thenReturn(dataContext);
@@ -151,10 +152,10 @@ public class TestProjectTranslator extends TranslatorTestBase {
     final Object mockFieldObj = new Object();
 
     doAnswer( invocation -> {
-      Object[] retValue = invocation.getArgumentAt(3, Object[].class);
+      Object[] retValue = invocation.getArgumentAt(4, Object[].class);
       retValue[0] = mockFieldObj;
       return null;
-    }).when(mockExpr).execute(eq(executionContext), eq(context), eq(dataContext),
+    }).when(mockExpr).execute(eq(executionContext), eq(mockContext), eq(dataContext),
         eq(mockInputMsg.getSamzaSqlRelRecord().getFieldValues().toArray()), eq(result));
     SamzaSqlRelMessage retMsg = (SamzaSqlRelMessage) mapFn.apply(mockInputMsg);
     assertEquals(retMsg.getSamzaSqlRelRecord().getFieldNames(),
@@ -170,6 +171,7 @@ public class TestProjectTranslator extends TranslatorTestBase {
     assertEquals(1, testMetricsRegistryImpl.getCounters().get(LOGICAL_OP_ID).get(1).getCount());
 
   }
+
 
   @Test
   public void testTranslateWithFlatten() throws IOException, ClassNotFoundException {
@@ -303,17 +305,16 @@ public class TestProjectTranslator extends TranslatorTestBase {
         new SamzaSqlRelMsgMetadata("", "", ""));
     SamzaSqlExecutionContext executionContext = mock(SamzaSqlExecutionContext.class);
     DataContext dataContext = mock(DataContext.class);
-    Context context = mock(Context.class);
     when(mockTranslatorContext.getExecutionContext()).thenReturn(executionContext);
     when(mockTranslatorContext.getDataContext()).thenReturn(dataContext);
     Object[] result = new Object[1];
     final Object mockFieldObj = new Object();
 
     doAnswer( invocation -> {
-      Object[] retValue = invocation.getArgumentAt(3, Object[].class);
+      Object[] retValue = invocation.getArgumentAt(4, Object[].class);
       retValue[0] = mockFieldObj;
       return null;
-    }).when(mockExpr).execute(eq(executionContext), eq(context), eq(dataContext),
+    }).when(mockExpr).execute(eq(executionContext), eq(mockContext), eq(dataContext),
         eq(mockInputMsg.getSamzaSqlRelRecord().getFieldValues().toArray()), eq(result));
     SamzaSqlRelMessage retMsg = (SamzaSqlRelMessage) mapFn.apply(mockInputMsg);
     assertEquals(retMsg.getSamzaSqlRelRecord().getFieldNames(),

--- a/samza-sql/src/test/java/org/apache/samza/sql/translator/TestProjectTranslator.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/translator/TestProjectTranslator.java
@@ -143,6 +143,7 @@ public class TestProjectTranslator extends TranslatorTestBase {
     SamzaSqlRelMessage mockInputMsg = new SamzaSqlRelMessage(new ArrayList<>(), new ArrayList<>(),
         new SamzaSqlRelMsgMetadata("", "", ""));
     SamzaSqlExecutionContext executionContext = mock(SamzaSqlExecutionContext.class);
+    Context context = mock(Context.class);
     DataContext dataContext = mock(DataContext.class);
     when(mockTranslatorContext.getExecutionContext()).thenReturn(executionContext);
     when(mockTranslatorContext.getDataContext()).thenReturn(dataContext);
@@ -153,7 +154,7 @@ public class TestProjectTranslator extends TranslatorTestBase {
       Object[] retValue = invocation.getArgumentAt(3, Object[].class);
       retValue[0] = mockFieldObj;
       return null;
-    }).when(mockExpr).execute(eq(executionContext), eq(dataContext),
+    }).when(mockExpr).execute(eq(executionContext), eq(context), eq(dataContext),
         eq(mockInputMsg.getSamzaSqlRelRecord().getFieldValues().toArray()), eq(result));
     SamzaSqlRelMessage retMsg = (SamzaSqlRelMessage) mapFn.apply(mockInputMsg);
     assertEquals(retMsg.getSamzaSqlRelRecord().getFieldNames(),
@@ -302,6 +303,7 @@ public class TestProjectTranslator extends TranslatorTestBase {
         new SamzaSqlRelMsgMetadata("", "", ""));
     SamzaSqlExecutionContext executionContext = mock(SamzaSqlExecutionContext.class);
     DataContext dataContext = mock(DataContext.class);
+    Context context = mock(Context.class);
     when(mockTranslatorContext.getExecutionContext()).thenReturn(executionContext);
     when(mockTranslatorContext.getDataContext()).thenReturn(dataContext);
     Object[] result = new Object[1];
@@ -311,7 +313,7 @@ public class TestProjectTranslator extends TranslatorTestBase {
       Object[] retValue = invocation.getArgumentAt(3, Object[].class);
       retValue[0] = mockFieldObj;
       return null;
-    }).when(mockExpr).execute(eq(executionContext), eq(dataContext),
+    }).when(mockExpr).execute(eq(executionContext), eq(context), eq(dataContext),
         eq(mockInputMsg.getSamzaSqlRelRecord().getFieldValues().toArray()), eq(result));
     SamzaSqlRelMessage retMsg = (SamzaSqlRelMessage) mapFn.apply(mockInputMsg);
     assertEquals(retMsg.getSamzaSqlRelRecord().getFieldNames(),

--- a/samza-sql/src/test/java/org/apache/samza/sql/util/MyTestArrayUdf.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/util/MyTestArrayUdf.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.samza.config.Config;
+import org.apache.samza.context.Context;
 import org.apache.samza.sql.schema.SamzaSqlFieldType;
 import org.apache.samza.sql.udfs.SamzaSqlUdf;
 import org.apache.samza.sql.udfs.SamzaSqlUdfMethod;
@@ -32,7 +33,7 @@ import org.apache.samza.sql.udfs.ScalarUdf;
 @SamzaSqlUdf(name = "MyTestArray", description = "Test udf that returns an array")
 public class MyTestArrayUdf implements ScalarUdf {
   @Override
-  public void init(Config udfConfig) {
+  public void init(Config udfConfig, Context context) {
   }
 
   @SamzaSqlUdfMethod(params = SamzaSqlFieldType.INT32)

--- a/samza-sql/src/test/java/org/apache/samza/sql/util/MyTestPolyUdf.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/util/MyTestPolyUdf.java
@@ -19,6 +19,7 @@
 package org.apache.samza.sql.util;
 
 import org.apache.samza.config.Config;
+import org.apache.samza.context.Context;
 import org.apache.samza.sql.schema.SamzaSqlFieldType;
 import org.apache.samza.sql.udfs.SamzaSqlUdf;
 import org.apache.samza.sql.udfs.SamzaSqlUdfMethod;
@@ -46,7 +47,7 @@ public class MyTestPolyUdf implements ScalarUdf {
 
 
   @Override
-  public void init(Config udfConfig) {
+  public void init(Config udfConfig, Context context) {
     LOG.info("Init called with {}", udfConfig);
   }
 }

--- a/samza-sql/src/test/java/org/apache/samza/sql/util/MyTestUdf.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/util/MyTestUdf.java
@@ -20,6 +20,7 @@
 package org.apache.samza.sql.util;
 
 import org.apache.samza.config.Config;
+import org.apache.samza.context.Context;
 import org.apache.samza.sql.schema.SamzaSqlFieldType;
 import org.apache.samza.sql.udfs.SamzaSqlUdf;
 import org.apache.samza.sql.udfs.SamzaSqlUdfMethod;
@@ -48,7 +49,7 @@ public class MyTestUdf implements ScalarUdf {
 
 
   @Override
-  public void init(Config udfConfig) {
+  public void init(Config udfConfig, Context context) {
     LOG.info("Init called with {}", udfConfig);
   }
 }


### PR DESCRIPTION
This change provides ability for the UDFs to access the Samza context. Context is needed by the UDFs for various reasons
1. To create metrics
2. To access configs
3. Access any external contexts 