### PR TITLE
SAMZA-2295 : records-lag based topic metrics not working for topics with periods (dot, '.') in them

### DIFF
--- a/samza-kafka/src/main/scala/org/apache/samza/system/kafka/KafkaConsumerProxy.java
+++ b/samza-kafka/src/main/scala/org/apache/samza/system/kafka/KafkaConsumerProxy.java
@@ -397,7 +397,9 @@ public class KafkaConsumerProxy<K, V> {
         // These are required by the KafkaConsumer to get the metrics
         HashMap<String, String> tags = new HashMap<>();
         tags.put("client-id", clientId);
-        tags.put("topic", tp.topic());
+        // kafka replaces '.' with underscore '_' in many/all of their metrics tags for topic names.
+        // see https://github.com/apache/kafka/commit/5d81639907869ce7355c40d2bac176a655e52074#diff-b45245913eaae46aa847d2615d62cde0R1331
+        tags.put("topic", tp.topic().replace('.', '_'));
         tags.put("partition", Integer.toString(tp.partition()));
 
         perPartitionMetrics.put(ssp, new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags));


### PR DESCRIPTION
Fix for topic lag metrics where topic contains period (.)

`messages-behind-high-watermark` and `high-watermark` are calculated from kafka's `records-lag` consumer metric. In version 1.1 or so, when metrics moved from including the topic name in the metric name to using tags, they added a replacement of period to underscore. See commit :
https://github.com/apache/kafka/commit/5d81639907869ce7355c40d2bac176a655e52074#diff-b45245913eaae46aa847d2615d62cde0R1331

When Samza refactored to match this, the same replacement was not made, so the lookup of the "records-lag" metric in KafkaConsumerProxy fails to find a match.

The related commit on Samza is here:
https://github.com/apache/samza/commit/01c06055057e8c260e73bf3f7db7b9eb53af3745#diff-b56db493dfdd2fd2d471f6df342fe661R400


The fix is a simple replacement added to the line above. 