### PR TITLE
SAMZA-2277: Semantics for cluster-manager.container.retry.window.ms not reflected in code

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerProcessManager.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerProcessManager.java
@@ -531,10 +531,14 @@ public class ContainerProcessManager implements ClusterResourceManager.Callback 
   }
 
   @VisibleForTesting
-  boolean getTooManyFailedContainers() { return tooManyFailedContainers; }
+  boolean getTooManyFailedContainers() {
+    return tooManyFailedContainers;
+  }
 
   @VisibleForTesting
-  Map<String, ProcessorFailure> getProcessorFailures() { return processorFailures; }
+  Map<String, ProcessorFailure> getProcessorFailures() {
+    return processorFailures;
+  }
 
   /**
    * Returns an instantiated {@link ResourceManagerFactory} from a {@link ClusterManagerConfig}. The

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerProcessManager.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerProcessManager.java
@@ -349,6 +349,10 @@ public class TestContainerProcessManager {
     taskManager.stop();
   }
 
+  /**
+   * Test scenario where a container fails multiple times but failures are more than retryWindow apart.
+   * @throws Exception
+   */
   @Test
   public void testContainerRequestedRetriesExceedingWindowOnFailureWithUnknownCode() throws Exception {
     int maxRetries = 3;
@@ -385,7 +389,7 @@ public class TestContainerProcessManager {
     int longWindow = clusterManagerConfig.getContainerRetryWindowMs() + 10;
     cpm.getProcessorFailures().put(processorId, new ProcessorFailure(1, Instant.now().minusMillis(longWindow).toEpochMilli()));
     cpm.onResourceCompleted(new SamzaResourceStatus(container.getContainerId(), "diagnostics", 1));
-    assertEquals(false, cpm.getTooManyFailedContainers());
+    assertEquals(false, cpm.getJobFailureCriteriaMet());
     assertEquals(1, cpm.getProcessorFailures().get(processorId).getCount());
 
     cpm.onResourceAllocated(container);
@@ -399,7 +403,7 @@ public class TestContainerProcessManager {
     // Mock 3rd failure exceeding retry window.
     cpm.getProcessorFailures().put(processorId, new ProcessorFailure(2, Instant.now().minusMillis(longWindow).toEpochMilli()));
     cpm.onResourceCompleted(new SamzaResourceStatus(container.getContainerId(), "diagnostics", 1));
-    assertEquals(false, cpm.getTooManyFailedContainers());
+    assertEquals(false, cpm.getJobFailureCriteriaMet());
     assertEquals(1, cpm.getProcessorFailures().get(processorId).getCount());
 
     cpm.onResourceAllocated(container);
@@ -413,7 +417,7 @@ public class TestContainerProcessManager {
     // Mock 4th failure exceeding retry window.
     cpm.getProcessorFailures().put(processorId, new ProcessorFailure(3, Instant.now().minusMillis(longWindow).toEpochMilli()));
     cpm.onResourceCompleted(new SamzaResourceStatus(container.getContainerId(), "diagnostics", 1));
-    assertEquals(false, cpm.getTooManyFailedContainers());
+    assertEquals(false, cpm.getJobFailureCriteriaMet());
     assertEquals(1, cpm.getProcessorFailures().get(processorId).getCount());
 
     cpm.stop();
@@ -454,7 +458,7 @@ public class TestContainerProcessManager {
     // Mock 2nd failure not exceeding retry window.
     cpm.getProcessorFailures().put(processorId, new ProcessorFailure(1, Instant.now().toEpochMilli()));
     cpm.onResourceCompleted(new SamzaResourceStatus(container.getContainerId(), "diagnostics", 1));
-    assertEquals(false, cpm.getTooManyFailedContainers());
+    assertEquals(false, cpm.getJobFailureCriteriaMet());
     assertEquals(2, cpm.getProcessorFailures().get(processorId).getCount());
 
     cpm.onResourceAllocated(container);
@@ -468,7 +472,7 @@ public class TestContainerProcessManager {
     // Mock 3rd failure not exceeding retry window.
     cpm.getProcessorFailures().put(processorId, new ProcessorFailure(2, Instant.now().toEpochMilli()));
     cpm.onResourceCompleted(new SamzaResourceStatus(container.getContainerId(), "diagnostics", 1));
-    assertEquals(false, cpm.getTooManyFailedContainers());
+    assertEquals(false, cpm.getJobFailureCriteriaMet());
     assertEquals(3, cpm.getProcessorFailures().get(processorId).getCount());
 
     cpm.onResourceAllocated(container);
@@ -482,7 +486,7 @@ public class TestContainerProcessManager {
     // Mock 4th failure not exceeding retry window.
     cpm.getProcessorFailures().put(processorId, new ProcessorFailure(3, Instant.now().toEpochMilli()));
     cpm.onResourceCompleted(new SamzaResourceStatus(container.getContainerId(), "diagnostics", 1));
-    assertEquals(true, cpm.getTooManyFailedContainers()); // expecting failed container
+    assertEquals(true, cpm.getJobFailureCriteriaMet()); // expecting failed container
     assertEquals(3, cpm.getProcessorFailures().get(processorId).getCount()); // count won't update on failure
 
     cpm.stop();

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerProcessManager.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerProcessManager.java
@@ -383,10 +383,10 @@ public class TestContainerProcessManager {
 
     // Mock 2nd failure exceeding retry window.
     int longWindow = clusterManagerConfig.getContainerRetryWindowMs() + 10;
-    cpm.processorFailures.put(processorId, new ProcessorFailure(1, Instant.now().minusMillis(longWindow).toEpochMilli()));
+    cpm.getProcessorFailures().put(processorId, new ProcessorFailure(1, Instant.now().minusMillis(longWindow).toEpochMilli()));
     cpm.onResourceCompleted(new SamzaResourceStatus(container.getContainerId(), "diagnostics", 1));
-    assertEquals(false, cpm.tooManyFailedContainers);
-    assertEquals(1, cpm.processorFailures.get(processorId).getCount());
+    assertEquals(false, cpm.getTooManyFailedContainers());
+    assertEquals(1, cpm.getProcessorFailures().get(processorId).getCount());
 
     cpm.onResourceAllocated(container);
 
@@ -397,10 +397,10 @@ public class TestContainerProcessManager {
     cpm.onStreamProcessorLaunchSuccess(container);
 
     // Mock 3rd failure exceeding retry window.
-    cpm.processorFailures.put(processorId, new ProcessorFailure(2, Instant.now().minusMillis(longWindow).toEpochMilli()));
+    cpm.getProcessorFailures().put(processorId, new ProcessorFailure(2, Instant.now().minusMillis(longWindow).toEpochMilli()));
     cpm.onResourceCompleted(new SamzaResourceStatus(container.getContainerId(), "diagnostics", 1));
-    assertEquals(false, cpm.tooManyFailedContainers);
-    assertEquals(1, cpm.processorFailures.get(processorId).getCount());
+    assertEquals(false, cpm.getTooManyFailedContainers());
+    assertEquals(1, cpm.getProcessorFailures().get(processorId).getCount());
 
     cpm.onResourceAllocated(container);
 
@@ -411,10 +411,10 @@ public class TestContainerProcessManager {
     cpm.onStreamProcessorLaunchSuccess(container);
 
     // Mock 4th failure exceeding retry window.
-    cpm.processorFailures.put(processorId, new ProcessorFailure(3, Instant.now().minusMillis(longWindow).toEpochMilli()));
+    cpm.getProcessorFailures().put(processorId, new ProcessorFailure(3, Instant.now().minusMillis(longWindow).toEpochMilli()));
     cpm.onResourceCompleted(new SamzaResourceStatus(container.getContainerId(), "diagnostics", 1));
-    assertEquals(false, cpm.tooManyFailedContainers);
-    assertEquals(1, cpm.processorFailures.get(processorId).getCount());
+    assertEquals(false, cpm.getTooManyFailedContainers());
+    assertEquals(1, cpm.getProcessorFailures().get(processorId).getCount());
 
     cpm.stop();
   }
@@ -452,10 +452,10 @@ public class TestContainerProcessManager {
     cpm.onStreamProcessorLaunchSuccess(container);
 
     // Mock 2nd failure not exceeding retry window.
-    cpm.processorFailures.put(processorId, new ProcessorFailure(1, Instant.now().toEpochMilli()));
+    cpm.getProcessorFailures().put(processorId, new ProcessorFailure(1, Instant.now().toEpochMilli()));
     cpm.onResourceCompleted(new SamzaResourceStatus(container.getContainerId(), "diagnostics", 1));
-    assertEquals(false, cpm.tooManyFailedContainers);
-    assertEquals(2, cpm.processorFailures.get(processorId).getCount());
+    assertEquals(false, cpm.getTooManyFailedContainers());
+    assertEquals(2, cpm.getProcessorFailures().get(processorId).getCount());
 
     cpm.onResourceAllocated(container);
 
@@ -466,10 +466,10 @@ public class TestContainerProcessManager {
     cpm.onStreamProcessorLaunchSuccess(container);
 
     // Mock 3rd failure not exceeding retry window.
-    cpm.processorFailures.put(processorId, new ProcessorFailure(2, Instant.now().toEpochMilli()));
+    cpm.getProcessorFailures().put(processorId, new ProcessorFailure(2, Instant.now().toEpochMilli()));
     cpm.onResourceCompleted(new SamzaResourceStatus(container.getContainerId(), "diagnostics", 1));
-    assertEquals(false, cpm.tooManyFailedContainers);
-    assertEquals(3, cpm.processorFailures.get(processorId).getCount());
+    assertEquals(false, cpm.getTooManyFailedContainers());
+    assertEquals(3, cpm.getProcessorFailures().get(processorId).getCount());
 
     cpm.onResourceAllocated(container);
 
@@ -480,10 +480,10 @@ public class TestContainerProcessManager {
     cpm.onStreamProcessorLaunchSuccess(container);
 
     // Mock 4th failure not exceeding retry window.
-    cpm.processorFailures.put(processorId, new ProcessorFailure(3, Instant.now().toEpochMilli()));
+    cpm.getProcessorFailures().put(processorId, new ProcessorFailure(3, Instant.now().toEpochMilli()));
     cpm.onResourceCompleted(new SamzaResourceStatus(container.getContainerId(), "diagnostics", 1));
-    assertEquals(true, cpm.tooManyFailedContainers); // expecting failed container
-    assertEquals(3, cpm.processorFailures.get(processorId).getCount()); // count won't update on failure
+    assertEquals(true, cpm.getTooManyFailedContainers()); // expecting failed container
+    assertEquals(3, cpm.getProcessorFailures().get(processorId).getCount()); // count won't update on failure
 
     cpm.stop();
   }


### PR DESCRIPTION
In the current code, the window is only applied and checked on the last retry. However, the check should be done at all retries.

This was found during #1104 

@rmatharu please take a look