### PR TITLE
SAMZA-2262: Change container-startup-time to a gauge from a timer and to ms instead of ns

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -758,7 +758,7 @@ class SamzaContainer(
       if (containerListener != null) {
         containerListener.afterStart()
       }
-      metrics.containerStartupTime.update(System.nanoTime() - startTime)
+      metrics.containerStartupTime.set(System.nanoTime() - startTime)
       if (taskInstances.size > 0)
         runLoop.run
       else

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -758,7 +758,7 @@ class SamzaContainer(
       if (containerListener != null) {
         containerListener.afterStart()
       }
-      metrics.containerStartupTime.set(System.nanoTime() - startTime)
+      metrics.containerStartupTime.set((System.nanoTime() - startTime)/1000000)
       if (taskInstances.size > 0)
         runLoop.run
       else

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
@@ -40,7 +40,7 @@ class SamzaContainerMetrics(
   val processNs = newTimer("process-ns")
   val commitNs = newTimer("commit-ns")
   val blockNs = newTimer("block-ns")
-  val containerStartupTime = newGauge("container-startup-time", 0.0F)
+  val containerStartupTime = newGauge("container-startup-time", 0L)
   val utilization = newGauge("event-loop-utilization", 0.0F)
   val diskUsageBytes = newGauge("disk-usage-bytes", 0L)
   val diskQuotaBytes = newGauge("disk-quota-bytes", Long.MaxValue)

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
@@ -40,7 +40,7 @@ class SamzaContainerMetrics(
   val processNs = newTimer("process-ns")
   val commitNs = newTimer("commit-ns")
   val blockNs = newTimer("block-ns")
-  val containerStartupTime = newTimer("container-startup-time")
+  val containerStartupTime = newGauge("container-startup-time", 0.0F)
   val utilization = newGauge("event-loop-utilization", 0.0F)
   val diskUsageBytes = newGauge("disk-usage-bytes", 0L)
   val diskQuotaBytes = newGauge("disk-quota-bytes", Long.MaxValue)

--- a/samza-core/src/test/scala/org/apache/samza/container/TestSamzaContainer.scala
+++ b/samza-core/src/test/scala/org/apache/samza/container/TestSamzaContainer.scala
@@ -80,7 +80,7 @@ class TestSamzaContainer extends AssertionsForJUnit with MockitoSugar {
   def setup(): Unit = {
     MockitoAnnotations.initMocks(this)
     setupSamzaContainer(Some(this.applicationContainerContext))
-    when(this.metrics.containerStartupTime).thenReturn(mock[Gauge[Float]])
+    when(this.metrics.containerStartupTime).thenReturn(mock[Gauge[Long]])
   }
 
   @Test

--- a/samza-core/src/test/scala/org/apache/samza/container/TestSamzaContainer.scala
+++ b/samza-core/src/test/scala/org/apache/samza/container/TestSamzaContainer.scala
@@ -80,7 +80,7 @@ class TestSamzaContainer extends AssertionsForJUnit with MockitoSugar {
   def setup(): Unit = {
     MockitoAnnotations.initMocks(this)
     setupSamzaContainer(Some(this.applicationContainerContext))
-    when(this.metrics.containerStartupTime).thenReturn(mock[Timer])
+    when(this.metrics.containerStartupTime).thenReturn(mock[Gauge[Float]])
   }
 
   @Test


### PR DESCRIPTION
This metric is the diff of System.nanoTime() which is a positive long (since the number of nano seconds for which a JVM a running shouldnt be negative). 
Therefore I am using a long for it.