### PR TITLE
SAMZA-2301: Improve zookeeper metadata-store implementation

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/job/model/JobModelUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/job/model/JobModelUtil.java
@@ -93,7 +93,11 @@ public class JobModelUtil {
   public static JobModel readJobModel(String jobModelVersion, MetadataStore metadataStore) {
     try {
       byte[] jobModelAsBytes = metadataStore.get(getJobModelKey(jobModelVersion));
-      return MAPPER.readValue(new String(jobModelAsBytes, UTF_8), JobModel.class);
+      if (jobModelAsBytes != null) {
+        return MAPPER.readValue(new String(jobModelAsBytes, UTF_8), JobModel.class);
+      } else {
+        return null;
+      }
     } catch (Exception e) {
       throw new SamzaException(String.format("Exception occurred when reading JobModel version: %s from metadata store.", jobModelVersion), e);
     }

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkMetadataStore.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkMetadataStore.java
@@ -61,7 +61,7 @@ public class TestZkMetadataStore {
   @Before
   public void beforeTest() {
     String testZkConnectionString = String.format("%s:%s", LOCALHOST, zkServer.getPort());
-    Config zkConfig = new MapConfig(ImmutableMap.of(ZkConfig.ZK_CONNECT, testZkConnectionString));
+    Config zkConfig = new MapConfig(ImmutableMap.of(ZkConfig.ZK_CONNECT, testZkConnectionString, "job.coordinator.zk.session.timeout.ms", "10"));
     zkMetadataStore = new ZkMetadataStoreFactory().getMetadataStore(String.format("%s", RandomStringUtils.randomAlphabetic(5)), zkConfig, new MetricsRegistryMap());
   }
 


### PR DESCRIPTION

- We've observed corner cases where-in all the instances of an standalone application do not see the same state in zookeeper, i.e, some instance see the up-to-date JobModel state and some see an out-dated inconsistent state. There is an minuscule propagation delay(depending upon n/w bandwidth) between the leader of zookeeper quorum and the other servers in the ensemble. Consider the case where an follower undergoes the following execution sequence. 
   - Follower receives an jobModel version change notification from a zookeeper server.
   - Follower tries to read JobModel, but receives a session disconnect from the  up-to date zookeeper server. IOTec ZkClient library retries connecting to other servers in the ensemble and connection to an out-dated zookeeper server is established successfully. The read for JobModel from this out-dated zookeeper server would return null for the new JobModel zookeeper path and there by killing the standalone processor. 
    

This patch solves the problem,. by adding fixed retries in the zookeeper metadata-store read path. 

