### PR TITLE
[SAMZA-2198] Fix deadlock in container signal handler

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/runtime/ClusterBasedProcessorLifecycleListener.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/ClusterBasedProcessorLifecycleListener.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.runtime;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.TaskConfig;
+import org.apache.samza.container.SamzaContainerListener;
+import org.apache.samza.util.ThreadUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ClusterBasedProcessorLifecycleListener implements SamzaContainerListener {
+  private static final Logger log = LoggerFactory.getLogger(ClusterBasedProcessorLifecycleListener.class);
+  private final Runnable onSignal;
+  private Thread shutdownHookThread = null;
+  private CountDownLatch shutdownLatch = new CountDownLatch(1);
+  private TaskConfig taskConfig;
+  private ProcessorLifecycleListener processorLifecycleListener;
+  private volatile Throwable containerException = null;
+
+  ClusterBasedProcessorLifecycleListener(Config config, ProcessorLifecycleListener processorLifecycleListener,
+      Runnable onSignal) {
+    this.taskConfig = new TaskConfig(config);
+    this.processorLifecycleListener = processorLifecycleListener;
+    this.onSignal = onSignal;
+  }
+
+  @Override
+  public void beforeStart() {
+    log.info("Before starting the container.");
+    addShutdownHook();
+    processorLifecycleListener.beforeStart();
+  }
+
+  @Override
+  public void afterStart() {
+    log.info("Container Started");
+    processorLifecycleListener.afterStart();
+  }
+
+  @Override
+  public void afterStop() {
+    log.info("Container Stopped");
+    processorLifecycleListener.afterStop();
+    removeShutdownHook();
+    shutdownLatch.countDown();
+  }
+
+  @Override
+  public void afterFailure(Throwable t) {
+    log.info("Container Failed");
+    containerException = t;
+    processorLifecycleListener.afterFailure(t);
+    removeShutdownHook();
+    shutdownLatch.countDown();
+  }
+
+  Throwable getContainerException() {
+    return containerException;
+  }
+
+  private void removeShutdownHook() {
+    try {
+      if (shutdownHookThread != null) {
+        removeJVMShutdownHook();
+      }
+    } catch (IllegalStateException e) {
+      // Thrown when then JVM is already shutting down, so safe to ignore.
+    }
+  }
+
+  private void addShutdownHook() {
+    shutdownHookThread = new Thread("Samza Container Shutdown Hook Thread") {
+      @Override
+      public void run() {
+        long shutdownMs = taskConfig.getShutdownMs();
+        log.info("Attempting to shutdown container from inside shutdownHook, will wait up to {} ms.", shutdownMs);
+        try {
+          onSignal.run();
+          boolean hasShutdown = shutdownLatch.await(shutdownMs, TimeUnit.MILLISECONDS);
+          if (hasShutdown) {
+            log.info("Shutdown complete");
+          } else {
+            log.error("Did not shut down within {} ms, exiting.", shutdownMs);
+            ThreadUtil.logThreadDump("Thread dump from Samza Container Shutdown Hook.");
+          }
+        } catch (InterruptedException e) {
+          log.error("Shutdown hook inturrupted while waiting on runLoop to shutdown");
+          ThreadUtil.logThreadDump("Thread dump from Samza Container Shutdown Hook.");
+        }
+      }
+    };
+    addJVMShutdownHook();
+  }
+
+  @VisibleForTesting
+  Thread getShutdownHookThread() {
+    return this.shutdownHookThread;
+  }
+
+  @VisibleForTesting
+  void addJVMShutdownHook() {
+    Runtime.getRuntime().addShutdownHook(shutdownHookThread);
+    log.info("Added Samza container shutdown hook");
+  }
+
+  @VisibleForTesting
+  void removeJVMShutdownHook() {
+    Runtime.getRuntime().removeShutdownHook(shutdownHookThread);
+    log.info("Removed Samza container shutdown hook");
+  }
+}

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -707,7 +707,6 @@ class SamzaContainer(
   private val jobConfig = new JobConfig(config)
   private val taskConfig = new TaskConfig(config)
   val shutdownMs: Long = taskConfig.getShutdownMs
-  var shutdownHookThread: Thread = null
   var jmxServer: JmxServer = null
 
   @volatile private var status = SamzaContainerStatus.NOT_STARTED

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -974,39 +974,6 @@ class SamzaContainer(
     }
   }
 
-  def addShutdownHook {
-    shutdownHookThread = new Thread("Samza Container Shutdown Hook Thread") {
-      override def run() = {
-        val SHUTDOWN_POLL_TIME_MS = 1000
-        info("Shutting down, will wait up to %s ms." format shutdownMs)
-        shutdownRunLoop() //TODO: Pull out shutdown hook to LocalContainerRunner or SP
-        val endTime = System.currentTimeMillis() + shutdownMs
-        while (!hasStopped && System.currentTimeMillis() < endTime) {
-          Thread.sleep(SHUTDOWN_POLL_TIME_MS)
-        }
-        if (hasStopped) {
-          info("Shutdown complete")
-        } else {
-          error("Did not shut down within %s ms, exiting." format shutdownMs)
-          ThreadUtil.logThreadDump("Thread dump from Samza Container Shutdown Hook.")
-        }
-      }
-    }
-    Runtime.getRuntime().addShutdownHook(shutdownHookThread)
-  }
-
-  def removeShutdownHook = {
-    try {
-      if (shutdownHookThread != null) {
-        Runtime.getRuntime.removeShutdownHook(shutdownHookThread)
-      }
-    } catch {
-      case e: IllegalStateException => {
-        // Thrown when then JVM is already shutting down, so safe to ignore.
-      }
-    }
-  }
-
   def shutdownConsumers {
     info("Shutting down consumer multiplexer.")
 

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -753,7 +753,6 @@ class SamzaContainer(
       startConsumers
       startSecurityManger
 
-      addShutdownHook
       info("Entering run loop.")
       status = SamzaContainerStatus.STARTED
       if (containerListener != null) {
@@ -777,7 +776,6 @@ class SamzaContainer(
 
     try {
       info("Shutting down SamzaContainer.")
-      removeShutdownHook
       if (jmxServer != null) {
         jmxServer.stop
       }

--- a/samza-core/src/test/java/org/apache/samza/runtime/TestClusterBasedProcessorLifecycleListener.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestClusterBasedProcessorLifecycleListener.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.runtime;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.samza.SamzaException;
+import org.apache.samza.config.MapConfig;
+import org.apache.samza.config.TaskConfig;
+import org.apache.samza.container.RunLoop;
+import org.apache.samza.container.SamzaContainer;
+import org.apache.samza.processor.StreamProcessorTestUtils;
+import org.apache.samza.task.StreamTask;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.*;
+
+
+public class TestClusterBasedProcessorLifecycleListener {
+
+  private SamzaContainer container;
+  private RunLoop mockRunLoop;
+  private ClusterBasedProcessorLifecycleListener clusterBasedProcessorLifecycleListener;
+  private ProcessorLifecycleListener processorLifecycleListener;
+  private Runnable mockOnSignal;
+
+  @Before
+  public void setup() {
+    mockRunLoop = mock(RunLoop.class);
+    mockOnSignal = mock(Runnable.class);
+    container = StreamProcessorTestUtils.getDummyContainer(mockRunLoop, Mockito.mock(StreamTask.class));
+    processorLifecycleListener = mock(ProcessorLifecycleListener.class);
+    clusterBasedProcessorLifecycleListener =
+        spy(new ClusterBasedProcessorLifecycleListener(new MapConfig(ImmutableMap.of(TaskConfig.TASK_SHUTDOWN_MS, "1")),
+            processorLifecycleListener, mockOnSignal));
+    container.setContainerListener(clusterBasedProcessorLifecycleListener);
+    doNothing().when(clusterBasedProcessorLifecycleListener).addJVMShutdownHook();
+    doNothing().when(clusterBasedProcessorLifecycleListener).removeJVMShutdownHook();
+  }
+
+  @Test
+  public void testProcessorLifecycleListenerIsCalledOnContainerShutdown() {
+    container.run();
+    container.shutdown();
+
+    Mockito.verify(clusterBasedProcessorLifecycleListener, Mockito.times(1)).addJVMShutdownHook();
+    Mockito.verify(clusterBasedProcessorLifecycleListener, Mockito.times(1)).removeJVMShutdownHook();
+    Mockito.verify(processorLifecycleListener, Mockito.times(1)).beforeStart();
+    Mockito.verify(processorLifecycleListener, Mockito.times(1)).afterStart();
+    Mockito.verify(processorLifecycleListener, Mockito.times(1)).afterStop();
+    Mockito.verify(processorLifecycleListener, Mockito.times(0)).afterFailure(any(Throwable.class));
+  }
+
+  @Test
+  public void testProcessorLifecycleListenerIsCalledOnContainerError() {
+    SamzaException e = new SamzaException("Should call afterFailure");
+    doAnswer(invocation -> {
+      throw e;
+    }).when(mockRunLoop).run();
+
+    container.run();
+
+    Mockito.verify(clusterBasedProcessorLifecycleListener, Mockito.times(1)).addJVMShutdownHook();
+    Mockito.verify(clusterBasedProcessorLifecycleListener, Mockito.times(1)).removeJVMShutdownHook();
+    Mockito.verify(processorLifecycleListener, Mockito.times(1)).beforeStart();
+    Mockito.verify(processorLifecycleListener, Mockito.times(1)).afterStart();
+    Mockito.verify(processorLifecycleListener, Mockito.times(0)).afterStop();
+    Mockito.verify(processorLifecycleListener, Mockito.times(1)).afterFailure(e);
+  }
+
+  @Test
+  public void testShutdownHookInvokesOnSignalCallback() {
+    doNothing().when(mockOnSignal).run();
+    container.run();
+
+    // Simulating signal handler invocation by JVM
+    clusterBasedProcessorLifecycleListener.getShutdownHookThread().run();
+    Mockito.verify(mockOnSignal, Mockito.times(1)).run();
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/runtime/TestClusterBasedProcessorLifecycleListener.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestClusterBasedProcessorLifecycleListener.java
@@ -73,8 +73,8 @@ public class TestClusterBasedProcessorLifecycleListener {
   public void testProcessorLifecycleListenerIsCalledOnContainerError() {
     SamzaException e = new SamzaException("Should call afterFailure");
     doAnswer(invocation -> {
-      throw e;
-    }).when(mockRunLoop).run();
+        throw e;
+      }).when(mockRunLoop).run();
 
     container.run();
 


### PR DESCRIPTION
The fix removes join() on the main thread from the shutdown
hook which causes a deadlock when a signal is received.
The shutdown hook now polls periodically to check
the container status on shutdown.