### PR TITLE
SAMZA-2235: Move the merging of side inputs with task inputs from the ExecutionPlanner to the JobModelManager

### DIFF
--- a/samza-azure/src/main/java/org/apache/samza/coordinator/AzureJobCoordinator.java
+++ b/samza-azure/src/main/java/org/apache/samza/coordinator/AzureJobCoordinator.java
@@ -272,7 +272,7 @@ public class AzureJobCoordinator implements JobCoordinator {
   private Set<SystemStreamPartition> getInputStreamPartitions() {
     TaskConfig taskConfig = new TaskConfig(config);
     scala.collection.immutable.Set<SystemStream> inputSystemStreams =
-        JavaConverters.asScalaSetConverter(taskConfig.getInputStreams()).asScala().toSet();
+        JavaConverters.asScalaSetConverter(taskConfig.getAllInputStreams()).asScala().toSet();
 
     // Get the set of partitions for each SystemStream from the stream metadata
     Set<SystemStreamPartition>

--- a/samza-core/src/main/java/org/apache/samza/execution/JobNodeConfigurationGenerator.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/JobNodeConfigurationGenerator.java
@@ -250,7 +250,6 @@ import org.slf4j.LoggerFactory;
             sideInputs.stream()
                 .map(sideInput -> StreamUtil.getSystemStreamFromNameOrId(originalConfig, sideInput))
                 .forEach(systemStream -> {
-                    inputs.add(StreamUtil.getNameFromSystemStream(systemStream));
                     generatedConfig.put(String.format(StreamConfig.STREAM_PREFIX() + StreamConfig.BOOTSTRAP(),
                         systemStream.getSystem(), systemStream.getStream()), "true");
                   });

--- a/samza-core/src/main/java/org/apache/samza/execution/JobNodeConfigurationGenerator.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/JobNodeConfigurationGenerator.java
@@ -241,7 +241,8 @@ import org.slf4j.LoggerFactory;
         TableConfigGenerator.generate(
             new MapConfig(generatedConfig), new ArrayList<>(tables.values())));
 
-    // Add side inputs to the inputs and mark the stream as bootstrap
+    // marks the side input streams as bootstrap. should be moved to localTableDescriptor#toConfig
+    // once StreamUtil/StreamConfig is moved to samza-api.
     tables.values().forEach(tableDescriptor -> {
         if (tableDescriptor instanceof LocalTableDescriptor) {
           LocalTableDescriptor localTableDescriptor = (LocalTableDescriptor) tableDescriptor;

--- a/samza-core/src/test/java/org/apache/samza/config/TestTaskConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestTaskConfig.java
@@ -296,12 +296,16 @@ public class TestTaskConfig {
   public void testGetAllInputStreams() {
     Config config = new MapConfig(ImmutableMap.of(
         TaskConfig.INPUT_STREAMS, "kafka.foo, otherKafka.bar",
-        TaskConfig.BROADCAST_INPUT_STREAMS, "kafka.bar#4, otherKafka.foo#5"));
+        TaskConfig.BROADCAST_INPUT_STREAMS, "kafka.bar#4, otherKafka.foo#5",
+        String.format(StorageConfig.FACTORY, "testStore"), "factory",
+        String.format(StorageConfig.SIDE_INPUTS, "testStore"), "kafka.baz, otherKafka.baz"));
     Set<SystemStream> expected = ImmutableSet.of(
         new SystemStream("kafka", "foo"),
         new SystemStream("otherKafka", "bar"),
         new SystemStream("kafka", "bar"),
-        new SystemStream("otherKafka", "foo"));
+        new SystemStream("otherKafka", "foo"),
+        new SystemStream("kafka", "baz"),
+        new SystemStream("otherKafka", "baz"));
     assertEquals(expected, new TaskConfig(config).getAllInputStreams());
 
     Config configOnlyBroadcast = new MapConfig(ImmutableMap.of(
@@ -316,6 +320,15 @@ public class TestTaskConfig {
         new SystemStream("kafka", "foo"),
         new SystemStream("otherKafka", "bar"));
     assertEquals(expectedOnlyInputs, new TaskConfig(configOnlyInputs).getAllInputStreams());
+
+    Config configOnlySideInputs = new MapConfig(ImmutableMap.of(
+        String.format(StorageConfig.FACTORY, "testStore"), "factory",
+        String.format(StorageConfig.SIDE_INPUTS, "testStore"), "kafka.baz, otherKafka.baz"
+    ));
+    Set<SystemStream> expectedOnlySideInputs = ImmutableSet.of(
+        new SystemStream("kafka", "baz"),
+        new SystemStream("otherKafka", "baz"));
+    assertEquals(expectedOnlySideInputs, new TaskConfig(configOnlySideInputs).getAllInputStreams());
 
     assertTrue(new TaskConfig(new MapConfig()).getAllInputStreams().isEmpty());
   }


### PR DESCRIPTION
Currently side inputs configured using descriptors are merged with task.inputs in the Planner (JobNodeConfigurationGenerator). For low level API, users are expected to add them to task.inputs manually. Since this can be error prone (easy to forget) and tedious, it'll be better to do this ourselves.

A clean way to get the same behavior consistently across all APIs would be to treat the side inputs and task.inputs configs separately and do the side inputs and task inputs merge at read time when we want to get "all inputs".