### PR TITLE
SAMZA-2271: Add Metdata store putAll API

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/metadatastore/MetadataStore.java
+++ b/samza-api/src/main/java/org/apache/samza/metadatastore/MetadataStore.java
@@ -18,8 +18,8 @@
  */
 package org.apache.samza.metadatastore;
 
-import org.apache.samza.annotation.InterfaceStability;
 import java.util.Map;
+import org.apache.samza.annotation.InterfaceStability;
 
 /**
  * Store abstraction responsible for managing the metadata of a Samza job.
@@ -48,6 +48,17 @@ public interface MetadataStore {
    * @param value the value with which the specified {@code key} is to be associated.
    */
   void put(String key, byte[] value);
+
+  /**
+   * Updates the mapping with the specified map.
+   *
+   * @param entries mapping of key to values to write to the metadata store
+   */
+  default void putAll(Map<String, byte[]> entries) {
+    for (Map.Entry<String, byte[]> entry : entries.entrySet()) {
+      put(entry.getKey(), entry.getValue());
+    }
+  }
 
   /**
    * Deletes the mapping for the specified {@code key} from this metadata store (if such mapping exists).

--- a/samza-core/src/main/java/org/apache/samza/coordinator/metadatastore/NamespaceAwareCoordinatorStreamStore.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/metadatastore/NamespaceAwareCoordinatorStreamStore.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import org.apache.samza.coordinator.metadatastore.CoordinatorStreamStore.CoordinatorMessageKey;
 import org.apache.samza.metadatastore.MetadataStore;
 
@@ -61,6 +62,14 @@ public class NamespaceAwareCoordinatorStreamStore implements MetadataStore {
   public void put(String key, byte[] value) {
     String coordinatorMessageKeyAsJson = getCoordinatorMessageKey(key);
     metadataStore.put(coordinatorMessageKeyAsJson, value);
+  }
+
+  @Override
+  public void putAll(Map<String, byte[]> entries) {
+    Map<String, byte[]> mapWithCoordinatorMessageKeys =
+        entries.entrySet().stream()
+            .collect(Collectors.toMap(e -> getCoordinatorMessageKey(e.getKey()), e -> e.getValue()));
+    metadataStore.putAll(mapWithCoordinatorMessageKeys);
   }
 
   @Override

--- a/samza-core/src/test/java/org/apache/samza/coordinator/metadatastore/TestCoordinatorStreamStore.java
+++ b/samza-core/src/test/java/org/apache/samza/coordinator/metadatastore/TestCoordinatorStreamStore.java
@@ -19,6 +19,7 @@
 package org.apache.samza.coordinator.metadatastore;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.MapConfig;
 import org.apache.samza.coordinator.stream.messages.SetTaskContainerMapping;
@@ -27,7 +28,7 @@ import org.apache.samza.serializers.Serde;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import java.util.*;
+import org.mockito.Mockito;
 
 public class TestCoordinatorStreamStore {
 
@@ -81,6 +82,30 @@ public class TestCoordinatorStreamStore {
     coordinatorStreamStore.put(key, value1);
     Assert.assertEquals(value1, coordinatorStreamStore.get(key));
     Assert.assertEquals(1, namespaceAwareCoordinatorStreamStore.all().size());
+  }
+
+  @Test
+  public void testPutAll() {
+    CoordinatorStreamStore spyCoordinatorStreamStore = Mockito.spy(coordinatorStreamStore);
+    String key1 = getCoordinatorMessageKey("test-key1");
+    String key2 = getCoordinatorMessageKey("test-key2");
+    String key3 = getCoordinatorMessageKey("test-key3");
+    String key4 = getCoordinatorMessageKey("test-key4");
+    String key5 = getCoordinatorMessageKey("test-key5");
+    byte[] value1 = getValue("test-value1");
+    byte[] value2 = getValue("test-value2");
+    byte[] value3 = getValue("test-value3");
+    byte[] value4 = getValue("test-value4");
+    byte[] value5 = getValue("test-value5");
+    ImmutableMap<String, byte[]> map =
+        ImmutableMap.of(key1, value1, key2, value2, key3, value3, key4, value4, key5, value5);
+    spyCoordinatorStreamStore.putAll(map);
+    Assert.assertEquals(value1, spyCoordinatorStreamStore.get(key1));
+    Assert.assertEquals(value2, spyCoordinatorStreamStore.get(key2));
+    Assert.assertEquals(value3, spyCoordinatorStreamStore.get(key3));
+    Assert.assertEquals(value4, spyCoordinatorStreamStore.get(key4));
+    Assert.assertEquals(value5, spyCoordinatorStreamStore.get(key5));
+    Mockito.verify(spyCoordinatorStreamStore).flush(); // verify flush called only once during putAll
   }
 
   @Test

--- a/samza-core/src/test/java/org/apache/samza/coordinator/metadatastore/TestNamespaceAwareCoordinatorStreamStore.java
+++ b/samza-core/src/test/java/org/apache/samza/coordinator/metadatastore/TestNamespaceAwareCoordinatorStreamStore.java
@@ -63,6 +63,29 @@ public class TestNamespaceAwareCoordinatorStreamStore {
   }
 
   @Test
+  public void testPutAllShouldDelegateTheInvocationToUnderlyingStore() {
+    byte[] value = RandomStringUtils.randomAlphabetic(5).getBytes(StandardCharsets.UTF_8);
+    ImmutableMap<String, byte[]> map = ImmutableMap.of(
+        "key1", value,
+        "key2", value,
+        "key3", value,
+        "key4", value,
+        "key5", value);
+    ImmutableMap<String, byte[]> namespacedMap = ImmutableMap.of(
+        CoordinatorStreamStore.serializeCoordinatorMessageKeyToJson(namespace, "key1"), value,
+        CoordinatorStreamStore.serializeCoordinatorMessageKeyToJson(namespace, "key2"), value,
+        CoordinatorStreamStore.serializeCoordinatorMessageKeyToJson(namespace, "key3"), value,
+        CoordinatorStreamStore.serializeCoordinatorMessageKeyToJson(namespace, "key4"), value,
+        CoordinatorStreamStore.serializeCoordinatorMessageKeyToJson(namespace, "key5"), value);
+
+    Mockito.doNothing().when(coordinatorStreamStore).putAll(namespacedMap);
+
+    namespaceAwareCoordinatorStreamStore.putAll(map);
+
+    Mockito.verify(coordinatorStreamStore).putAll(namespacedMap);
+  }
+
+  @Test
   public void testDeleteShouldDelegateTheInvocationToUnderlyingStore() {
     String namespacedKey = CoordinatorStreamStore.serializeCoordinatorMessageKeyToJson(namespace, KEY1);
 


### PR DESCRIPTION
Add a putsAll API to the metadata store API. This allows for a delayed flush() call for underlying stores that require a flush() after write such as Kafka. 