### PR TITLE
SAMZA-2278: Delete all for startpoints and fan outs.

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/startpoint/StartpointManager.java
+++ b/samza-core/src/main/java/org/apache/samza/startpoint/StartpointManager.java
@@ -211,6 +211,16 @@ public class StartpointManager {
   }
 
   /**
+   * Deletes all {@link Startpoint}s
+   */
+  public void deleteAllStartpoints() {
+    Set<String> readWriteKeys = readWriteStore.all().keySet();
+    for (String key : readWriteKeys) {
+      readWriteStore.delete(key);
+    }
+  }
+
+  /**
    * The Startpoints that are written to with {@link #writeStartpoint(SystemStreamPartition, Startpoint)} and with
    * {@link #writeStartpoint(SystemStreamPartition, TaskName, Startpoint)} are moved from a "read-write" namespace
    * to a "fan out" namespace.
@@ -304,6 +314,16 @@ public class StartpointManager {
     Preconditions.checkNotNull(taskName, "TaskName cannot be null");
 
     fanOutStore.delete(toFanOutStoreKey(taskName));
+  }
+
+  /**
+   * Deletes all fanned out {@link Startpoint}s
+   */
+  public void removeAllFanOuts() {
+    Set<String> fanOutKeys = fanOutStore.all().keySet();
+    for (String key : fanOutKeys) {
+      fanOutStore.delete(key);
+    }
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Added a "delete all" for startpoints so we have the ability to delete all in case we run into situations where the startpoints poses a problem for the job.