### PR TITLE
Samza-2287: Removing RegEx based matching while parsing the sql statement

### DIFF
--- a/samza-sql/src/main/java/org/apache/samza/sql/util/SamzaSqlQueryParser.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/util/SamzaSqlQueryParser.java
@@ -117,10 +117,16 @@ public class SamzaSqlQueryParser {
         LOG.info("Parsed select query {} from sql {}", selectQuery, sql);
         sources = getSourcesFromSelectQuery(sqlSelect);
       } else {
-        throw new SamzaException("Sql query is not of the expected format");
+        String msg = String.format("Sql query is not of the expected format. Select node expected, found %s",
+            sqlInsert.getSource().getClass().toString());
+        LOG.error(msg);
+        throw new SamzaException(msg);
       }
     } else {
-      throw new SamzaException("Sql query is not of the expected format");
+      String msg = String.format("Sql query is not of the expected format. Insert node expected, found %s",
+          sqlNode.getClass().toString());
+      LOG.error(msg);
+      throw new SamzaException(msg);
     }
 
     return new QueryInfo(selectQuery, sources, sink, sql);

--- a/samza-sql/src/main/java/org/apache/samza/sql/util/SamzaSqlQueryParser.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/util/SamzaSqlQueryParser.java
@@ -53,12 +53,15 @@ import org.apache.calcite.tools.Planner;
 import org.apache.samza.SamzaException;
 import org.apache.samza.sql.interfaces.SamzaSqlDriver;
 import org.apache.samza.sql.interfaces.SamzaSqlJavaTypeFactoryImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * Utility class that is used to parse the Samza sql query to figure out the sources, sink etc..
  */
 public class SamzaSqlQueryParser {
+  private static final Logger LOG = LoggerFactory.getLogger(SamzaSqlQueryParser.class);
 
   private SamzaSqlQueryParser() {
   }
@@ -94,13 +97,6 @@ public class SamzaSqlQueryParser {
   }
 
   public static QueryInfo parseQuery(String sql) {
-
-    Pattern insertIntoSqlPattern = Pattern.compile("insert into (.*) (select .* from (.*))", Pattern.CASE_INSENSITIVE);
-    Matcher m = insertIntoSqlPattern.matcher(sql);
-    if (!m.matches()) {
-      throw new SamzaException("Invalid query format");
-    }
-
     Planner planner = createPlanner();
     SqlNode sqlNode;
     try {
@@ -117,7 +113,8 @@ public class SamzaSqlQueryParser {
       sink = sqlInsert.getTargetTable().toString();
       if (sqlInsert.getSource() instanceof SqlSelect) {
         SqlSelect sqlSelect = (SqlSelect) sqlInsert.getSource();
-        selectQuery = m.group(2);
+        selectQuery = sqlSelect.toString();
+        LOG.info("Parsed select query {} from sql {}", selectQuery, sql);
         sources = getSourcesFromSelectQuery(sqlSelect);
       } else {
         throw new SamzaException("Sql query is not of the expected format");

--- a/samza-sql/src/test/java/org/apache/samza/sql/util/TestSamzaSqlQueryParser.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/util/TestSamzaSqlQueryParser.java
@@ -31,7 +31,6 @@ public class TestSamzaSqlQueryParser {
   public void testParseQuery() {
     QueryInfo queryInfo = SamzaSqlQueryParser.parseQuery("insert into log.foo select * from tracking.bar");
     Assert.assertEquals("log.foo", queryInfo.getSink());
-    Assert.assertEquals(queryInfo.getSelectQuery(), "select * from tracking.bar", queryInfo.getSelectQuery());
     Assert.assertEquals(1, queryInfo.getSources().size());
     Assert.assertEquals("tracking.bar", queryInfo.getSources().get(0));
   }

--- a/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
@@ -266,7 +266,7 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(configs, numMessages);
     String sql1 = "Insert into testavro.outputTopic(id, long_value) "
-        + " select id, TIMESTAMPDIFF(HOUR, CURRENT_TIMESTAMP, LOCALTIMESTAMP) + MONTH(CURRENT_DATE) as long_value from testavro.SIMPLE1";
+        + " select id, TIMESTAMPDIFF(HOUR, CURRENT_TIMESTAMP(), LOCALTIMESTAMP()) + MONTH(CURRENT_DATE()) as long_value from testavro.SIMPLE1";
     List<String> sqlStmts = Arrays.asList(sql1);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
     runApplication(new MapConfig(staticConfigs));


### PR DESCRIPTION
SamzaSQLQueryParser uses a brittle regEx parsing to fetch the SQL statement from the SQL. Removing this Regex parsing and use the string generated from SqlSelect node.