### PR TITLE
SAMZA-2292: [Test improvement] Enable kafka topic deletion for integration test harnesses to improve test run times

### DIFF
--- a/samza-test/src/test/scala/org/apache/samza/test/harness/AbstractKafkaServerTestHarness.scala
+++ b/samza-test/src/test/scala/org/apache/samza/test/harness/AbstractKafkaServerTestHarness.scala
@@ -74,6 +74,7 @@ abstract class AbstractKafkaServerTestHarness extends AbstractZookeeperTestHarne
   def overridingProps: Properties = {
     val props = new Properties
     props.setProperty(KafkaConfig.NumPartitionsProp, 1.toString)
+    props.setProperty(KafkaConfig.DeleteTopicEnableProp, "true")
     props
   }
 


### PR DESCRIPTION
Build on my local machine went from over 26 minutes to ~23.5 minutes.