### PR TITLE
Minor: Increase Travis-CI timeout to 40 min.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jdk:
 
 script:
   ## travis_wait increases build idle-wait time from 10 minutes to 30 minutes.
-  - travis_wait 30 ./gradlew clean build
+  - travis_wait 40 ./gradlew clean build
 #  - type sonar-scanner &>/dev/null; if [ $? -eq 0 ]; then sonar-scanner; else echo "Not running sonar"; fi
 
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jdk:
   - oraclejdk8
 
 script:
-  ## travis_wait increases build idle-wait time from 10 minutes to 30 minutes.
+  ## travis_wait increases build idle-wait time from 10 minutes to 40 minutes.
   - travis_wait 40 ./gradlew clean build
 #  - type sonar-scanner &>/dev/null; if [ $? -eq 0 ]; then sonar-scanner; else echo "Not running sonar"; fi
 


### PR DESCRIPTION
The builds are close to hitting the 30 min timeout limit. This increases the limit to 40 min.