### PR TITLE
Transactional State [1/5]: Added Store Checkpoint API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,6 +184,7 @@ project(":samza-core_$scalaSuffix") {
     compile "net.sf.jopt-simple:jopt-simple:$joptSimpleVersion"
     compile "org.apache.commons:commons-collections4:$apacheCommonsCollections4Version"
     compile "org.apache.commons:commons-lang3:$commonsLang3Version"
+    compile "commons-io:commons-io:$commonsIoVersion"
     compile "org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion"
     compile "org.eclipse.jetty:jetty-webapp:$jettyVersion"
     compile "org.scala-lang:scala-library:$scalaVersion"

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -25,6 +25,7 @@
   commonsCollectionVersion = "3.2.1"
   commonsHttpClientVersion = "3.1"
   commonsLang3Version = "3.4"
+  commonsIoVersion = "2.6"
   elasticsearchVersion = "2.2.0"
   gsonVersion = "2.8.5"
   guavaVersion = "23.0"

--- a/samza-api/src/main/java/org/apache/samza/storage/StorageEngine.java
+++ b/samza-api/src/main/java/org/apache/samza/storage/StorageEngine.java
@@ -21,6 +21,8 @@ package org.apache.samza.storage;
 
 import java.util.Iterator;
 
+import java.nio.file.Path;
+import java.util.Optional;
 import org.apache.samza.system.IncomingMessageEnvelope;
 
 /**
@@ -50,6 +52,11 @@ public interface StorageEngine {
    * Flush any cached messages
    */
   void flush();
+
+  /**
+   * Checkpoint store snapshots.
+   */
+  Optional<Path> checkpoint(String id);
 
   /**
    * Close the storage engine

--- a/samza-api/src/main/java/org/apache/samza/storage/kv/KeyValueStore.java
+++ b/samza-api/src/main/java/org/apache/samza/storage/kv/KeyValueStore.java
@@ -19,9 +19,12 @@
 
 package org.apache.samza.storage.kv;
 
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+
 
 /**
  * A key-value store that supports put, get, delete, and range queries.
@@ -141,4 +144,9 @@ public interface KeyValueStore<K, V> {
    * Flushes this key-value store, if applicable.
    */
   void flush();
+
+  /**
+   * Checkpoint the store snapshot.
+   */
+  Optional<Path> checkpoint(String id);
 }

--- a/samza-core/src/main/java/org/apache/samza/operators/util/InternalInMemoryStore.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/util/InternalInMemoryStore.java
@@ -24,11 +24,13 @@ import org.apache.samza.storage.kv.KeyValueSnapshot;
 import org.apache.samza.storage.kv.KeyValueIterator;
 import org.apache.samza.storage.kv.KeyValueStore;
 
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Implements a {@link KeyValueStore} using an in-memory Java Map.
@@ -135,5 +137,10 @@ public class InternalInMemoryStore<K, V> implements KeyValueStore<K, V> {
   @Override
   public void flush() {
     //not applicable
+  }
+
+  @Override
+  public Optional<Path> checkpoint(String id) {
+    return Optional.empty();
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/store/TestInMemoryStore.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/store/TestInMemoryStore.java
@@ -25,10 +25,12 @@ import org.apache.samza.storage.kv.KeyValueSnapshot;
 import org.apache.samza.storage.kv.KeyValueIterator;
 import org.apache.samza.storage.kv.KeyValueStore;
 
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 
@@ -127,6 +129,11 @@ public class TestInMemoryStore<K, V> implements KeyValueStore<K, V> {
   @Override
   public void flush() {
 
+  }
+
+  @Override
+  public Optional<Path> checkpoint(String id) {
+    return Optional.empty();
   }
 
   private static class InMemoryIterator<K, V> implements KeyValueIterator<K, V> {

--- a/samza-core/src/test/java/org/apache/samza/storage/MockStorageEngine.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/MockStorageEngine.java
@@ -20,11 +20,13 @@
 package org.apache.samza.storage;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 
 import java.util.List;
+import java.util.Optional;
 import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.system.SystemStreamPartition;
 
@@ -58,6 +60,11 @@ public class MockStorageEngine implements StorageEngine {
 
   @Override
   public void flush() {
+  }
+
+  @Override
+  public Optional<Path> checkpoint(String id) {
+    return Optional.empty();
   }
 
   @Override

--- a/samza-kv-inmemory/src/main/scala/org/apache/samza/storage/kv/inmemory/InMemoryKeyValueStore.scala
+++ b/samza-kv-inmemory/src/main/scala/org/apache/samza/storage/kv/inmemory/InMemoryKeyValueStore.scala
@@ -21,7 +21,9 @@ package org.apache.samza.storage.kv.inmemory
 import com.google.common.primitives.UnsignedBytes
 import org.apache.samza.util.Logging
 import org.apache.samza.storage.kv._
+import java.nio.file.Path
 import java.util
+import java.util.Optional
 
 /**
  * In memory implementation of a key value store.
@@ -123,5 +125,10 @@ class InMemoryKeyValueStore(val metrics: KeyValueStoreMetrics = new KeyValueStor
 
       override def close() { }
     }
+  }
+
+  override def checkpoint(id: String): Optional[Path] = {
+    // No checkpoint being persisted. State restores from Changelog.
+    Optional.empty()
   }
 }

--- a/samza-kv-rocksdb/src/main/scala/org/apache/samza/storage/kv/RocksDbKeyValueStore.scala
+++ b/samza-kv-rocksdb/src/main/scala/org/apache/samza/storage/kv/RocksDbKeyValueStore.scala
@@ -20,13 +20,16 @@
 package org.apache.samza.storage.kv
 
 import java.io.File
+import java.nio.file.{Path, Paths}
 import java.util
-import java.util.Comparator
+import java.util.{Comparator, Optional}
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantReadWriteLock
 
-import org.apache.samza.SamzaException
+import org.apache.commons.io.FileUtils
+import org.apache.samza.{SamzaException, checkpoint}
 import org.apache.samza.config.Config
+import org.apache.samza.serializers.CheckpointSerde
 import org.apache.samza.util.Logging
 import org.rocksdb.{TtlDB, _}
 
@@ -234,6 +237,13 @@ class RocksDbKeyValueStore(
     trace("Flushing store: %s" format storeName)
     db.flush(flushOptions)
     trace("Flushed store: %s" format storeName)
+  }
+
+  override def checkpoint(id: String): Optional[Path] = {
+    val checkpoint = Checkpoint.create(db)
+    val checkpointPath = dir.getPath + "-" + id
+    checkpoint.createCheckpoint(checkpointPath)
+    Optional.of(Paths.get(checkpointPath))
   }
 
   def close(): Unit = {

--- a/samza-kv/src/main/java/org/apache/samza/storage/kv/LargeMessageSafeStore.java
+++ b/samza-kv/src/main/java/org/apache/samza/storage/kv/LargeMessageSafeStore.java
@@ -18,8 +18,10 @@
  */
 package org.apache.samza.storage.kv;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.apache.samza.metrics.MetricsRegistryMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -121,6 +123,11 @@ public class LargeMessageSafeStore implements KeyValueStore<byte[], byte[]> {
   @Override
   public void flush() {
     store.flush();
+  }
+
+  @Override
+  public Optional<Path> checkpoint(String id) {
+    return store.checkpoint(id);
   }
 
   private void validateMessageSize(byte[] message) {

--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/AccessLoggedStore.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/AccessLoggedStore.scala
@@ -20,7 +20,10 @@
 package org.apache.samza.storage.kv
 
 
+import java.nio.file.Path
 import java.util
+import java.util.Optional
+
 import org.apache.samza.config.StorageConfig
 import org.apache.samza.task.MessageCollector
 import org.apache.samza.util.Logging
@@ -158,5 +161,9 @@ class AccessLoggedStore[K, V](
     }
     val bytes = keySerde.toBytes(key)
     bytes
+  }
+
+  override def checkpoint(id: String): Optional[Path] = {
+    store.checkpoint(id)
   }
 }

--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/CachedStore.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/CachedStore.scala
@@ -21,7 +21,8 @@ package org.apache.samza.storage.kv
 
 import org.apache.samza.util.Logging
 import scala.collection._
-import java.util.Arrays
+import java.nio.file.Path
+import java.util.{Arrays, Optional}
 
 /**
  * A write-behind caching layer around the rocksdb store. The purpose of this cache is three-fold:
@@ -290,6 +291,10 @@ class CachedStore[K, V](
 
   override def snapshot(from: K, to: K): KeyValueSnapshot[K, V] = {
     store.snapshot(from, to)
+  }
+
+  override def checkpoint(id: String): Optional[Path] = {
+    store.checkpoint(id)
   }
 }
 

--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/KeyValueStorageEngineMetrics.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/KeyValueStorageEngineMetrics.scala
@@ -34,6 +34,7 @@ class KeyValueStorageEngineMetrics(
   val deletes = newCounter("deletes")
   val deleteAlls = newCounter("delete-alls")
   val flushes = newCounter("flushes")
+  val checkpoints = newCounter("checkpoints")
   val alls = newCounter("alls")
   val ranges = newCounter("ranges")
   val snapshots = newCounter("snapshots")
@@ -45,15 +46,16 @@ class KeyValueStorageEngineMetrics(
   val deleteNs = newTimer("delete-ns")
   val deleteAllNs = newTimer("delete-all-ns")
   val flushNs = newTimer("flush-ns")
+  val checkpointNs = newTimer("checkpoint-ns")
   val allNs = newTimer("all-ns")
   val rangeNs = newTimer("range-ns")
   val snapshotNs = newTimer("snapshot-ns")
 
-  val restoredMessages = newCounter("messages-restored") //Deprecated
   val restoredMessagesGauge = newGauge("restored-messages", 0)
+  val trimmedMessagesGauge = newGauge("trimmed-messages", 0)
 
-  val restoredBytes = newCounter("messages-bytes") //Deprecated
   val restoredBytesGauge = newGauge("restored-bytes", 0)
+  val trimmedBytesGauge = newGauge("trimmed-bytes", 0)
 
   override def getPrefix = storeName + "-"
 }

--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/LoggedStore.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/LoggedStore.scala
@@ -19,6 +19,9 @@
 
 package org.apache.samza.storage.kv
 
+import java.nio.file.Path
+import java.util.Optional
+
 import org.apache.samza.util.Logging
 import org.apache.samza.system.{OutgoingMessageEnvelope, SystemStreamPartition}
 import org.apache.samza.task.MessageCollector
@@ -116,5 +119,9 @@ class LoggedStore[K, V](
 
   override def snapshot(from: K, to: K): KeyValueSnapshot[K, V] = {
     store.snapshot(from, to)
+  }
+
+  override def checkpoint(id: String): Optional[Path] = {
+    store.checkpoint(id)
   }
 }

--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/NullSafeKeyValueStore.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/NullSafeKeyValueStore.scala
@@ -19,6 +19,9 @@
 
 package org.apache.samza.storage.kv
 
+import java.nio.file.Path
+import java.util.Optional
+
 import scala.collection.JavaConverters._
 
 object NullSafeKeyValueStore {
@@ -94,5 +97,9 @@ class NullSafeKeyValueStore[K, V](store: KeyValueStore[K, V]) extends KeyValueSt
     notNull(from, NullKeyErrorMessage)
     notNull(to, NullKeyErrorMessage)
     store.snapshot(from, to)
+  }
+
+  override def checkpoint(id: String): Optional[Path] = {
+    store.checkpoint(id)
   }
 }

--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/SerializedKeyValueStore.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/SerializedKeyValueStore.scala
@@ -19,6 +19,8 @@
 
 package org.apache.samza.storage.kv
 
+import java.nio.file.Path
+import java.util.Optional
 import org.apache.samza.util.Logging
 import org.apache.samza.serializers._
 
@@ -162,5 +164,9 @@ class SerializedKeyValueStore[K, V](
         snapshot.close()
       }
     }
+  }
+
+  override def checkpoint(id: String): Optional[Path] = {
+    store.checkpoint(id)
   }
 }

--- a/samza-kv/src/test/scala/org/apache/samza/storage/kv/MockKeyValueStore.scala
+++ b/samza-kv/src/test/scala/org/apache/samza/storage/kv/MockKeyValueStore.scala
@@ -21,6 +21,8 @@ package org.apache.samza.storage.kv
 
 import scala.collection.JavaConverters._
 import java.util
+import java.nio.file.Path
+import java.util.Optional
 
 /**
  * A mock key-value store wrapper that handles serialization
@@ -72,5 +74,9 @@ class MockKeyValueStore extends KeyValueStore[String, String] {
 
   override def snapshot(from: String, to: String): KeyValueSnapshot[String, String] = {
     throw new UnsupportedOperationException("iterator() not supported")
+  }
+
+  override def checkpoint(id: String): Optional[Path] = {
+    Optional.empty()
   }
 }

--- a/samza-kv/src/test/scala/org/apache/samza/storage/kv/TestKeyValueStorageEngine.scala
+++ b/samza-kv/src/test/scala/org/apache/samza/storage/kv/TestKeyValueStorageEngine.scala
@@ -26,6 +26,7 @@ import org.apache.samza.Partition
 import org.apache.samza.container.TaskName
 import org.apache.samza.storage.StoreProperties
 import org.apache.samza.system.{IncomingMessageEnvelope, SystemStreamPartition}
+import org.apache.samza.task.MessageCollector
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
 import org.mockito.Mockito._
@@ -42,8 +43,11 @@ class TestKeyValueStorageEngine {
     val storeName = "test-storeName"
     val storeDir = mock(classOf[File])
     val properties = mock(classOf[StoreProperties])
+    val changelogSSP = mock(classOf[SystemStreamPartition])
+    val changelogCollector = mock(classOf[MessageCollector])
     metrics = new KeyValueStorageEngineMetrics
-    engine = new KeyValueStorageEngine[String, String](storeName, storeDir, properties, wrapperKv, rawKv, metrics, clock = () => { getNextTimestamp() })
+    engine = new KeyValueStorageEngine[String, String](storeName, storeDir, properties, wrapperKv, rawKv,
+      changelogSSP, changelogCollector, metrics, clock = () => { getNextTimestamp() })
   }
 
   @After


### PR DESCRIPTION
This PR adds a new 'checkpoint' API to KeyValueStore that allows taking persistent (on-disk) snapshots of the local store state during commits for implementations that support it.

In RocksDB, this creates a new [Checkpoint](https://github.com/facebook/rocksdb/wiki/Checkpoints) directory. 

For supporting transactional state, during a commit, the newest changelog SSP offset is stored in the OFFSET file in this checkpoint directory, as well as in the checkpoint topic. During container start / store restore, the checkpoint directory corresponding to the changelog offset in the checkpoint topic is selected (if any) and used as the basis for restore.

Thanks to @xinyuiscool for contributing this.