### PR TITLE
SAMZA-2284: Remove redundant getStreamMetadata calls in SamzaContainer startup sequence.

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -579,6 +579,7 @@ object SamzaContainer extends Logging {
           exceptionHandler = TaskInstanceExceptionHandler(taskInstanceMetrics.get(taskName).get, taskConfig),
           jobModel = jobModel,
           streamMetadataCache = streamMetadataCache,
+          inputStreamMetadata = inputStreamMetadata,
           timerExecutor = timerExecutor,
           jobContext = jobContext,
           containerContext = containerContext,

--- a/samza-core/src/test/java/org/apache/samza/container/TestRunLoop.java
+++ b/samza-core/src/test/java/org/apache/samza/container/TestRunLoop.java
@@ -108,6 +108,7 @@ public class TestRunLoop {
         null,
         null,
         null,
+        null,
         mock(JobContext.class),
         mock(ContainerContext.class),
         Option.apply(null),

--- a/samza-core/src/test/scala/org/apache/samza/container/TestTaskInstance.scala
+++ b/samza-core/src/test/scala/org/apache/samza/container/TestTaskInstance.scala
@@ -271,6 +271,7 @@ class TestTaskInstance extends AssertionsForJUnit with MockitoSugar {
       .thenReturn(Collections.singletonMap(new Partition(0), sspMetadata))
 
     val ssp = new SystemStreamPartition("test-system", "test-stream", new Partition(0))
+    val inputStreamMetadata = collection.Map(ssp.getSystemStream -> systemStreamMetadata)
 
     val taskInstance = new TaskInstance(this.task,
       this.taskModel,
@@ -284,6 +285,7 @@ class TestTaskInstance extends AssertionsForJUnit with MockitoSugar {
       systemStreamPartitions = Set(ssp),
       exceptionHandler = this.taskInstanceExceptionHandler,
       streamMetadataCache = cacheMock,
+      inputStreamMetadata = Map.empty ++ inputStreamMetadata,
       jobContext = this.jobContext,
       containerContext = this.containerContext,
       applicationContainerContextOption = Some(this.applicationContainerContext),


### PR DESCRIPTION
**Problem:**

SamzaContainer startup sequence fetches the metadata of same input streams multiple times. Fetching the metadata of a stream entails making a expensive remote call to underlying messaging broker. This redundant fetch-input-stream-metadata API invocations incurred significant delays in the start of actual message processing in the samza job.

**Impact:**

1. With some samza jobs at LinkedIn, we observed that this fetch-input-stream-metadata loop took around 1.5 hrs to complete.
2. The redundant fetch-input-stream-metadata remote API calls will significantly increase the load on the underlying messaging broker.

**Fix:**

This patch fixes the unnecessary delay by fetching the metadata of the input streams only once in SamzaContainer(rather than once per SystemStreamPartition per task).

**Validation:**

1. Fix the existing unit-tests.
2. Verified this change with a sample samza-yarn job in LinkedIn and with a hello-samza job from samza-hello-world examples in OSS. 