### PR TITLE
SAMZA-2245: check jar path under java home

### DIFF
--- a/samza-shell/src/main/bash/run-class.sh
+++ b/samza-shell/src/main/bash/run-class.sh
@@ -81,7 +81,8 @@ else
   echo generated from BASE_LIB_DIR CLASSPATH=$CLASSPATH
 fi
 
-if [ -z "$JAVA_HOME" ]; then
+# In some cases (AWS) $JAVA_HOME/bin doesn't contain jar.
+if [ -z "$JAVA_HOME" ] || [ ! -e "$JAVA_HOME/bin/jar" ]; then
   JAR="jar"
 else
   JAR="$JAVA_HOME/bin/jar"


### PR DESCRIPTION
Samza 1.1.0 on AWS EMR (emr - 5.13.0, amazon 2.8.3, zookeeper 3.4.10) not working because run-class.sh assumes if JAVA_HOME is defined, jar exists under $JAVA_HOME/bin. This turns out not the case.