### PR TITLE
SAMZA-2248: Fix AM bookkeeping on receiving dead container notifications

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/clustermanager/AbstractContainerAllocator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/AbstractContainerAllocator.java
@@ -260,6 +260,14 @@ public abstract class AbstractContainerAllocator implements Runnable {
   }
 
   /**
+   * Releases a single resource based on containerId.
+   * @param containerId container ID
+   */
+  public final void releaseResource(String containerId) {
+    resourceRequestState.releaseResource(containerId);
+  }
+
+  /**
    * Stops the Allocator. Setting this flag to false exits the allocator loop.
    */
   public void stop() {

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerProcessManager.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerProcessManager.java
@@ -319,6 +319,12 @@ public class ContainerProcessManager implements ClusterResourceManager.Callback 
     if (processorId == null) {
       log.info("No running Processor ID found for Container ID: {} with Status: {}. Ignoring redundant notification.", containerId, resourceStatus.toString());
       state.redundantNotifications.incrementAndGet();
+
+      if (resourceStatus.getExitCode() != SamzaResourceStatus.SUCCESS) {
+        // the requested container failed before allocating the request to it.
+        // Remove from the buffer if it is there
+        containerAllocator.releaseResource(containerId);
+      }
       return;
     }
     state.runningProcessors.remove(processorId);

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerProcessManager.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerProcessManager.java
@@ -321,7 +321,7 @@ public class ContainerProcessManager implements ClusterResourceManager.Callback 
       state.redundantNotifications.incrementAndGet();
 
       if (resourceStatus.getExitCode() != SamzaResourceStatus.SUCCESS) {
-        // the requested container failed before allocating the request to it.
+        // the requested container failed before assigning the request to it.
         // Remove from the buffer if it is there
         containerAllocator.releaseResource(containerId);
       }

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ResourceRequestState.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ResourceRequestState.java
@@ -18,6 +18,7 @@
  */
 package org.apache.samza.clustermanager;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -226,6 +227,25 @@ public class ResourceRequestState {
         clearState();
       }
       return numReleasedResources;
+    }
+  }
+
+  /**
+   * Releases a single resource based on containerId.
+   * @param containerId Yarn container ID
+   */
+  public void releaseResource(String containerId) {
+    if (StringUtils.isEmpty(containerId)) {
+      log.warn("ContainerId is not specified");
+      return;
+    }
+
+    synchronized (lock) {
+      allocatedResources.values().forEach(resources -> {
+          if (resources != null) {
+            resources.removeIf(r -> containerId.equals(r.getContainerId()));
+          }
+        });
     }
   }
 

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerRequestState.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerRequestState.java
@@ -193,4 +193,20 @@ public class TestContainerRequestState {
 
   }
 
+  @Test
+  public void testReleaseResource() {
+    // Host-affinity is enabled
+    ResourceRequestState state = new ResourceRequestState(true, manager);
+
+    SamzaResource container = new SamzaResource(1, 1024, "abc", "id0");
+
+    SamzaResource container1 = new SamzaResource(1, 1024, ANY_HOST, "id1");
+    state.addResource(container);
+    state.addResource(container1);
+
+
+    state.releaseResource("id0");
+    assertEquals(0, state.getResourcesOnAHost("abc"));
+    assertEquals(1, state.getResourcesOnAHost(ANY_HOST));
+  }
 }

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerRequestState.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerRequestState.java
@@ -198,15 +198,23 @@ public class TestContainerRequestState {
     // Host-affinity is enabled
     ResourceRequestState state = new ResourceRequestState(true, manager);
 
-    SamzaResource container = new SamzaResource(1, 1024, "abc", "id0");
+    SamzaResourceRequest request = new SamzaResourceRequest(1, 1024, "abc", "0");
+    SamzaResourceRequest request1 = new SamzaResourceRequest(1, 1024, "def", "0");
+    state.addResourceRequest(request);
+    state.addResourceRequest(request1);
 
+    SamzaResource container = new SamzaResource(1, 1024, "abc", "id0");
     SamzaResource container1 = new SamzaResource(1, 1024, ANY_HOST, "id1");
     state.addResource(container);
     state.addResource(container1);
 
-
     state.releaseResource("id0");
-    assertEquals(0, state.getResourcesOnAHost("abc"));
-    assertEquals(1, state.getResourcesOnAHost(ANY_HOST));
+    assertEquals(0, state.getResourcesOnAHost("abc").size());
+    assertEquals(1, state.getResourcesOnAHost(ANY_HOST).size());
+
+    state.releaseResource("id1");
+    assertEquals(0, state.getResourcesOnAHost("abc").size());
+    assertEquals(0, state.getResourcesOnAHost(ANY_HOST).size());
+
   }
 }


### PR DESCRIPTION
Fixed the following issue:

1. AM gets extra containers from the RM which it saves for later use
2. When the container that we saved in step1 dies, the AM on receiving this callback does nothing about it.
3. Later, when we are looking for a container to use - we pick up the dead container that we saved and did not clean up (step 1&2) and launch a container. 
4. Now, if this launched container ever dies - the RM will never notify the AM about it since it see's it as a duplicate (step 2)
5. Job is left without the container rescheduled and will need to be restarted.