### PR TITLE
Transactional State [3/5]: Made StorageManagerUtil and FileUtil non-static for mocking side effects in tests

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/storage/StorageManagerUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/StorageManagerUtil.java
@@ -67,7 +67,7 @@ public class StorageManagerUtil {
    * @param oldestOffset oldest offset for the ssp from the source
    * @return starting offset for the incoming {@link SystemStreamPartition}
    */
-  public static String getStartingOffset(
+  public String getStartingOffset(
       SystemStreamPartition ssp, SystemAdmin admin, String fileOffset, String oldestOffset) {
     String startingOffset = oldestOffset;
     if (fileOffset != null) {
@@ -97,7 +97,7 @@ public class StorageManagerUtil {
    * @param isSideInput true if store is a side-input store, false if it is a regular store
    * @return true if the store is stale, false otherwise
    */
-  public static boolean isStaleStore(File storeDir, long storeDeleteRetentionInMs, long currentTimeMs, boolean isSideInput) {
+  public boolean isStaleStore(File storeDir, long storeDeleteRetentionInMs, long currentTimeMs, boolean isSideInput) {
     long offsetFileLastModifiedTime;
     boolean isStaleStore = false;
     String storePath = storeDir.toPath().toString();
@@ -137,20 +137,20 @@ public class StorageManagerUtil {
    * An offset file associated with logged store {@code storeDir} is valid if it exists and is not empty.
    *
    * @param storeDir the base directory of the store
-   * @param storeSSPs storeSSPs (if any) associated with the store
+   * @param storeSSPs ssps (if any) associated with the store
    * @param isSideInput true if store is a side-input store, false if it is a regular store
    * @return true if the offset file is valid. false otherwise.
    */
-  public static boolean isOffsetFileValid(File storeDir, Set<SystemStreamPartition> storeSSPs, boolean isSideInput) {
+  public boolean isOffsetFileValid(File storeDir, Set<SystemStreamPartition> storeSSPs, boolean isSideInput) {
     boolean hasValidOffsetFile = false;
     if (storeDir.exists()) {
       Map<SystemStreamPartition, String> offsetContents = readOffsetFile(storeDir, storeSSPs, isSideInput);
       if (offsetContents == null) {
-        LOG.info("Offset file does not exist. Store directory: {}", storeDir.toPath());
+        LOG.info("Offset file is invalid since it does not exist. Store directory: {}", storeDir.toPath());
       } else if (offsetContents.isEmpty()) {
-        LOG.info("Offset file is empty. Store directory: {}", storeDir.toPath());
+        LOG.info("Offset file is invalid since it is empty. Store directory: {}", storeDir.toPath());
       } else if (!offsetContents.keySet().equals(storeSSPs)) {
-        LOG.info("Offset file is invalid since change-log SSPs don't match. "
+        LOG.info("Offset file is invalid since changelog or side input SSPs don't match. "
             + "Store directory: {}. SSPs from offset-file: {} SSPs expected: {} ",
             storeDir.toPath(), offsetContents.keySet(), storeSSPs);
       } else {
@@ -163,29 +163,27 @@ public class StorageManagerUtil {
 
   /**
    * Write the given SSP-Offset map into the offsets file.
-   * @param storeBaseDir the base directory of the store
-   * @param storeName the store name to use
-   * @param taskName the task name which is referencing the store
+   * @param storeDir the directory of the store
    * @param offsets The SSP-offset to write
    * @param isSideInput true if store is a side-input store, false if it is a regular store
    * @throws IOException because of deserializing to json
    */
-  public static void writeOffsetFile(File storeBaseDir, String storeName, TaskName taskName, TaskMode taskMode,
-      Map<SystemStreamPartition, String> offsets, boolean isSideInput) throws IOException {
+  public void writeOffsetFile(File storeDir, Map<SystemStreamPartition, String> offsets, boolean isSideInput) throws IOException {
 
     // First, we write the new-format offset file
-    File offsetFile = new File(getStorePartitionDir(storeBaseDir, storeName, taskName, taskMode), OFFSET_FILE_NAME_NEW);
+    File offsetFile = new File(storeDir, OFFSET_FILE_NAME_NEW);
     String fileContents = OBJECT_WRITER.writeValueAsString(offsets);
-    FileUtil.writeWithChecksum(offsetFile, fileContents);
+    FileUtil fileUtil = new FileUtil();
+    fileUtil.writeWithChecksum(offsetFile, fileContents);
 
     // Now we write the old format offset file, which are different for store-offset and side-inputs
     if (isSideInput) {
-      offsetFile = new File(getStorePartitionDir(storeBaseDir, storeName, taskName, taskMode), SIDE_INPUT_OFFSET_FILE_NAME_LEGACY);
+      offsetFile = new File(storeDir, SIDE_INPUT_OFFSET_FILE_NAME_LEGACY);
       fileContents = OBJECT_WRITER.writeValueAsString(offsets);
-      FileUtil.writeWithChecksum(offsetFile, fileContents);
+      fileUtil.writeWithChecksum(offsetFile, fileContents);
     } else {
-      offsetFile = new File(getStorePartitionDir(storeBaseDir, storeName, taskName, taskMode), OFFSET_FILE_NAME_LEGACY);
-      FileUtil.writeWithChecksum(offsetFile, offsets.entrySet().iterator().next().getValue());
+      offsetFile = new File(storeDir, OFFSET_FILE_NAME_LEGACY);
+      fileUtil.writeWithChecksum(offsetFile, offsets.entrySet().iterator().next().getValue());
     }
   }
 
@@ -195,7 +193,7 @@ public class StorageManagerUtil {
    * @param storeName the store name to use
    * @param taskName the task name which is referencing the store
    */
-  public static void deleteOffsetFile(File storeBaseDir, String storeName, TaskName taskName) {
+  public void deleteOffsetFile(File storeBaseDir, String storeName, TaskName taskName) {
     deleteOffsetFile(storeBaseDir, storeName, taskName, OFFSET_FILE_NAME_NEW);
     deleteOffsetFile(storeBaseDir, storeName, taskName, OFFSET_FILE_NAME_LEGACY);
   }
@@ -203,10 +201,10 @@ public class StorageManagerUtil {
   /**
    * Delete the given offsetFile for the store if it exists.
    */
-  private static void deleteOffsetFile(File storeBaseDir, String storeName, TaskName taskName, String offsetFileName) {
-    File offsetFile = new File(getStorePartitionDir(storeBaseDir, storeName, taskName, TaskMode.Active), offsetFileName);
+  private void deleteOffsetFile(File storeBaseDir, String storeName, TaskName taskName, String offsetFileName) {
+    File offsetFile = new File(getTaskStoreDir(storeBaseDir, storeName, taskName, TaskMode.Active), offsetFileName);
     if (offsetFile.exists()) {
-      FileUtil.rm(offsetFile);
+      new FileUtil().rm(offsetFile);
     }
   }
 
@@ -216,7 +214,7 @@ public class StorageManagerUtil {
    * @param storeDir the base directory of the store
    * @return true if a non-empty storeDir exists, false otherwise
    */
-  public static boolean storeExists(File storeDir) {
+  public boolean storeExists(File storeDir) {
     return storeDir.exists() && storeDir.list().length > 0;
   }
 
@@ -228,7 +226,7 @@ public class StorageManagerUtil {
    * @param isSideInput, true if the store is a side-input store, false otherwise
    * @return the content of the offset file if it exists for the store, null otherwise.
    */
-  public static Map<SystemStreamPartition, String> readOffsetFile(File storagePartitionDir, Set<SystemStreamPartition> storeSSPs, boolean isSideInput) {
+  public Map<SystemStreamPartition, String> readOffsetFile(File storagePartitionDir, Set<SystemStreamPartition> storeSSPs, boolean isSideInput) {
 
     File offsetFileRefNew = new File(storagePartitionDir, OFFSET_FILE_NAME_NEW);
     File offsetFileRefLegacy = new File(storagePartitionDir, OFFSET_FILE_NAME_LEGACY);
@@ -247,7 +245,6 @@ public class StorageManagerUtil {
     } else {
       return new HashMap<>();
     }
-
   }
 
   /**
@@ -258,16 +255,16 @@ public class StorageManagerUtil {
    * @param storeSSPs SSPs associated with the store (if any)
    * @return the content of the offset file if it exists for the store, null otherwise.
    */
-  private static Map<SystemStreamPartition, String> readOffsetFile(File storagePartitionDir, String offsetFileName, Set<SystemStreamPartition> storeSSPs) {
+  private Map<SystemStreamPartition, String> readOffsetFile(File storagePartitionDir, String offsetFileName, Set<SystemStreamPartition> storeSSPs) {
     Map<SystemStreamPartition, String> offsets = new HashMap<>();
     String fileContents = null;
     File offsetFileRef = new File(storagePartitionDir, offsetFileName);
     String storePath = storagePartitionDir.getPath();
 
     if (offsetFileRef.exists()) {
-      LOG.info("Found offset file in storage partition directory: {}", storePath);
+      LOG.debug("Found offset file in storage partition directory: {}", storePath);
       try {
-        fileContents = FileUtil.readWithChecksum(offsetFileRef);
+        fileContents = new FileUtil().readWithChecksum(offsetFileRef);
         offsets = OBJECT_MAPPER.readValue(fileContents, OFFSETS_TYPE_REFERENCE);
       } catch (JsonParseException | JsonMappingException e) {
         LOG.info("Exception in json-parsing offset file {} {}, reading as string offset-value", storagePartitionDir.toPath(), offsetFileName);
@@ -293,7 +290,7 @@ public class StorageManagerUtil {
    * @param taskMode the mode of the given task
    * @return the partition directory for the store
    */
-  public static File getStorePartitionDir(File storeBaseDir, String storeName, TaskName taskName, TaskMode taskMode) {
+  public File getTaskStoreDir(File storeBaseDir, String storeName, TaskName taskName, TaskMode taskMode) {
     TaskName taskNameForDirName = taskName;
     if (taskMode.equals(TaskMode.Standby)) {
       taskNameForDirName =  StandbyTaskUtil.getActiveTaskName(taskName);

--- a/samza-core/src/main/java/org/apache/samza/util/DiagnosticsUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/util/DiagnosticsUtil.java
@@ -80,7 +80,7 @@ public class DiagnosticsUtil {
       MetricsSnapshot metricsSnapshot = new MetricsSnapshot(metricsHeader, new Metrics());
       MetadataFileContents metadataFileContents =
           new MetadataFileContents("1", new String(new MetricsSnapshotSerdeV2().toBytes(metricsSnapshot)));
-      FileUtil.writeToTextFile(metadataFile.get(), new String(new JsonSerde<>().toBytes(metadataFileContents)), false);
+      new FileUtil().writeToTextFile(metadataFile.get(), new String(new JsonSerde<>().toBytes(metadataFileContents)), false);
     } else {
       log.info("Skipping writing metadata file.");
     }

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -168,6 +168,7 @@ public class ContainerStorageManager {
   private volatile Throwable sideInputException = null;
 
   private final Config config;
+  private final StorageManagerUtil storageManagerUtil = new StorageManagerUtil();
 
   public ContainerStorageManager(ContainerModel containerModel,
       StreamMetadataCache streamMetadataCache,
@@ -470,9 +471,11 @@ public class ContainerStorageManager {
     // for non logged stores
     File storeDirectory;
     if (changeLogSystemStreamPartition != null || sideInputSystemStreams.containsKey(storeName)) {
-      storeDirectory = StorageManagerUtil.getStorePartitionDir(this.loggedStoreBaseDirectory, storeName, taskName, taskModel.getTaskMode());
+      storeDirectory = storageManagerUtil.getTaskStoreDir(this.loggedStoreBaseDirectory, storeName, taskName,
+          taskModel.getTaskMode());
     } else {
-      storeDirectory = StorageManagerUtil.getStorePartitionDir(this.nonLoggedStoreBaseDirectory, storeName, taskName, taskModel.getTaskMode());
+      storeDirectory = storageManagerUtil.getTaskStoreDir(this.nonLoggedStoreBaseDirectory, storeName, taskName,
+          taskModel.getTaskMode());
     }
 
     this.storeDirectoryPaths.add(storeDirectory.toPath());
@@ -957,31 +960,33 @@ public class ContainerStorageManager {
      */
     private void cleanBaseDirsAndReadOffsetFiles() {
       LOG.debug("Cleaning base directories for stores.");
-
+      FileUtil fileUtil = new FileUtil();
       taskStores.forEach((storeName, storageEngine) -> {
           if (!storageEngine.getStoreProperties().isLoggedStore()) {
             File nonLoggedStorePartitionDir =
-                StorageManagerUtil.getStorePartitionDir(nonLoggedStoreBaseDirectory, storeName, taskModel.getTaskName(), taskModel.getTaskMode());
+                storageManagerUtil.getTaskStoreDir(nonLoggedStoreBaseDirectory, storeName, taskModel.getTaskName(),
+                    taskModel.getTaskMode());
             LOG.info("Got non logged storage partition directory as " + nonLoggedStorePartitionDir.toPath().toString());
 
             if (nonLoggedStorePartitionDir.exists()) {
               LOG.info("Deleting non logged storage partition directory " + nonLoggedStorePartitionDir.toPath().toString());
-              FileUtil.rm(nonLoggedStorePartitionDir);
+              fileUtil.rm(nonLoggedStorePartitionDir);
             }
           } else {
             File loggedStorePartitionDir =
-                StorageManagerUtil.getStorePartitionDir(loggedStoreBaseDirectory, storeName, taskModel.getTaskName(), taskModel.getTaskMode());
+                storageManagerUtil.getTaskStoreDir(loggedStoreBaseDirectory, storeName, taskModel.getTaskName(),
+                    taskModel.getTaskMode());
             LOG.info("Got logged storage partition directory as " + loggedStorePartitionDir.toPath().toString());
 
             // Delete the logged store if it is not valid.
             if (!isLoggedStoreValid(storeName, loggedStorePartitionDir)) {
               LOG.info("Deleting logged storage partition directory " + loggedStorePartitionDir.toPath().toString());
-              FileUtil.rm(loggedStorePartitionDir);
+              fileUtil.rm(loggedStorePartitionDir);
             } else {
 
               SystemStreamPartition changelogSSP = new SystemStreamPartition(changelogSystemStreams.get(storeName), taskModel.getChangelogPartition());
               Map<SystemStreamPartition, String> offset =
-                  StorageManagerUtil.readOffsetFile(loggedStorePartitionDir, Collections.singleton(changelogSSP), false);
+                  storageManagerUtil.readOffsetFile(loggedStorePartitionDir, Collections.singleton(changelogSSP), false);
               LOG.info("Read offset {} for the store {} from logged storage partition directory {}", offset, storeName, loggedStorePartitionDir);
 
               if (offset.containsKey(changelogSSP)) {
@@ -1003,11 +1008,11 @@ public class ContainerStorageManager {
      */
     private boolean isLoggedStoreValid(String storeName, File loggedStoreDir) {
       long changeLogDeleteRetentionInMs = new StorageConfig(config).getChangeLogDeleteRetentionInMs(storeName);
-
       if (changelogSystemStreams.containsKey(storeName)) {
         SystemStreamPartition changelogSSP = new SystemStreamPartition(changelogSystemStreams.get(storeName), taskModel.getChangelogPartition());
-        return this.taskStores.get(storeName).getStoreProperties().isPersistedToDisk() && StorageManagerUtil.isOffsetFileValid(loggedStoreDir, Collections.singleton(changelogSSP), false)
-            && !StorageManagerUtil.isStaleStore(loggedStoreDir, changeLogDeleteRetentionInMs, clock.currentTimeMillis(), false);
+        return this.taskStores.get(storeName).getStoreProperties().isPersistedToDisk()
+            && storageManagerUtil.isOffsetFileValid(loggedStoreDir, Collections.singleton(changelogSSP), false)
+            && !storageManagerUtil.isStaleStore(loggedStoreDir, changeLogDeleteRetentionInMs, clock.currentTimeMillis(), false);
       }
 
       return false;
@@ -1022,7 +1027,7 @@ public class ContainerStorageManager {
           if (storageEngine.getStoreProperties().isLoggedStore()) {
 
             File loggedStorePartitionDir =
-                StorageManagerUtil.getStorePartitionDir(loggedStoreBaseDirectory, storeName, taskModel.getTaskName(), taskModel.getTaskMode());
+                storageManagerUtil.getTaskStoreDir(loggedStoreBaseDirectory, storeName, taskModel.getTaskName(), taskModel.getTaskMode());
 
             LOG.info("Using logged storage partition directory: " + loggedStorePartitionDir.toPath().toString()
                 + " for store: " + storeName);
@@ -1032,7 +1037,7 @@ public class ContainerStorageManager {
             }
           } else {
             File nonLoggedStorePartitionDir =
-                StorageManagerUtil.getStorePartitionDir(nonLoggedStoreBaseDirectory, storeName, taskModel.getTaskName(), taskModel.getTaskMode());
+                storageManagerUtil.getTaskStoreDir(nonLoggedStoreBaseDirectory, storeName, taskModel.getTaskName(), taskModel.getTaskMode());
             LOG.info("Using non logged storage partition directory: " + nonLoggedStorePartitionDir.toPath().toString()
                 + " for store: " + storeName);
             nonLoggedStorePartitionDir.mkdirs();
@@ -1140,7 +1145,7 @@ public class ContainerStorageManager {
       }
 
       String oldestOffset = changeLogOldestOffsets.get(systemStreamPartition.getSystemStream());
-      return StorageManagerUtil.getStartingOffset(systemStreamPartition, systemAdmin, fileOffset, oldestOffset);
+      return storageManagerUtil.getStartingOffset(systemStreamPartition, systemAdmin, fileOffset, oldestOffset);
     }
 
 

--- a/samza-core/src/main/scala/org/apache/samza/storage/TaskStorageManager.scala
+++ b/samza-core/src/main/scala/org/apache/samza/storage/TaskStorageManager.scala
@@ -89,15 +89,17 @@ class TaskStorageManager(
         val newestOffset = if (sspMetadata == null) null else sspMetadata.getNewestOffset
         debug("Got offset %s for store %s" format(newestOffset, storeName))
 
+        val storageManagerUtil = new StorageManagerUtil()
         if (newestOffset != null) {
           debug("Storing offset for store in OFFSET file ")
 
           // TaskStorageManagers are only spun-up for active tasks
-          StorageManagerUtil.writeOffsetFile(loggedStoreBaseDir, storeName, taskName, TaskMode.Active, Map(ssp -> newestOffset).asJava, false)
+          val currentStoreDir = storageManagerUtil.getTaskStoreDir(loggedStoreBaseDir, storeName, taskName, TaskMode.Active)
+          storageManagerUtil.writeOffsetFile(currentStoreDir, Map(ssp -> newestOffset).asJava, false)
           debug("Successfully stored offset %s for store %s in OFFSET file " format(newestOffset, storeName))
         } else {
           //if newestOffset is null, then it means the store is (or has become) empty. No need to persist the offset file
-          StorageManagerUtil.deleteOffsetFile(loggedStoreBaseDir, storeName, taskName);
+          storageManagerUtil.deleteOffsetFile(loggedStoreBaseDir, storeName, taskName);
           debug("Not storing OFFSET file for taskName %s. Store %s backed by changelog topic: %s, partition: %s is empty. " format (taskName, storeName, systemStream.getStream, partition.getPartitionId))
         }
       } catch {

--- a/samza-core/src/main/scala/org/apache/samza/util/FileUtil.scala
+++ b/samza-core/src/main/scala/org/apache/samza/util/FileUtil.scala
@@ -27,7 +27,7 @@ import java.util.zip.CRC32
 
 import org.apache.samza.util.Util.info
 
-object FileUtil extends Logging {
+class FileUtil extends Logging {
   /**
     * Writes checksum & data to a file
     * Checksum is pre-fixed to the data and is a 32-bit long type data.
@@ -51,7 +51,7 @@ object FileUtil extends Logging {
     }
 
     //atomic swap of tmp and real offset file
-    swapFiles(tmpFile, file)
+    move(tmpFile, file)
   }
 
   /**
@@ -68,7 +68,7 @@ object FileUtil extends Logging {
 
     //atomic swap of tmp and real file if we need to append
     if (append) {
-      swapFiles(file, tmpFile)
+      move(file, tmpFile)
     }
 
     try {
@@ -83,11 +83,13 @@ object FileUtil extends Logging {
     }
 
     //atomic swap of tmp and real file
-    swapFiles(tmpFile, file)
+    move(tmpFile, file)
   }
 
-  private def swapFiles(source: File, destination: File) : Unit = {
-    //atomic swap of source and destination file
+  /**
+   * Moves source file to destination file, replacing destination file if it already exists.
+   */
+  def move(source: File, destination: File) : Unit = {
     try {
       if (source.exists()) {
         Files.move(source.toPath, destination.toPath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
@@ -139,6 +141,14 @@ object FileUtil extends Logging {
     } else {
       file.delete()
     }
+  }
+
+  def exists(path: Path): Boolean = {
+    Files.exists(path)
+  }
+
+  def createDirectories(path: Path): Path = {
+    Files.createDirectories(path)
   }
 
   /**

--- a/samza-core/src/test/scala/org/apache/samza/util/TestFileUtil.scala
+++ b/samza-core/src/test/scala/org/apache/samza/util/TestFileUtil.scala
@@ -28,13 +28,14 @@ import org.junit.Test
 
 class TestFileUtil {
   val data = "100"
-  val checksum = FileUtil.getChecksum(data)
+  val fileUtil = new FileUtil()
+  val checksum = fileUtil.getChecksum(data)
   val file = new File(System.getProperty("java.io.tmpdir"), "test")
 
   @Test
   def testWriteDataToFile() {
     // Invoke test
-    FileUtil.writeWithChecksum(file, data)
+    fileUtil.writeWithChecksum(file, data)
 
     // Check that file exists
     assertTrue("File was not created!", file.exists())
@@ -53,9 +54,9 @@ class TestFileUtil {
     // Invoke test
     val file = new File(System.getProperty("java.io.tmpdir"), "test2")
     // write the same file three times
-    FileUtil.writeWithChecksum(file, data)
-    FileUtil.writeWithChecksum(file, data)
-    FileUtil.writeWithChecksum(file, data)
+    fileUtil.writeWithChecksum(file, data)
+    fileUtil.writeWithChecksum(file, data)
+    fileUtil.writeWithChecksum(file, data)
 
     // Check that file exists
     assertTrue("File was not created!", file.exists())
@@ -81,7 +82,7 @@ class TestFileUtil {
     fos.close()
 
     // Invoke test
-    val result = FileUtil.readWithChecksum(file)
+    val result = fileUtil.readWithChecksum(file)
 
     // Check data returned
     assertEquals(data, result)
@@ -98,7 +99,7 @@ class TestFileUtil {
     fos.close()
 
     // Invoke test
-    val result = FileUtil.readWithChecksum(file)
+    val result = fileUtil.readWithChecksum(file)
 
     // Check data returned
     assertNull(result)

--- a/samza-kv-rocksdb/src/main/java/org/apache/samza/storage/kv/RocksDbOptionsHelper.java
+++ b/samza-kv-rocksdb/src/main/java/org/apache/samza/storage/kv/RocksDbOptionsHelper.java
@@ -116,7 +116,8 @@ public class RocksDbOptionsHelper {
     // use prepareForBulk load only when i. the store is being requested in BulkLoad mode
     // and ii. the storeDirectory does not exist (fresh restore), because bulk load does not work seamlessly with
     // existing stores : https://github.com/facebook/rocksdb/issues/2734
-    if(storeMode.equals(StorageEngineFactory.StoreMode.BulkLoad) && !StorageManagerUtil.storeExists(storeDir)) {
+    StorageManagerUtil storageManagerUtil = new StorageManagerUtil();
+    if(storeMode.equals(StorageEngineFactory.StoreMode.BulkLoad) && !storageManagerUtil.storeExists(storeDir)) {
       log.info("Using prepareForBulkLoad for restore to " + storeDir);
       options.prepareForBulkLoad();
     }

--- a/samza-rest/src/main/java/org/apache/samza/monitor/LocalStoreMonitor.java
+++ b/samza-rest/src/main/java/org/apache/samza/monitor/LocalStoreMonitor.java
@@ -100,8 +100,8 @@ public class LocalStoreMonitor implements Monitor {
               LOG.info(String.format("Local store: %s is actively used by the task: %s.", storeName, task.getTaskName()));
             } else {
               LOG.info(String.format("Local store: %s not used by the task: %s.", storeName, task.getTaskName()));
-              markSweepTaskStore(StorageManagerUtil.getStorePartitionDir(jobDir, storeName, new TaskName(task.getTaskName()),
-                  TaskMode.Active));
+              markSweepTaskStore(new StorageManagerUtil().getTaskStoreDir(jobDir, storeName,
+                  new TaskName(task.getTaskName()), TaskMode.Active));
             }
           }
         }

--- a/samza-test/src/main/java/org/apache/samza/test/framework/TestRunner.java
+++ b/samza-test/src/main/java/org/apache/samza/test/framework/TestRunner.java
@@ -419,7 +419,7 @@ public class TestRunner {
   private void deleteDirectory(String path) {
     File dir = new File(path);
     LOG.info("Deleting the directory " + path);
-    FileUtil.rm(dir);
+    new FileUtil().rm(dir);
     if (dir.exists()) {
       LOG.warn("Could not delete the directory " + path);
     }

--- a/samza-test/src/main/scala/org/apache/samza/test/performance/TestKeyValuePerformance.scala
+++ b/samza-test/src/main/scala/org/apache/samza/test/performance/TestKeyValuePerformance.scala
@@ -155,7 +155,7 @@ object TestKeyValuePerformance extends Logging {
         // Run the test method
         testMethod(db, storageConfig.subset("set-" + testSet + ".", true))
 
-        FileUtil.rm(output)
+        new FileUtil().rm(output)
       })
     }
   }


### PR DESCRIPTION
This PR changes StorageManagerUtil and FileUtil method to instance methods instead of static methods. Since many of these methods have side effects (modify disk contents), this helps mock their behavior in unit tests without performing actual I/O or using PowerMock.