### PR TITLE
SAMZA-2318: Empty config values from coordinator stream shouldn't be removed

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/util/CoordinatorStreamUtil.scala
+++ b/samza-core/src/main/scala/org/apache/samza/util/CoordinatorStreamUtil.scala
@@ -131,8 +131,8 @@ object CoordinatorStreamUtil extends Logging {
       } else {
         val valueSerde: CoordinatorStreamValueSerde = new CoordinatorStreamValueSerde(SetConfig.TYPE)
         val valueAsString: String = valueSerde.fromBytes(valueAsBytes)
-        if (StringUtils.isBlank(valueAsString)) {
-          warn("Value for key: %s in config is empty or null. Ignoring it." format key)
+        if (valueAsString == null) {
+          warn("Value for key: %s in config is decoded to be null. Ignoring it." format key)
         } else {
           configMap.put(key, valueAsString)
         }

--- a/samza-core/src/test/scala/org/apache/samza/util/TestCoordinatorStreamUtil.scala
+++ b/samza-core/src/test/scala/org/apache/samza/util/TestCoordinatorStreamUtil.scala
@@ -18,8 +18,13 @@
  */
 package org.apache.samza.util
 
+import java.util
+
+import org.apache.samza.coordinator.metadatastore.CoordinatorStreamStore
+import org.apache.samza.coordinator.stream.CoordinatorStreamValueSerde
+import org.apache.samza.coordinator.stream.messages.SetConfig
 import org.apache.samza.system.{StreamSpec, SystemAdmin, SystemStream}
-import org.junit.Test
+import org.junit.{Assert, Test}
 import org.mockito.Matchers.any
 import org.mockito.Mockito
 
@@ -33,5 +38,32 @@ class TestCoordinatorStreamUtil {
     CoordinatorStreamUtil.createCoordinatorStream(systemStream, systemAdmin)
     Mockito.verify(systemStream).getStream
     Mockito.verify(systemAdmin).createStream(any(classOf[StreamSpec]))
+  }
+
+  @Test
+  def testReadConfigFromCoordinatorStream {
+    val keyForNonBlankVal = "app.id"
+    val nonBlankVal = "1"
+    val keyForEmptyVal = "task.opt"
+    val emptyVal = ""
+    val keyForNullVal = "zk.server"
+    val nullVal = null
+
+    val valueSerde = new CoordinatorStreamValueSerde(SetConfig.TYPE)
+    val configMap = new util.HashMap[String, Array[Byte]]() {
+      put(CoordinatorStreamStore.serializeCoordinatorMessageKeyToJson(SetConfig.TYPE, keyForNonBlankVal),
+        valueSerde.toBytes(nonBlankVal))
+      put(CoordinatorStreamStore.serializeCoordinatorMessageKeyToJson(SetConfig.TYPE, keyForEmptyVal),
+        valueSerde.toBytes(emptyVal))
+    }
+
+    val coordinatorStreamStore = Mockito.mock(classOf[CoordinatorStreamStore])
+    Mockito.when(coordinatorStreamStore.all()).thenReturn(configMap)
+
+    val configFromCoordinatorStream = CoordinatorStreamUtil.readConfigFromCoordinatorStream(coordinatorStreamStore)
+
+    Assert.assertEquals(configFromCoordinatorStream.get(keyForNonBlankVal), nonBlankVal)
+    Assert.assertEquals(configFromCoordinatorStream.get(keyForEmptyVal), emptyVal)
+    Assert.assertFalse(configFromCoordinatorStream.containsKey(keyForNullVal))
   }
 }

--- a/samza-core/src/test/scala/org/apache/samza/util/TestCoordinatorStreamUtil.scala
+++ b/samza-core/src/test/scala/org/apache/samza/util/TestCoordinatorStreamUtil.scala
@@ -55,6 +55,8 @@ class TestCoordinatorStreamUtil {
         valueSerde.toBytes(nonBlankVal))
       put(CoordinatorStreamStore.serializeCoordinatorMessageKeyToJson(SetConfig.TYPE, keyForEmptyVal),
         valueSerde.toBytes(emptyVal))
+      put(CoordinatorStreamStore.serializeCoordinatorMessageKeyToJson(SetConfig.TYPE, keyForNullVal),
+        valueSerde.toBytes(nullVal))
     }
 
     val coordinatorStreamStore = Mockito.mock(classOf[CoordinatorStreamStore])


### PR DESCRIPTION

In the previous PR: https://github.com/apache/samza/pull/1010/files
config with null/empty values will be filter out when reading the coordinator stream,
this will cause some problems when the user expects an empty string to be a value config.