### PR TITLE
[SAMZA-2283] Samza Sql Diagnostics: use Nanosecond for logical operator processing time and query latency

### DIFF
--- a/samza-sql/src/main/java/org/apache/samza/sql/SamzaSqlInputTransformer.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/SamzaSqlInputTransformer.java
@@ -19,7 +19,6 @@
 
 package org.apache.samza.sql;
 
-import java.time.Instant;
 import net.jodah.failsafe.internal.util.Assert;
 import org.apache.samza.operators.KV;
 import org.apache.samza.sql.data.SamzaSqlRelMsgMetadata;
@@ -40,9 +39,7 @@ public class SamzaSqlInputTransformer implements InputTransformer {
   public Object apply(IncomingMessageEnvelope ime) {
     Assert.notNull(ime, "ime is null");
     KV<Object, Object> keyAndMessageKV = KV.of(ime.getKey(), ime.getMessage());
-    SamzaSqlRelMsgMetadata metadata = new SamzaSqlRelMsgMetadata(
-        (ime.getEventTime() == 0) ? "" : Instant.ofEpochMilli(ime.getEventTime()).toString(),
-        (ime.getArrivalTime() == 0) ? "" : Instant.ofEpochMilli(ime.getArrivalTime()).toString(), null);
+    SamzaSqlRelMsgMetadata metadata = new SamzaSqlRelMsgMetadata(ime.getEventTime(), ime.getArrivalTime());
     SamzaSqlInputMessage samzaMsg = SamzaSqlInputMessage.of(keyAndMessageKV, metadata);
     return  samzaMsg;
   }

--- a/samza-sql/src/main/java/org/apache/samza/sql/avro/AvroRelConverter.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/avro/AvroRelConverter.java
@@ -96,7 +96,7 @@ public class AvroRelConverter implements SamzaRelConverter {
     }
 
     return new SamzaSqlRelMessage(samzaMessage.getKey(), payloadFieldNames, payloadFieldValues,
-        new SamzaSqlRelMsgMetadata("", "", ""));
+        new SamzaSqlRelMsgMetadata(0L, 0L));
   }
 
   /**
@@ -107,8 +107,7 @@ public class AvroRelConverter implements SamzaRelConverter {
     List<String> payloadFieldNames = new ArrayList<>();
     List<Object> payloadFieldValues = new ArrayList<>();
     fetchFieldNamesAndValuesFromIndexedRecord(record, payloadFieldNames, payloadFieldValues, schema);
-    return new SamzaSqlRelMessage(key, payloadFieldNames, payloadFieldValues,
-        new SamzaSqlRelMsgMetadata("", "", ""));
+    return new SamzaSqlRelMessage(key, payloadFieldNames, payloadFieldValues, new SamzaSqlRelMsgMetadata(0L, 0L));
   }
 
   public static void fetchFieldNamesAndValuesFromIndexedRecord(IndexedRecord record, List<String> fieldNames,

--- a/samza-sql/src/main/java/org/apache/samza/sql/data/SamzaSqlRelMessage.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/data/SamzaSqlRelMessage.java
@@ -130,16 +130,16 @@ public class SamzaSqlRelMessage implements Serializable {
     return key;
   }
 
-  public void setEventTime(String eventTime) {
+  public void setEventTime(long eventTime) {
     this.samzaSqlRelMsgMetadata.setEventTime(eventTime);
   }
 
-  public void setArrivalTime(String arrivalTime) {
+  public void setArrivalTime(long arrivalTime) {
     this.samzaSqlRelMsgMetadata.setArrivalTime(arrivalTime);
   }
 
-  public void setScanTime(String scanTime) {
-    this.samzaSqlRelMsgMetadata.setScanTime(scanTime);
+  public void setScanTime(long scanTimeNs, long scanTimeMs) {
+    this.samzaSqlRelMsgMetadata.setScanTime(scanTimeNs, scanTimeMs);
   }
 
   @Override

--- a/samza-sql/src/main/java/org/apache/samza/sql/data/SamzaSqlRelMsgMetadata.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/data/SamzaSqlRelMsgMetadata.java
@@ -20,7 +20,6 @@
 package org.apache.samza.sql.data;
 
 import java.io.Serializable;
-import java.time.Instant;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonProperty;
 
@@ -56,60 +55,82 @@ public class SamzaSqlRelMsgMetadata implements Serializable {
    * TODO: copy eventTime through from source to RelMessage
    */
   @JsonProperty("eventTime")
-  private String eventTime;
+  private long eventTime = 0L;
 
   /**
    * the timestamp of when Samza App received the event
    * TODO: set arrivalTime during conversion from IME to SamzaMessage
    */
   @JsonProperty("arrivalTime")
-  private String arrivalTime;
+  private long arrivalTime = 0L;
 
   /**
-   * the timestamp when SamzaSQL query starts processing the event
-   * set by the SamzaSQL Scan operator
+   * the System.nanoTime when SamzaSQL query starts processing the event
+   * set by the SamzaSQL Scan operator, used by QueryTranslator to calculate
+   * the Query Latency
+   *
+   * Note: using JsonPeoperty("scanTim") for backward compatibility
    */
   @JsonProperty("scanTime")
-  private String scanTime;
+  private long scanTimeNanos = 0L;
 
-  public SamzaSqlRelMsgMetadata(@JsonProperty("eventTime") String eventTime, @JsonProperty("arrivalTime") String arrivalTime,
-      @JsonProperty("scanTime") String scanTime) {
+  /**
+   * the tiemstamp when SamzSQL wuery starts processing the event
+   * set by the SamzaSQL Scan oeprator, used by QueryTranslator to calculate
+   * the Queuing Latency
+   */
+  @JsonProperty("scanTimeMillis")
+  private long scanTimeMillis = 0L;
+
+  public SamzaSqlRelMsgMetadata(@JsonProperty("eventTime") long eventTime, @JsonProperty("arrivalTime") long arrivalTime,
+      @JsonProperty("scanTime") long scanTimeNanos, @JsonProperty("scanTimeMillis") long scanTimeMillis) {
     this.eventTime = eventTime;
     this.arrivalTime = arrivalTime;
-    this.scanTime = scanTime;
+    this.scanTimeNanos = scanTimeNanos;
+    this.scanTimeMillis = scanTimeMillis;
   }
 
-  public SamzaSqlRelMsgMetadata(String eventTime, String arrivalTime, String scanTime, boolean isNewInputMessage) {
-    this(eventTime, arrivalTime, scanTime);
+  public SamzaSqlRelMsgMetadata(long eventTime, long arrivalTime, long scanTimeNanos, long scanTimeMillis,
+      boolean isNewInputMessage) {
+    this(eventTime, arrivalTime, scanTimeNanos, scanTimeMillis);
     this.isNewInputMessage = isNewInputMessage;
   }
 
-  @JsonProperty("eventTime")
-  public String getEventTime() { return eventTime;}
+  public SamzaSqlRelMsgMetadata(long eventTime, long arrivalTime) {
+    this(eventTime, arrivalTime, 0L, 0L);
+  }
 
-  public void setEventTime(String eventTime) {
+
+      @JsonProperty("eventTime")
+  public long getEventTime() { return eventTime;}
+
+  public void setEventTime(long eventTime) {
     this.eventTime = eventTime;
   }
 
-  public boolean hasEventTime() { return eventTime != null && !eventTime.isEmpty(); }
+  public boolean hasEventTime() { return eventTime != 0L; }
 
   @JsonProperty("arrivalTime")
-  public String getarrivalTime() { return arrivalTime;}
+  public long getArrivalTime() { return arrivalTime;}
 
-  public void setArrivalTime(String arrivalTime) {
+  public void setArrivalTime(long arrivalTime) {
     this.arrivalTime = arrivalTime;
   }
 
-  public boolean hasArrivalTime() { return arrivalTime != null && !arrivalTime.isEmpty(); }
+  public boolean hasArrivalTime() { return arrivalTime != 0L; }
 
   @JsonProperty("scanTime")
-  public String getscanTime() { return scanTime;}
+  public long getScanTimeNanos() { return scanTimeNanos;}
 
-  public void setScanTime(String scanTime) {
-    this.scanTime = scanTime;
+  @JsonProperty("scanTimeMillis")
+  public long getScanTimeMillis() { return scanTimeMillis;}
+
+  public void setScanTime(long scanTimeNano, long scanTimeMillis) {
+    this.scanTimeNanos = scanTimeNano;
+    this.scanTimeMillis = scanTimeMillis;
   }
 
-  public boolean hasScanTime() { return scanTime != null && !scanTime.isEmpty(); }
+  public boolean hasScanTime() { return scanTimeNanos != 0L; }
 
   @JsonIgnore
   public  void setIsSystemMessage(boolean isSystemMessage) {
@@ -123,7 +144,7 @@ public class SamzaSqlRelMsgMetadata implements Serializable {
 
   @Override
   public String toString() {
-    return "[Metadata:{" + eventTime + " " + arrivalTime + " " + scanTime + "}]";
+    return "[Metadata:{" + eventTime + " " + arrivalTime + " " + scanTimeNanos + " " + scanTimeMillis + "}]";
   }
 
 }

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/LogicalAggregateTranslator.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/LogicalAggregateTranslator.java
@@ -20,7 +20,6 @@
 package org.apache.samza.sql.translator;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.calcite.rel.logical.LogicalAggregate;
@@ -81,7 +80,7 @@ class LogicalAggregateTranslator {
                 List<Object> fieldValues = windowPane.getKey().getKey().getSamzaSqlRelRecord().getFieldValues();
                 fieldNames.add(aggFieldNames.get(0));
                 fieldValues.add(windowPane.getMessage());
-                return new SamzaSqlRelMessage(fieldNames, fieldValues, new SamzaSqlRelMsgMetadata("", "", ""));
+                return new SamzaSqlRelMessage(fieldNames, fieldValues, new SamzaSqlRelMsgMetadata(0L, 0L));
               });
     context.registerMessageStream(aggregate.getId(), outputStream);
     outputStream.map(new TranslatorOutputMetricsMapFunction(logicalOpId));

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/TranslatorConstants.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/TranslatorConstants.java
@@ -20,10 +20,10 @@
 package org.apache.samza.sql.translator;
 
 public class TranslatorConstants {
-  public static final String PROCESSING_TIME_NAME = "processingTimeMs";
-  public static final String TOTAL_LATENCY_NAME = "totalLatencyMs";
-  public static final String QUERY_LATENCY_NAME = "queryLatencyMs";
-  public static final String QUEUEING_LATENCY_NAME = "queueingLatencyMs";
+  public static final String PROCESSING_TIME_NAME = "processingTimeNanos";
+  public static final String QUEUEING_LATENCY_MILLIS_NAME = "queueingLatencyMillis";
+  public static final String QUERY_LATENCY_NANOS_NAME = "queryLatencyNanos";
+  public static final String TOTAL_LATENCY_MILLIS_NAME = "totalLatencyMillis";
   public static final String INPUT_EVENTS_NAME = "inputEvents";
   public static final String FILTERED_EVENTS_NAME = "filteredEvents";
   public static final String OUTPUT_EVENTS_NAME = "outputEvents";

--- a/samza-sql/src/test/java/org/apache/samza/sql/data/TestSamzaSqlRelMessage.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/data/TestSamzaSqlRelMessage.java
@@ -19,12 +19,10 @@
 
 package org.apache.samza.sql.data;
 
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.samza.sql.SamzaSqlRelRecord;
-import org.apache.samza.sql.data.SamzaSqlRelMessage;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -36,33 +34,33 @@ public class TestSamzaSqlRelMessage {
 
   @Test
   public void testGetField() {
-    SamzaSqlRelMessage message = new SamzaSqlRelMessage(names, values, new SamzaSqlRelMsgMetadata("", "", ""));
+    SamzaSqlRelMessage message = new SamzaSqlRelMessage(names, values, new SamzaSqlRelMsgMetadata(0L, 0L));
     Assert.assertEquals(values.get(0), message.getSamzaSqlRelRecord().getField(names.get(0)).get());
     Assert.assertEquals(values.get(1), message.getSamzaSqlRelRecord().getField(names.get(1)).get());
   }
 
   @Test
   public void testGetNonExistentField() {
-    SamzaSqlRelMessage message = new SamzaSqlRelMessage(names, values, new SamzaSqlRelMsgMetadata("", "", ""));
+    SamzaSqlRelMessage message = new SamzaSqlRelMessage(names, values, new SamzaSqlRelMsgMetadata(0L, 0L));
     Assert.assertFalse(message.getSamzaSqlRelRecord().getField("field3").isPresent());
   }
 
   @Test
   public void testEquality() {
-    SamzaSqlRelMessage message1 = new SamzaSqlRelMessage(names, values, new SamzaSqlRelMsgMetadata("", "", ""));
+    SamzaSqlRelMessage message1 = new SamzaSqlRelMessage(names, values, new SamzaSqlRelMsgMetadata(0L, 0L));
     SamzaSqlRelMessage message2 =
         new SamzaSqlRelMessage(Arrays.asList("field1", "field2"), Arrays.asList("value1", "value2"),
-            new SamzaSqlRelMsgMetadata("", "", ""));
+            new SamzaSqlRelMsgMetadata(0L, 0L));
     Assert.assertEquals(message1, message2);
     Assert.assertEquals(message1.hashCode(), message2.hashCode());
   }
 
   @Test
   public void testInEquality() {
-    SamzaSqlRelMessage message1 = new SamzaSqlRelMessage(names, values, new SamzaSqlRelMsgMetadata("", "", ""));
+    SamzaSqlRelMessage message1 = new SamzaSqlRelMessage(names, values, new SamzaSqlRelMsgMetadata(0L, 0L));
     SamzaSqlRelMessage message2 =
         new SamzaSqlRelMessage(Arrays.asList("field1", "field2"), Arrays.asList("value2", "value2"),
-            new SamzaSqlRelMsgMetadata("", "", ""));
+            new SamzaSqlRelMsgMetadata(0L, 0L));
     Assert.assertNotEquals(message1, message2);
     Assert.assertNotEquals(message1.hashCode(), message2.hashCode());
   }
@@ -70,7 +68,7 @@ public class TestSamzaSqlRelMessage {
   @Test
   public void testCompositeKeyCreation() {
     List<String> keyPartNames = Arrays.asList("kfield1", "kfield2");
-    SamzaSqlRelMessage message = new SamzaSqlRelMessage(names, values, new SamzaSqlRelMsgMetadata("", "", ""));
+    SamzaSqlRelMessage message = new SamzaSqlRelMessage(names, values, new SamzaSqlRelMsgMetadata(0L, 0L));
 
     SamzaSqlRelRecord relRecord1 = SamzaSqlRelMessage.createSamzaSqlCompositeKey(message, Collections.singletonList(0));
     Assert.assertEquals(relRecord1.getFieldNames().size(), 1);
@@ -89,7 +87,7 @@ public class TestSamzaSqlRelMessage {
   @Test (expected = IllegalArgumentException.class)
   public void testCompositeKeyCreationWithInEqualKeyNameValues() {
     List<String> keyPartNames = Arrays.asList("kfield1", "kfield2");
-    SamzaSqlRelMessage message = new SamzaSqlRelMessage(names, values, new SamzaSqlRelMsgMetadata("", "", ""));
+    SamzaSqlRelMessage message = new SamzaSqlRelMessage(names, values, new SamzaSqlRelMsgMetadata(0L, 0L));
 
     SamzaSqlRelRecord relRecord1 = SamzaSqlRelMessage.createSamzaSqlCompositeKey(message, Arrays.asList(1, 0),
         SamzaSqlRelMessage.getSamzaSqlCompositeKeyFieldNames(keyPartNames, Arrays.asList(1)));

--- a/samza-sql/src/test/java/org/apache/samza/sql/serializers/TestSamzaSqlRelMessageSerde.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/serializers/TestSamzaSqlRelMessageSerde.java
@@ -19,7 +19,6 @@
 
 package org.apache.samza.sql.serializers;
 
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -38,7 +37,6 @@ import org.apache.samza.sql.avro.schemas.Profile;
 import org.apache.samza.sql.avro.schemas.StreetNumRecord;
 import org.apache.samza.sql.data.SamzaSqlRelMessage;
 import org.apache.samza.sql.data.SamzaSqlRelMsgMetadata;
-import org.apache.samza.sql.serializers.SamzaSqlRelMessageSerdeFactory;
 import org.apache.samza.system.SystemStream;
 import org.junit.Assert;
 import org.junit.Test;
@@ -53,7 +51,7 @@ public class TestSamzaSqlRelMessageSerde {
 
   @Test
   public void testWithDifferentFields() {
-    SamzaSqlRelMessage message = new SamzaSqlRelMessage(names, values, new SamzaSqlRelMsgMetadata("", "", ""));
+    SamzaSqlRelMessage message = new SamzaSqlRelMessage(names, values, new SamzaSqlRelMsgMetadata(0L, 0L));
     SamzaSqlRelMessageSerde serde =
         (SamzaSqlRelMessageSerde) new SamzaSqlRelMessageSerdeFactory().getSerde(null, null);
     SamzaSqlRelMessage resultMsg = serde.fromBytes(serde.toBytes(message));

--- a/samza-sql/src/test/java/org/apache/samza/sql/serializers/TestSamzaSqlRelRecordSerde.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/serializers/TestSamzaSqlRelRecordSerde.java
@@ -19,7 +19,6 @@
 
 package org.apache.samza.sql.serializers;
 
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -51,7 +50,7 @@ public class TestSamzaSqlRelRecordSerde {
   @Test
   public void testWithDifferentFields() {
     SamzaSqlRelRecord record =
-        new SamzaSqlRelMessage(names, values, new SamzaSqlRelMsgMetadata("", "", "")).getSamzaSqlRelRecord();
+        new SamzaSqlRelMessage(names, values, new SamzaSqlRelMsgMetadata(0L, 0L)).getSamzaSqlRelRecord();
     SamzaSqlRelRecordSerde serde =
         (SamzaSqlRelRecordSerde) new SamzaSqlRelRecordSerdeFactory().getSerde(null, null);
     SamzaSqlRelRecord resultRecord = serde.fromBytes(serde.toBytes(record));

--- a/samza-sql/src/test/java/org/apache/samza/sql/translator/TestFilterTranslator.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/translator/TestFilterTranslator.java
@@ -125,7 +125,7 @@ public class TestFilterTranslator extends TranslatorTestBase {
 
     // Calling filterFn.apply() to verify the filter function is correctly applied to the input message
     SamzaSqlRelMessage mockInputMsg = new SamzaSqlRelMessage(new ArrayList<>(), new ArrayList<>(),
-        new SamzaSqlRelMsgMetadata("", "", ""));
+        new SamzaSqlRelMsgMetadata(0L, 0L));
     SamzaSqlExecutionContext executionContext = mock(SamzaSqlExecutionContext.class);
     DataContext dataContext = mock(DataContext.class);
     when(mockTranslatorContext.getExecutionContext()).thenReturn(executionContext);

--- a/samza-sql/src/test/java/org/apache/samza/sql/translator/TestProjectTranslator.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/translator/TestProjectTranslator.java
@@ -20,7 +20,6 @@ package org.apache.samza.sql.translator;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,10 +27,7 @@ import org.apache.calcite.DataContext;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rex.RexCall;
-import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.sql.validate.SqlUserDefinedFunction;
 import org.apache.calcite.util.Pair;
 import org.apache.samza.application.descriptors.StreamApplicationDescriptorImpl;
 import org.apache.samza.context.ContainerContext;
@@ -39,8 +35,6 @@ import org.apache.samza.context.Context;
 import org.apache.samza.operators.MessageStream;
 import org.apache.samza.operators.MessageStreamImpl;
 import org.apache.samza.operators.functions.MapFunction;
-import org.apache.samza.operators.functions.ScheduledFunction;
-import org.apache.samza.operators.functions.WatermarkFunction;
 import org.apache.samza.operators.spec.OperatorSpec;
 import org.apache.samza.operators.spec.StreamOperatorSpec;
 import org.apache.samza.sql.data.Expression;
@@ -52,7 +46,6 @@ import org.apache.samza.sql.runner.SamzaSqlApplicationContext;
 import org.apache.samza.sql.util.TestMetricsRegistryImpl;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.internal.matchers.Any;
 import org.mockito.internal.util.reflection.Whitebox;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -143,7 +136,7 @@ public class TestProjectTranslator extends TranslatorTestBase {
 
     // Calling mapFn.apply() to verify the filter function is correctly applied to the input message
     SamzaSqlRelMessage mockInputMsg = new SamzaSqlRelMessage(new ArrayList<>(), new ArrayList<>(),
-        new SamzaSqlRelMsgMetadata("", "", ""));
+        new SamzaSqlRelMsgMetadata(0L, 0L));
     SamzaSqlExecutionContext executionContext = mock(SamzaSqlExecutionContext.class);
     DataContext dataContext = mock(DataContext.class);
     when(mockTranslatorContext.getExecutionContext()).thenReturn(executionContext);

--- a/samza-sql/src/test/java/org/apache/samza/sql/translator/TestSamzaSqlLocalTableJoinFunction.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/translator/TestSamzaSqlLocalTableJoinFunction.java
@@ -19,7 +19,6 @@
 
 package org.apache.samza.sql.translator;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -44,8 +43,8 @@ public class TestSamzaSqlLocalTableJoinFunction {
 
   @Test
   public void testWithInnerJoinWithTableOnRight() {
-    SamzaSqlRelMessage streamMsg = new SamzaSqlRelMessage(streamFieldNames, streamFieldValues, new SamzaSqlRelMsgMetadata("", "", ""));
-    SamzaSqlRelMessage tableMsg = new SamzaSqlRelMessage(tableFieldNames, tableFieldValues, new SamzaSqlRelMsgMetadata("", "", ""));
+    SamzaSqlRelMessage streamMsg = new SamzaSqlRelMessage(streamFieldNames, streamFieldValues, new SamzaSqlRelMsgMetadata(0L, 0L));
+    SamzaSqlRelMessage tableMsg = new SamzaSqlRelMessage(tableFieldNames, tableFieldValues, new SamzaSqlRelMsgMetadata(0L, 0L));
     JoinRelType joinRelType = JoinRelType.INNER;
     List<Integer> streamKeyIds = Arrays.asList(0, 1);
     List<Integer> tableKeyIds = Arrays.asList(0, 1);
@@ -77,8 +76,8 @@ public class TestSamzaSqlLocalTableJoinFunction {
 
   @Test
   public void testWithInnerJoinWithTableOnLeft() {
-    SamzaSqlRelMessage streamMsg = new SamzaSqlRelMessage(streamFieldNames, streamFieldValues, new SamzaSqlRelMsgMetadata("", "", ""));
-    SamzaSqlRelMessage tableMsg = new SamzaSqlRelMessage(tableFieldNames, tableFieldValues, new SamzaSqlRelMsgMetadata("", "", ""));
+    SamzaSqlRelMessage streamMsg = new SamzaSqlRelMessage(streamFieldNames, streamFieldValues, new SamzaSqlRelMsgMetadata(0L, 0L));
+    SamzaSqlRelMessage tableMsg = new SamzaSqlRelMessage(tableFieldNames, tableFieldValues, new SamzaSqlRelMsgMetadata(0L, 0L));
     JoinRelType joinRelType = JoinRelType.INNER;
     List<Integer> streamKeyIds = Arrays.asList(0, 2);
     List<Integer> tableKeyIds = Arrays.asList(0, 2);
@@ -111,7 +110,7 @@ public class TestSamzaSqlLocalTableJoinFunction {
   @Test
   public void testNullRecordWithInnerJoin() {
     SamzaSqlRelMessage streamMsg = new SamzaSqlRelMessage(streamFieldNames, streamFieldValues,
-        new SamzaSqlRelMsgMetadata("", "", ""));
+        new SamzaSqlRelMsgMetadata(0L, 0L));
     JoinRelType joinRelType = JoinRelType.INNER;
     List<Integer> streamKeyIds = Arrays.asList(0, 1);
     List<Integer> tableKeyIds = Arrays.asList(2, 3);
@@ -135,7 +134,7 @@ public class TestSamzaSqlLocalTableJoinFunction {
   @Test
   public void testNullRecordWithLeftOuterJoin() {
     SamzaSqlRelMessage streamMsg = new SamzaSqlRelMessage(streamFieldNames, streamFieldValues,
-        new SamzaSqlRelMsgMetadata("", "", ""));
+        new SamzaSqlRelMsgMetadata(0L, 0L));
     JoinRelType joinRelType = JoinRelType.LEFT;
     List<Integer> streamKeyIds = Arrays.asList(0, 1);
     List<Integer> tableKeyIds = Arrays.asList(2, 3);

--- a/samza-sql/src/test/java/org/apache/samza/sql/translator/TestSamzaSqlRemoteTableJoinFunction.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/translator/TestSamzaSqlRemoteTableJoinFunction.java
@@ -69,7 +69,7 @@ public class TestSamzaSqlRemoteTableJoinFunction {
     tableRecord.put("name", "name1");
 
     SamzaSqlRelMessage streamMsg = new SamzaSqlRelMessage(streamFieldNames, streamFieldValues,
-        new SamzaSqlRelMsgMetadata("", "", ""));
+        new SamzaSqlRelMsgMetadata(0L, 0L));
     SamzaSqlRelMessage tableMsg = relConverter.convertToRelMessage(new KV(tableRecord.get("id"), tableRecord));
     JoinRelType joinRelType = JoinRelType.INNER;
     List<Integer> streamKeyIds = Arrays.asList(1);


### PR DESCRIPTION
1) Use nanoTime for SamzaSql specific latency metrics (i.e., logical operator processing time, and query latency)
2) remove some unused imports