### PR TITLE
SAMZA-2321: Samza-sql - Introduce REAL Samza sql schema type

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/sql/schema/SamzaSqlFieldType.java
+++ b/samza-api/src/main/java/org/apache/samza/sql/schema/SamzaSqlFieldType.java
@@ -28,8 +28,9 @@ public enum SamzaSqlFieldType {
   INT32, // four-byte signed integer.
   INT64, // eight-byte signed integer.
   DECIMAL, // Decimal integer
-  FLOAT,
-  DOUBLE,
+  REAL, // 4 bytes
+  FLOAT, // 8 bytes
+  DOUBLE, // 8 bytes
   STRING, // String.
   DATETIME, // Date and time.
   BOOLEAN, // Boolean.

--- a/samza-sql/src/main/java/org/apache/samza/sql/avro/AvroRelConverter.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/avro/AvroRelConverter.java
@@ -270,9 +270,6 @@ public class AvroRelConverter implements SamzaRelConverter {
         return new ByteString(fixed.bytes());
       case BYTES:
         return new ByteString(((ByteBuffer) avroObj).array());
-      case FLOAT:
-        // Convert Float to Double similar to how JavaTypeFactoryImpl represents Float type
-        return Double.parseDouble(Float.toString((Float) avroObj));
 
       default:
         return avroObj;
@@ -296,8 +293,6 @@ public class AvroRelConverter implements SamzaRelConverter {
         return relObj instanceof ByteString;
       case BYTES:
         return relObj instanceof ByteString;
-      case FLOAT:
-        return relObj instanceof Float || relObj instanceof Double;
       default:
         return true;
     }
@@ -319,8 +314,6 @@ public class AvroRelConverter implements SamzaRelConverter {
         return avroObj instanceof GenericData.Fixed;
       case BYTES:
         return avroObj instanceof ByteBuffer;
-      case FLOAT:
-        return avroObj instanceof Float;
       default:
         return true;
     }

--- a/samza-sql/src/main/java/org/apache/samza/sql/avro/AvroTypeFactoryImpl.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/avro/AvroTypeFactoryImpl.java
@@ -81,7 +81,8 @@ public class AvroTypeFactoryImpl extends SqlTypeFactoryImpl {
       case DOUBLE:
         return SqlFieldSchema.createPrimitiveSchema(SamzaSqlFieldType.DOUBLE, isNullable, isOptional);
       case FLOAT:
-        return SqlFieldSchema.createPrimitiveSchema(SamzaSqlFieldType.FLOAT, isNullable, isOptional);
+        // Avro FLOAT is 4 bytes which maps to Sql REAL. Sql FLOAT is 8-bytes
+        return SqlFieldSchema.createPrimitiveSchema(SamzaSqlFieldType.REAL, isNullable, isOptional);
       case ENUM:
         return SqlFieldSchema.createPrimitiveSchema(SamzaSqlFieldType.STRING, isNullable, isOptional);
       case UNION:

--- a/samza-sql/src/main/java/org/apache/samza/sql/planner/RelSchemaConverter.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/planner/RelSchemaConverter.java
@@ -79,6 +79,8 @@ public class RelSchemaConverter extends SqlTypeFactoryImpl {
         return createTypeWithNullability(createSqlType(SqlTypeName.BOOLEAN), fieldSchema.isNullable());
       case DOUBLE:
         return createTypeWithNullability(createSqlType(SqlTypeName.DOUBLE), fieldSchema.isNullable());
+      case REAL:
+        return createTypeWithNullability(createSqlType(SqlTypeName.REAL), fieldSchema.isNullable());
       case FLOAT:
         return createTypeWithNullability(createSqlType(SqlTypeName.FLOAT), fieldSchema.isNullable());
       case STRING:

--- a/samza-sql/src/test/java/org/apache/samza/sql/avro/TestAvroRelConversion.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/avro/TestAvroRelConversion.java
@@ -56,7 +56,6 @@ import org.apache.samza.sql.avro.schemas.PhoneNumber;
 import org.apache.samza.sql.avro.schemas.Profile;
 import org.apache.samza.sql.avro.schemas.SimpleRecord;
 import org.apache.samza.sql.avro.schemas.StreetNumRecord;
-import org.apache.samza.sql.avro.schemas.SubRecord;
 import org.apache.samza.sql.data.SamzaSqlRelMessage;
 import org.apache.samza.sql.planner.RelSchemaConverter;
 import org.apache.samza.sql.schema.SqlSchema;
@@ -353,7 +352,7 @@ public class TestAvroRelConversion {
     Assert.assertEquals(message.getSamzaSqlRelRecord().getField("bool_value").get(), boolValue);
     Assert.assertEquals(message.getSamzaSqlRelRecord().getField("double_value").get(), doubleValue);
     Assert.assertEquals(message.getSamzaSqlRelRecord().getField("string_value").get(), new Utf8(testStrValue));
-    Assert.assertEquals(message.getSamzaSqlRelRecord().getField("float_value").get(), doubleValue);
+    Assert.assertEquals(message.getSamzaSqlRelRecord().getField("float_value").get(), floatValue);
     Assert.assertEquals(message.getSamzaSqlRelRecord().getField("long_value").get(), longValue);
     if (unionValue instanceof String) {
       Assert.assertEquals(message.getSamzaSqlRelRecord().getField("union_value").get(), new Utf8((String) unionValue));
@@ -386,10 +385,6 @@ public class TestAvroRelConversion {
         Assert.assertTrue(record.get(field.name()).equals(complexRecordValue.get(field.name())));
       } else {
         Object expected = complexRecordValue.get(field.name());
-        if (expected instanceof Float) {
-          // AvroRelConverter converts float to double to be in sync with what Calcite does in JavaTypeFactoryImpl
-          expected = Double.parseDouble(Float.toString((Float) expected));
-        }
         Assert.assertEquals(expected, record.get(field.name()));
       }
     }

--- a/samza-sql/src/test/java/org/apache/samza/sql/system/TestAvroSystemFactory.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/system/TestAvroSystemFactory.java
@@ -325,6 +325,8 @@ public class TestAvroSystemFactory implements SystemFactory {
       record.put("id", index);
       record.put("string_value", "Name" + index);
       record.put("bytes_value", ByteBuffer.wrap(("sample bytes").getBytes()));
+      record.put("float_value", index + 0.123456f);
+      record.put("double_value", index + 0.0123456789);
       MyFixed myFixedVar = new MyFixed();
       myFixedVar.bytes(DEFAULT_TRACKING_ID_BYTES);
       record.put("fixed_value", myFixedVar);

--- a/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
@@ -304,7 +304,7 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
         .sorted()
         .collect(Collectors.toList());
     Assert.assertEquals(numMessages, outMessages.size());
-    Assert.assertTrue(IntStream.range(0, numMessages).boxed().collect(Collectors.toList()).equals(outMessages));
+    Assert.assertEquals(IntStream.range(0, numMessages).boxed().collect(Collectors.toList()), outMessages);
   }
 
   @Test
@@ -315,6 +315,51 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);
     String sql1 = "Insert into testavro.outputTopic"
         + " select * from testavro.COMPLEX1 where bool_value IS TRUE";
+    List<String> sqlStmts = Arrays.asList(sql1);
+    staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
+
+    Config config = new MapConfig(staticConfigs);
+    new SamzaSqlValidator(config).validate(sqlStmts);
+
+    runApplication(config);
+
+    List<OutgoingMessageEnvelope> outMessages = new ArrayList<>(TestAvroSystemFactory.messages);
+    Assert.assertEquals(numMessages / 2, outMessages.size());
+  }
+
+  @Test
+  public void testEndToEndWithFloatToStringConversion() throws Exception {
+    int numMessages = 20;
+
+    TestAvroSystemFactory.messages.clear();
+    Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);
+    String sql1 = "Insert into testavro.outputTopic"
+        + " select 'urn:li:member:' || cast(cast(float_value as int) as varchar) as string_value, id, float_value, "
+        + " double_value, true as bool_value from testavro.COMPLEX1";
+    List<String> sqlStmts = Arrays.asList(sql1);
+    staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
+
+    Config config = new MapConfig(staticConfigs);
+    new SamzaSqlValidator(config).validate(sqlStmts);
+
+    runApplication(config);
+
+    List<Integer> outMessages = TestAvroSystemFactory.messages.stream()
+        .map(x -> Integer.valueOf(((GenericRecord) x.getMessage()).get("string_value").toString().split(":")[3]))
+        .sorted()
+        .collect(Collectors.toList());
+    Assert.assertEquals(numMessages, outMessages.size());
+    Assert.assertEquals(IntStream.range(0, numMessages).boxed().collect(Collectors.toList()), outMessages);
+  }
+
+  @Test
+  public void testEndToEndUdfWithDoubleValueArg() throws Exception {
+    int numMessages = 20;
+
+    TestAvroSystemFactory.messages.clear();
+    Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);
+    String sql1 = "Insert into testavro.outputTopic"
+        + " select MyFloatConvert(double_value) as id, true as bool_value from testavro.COMPLEX1 where bool_value IS TRUE";
     List<String> sqlStmts = Arrays.asList(sql1);
     staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
 

--- a/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
@@ -328,51 +328,6 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
   }
 
   @Test
-  public void testEndToEndWithFloatToStringConversion() throws Exception {
-    int numMessages = 20;
-
-    TestAvroSystemFactory.messages.clear();
-    Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);
-    String sql1 = "Insert into testavro.outputTopic"
-        + " select 'urn:li:member:' || cast(cast(float_value as int) as varchar) as string_value, id, float_value, "
-        + " double_value, true as bool_value from testavro.COMPLEX1";
-    List<String> sqlStmts = Arrays.asList(sql1);
-    staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
-
-    Config config = new MapConfig(staticConfigs);
-    new SamzaSqlValidator(config).validate(sqlStmts);
-
-    runApplication(config);
-
-    List<Integer> outMessages = TestAvroSystemFactory.messages.stream()
-        .map(x -> Integer.valueOf(((GenericRecord) x.getMessage()).get("string_value").toString().split(":")[3]))
-        .sorted()
-        .collect(Collectors.toList());
-    Assert.assertEquals(numMessages, outMessages.size());
-    Assert.assertEquals(IntStream.range(0, numMessages).boxed().collect(Collectors.toList()), outMessages);
-  }
-
-  @Test
-  public void testEndToEndUdfWithDoubleValueArg() throws Exception {
-    int numMessages = 20;
-
-    TestAvroSystemFactory.messages.clear();
-    Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);
-    String sql1 = "Insert into testavro.outputTopic"
-        + " select MyFloatConvert(double_value) as id, true as bool_value from testavro.COMPLEX1 where bool_value IS TRUE";
-    List<String> sqlStmts = Arrays.asList(sql1);
-    staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
-
-    Config config = new MapConfig(staticConfigs);
-    new SamzaSqlValidator(config).validate(sqlStmts);
-
-    runApplication(config);
-
-    List<OutgoingMessageEnvelope> outMessages = new ArrayList<>(TestAvroSystemFactory.messages);
-    Assert.assertEquals(numMessages / 2, outMessages.size());
-  }
-
-  @Test
   public void testEndToEndCompoundBooleanCheck() throws SamzaSqlValidatorException {
 
     int numMessages = 20;
@@ -515,6 +470,31 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     List<OutgoingMessageEnvelope> outMessages = new ArrayList<>(TestAvroSystemFactory.messages);
 
     Assert.assertEquals(numMessages, outMessages.size());
+  }
+
+  @Test
+  public void testEndToEndWithFloatToStringConversion() throws Exception {
+    int numMessages = 20;
+
+    TestAvroSystemFactory.messages.clear();
+    Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);
+    String sql1 = "Insert into testavro.outputTopic"
+        + " select 'urn:li:member:' || cast(cast(float_value as int) as varchar) as string_value, id, float_value, "
+        + " double_value, true as bool_value from testavro.COMPLEX1";
+    List<String> sqlStmts = Arrays.asList(sql1);
+    staticConfigs.put(SamzaSqlApplicationConfig.CFG_SQL_STMTS_JSON, JsonUtil.toJson(sqlStmts));
+
+    Config config = new MapConfig(staticConfigs);
+    new SamzaSqlValidator(config).validate(sqlStmts);
+
+    runApplication(config);
+
+    List<Integer> outMessages = TestAvroSystemFactory.messages.stream()
+        .map(x -> Integer.valueOf(((GenericRecord) x.getMessage()).get("string_value").toString().split(":")[3]))
+        .sorted()
+        .collect(Collectors.toList());
+    Assert.assertEquals(numMessages, outMessages.size());
+    Assert.assertEquals(IntStream.range(0, numMessages).boxed().collect(Collectors.toList()), outMessages);
   }
 
   @Ignore


### PR DESCRIPTION
In Sql, REAL is 4-bytes while FLOAT and DOUBLE are both 8-bytes. While in Java and Avro, FLOAT is 4-bytes and DOUBLE is 8-bytes.

Fix the discrepancy in Samza Sql code by introducing REAL Samza Sql schema type and do the right mapping in AvroTypeFactoryImpl and RelSchemaConverter. Changes made earlier in AvroRelConverter are reverted.

Equivalent change in Calcite was made as part of this ticket: https://issues.apache.org/jira/browse/CALCITE-638