### PR TITLE
SAMZA-2236: Make member table in BaseTableFunction transient

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/table/remote/BaseTableFunction.java
+++ b/samza-api/src/main/java/org/apache/samza/table/remote/BaseTableFunction.java
@@ -48,7 +48,7 @@ import org.apache.samza.table.AsyncReadWriteTable;
  */
 abstract public class BaseTableFunction implements TableFunction {
 
-  protected AsyncReadWriteTable table;
+  protected transient AsyncReadWriteTable table;
 
   @Override
   public void init(Context context, AsyncReadWriteTable table) {


### PR DESCRIPTION
This is to ensure the field "table" is not included in generated configuration for this table function.