### PR TITLE
Transactional State [5/5]: Added implementations for transactional state checkpoints and restore

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/storage/kv/KeyValueStore.java
+++ b/samza-api/src/main/java/org/apache/samza/storage/kv/KeyValueStore.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.samza.annotation.InterfaceStability;
 
 
 /**
@@ -146,7 +147,9 @@ public interface KeyValueStore<K, V> {
   void flush();
 
   /**
-   * Checkpoint the store snapshot.
+   * Create a persistent checkpoint / snapshot of the current store state and return it's path.
+   * @return the path of the persistent store checkpoint, or an empty optional if checkpoints are not supported.
    */
+  @InterfaceStability.Evolving
   Optional<Path> checkpoint(String id);
 }

--- a/samza-api/src/main/java/org/apache/samza/system/ChangelogSSPIterator.java
+++ b/samza-api/src/main/java/org/apache/samza/system/ChangelogSSPIterator.java
@@ -28,6 +28,17 @@ import java.util.Queue;
 import java.util.Set;
 import org.apache.samza.SamzaException;
 
+/**
+ * Iterates over messages in the provided changelog {@link SystemStreamPartition} using the provided
+ * {@link SystemConsumer} until all messages have been consumed.
+ *
+ * The iterator has a {@link Mode} that depends on its position in the changelog SSP. If trim mode
+ * is enabled, the mode switches to {@code TRIM} if the current message offset is greater than the
+ * provided {@code endOffset}, or if {@code endOffset} is null.
+ *
+ * The iterator mode is used during transactional state restore to determine which changelog SSP entries
+ * should be restored and which ones need to be reverted / trimmed from the changelog topic.
+ */
 public class ChangelogSSPIterator {
   public enum Mode {
     RESTORE,

--- a/samza-api/src/main/java/org/apache/samza/system/ChangelogSSPIterator.java
+++ b/samza-api/src/main/java/org/apache/samza/system/ChangelogSSPIterator.java
@@ -72,6 +72,8 @@ public class ChangelogSSPIterator {
 
     IncomingMessageEnvelope envelope = peeks.poll();
 
+    // if trimming changelog is enabled, then switch to trim mode if if we've consumed past the end offset
+    // (i.e., endOffset was null or current offset is > endOffset)
     if (this.trimEnabled && (endOffset == null || admin.offsetComparator(envelope.getOffset(), endOffset) > 0)) {
       mode = Mode.TRIM;
     }

--- a/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
@@ -106,9 +106,9 @@ public class TaskConfig extends MapConfig {
   private static final String BROADCAST_STREAM_RANGE_PATTERN = "^\\[[\\d]+\\-[\\d]+\\]$";
   public static final String CHECKPOINT_MANAGER_FACTORY = "task.checkpoint.factory";
 
-  public static final String TRANSACTIONAL_STATE_ENABLED = "samza.transactional.state.enabled";
+  public static final String TRANSACTIONAL_STATE_ENABLED = "task.transactional.state.enabled";
   private static final boolean DEFAULT_TRANSACTIONAL_STATE_ENABLED = false;
-  public static final String TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE = "samza.transactional.state.retain.existing.state";
+  public static final String TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE = "task.transactional.state.retain.existing.state";
   private static final boolean DEFAULT_TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE = true;
 
   public TaskConfig(Config config) {

--- a/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
@@ -108,7 +108,8 @@ public class TaskConfig extends MapConfig {
 
   public static final String TRANSACTIONAL_STATE_ENABLED = "task.transactional.state.enabled";
   private static final boolean DEFAULT_TRANSACTIONAL_STATE_ENABLED = false;
-  public static final String TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE = "task.transactional.state.retain.existing.state";
+  public static final String TRANSACTIONAL_STATE_RETAIN_EXISTING_CHANGELOG_STATE =
+      "task.transactional.state.retain.existing.changelog.state";
   private static final boolean DEFAULT_TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE = true;
 
   public TaskConfig(Config config) {
@@ -306,7 +307,7 @@ public class TaskConfig extends MapConfig {
     return getBoolean(TRANSACTIONAL_STATE_ENABLED, DEFAULT_TRANSACTIONAL_STATE_ENABLED);
   }
 
-  public boolean getTransactionalStateRetainExistingState() {
-    return getBoolean(TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE, DEFAULT_TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE);
+  public boolean getTransactionalStateRetainExistingChangelogState() {
+    return getBoolean(TRANSACTIONAL_STATE_RETAIN_EXISTING_CHANGELOG_STATE, DEFAULT_TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
@@ -106,8 +106,10 @@ public class TaskConfig extends MapConfig {
   private static final String BROADCAST_STREAM_RANGE_PATTERN = "^\\[[\\d]+\\-[\\d]+\\]$";
   public static final String CHECKPOINT_MANAGER_FACTORY = "task.checkpoint.factory";
 
-  public static final String TRANSACTIONAL_STATE_ENABLED = "task.transactional.state.enabled";
-  private static final boolean DEFAULT_TRANSACTIONAL_STATE_ENABLED = false;
+  public static final String TRANSACTIONAL_STATE_CHECKPOINT_ENABLED = "task.transactional.state.checkpoint.enabled";
+  private static final boolean DEFAULT_TRANSACTIONAL_STATE_CHECKPOINT_ENABLED = true;
+  public static final String TRANSACTIONAL_STATE_RESTORE_ENABLED = "task.transactional.state.restore.enabled";
+  private static final boolean DEFAULT_TRANSACTIONAL_STATE_RESTORE_ENABLED = false;
   public static final String TRANSACTIONAL_STATE_RETAIN_EXISTING_CHANGELOG_STATE =
       "task.transactional.state.retain.existing.changelog.state";
   private static final boolean DEFAULT_TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE = true;
@@ -303,8 +305,12 @@ public class TaskConfig extends MapConfig {
     }
   }
 
-  public boolean getTransactionalStateEnabled() {
-    return getBoolean(TRANSACTIONAL_STATE_ENABLED, DEFAULT_TRANSACTIONAL_STATE_ENABLED);
+  public boolean getTransactionalStateCheckpointEnabled() {
+    return getBoolean(TRANSACTIONAL_STATE_CHECKPOINT_ENABLED, DEFAULT_TRANSACTIONAL_STATE_CHECKPOINT_ENABLED);
+  }
+
+  public boolean getTransactionalStateRestoreEnabled() {
+    return getBoolean(TRANSACTIONAL_STATE_RESTORE_ENABLED, DEFAULT_TRANSACTIONAL_STATE_RESTORE_ENABLED);
   }
 
   public boolean getTransactionalStateRetainExistingChangelogState() {

--- a/samza-core/src/main/java/org/apache/samza/storage/StorageManagerUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/StorageManagerUtil.java
@@ -342,10 +342,11 @@ public class StorageManagerUtil {
       String taskStoreName = getTaskStoreDir(storeBaseDir, storeName, taskName, taskMode).getName();
 
       if (storeDir.exists()) { // new store or no local state
-        return Files.list(storeDir.toPath())
+        List<File> checkpointDirs = Files.list(storeDir.toPath())
             .map(Path::toFile)
             .filter(file -> file.getName().contains(taskStoreName + "-"))
             .collect(Collectors.toList());
+        return checkpointDirs;
       } else {
         return Collections.emptyList();
       }

--- a/samza-core/src/main/java/org/apache/samza/storage/StorageManagerUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/StorageManagerUtil.java
@@ -225,21 +225,19 @@ public class StorageManagerUtil {
   }
 
   /**
-   *  Delete the offset file for this task and store, if one exists.
-   * @param storeBaseDir the base directory of the store
-   * @param storeName the store name to use
-   * @param taskName the task name which is referencing the store
+   * Delete the offset file for this store, if one exists.
+   * @param storeDir the directory of the store
    */
-  public void deleteOffsetFile(File storeBaseDir, String storeName, TaskName taskName) {
-    deleteOffsetFile(storeBaseDir, storeName, taskName, OFFSET_FILE_NAME_NEW);
-    deleteOffsetFile(storeBaseDir, storeName, taskName, OFFSET_FILE_NAME_LEGACY);
+  public void deleteOffsetFile(File storeDir) {
+    deleteOffsetFile(storeDir, OFFSET_FILE_NAME_NEW);
+    deleteOffsetFile(storeDir, OFFSET_FILE_NAME_LEGACY);
   }
 
   /**
    * Delete the given offsetFile for the store if it exists.
    */
-  private void deleteOffsetFile(File storeBaseDir, String storeName, TaskName taskName, String offsetFileName) {
-    File offsetFile = new File(getTaskStoreDir(storeBaseDir, storeName, taskName, TaskMode.Active), offsetFileName);
+  private void deleteOffsetFile(File storeDir, String offsetFileName) {
+    File offsetFile = new File(storeDir, offsetFileName);
     if (offsetFile.exists()) {
       new FileUtil().rm(offsetFile);
     }

--- a/samza-core/src/main/java/org/apache/samza/storage/StorageManagerUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/StorageManagerUtil.java
@@ -357,7 +357,7 @@ public class StorageManagerUtil {
     }
   }
 
-  public void moveCheckpointFiles(File checkpointDir, File storeDir) {
+  public void restoreCheckpointFiles(File checkpointDir, File storeDir) {
     // the current task store dir should already be deleted for restore
     assert !storeDir.exists();
 

--- a/samza-core/src/main/java/org/apache/samza/storage/StorageManagerUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/StorageManagerUtil.java
@@ -20,12 +20,30 @@
 package org.apache.samza.storage;
 
 import com.google.common.collect.ImmutableMap;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.samza.SamzaException;
 import org.apache.samza.clustermanager.StandbyTaskUtil;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.StorageConfig;
 import org.apache.samza.container.TaskName;
 import org.apache.samza.job.model.TaskMode;
+import org.apache.samza.job.model.TaskModel;
 import org.apache.samza.serializers.model.SamzaObjectMapper;
 import org.apache.samza.system.SystemAdmin;
+import org.apache.samza.system.SystemStream;
 import org.apache.samza.system.SystemStreamPartition;
+import org.apache.samza.util.Clock;
 import org.apache.samza.util.FileUtil;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.map.JsonMappingException;
@@ -34,13 +52,6 @@ import org.codehaus.jackson.map.ObjectWriter;
 import org.codehaus.jackson.type.TypeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 
 public class StorageManagerUtil {
@@ -52,7 +63,7 @@ public class StorageManagerUtil {
   private static final TypeReference<Map<SystemStreamPartition, String>> OFFSETS_TYPE_REFERENCE =
             new TypeReference<Map<SystemStreamPartition, String>>() { };
   private static final ObjectWriter OBJECT_WRITER = OBJECT_MAPPER.writerWithType(OFFSETS_TYPE_REFERENCE);
-
+  private static final String SST_FILE_SUFFIX = ".sst";
 
   /**
    * Fetch the starting offset for the input {@link SystemStreamPartition}
@@ -134,7 +145,33 @@ public class StorageManagerUtil {
   }
 
   /**
-   * An offset file associated with logged store {@code storeDir} is valid if it exists and is not empty.
+   * Directory loggedStoreDir associated with the store storeName is valid if all of the following
+   * conditions are true:
+   * a) If the store is a persistent store.
+   * b) If there is a valid offset file associated with the store.
+   * c) If the store has not gone stale.
+   *
+   * @return true if the logged store is valid, false otherwise.
+   */
+  public boolean isLoggedStoreValid(String storeName, File loggedStoreDir, Config config,
+      Map<String, SystemStream> storeChangelogs, TaskModel taskModel, Clock clock, Map<String, StorageEngine> taskStores) {
+    long changeLogDeleteRetentionInMs = new StorageConfig(config).getChangeLogDeleteRetentionInMs(storeName);
+
+    if (storeChangelogs.containsKey(storeName)) {
+      SystemStreamPartition changelogSSP = new SystemStreamPartition(
+          storeChangelogs.get(storeName), taskModel.getChangelogPartition());
+
+      return taskStores.get(storeName).getStoreProperties().isPersistedToDisk()
+          && isOffsetFileValid(loggedStoreDir, Collections.singleton(changelogSSP), false)
+          && !isStaleStore(loggedStoreDir, changeLogDeleteRetentionInMs, clock.currentTimeMillis(), false);
+    }
+
+    return false;
+  }
+
+  /**
+   * An offset file associated with logged store {@code storeDir} is valid if it exists, is not empty,
+   * and the offsets are for the store's current changelog or side input SSPs.
    *
    * @param storeDir the base directory of the store
    * @param storeSSPs ssps (if any) associated with the store
@@ -296,5 +333,51 @@ public class StorageManagerUtil {
       taskNameForDirName =  StandbyTaskUtil.getActiveTaskName(taskName);
     }
     return new File(storeBaseDir, (storeName + File.separator + taskNameForDirName.toString()).replace(' ', '_'));
+  }
+
+  public List<File> getTaskStoreCheckpointDirs(File storeBaseDir, String storeName,
+      TaskName taskName, TaskMode taskMode) {
+    try {
+      File storeDir = new File(storeBaseDir, storeName);
+      String taskStoreName = getTaskStoreDir(storeBaseDir, storeName, taskName, taskMode).getName();
+
+      if (storeDir.exists()) { // new store or no local state
+        return Files.list(storeDir.toPath())
+            .map(Path::toFile)
+            .filter(file -> file.getName().contains(taskStoreName + "-"))
+            .collect(Collectors.toList());
+      } else {
+        return Collections.emptyList();
+      }
+    } catch (IOException e) {
+      throw new SamzaException(
+          String.format("Error finding checkpoint dirs for task: %s mode: %s store: %s in dir: %s",
+              taskName, taskMode, storeName, storeBaseDir), e);
+    }
+  }
+
+  public void moveCheckpointFiles(File checkpointDir, File storeDir) {
+    // the current task store dir should already be deleted for restore
+    assert !storeDir.exists();
+
+    try {
+      Files.createDirectory(storeDir.toPath());
+
+      for (File file : checkpointDir.listFiles()) {
+        String fileName = file.getName();
+        File targetFile = new File(storeDir, fileName);
+
+        if (fileName.endsWith(SST_FILE_SUFFIX)) {
+          // hardlink'ing the immutable sst-files.
+          Files.createLink(targetFile.toPath(), file.toPath());
+        } else {
+          // true copy for all other files.
+          Files.copy(file.toPath(), targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+      }
+    } catch (Exception e) {
+      throw new SamzaException(String.format(
+          "Failed to restore store from checkpoint dir: %s to current dir: %s", checkpointDir, storeDir), e);
+    }
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/storage/TaskRestoreManagerFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/TaskRestoreManagerFactory.java
@@ -50,7 +50,19 @@ class TaskRestoreManagerFactory {
       Clock clock) {
 
     if (new TaskConfig(config).getTransactionalStateEnabled()) {
-      throw new UnsupportedOperationException();
+      // Create checkpoint-snapshot based state restoration which is transactional.
+      return new TransactionalStateTaskRestoreManager(
+          taskModel,
+          taskStores,
+          changelogSystemStreams,
+          systemAdmins,
+          storeConsumers,
+          sspMetadataCache,
+          loggedStoreBaseDirectory,
+          nonLoggedStoreBaseDirectory,
+          config,
+          clock
+      );
     } else {
       // Create legacy offset-file based state restoration which is NOT transactional.
       return new NonTransactionalStateTaskRestoreManager(

--- a/samza-core/src/main/java/org/apache/samza/storage/TaskRestoreManagerFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/TaskRestoreManagerFactory.java
@@ -49,7 +49,7 @@ class TaskRestoreManagerFactory {
       Config config,
       Clock clock) {
 
-    if (new TaskConfig(config).getTransactionalStateEnabled()) {
+    if (new TaskConfig(config).getTransactionalStateRestoreEnabled()) {
       // Create checkpoint-snapshot based state restoration which is transactional.
       return new TransactionalStateTaskRestoreManager(
           taskModel,

--- a/samza-core/src/main/java/org/apache/samza/storage/TransactionalStateTaskRestoreManager.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/TransactionalStateTaskRestoreManager.java
@@ -406,7 +406,7 @@ public class TransactionalStateTaskRestoreManager implements TaskRestoreManager 
             loggedStoreBaseDirectory, storeName, taskName, taskMode);
         LOG.info("Moving logged store checkpoint directory: {} for store: {} in task: {} to current directory: {}",
             storeDirsToRetain.toString(), storeName, taskName, currentDir);
-        storageManagerUtil.moveCheckpointFiles(storeDirToRetain, currentDir);
+        storageManagerUtil.restoreCheckpointFiles(storeDirToRetain, currentDir);
         // do not remove the checkpoint directory yet. in case commit fails and container restarts,
         // we can retry the move. if we delete the checkpoint, the current dir will be deleted as well on
         // restart, and we will have to do a full restore.

--- a/samza-core/src/main/java/org/apache/samza/storage/TransactionalStateTaskRestoreManager.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/TransactionalStateTaskRestoreManager.java
@@ -1,0 +1,525 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.storage;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ListMultimap;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.samza.Partition;
+import org.apache.samza.SamzaException;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.TaskConfig;
+import org.apache.samza.container.TaskName;
+import org.apache.samza.job.model.TaskMode;
+import org.apache.samza.job.model.TaskModel;
+import org.apache.samza.system.ChangelogSSPIterator;
+import org.apache.samza.system.SSPMetadataCache;
+import org.apache.samza.system.SystemAdmin;
+import org.apache.samza.system.SystemAdmins;
+import org.apache.samza.system.SystemConsumer;
+import org.apache.samza.system.SystemStream;
+import org.apache.samza.system.SystemStreamPartition;
+import org.apache.samza.system.SystemStreamMetadata.SystemStreamPartitionMetadata;
+import org.apache.samza.util.Clock;
+import org.apache.samza.util.FileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class implements the state restore based on state snapshots of checkpoints and changelog.
+ */
+public class TransactionalStateTaskRestoreManager implements TaskRestoreManager {
+  private static final Logger LOG = LoggerFactory.getLogger(TransactionalStateTaskRestoreManager.class);
+
+  private final TaskModel taskModel;
+  private final Map<String, StorageEngine> storeEngines; // store name to storage engines
+  private final Map<String, SystemStream> storeChangelogs; // store name to changelog system stream
+  private final SystemAdmins systemAdmins;
+  private final Map<String, SystemConsumer> storeConsumers;
+  private final SSPMetadataCache sspMetadataCache;
+  private final File loggedStoreBaseDirectory;
+  private final File nonLoggedStoreBaseDirectory;
+  private final Config config;
+  private final Clock clock;
+  private final StorageManagerUtil storageManagerUtil;
+  private final FileUtil fileUtil;
+
+  private StoreActions storeActions; // available after init
+
+  public TransactionalStateTaskRestoreManager(
+      TaskModel taskModel,
+      Map<String, StorageEngine> storeEngines,
+      Map<String, SystemStream> storeChangelogs,
+      SystemAdmins systemAdmins,
+      Map<String, SystemConsumer> storeConsumers,
+      SSPMetadataCache sspMetadataCache,
+      File loggedStoreBaseDirectory,
+      File nonLoggedStoreBaseDirectory,
+      Config config,
+      Clock clock) {
+    this.taskModel = taskModel;
+    this.storeEngines = storeEngines;
+    this.storeChangelogs = storeChangelogs;
+    this.systemAdmins = systemAdmins;
+    this.storeConsumers = storeConsumers;
+    // OK to use SSPMetadataCache here since unlike commit newest changelog ssp offsets will not change
+    // between cache init and restore completion
+    this.sspMetadataCache = sspMetadataCache;
+    this.loggedStoreBaseDirectory = loggedStoreBaseDirectory;
+    this.nonLoggedStoreBaseDirectory = nonLoggedStoreBaseDirectory;
+    this.config = config;
+    this.clock = clock;
+    this.storageManagerUtil = new StorageManagerUtil();
+    this.fileUtil = new FileUtil();
+  }
+
+  @Override
+  public void init(Map<SystemStreamPartition, String> checkpointedChangelogOffsets) {
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> currentChangelogOffsets =
+        getCurrentChangelogOffsets(taskModel, storeChangelogs, sspMetadataCache);
+
+    this.storeActions = getStoreActions(taskModel, storeEngines, storeChangelogs,
+        checkpointedChangelogOffsets, currentChangelogOffsets, systemAdmins, storageManagerUtil,
+        loggedStoreBaseDirectory, nonLoggedStoreBaseDirectory, config, clock);
+
+    setupStoreDirs(taskModel, storeEngines, storeActions, storageManagerUtil, fileUtil,
+        loggedStoreBaseDirectory, nonLoggedStoreBaseDirectory);
+    registerStartingOffsets(taskModel, storeActions, storeChangelogs, systemAdmins, storeConsumers, currentChangelogOffsets);
+  }
+
+  @Override
+  public void restore() {
+    Map<String, RestoreOffsets> storesToRestore = storeActions.storesToRestore;
+
+    for (Map.Entry<String, RestoreOffsets> entry : storesToRestore.entrySet()) {
+      String storeName = entry.getKey();
+      String endOffset = entry.getValue().endingOffset;
+      SystemStream systemStream = storeChangelogs.get(storeName);
+      SystemAdmin systemAdmin = systemAdmins.getSystemAdmin(systemStream.getSystem());
+      SystemConsumer systemConsumer = storeConsumers.get(storeName);
+      SystemStreamPartition changelogSSP = new SystemStreamPartition(systemStream, taskModel.getChangelogPartition());
+
+      ChangelogSSPIterator changelogSSPIterator =
+          new ChangelogSSPIterator(systemConsumer, changelogSSP, endOffset, systemAdmin, true);
+      StorageEngine taskStore = storeEngines.get(storeName);
+
+      LOG.info("Restoring store: {} for task: {}", storeName, taskModel.getTaskName());
+      taskStore.restore(changelogSSPIterator);
+    }
+  }
+
+  /**
+   * Stop only persistent stores. In case of certain stores and store mode (such as RocksDB), this
+   * can invoke compaction. Persisted stores are recreated in read-write mode in {@link ContainerStorageManager}.
+   */
+  public void stopPersistentStores() {
+    TaskName taskName = taskModel.getTaskName();
+    storeEngines.forEach((storeName, storeEngine) -> {
+        if (storeEngine.getStoreProperties().isPersistedToDisk())
+          storeEngine.stop();
+        LOG.info("Stopped persistent store: {} in task: {}", storeName, taskName);
+      });
+  }
+
+  /**
+   * Get offset metadata for each changelog SSP for this task. A task may have multiple changelog streams
+   * (e.g., for different stores), but will have the same partition for all of them.
+   */
+  @VisibleForTesting
+  static Map<SystemStreamPartition, SystemStreamPartitionMetadata> getCurrentChangelogOffsets(
+      TaskModel taskModel, Map<String, SystemStream> storeChangelogs, SSPMetadataCache sspMetadataCache) {
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> changelogOffsets = new HashMap<>();
+
+    Partition changelogPartition = taskModel.getChangelogPartition();
+    for (Map.Entry<String, SystemStream> storeChangelog : storeChangelogs.entrySet()) {
+      SystemStream changelog = storeChangelog.getValue();
+      SystemStreamPartition changelogSSP = new SystemStreamPartition(
+          changelog.getSystem(), changelog.getStream(), changelogPartition);
+      SystemStreamPartitionMetadata metadata = sspMetadataCache.getMetadata(changelogSSP);
+      changelogOffsets.put(changelogSSP, metadata);
+    }
+
+    LOG.info("Got current changelog offsets for taskName: {} as: {}", taskModel.getTaskName(), changelogOffsets);
+    return changelogOffsets;
+  }
+
+  /**
+   * Marks each persistent but non-logged store for deletion.
+   *
+   * For each logged store, based on the current, checkpointed and local changelog offsets,
+   * 1. decides which directories (current and checkpoints) to delete for persistent stores.
+   * 2. decides which directories (checkpoints) to retain for persistent stores.
+   * 3. decides which stores (persistent or not) need to be restored, and the beginning and end offsets for the restore.
+   *
+   * When this method returns, in StoreActions,
+   * 1. all persistent store current directories will be present in storeDirsToDelete
+   * 2. each persistent store checkpoint directory will be present in either storeDirToRetain or storeDirsToDelete.
+   * 3. there will be at most one storeDirToRetain per persistent store, which will be a checkpoint directory.
+   * 4. any stores (persistent or not) that need to be restored from changelogs will be present in
+   *    storesToRestore with appropriate offsets.
+   */
+  @VisibleForTesting
+  static StoreActions getStoreActions(
+      TaskModel taskModel,
+      Map<String, StorageEngine> storeEngines,
+      Map<String, SystemStream> storeChangelogs,
+      Map<SystemStreamPartition, String> checkpointedChangelogOffsets,
+      Map<SystemStreamPartition, SystemStreamPartitionMetadata> currentChangelogOffsets,
+      SystemAdmins systemAdmins,
+      StorageManagerUtil storageManagerUtil,
+      File loggedStoreBaseDirectory,
+      File nonLoggedStoreBaseDirectory,
+      Config config,
+      Clock clock) {
+    TaskName taskName = taskModel.getTaskName();
+    TaskMode taskMode = taskModel.getTaskMode();
+
+    Map<String, File> storeDirToRetain = new HashMap<>();
+    ListMultimap<String, File> storeDirsToDelete = ArrayListMultimap.create();
+    Map<String, RestoreOffsets> storesToRestore = new HashMap<>();
+
+    storeEngines.forEach((storeName, storageEngine) -> {
+        // do nothing if store is non persistent and not logged (e.g. in memory cache only)
+        if (!storageEngine.getStoreProperties().isPersistedToDisk() &&
+          !storageEngine.getStoreProperties().isLoggedStore()) {
+          return;
+        }
+
+        // persistent but non-logged stores are always deleted
+        if (storageEngine.getStoreProperties().isPersistedToDisk() &&
+            !storageEngine.getStoreProperties().isLoggedStore()) {
+          File currentDir = storageManagerUtil.getTaskStoreDir(
+              nonLoggedStoreBaseDirectory, storeName, taskName, taskMode);
+          storeDirsToDelete.put(storeName, currentDir);
+          // persistent but non-logged stores should not have checkpoint dirs
+          return;
+        }
+
+        // get the oldest and newest current changelog SSP offsets as well as the checkpointed changelog SSP offset
+        SystemStream changelog = storeChangelogs.get(storeName);
+        SystemStreamPartition changelogSSP = new SystemStreamPartition(changelog, taskModel.getChangelogPartition());
+        SystemAdmin admin = systemAdmins.getSystemAdmin(changelogSSP.getSystem());
+        SystemStreamPartitionMetadata changelogSSPMetadata = currentChangelogOffsets.get(changelogSSP);
+        String oldestOffset = changelogSSPMetadata.getOldestOffset();
+        String newestOffset = changelogSSPMetadata.getNewestOffset();
+        String checkpointedOffset = checkpointedChangelogOffsets.get(changelogSSP);
+
+
+        Optional<File> currentDirOptional;
+        Optional<List<File>> checkpointDirsOptional;
+
+        if (!storageEngine.getStoreProperties().isPersistedToDisk()) {
+          currentDirOptional = Optional.empty();
+          checkpointDirsOptional = Optional.empty();
+        } else {
+          currentDirOptional = Optional.of(storageManagerUtil.getTaskStoreDir(
+              loggedStoreBaseDirectory, storeName, taskName, taskMode));
+          checkpointDirsOptional = Optional.of(storageManagerUtil.getTaskStoreCheckpointDirs(
+              loggedStoreBaseDirectory, storeName, taskName, taskMode));
+        }
+
+        LOG.info("For store: {} in task: {} got current dir: {}, checkpoint dirs: {}, checkpointed changelog offset: {}",
+            storeName, taskName, currentDirOptional, checkpointDirsOptional, checkpointedOffset);
+
+        // TODO BLOCKER pmaheshw: will do full restore from changelog even if retain existing state == true
+        // always delete current logged store dir for persistent stores.
+        currentDirOptional.ifPresent(currentDir -> storeDirsToDelete.put(storeName, currentDir));
+
+        // first check if checkpointed offset is invalid (i.e., out of range of current offsets, or null)
+        if (checkpointedOffset == null && oldestOffset != null) {
+          // this can mean that either this is the initial migration for this feature and there are no previously
+          // checkpointed changelog offsets, or that this is a new store or changelog topic after the initial migration.
+
+          // if this is the first time migration, it might be desirable to retain existing data.
+          // if this is new store or topic, it's possible that the container previously died after writing some data to
+          // the changelog but before a commit, so it's desirable to delete the store, not restore anything and
+          // trim the changelog
+
+          // since we can't easily tell the difference b/w the two scenarios by just looking at the store and changelogs,
+          // we'll request users to indicate whether to retain existing data using a config flag. this flag should only
+          // be set during migrations, and turned off after the first successful commit of the new container (i.e. next
+          // deploy). for simplicity, we'll always delete the local store, and restore from changelog if necessary.
+
+          checkpointDirsOptional.ifPresent(checkpointDirs ->
+              checkpointDirs.forEach(checkpointDir -> storeDirsToDelete.put(storeName, checkpointDir)));
+
+          if (new TaskConfig(config).getTransactionalStateRetainExistingState()) {
+            // mark for restore from (oldest, newest) to recreate local state.
+            LOG.warn("Checkpointed offset for store: {} in task: {} is null. Since retain existing state is true, " +
+                "local state will be restored from current changelog contents. " +
+                "There is no transactional local state guarantee.", storeName, taskName);
+            storesToRestore.put(storeName, new RestoreOffsets(oldestOffset, newestOffset));
+          } else {
+            LOG.warn("Checkpointed offset for store: {} in task: {} is null. Since retain existing state is false, " +
+                "any local state and changelog topic contents will be cleared", storeName, taskName);
+            // mark for restore from (oldest, null) to trim entire changelog.
+            storesToRestore.put(storeName, new RestoreOffsets(oldestOffset, null));
+          }
+        } else if (// check if the checkpointed offset is in range of current oldest and newest offsets
+            admin.offsetComparator(oldestOffset, checkpointedOffset) > 0 ||
+            admin.offsetComparator(checkpointedOffset, newestOffset) > 0) {
+          // checkpointed offset is out of range. this could mean that this is a TTL topic and the checkpointed
+          // offset was TTLd, or that the changelog topic was manually deleted and then recreated.
+          // we cannot guarantee transactional state for TTL stores, so delete everything and do a full restore
+          // for local store. if the topic was deleted and recreated, this will have the side effect of
+          // clearing the store as well.
+          LOG.warn("Checkpointed offset: {} for store: {} in task: {} is out of range of oldest: {} or newest: {} offset." +
+                  "Deleting existing store and restoring from changelog topic from oldest to newest offset. If the topic " +
+                  "has time-based retention, there is no transactional local state guarantees. If the topic was changed," +
+                  "local state will be cleaned up and fully restored to match the new topic contents.",
+              checkpointedOffset, storeName, taskName, oldestOffset, newestOffset);
+          checkpointDirsOptional.ifPresent(checkpointDirs ->
+              checkpointDirs.forEach(checkpointDir -> storeDirsToDelete.put(storeName, checkpointDir)));
+          storesToRestore.put(storeName, new RestoreOffsets(oldestOffset, newestOffset));
+        } else { // happy path. checkpointed offset is in range of current oldest and newest offsets
+          if (!checkpointDirsOptional.isPresent()) { // non-persistent logged store
+            storesToRestore.put(storeName, new RestoreOffsets(oldestOffset, checkpointedOffset));
+          } else { // persistent logged store
+            // if there exists a valid store checkpoint directory with oldest offset <= local offset <= checkpointed offset,
+            // retain it and restore the delta. delete all other checkpoint directories for the store. if more than one such
+            // checkpoint directory exists, retain the one with the highest local offset and delete the rest.
+            boolean hasValidCheckpointDir = false;
+            for (File checkpointDir: checkpointDirsOptional.get()) {
+              // TODO BLOCKER pmaheshw: should validation check / warn for compact lag config staleness too?
+              if (storageManagerUtil.isLoggedStoreValid(
+                  storeName, checkpointDir, config, storeChangelogs, taskModel, clock, storeEngines)) {
+                String localOffset = storageManagerUtil.readOffsetFile(
+                    checkpointDir, Collections.singleton(changelogSSP), false).get(changelogSSP);
+                LOG.info("Read local offset: {} for store: {} checkpoint dir: {} in task: {}", localOffset, storeName,
+                    checkpointDir, taskName);
+
+                if (admin.offsetComparator(localOffset, oldestOffset) >= 0 &&
+                    admin.offsetComparator(localOffset, checkpointedOffset) <= 0 &&
+                    (storesToRestore.get(storeName) == null ||
+                        admin.offsetComparator(localOffset, storesToRestore.get(storeName).startingOffset) > 0)) {
+                  hasValidCheckpointDir = true;
+                  storeDirToRetain.put(storeName, checkpointDir);
+                  LOG.info("Temporarily retaining checkpoint dir: {}", checkpointDir);
+                  // mark for restore even if local == checkpointed, so that the changelog gets trimmed.
+                  storesToRestore.put(storeName, new RestoreOffsets(localOffset, checkpointedOffset));
+                }
+              }
+            }
+
+            // delete all non-retained checkpoint directories
+            for (File checkpointDir: checkpointDirsOptional.get()) {
+              if (storeDirToRetain.get(storeName) == null ||
+                  !storeDirToRetain.get(storeName).equals(checkpointDir)) {
+                storeDirsToDelete.put(storeName, checkpointDir);
+              }
+            }
+
+            // if the store had not valid checkpoint dirs to retain, restore from changelog
+            if (!hasValidCheckpointDir) {
+              storesToRestore.put(storeName, new RestoreOffsets(oldestOffset, checkpointedOffset));
+            }
+          }
+        }
+      });
+
+    LOG.info("Determined the following store actions for stores in task: {}:", taskName);
+    LOG.info("Store directories to retain: {}", storeDirToRetain);
+    LOG.info("Store directories to delete: {}", storeDirsToDelete);
+    LOG.info("Stores to restore: {}", storesToRestore);
+    return new StoreActions(storeDirToRetain, storeDirsToDelete, storesToRestore);
+  }
+
+  /**
+   * For each store for this task,
+   * a. Deletes current directory if persistent but non-logged store.
+   * b. Deletes current and checkpoint directories if persistent logged store and directory is marked for deletion
+   * c. Moves the valid persistent logged store checkpoint directory to current directory if marked for retention.
+   * d. Creates all missing (i.e. not retained in step c) persistent logged store dirs.
+   *
+   * When this method returns,
+   * a. There will be a empty current dir for each persistent but non-logged store.
+   * b. There will be a current dir for each persistent logged store. This dir may or may not be empty.
+   * c. There will be no remaining checkpoint dirs for persistent logged stores.
+   */
+  @VisibleForTesting
+  static void setupStoreDirs(
+      TaskModel taskModel,
+      Map<String, StorageEngine> storeEngines,
+      StoreActions storeActions,
+      StorageManagerUtil storageManagerUtil,
+      FileUtil fileUtil,
+      File loggedStoreBaseDirectory,
+      File nonLoggedStoreBaseDirectory) {
+    TaskName taskName = taskModel.getTaskName();
+    TaskMode taskMode = taskModel.getTaskMode();
+    ListMultimap<String, File> storeDirsToDelete = storeActions.storeDirsToDelete;
+    Map<String, File> storeDirsToRetain = storeActions.storeDirsToRetain;
+
+    // delete all persistent store directories marked for deletion
+    storeDirsToDelete.entries().forEach(entry -> {
+        String storeName = entry.getKey();
+        File storeDirToDelete = entry.getValue();
+        LOG.info("Deleting persistent store directory: {} for store: {} in task: {}",
+            storeDirToDelete, storeName, taskName);
+        fileUtil.rm(storeDirToDelete);
+      });
+
+    // rename all retained persistent logged store checkpoint directories to current directory
+    storeDirsToRetain.forEach((storeName, storeDirToRetain) -> {
+        File currentDir = storageManagerUtil.getTaskStoreDir(
+            loggedStoreBaseDirectory, storeName, taskName, taskMode);
+        LOG.info("Moving logged store checkpoint directory: {} for store: {} in task: {} to current directory: {}",
+            storeDirsToRetain.toString(), storeName, taskName, currentDir);
+        storageManagerUtil.moveCheckpointFiles(storeDirToRetain, currentDir);
+        // do not remove the checkpoint directory yet. in case commit fails and container restarts,
+        // we can retry the move. if we delete the checkpoint, the current dir will be deleted as well on
+        // restart, and we will have to do a full restore.
+      });
+
+    // create any missing (not retained) current directories for persistent stores
+    storeEngines.forEach((storeName, storageEngine) -> {
+        if (storageEngine.getStoreProperties().isPersistedToDisk()) {
+          File currentDir;
+          if (storageEngine.getStoreProperties().isLoggedStore()) {
+            currentDir = storageManagerUtil.getTaskStoreDir(
+                loggedStoreBaseDirectory, storeName, taskName, taskMode);
+          } else {
+            currentDir = storageManagerUtil.getTaskStoreDir(
+                nonLoggedStoreBaseDirectory, storeName, taskName, taskMode);
+          }
+
+          try {
+            if (!fileUtil.exists(currentDir.toPath())) {
+              LOG.info("Creating missing persistent store current directory: {} for store: {} in task: {}",
+                  currentDir, storeName, taskName);
+              fileUtil.createDirectories(currentDir.toPath());
+            }
+          } catch (Exception e) {
+            throw new SamzaException(String.format("Error setting up current directory for store: %s", storeName), e);
+          }
+        }
+      });
+  }
+
+  /**
+   * Determines the starting offset for each store changelog SSP that needs to be restored from,
+   * and registers it with the respective SystemConsumer.
+   */
+  @VisibleForTesting
+  static void registerStartingOffsets(
+      TaskModel taskModel,
+      StoreActions storeActions,
+      Map<String, SystemStream> storeChangelogs,
+      SystemAdmins systemAdmins,
+      Map<String, SystemConsumer> storeConsumers,
+      Map<SystemStreamPartition, SystemStreamPartitionMetadata> currentChangelogOffsets) {
+    Map<String, RestoreOffsets> storesToRestore = storeActions.storesToRestore;
+
+    // must register at least one SSP with each changelog system consumer otherwise start will throw.
+    // hence we register upcoming offset as the dummy offset by default and override it later if necessary.
+    // using upcoming offset ensures that no messages are replayed by default.
+    storeChangelogs.forEach((storeName, changelog) -> {
+        SystemStreamPartition changelogSSP = new SystemStreamPartition(changelog, taskModel.getChangelogPartition());
+        SystemConsumer systemConsumer = storeConsumers.get(storeName);
+        SystemStreamPartitionMetadata currentOffsets = currentChangelogOffsets.get(changelogSSP);
+        String upcomingOffset = currentOffsets.getUpcomingOffset();
+        LOG.info("Initially registering upcoming offset: {} as the starting offest for changelog ssp: {}. " +
+            "This might be overridden later for stores that need restoring.", upcomingOffset, changelogSSP);
+        systemConsumer.register(changelogSSP, upcomingOffset);
+      });
+
+    // now register the actual starting offset if necessary. system consumer will ensure that the lower of the
+    // two registered offsets is used as the starting offset.
+    storesToRestore.forEach((storeName, restoreOffsets) -> {
+        SystemStream changelog = storeChangelogs.get(storeName);
+        SystemStreamPartition changelogSSP = new SystemStreamPartition(changelog, taskModel.getChangelogPartition());
+        SystemAdmin systemAdmin = systemAdmins.getSystemAdmin(changelog.getSystem());
+        validateRestoreOffsets(restoreOffsets, systemAdmin);
+
+        SystemConsumer systemConsumer = storeConsumers.get(storeName);
+        SystemStreamPartitionMetadata currentOffsets = currentChangelogOffsets.get(changelogSSP);
+        String oldestOffset = currentOffsets.getOldestOffset();
+
+        // if the starting offset equals oldest offset (e.g. for full restore), start from the oldest offset (inclusive).
+        // else, start from the next (upcoming) offset.
+        String startingOffset;
+        if (systemAdmin.offsetComparator(restoreOffsets.startingOffset, oldestOffset) == 0) {
+          startingOffset = oldestOffset;
+        } else {
+          Map<SystemStreamPartition, String> offsetMap = ImmutableMap.of(changelogSSP, restoreOffsets.startingOffset);
+          startingOffset = systemAdmin.getOffsetsAfter(offsetMap).get(changelogSSP);
+        }
+        LOG.info("Registering starting offset: {} for changelog ssp: {}", startingOffset, changelogSSP);
+        systemConsumer.register(changelogSSP, startingOffset);
+      });
+  }
+
+  private static void validateRestoreOffsets(RestoreOffsets restoreOffsets, SystemAdmin systemAdmin) {
+    String startingOffset = restoreOffsets.startingOffset;
+    String endingOffset = restoreOffsets.endingOffset;
+    // cannot enforce that starting offset be non null since SSPMetadata allows oldest offset == null for empty topics.
+    if (endingOffset != null) {
+      Preconditions.checkState(systemAdmin.offsetComparator(endingOffset, startingOffset) >= 0,
+          String.format("Ending offset: %s must be equal to or greater than starting offset: %s",
+              endingOffset, startingOffset));
+    }
+  }
+
+  @VisibleForTesting
+  static class StoreActions {
+    final Map<String, File> storeDirsToRetain;
+    final ListMultimap<String, File> storeDirsToDelete;
+    final Map<String, RestoreOffsets> storesToRestore;
+
+    StoreActions(Map<String, File> storeDirsToRetain,
+        ListMultimap<String, File> storeDirsToDelete,
+        Map<String, RestoreOffsets> storesToRestore) {
+      this.storeDirsToRetain = storeDirsToRetain;
+      this.storeDirsToDelete = storeDirsToDelete;
+      this.storesToRestore = storesToRestore;
+    }
+  }
+
+  /**
+   * Starting offset must be non-null, and a non-null ending offset must be equal to or greater than starting offset.
+   *
+   * If ending offset == null (e.g. empty topic) or starting offset == ending offset, we should trim everything
+   * from starting to head. E.g. to trim entire changelog, restore offsets == (oldest, null).
+   */
+  @VisibleForTesting
+  static class RestoreOffsets {
+    final String startingOffset;
+    final String endingOffset;
+
+    RestoreOffsets(String startingOffset, String endingOffset) {
+      this.startingOffset = startingOffset;
+      this.endingOffset = endingOffset;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("startingOffset: %s, endingOffset: %s", startingOffset, endingOffset);
+    }
+  }
+}

--- a/samza-core/src/main/scala/org/apache/samza/checkpoint/OffsetManager.scala
+++ b/samza-core/src/main/scala/org/apache/samza/checkpoint/OffsetManager.scala
@@ -343,7 +343,12 @@ class OffsetManager(
         val sspToOffsets = checkpoint.getOffsets
         if(sspToOffsets != null) {
           sspToOffsets.asScala.foreach {
-            case (ssp, cp) => offsetManagerMetrics.checkpointedOffsets.get(ssp).set(cp)
+            case (ssp, cp) => {
+              val metric = offsetManagerMetrics.checkpointedOffsets.get(ssp)
+              // metric will be null for changelog SSPs since they're not registered with / tracked by the
+              // OffsetManager. Ignore such SSPs.
+              if (metric != null) metric.set(cp)
+            }
           }
         }
       }

--- a/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
@@ -122,7 +122,7 @@ class TaskInstance(
     initCaughtUpMapping()
 
     val taskConfig = new TaskConfig(config)
-    if (taskConfig.getTransactionalStateEnabled() && taskConfig.getCommitMs > 0) {
+    if (taskConfig.getTransactionalStateRestoreEnabled() && taskConfig.getCommitMs > 0) {
       // Commit immediately so the trimmed changelog messages
       // will be sealed in a checkpoint
       commit

--- a/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
@@ -24,8 +24,8 @@ import java.util.{Objects, Optional}
 import java.util.concurrent.ScheduledExecutorService
 
 import org.apache.samza.SamzaException
-import org.apache.samza.checkpoint.OffsetManager
-import org.apache.samza.config.{Config, StreamConfig}
+import org.apache.samza.checkpoint.{Checkpoint, OffsetManager}
+import org.apache.samza.config.{Config, StreamConfig, TaskConfig}
 import org.apache.samza.context._
 import org.apache.samza.job.model.{JobModel, TaskModel}
 import org.apache.samza.scheduler.{CallbackSchedulerImpl, EpochTimeScheduler, ScheduledCallback}
@@ -60,8 +60,7 @@ class TaskInstance(
   containerContext: ContainerContext,
   applicationContainerContextOption: Option[ApplicationContainerContext],
   applicationTaskContextFactoryOption: Option[ApplicationTaskContextFactory[ApplicationTaskContext]],
-  externalContextOption: Option[ExternalContext]
-) extends Logging {
+  externalContextOption: Option[ExternalContext]) extends Logging {
 
   val taskName: TaskName = taskModel.getTaskName
   val isInitableTask = task.isInstanceOf[InitableTask]
@@ -121,6 +120,13 @@ class TaskInstance(
 
   def initTask {
     initCaughtUpMapping()
+
+    val taskConfig = new TaskConfig(config)
+    if (taskConfig.getTransactionalStateEnabled() && taskConfig.getCommitMs > 0) {
+      // Commit immediately so the trimmed changelog messages
+      // will be sealed in a checkpoint
+      commit
+    }
 
     if (isInitableTask) {
       debug("Initializing task for taskName: %s" format taskName)
@@ -227,26 +233,50 @@ class TaskInstance(
   def commit {
     metrics.commits.inc
 
-    val checkpoint = offsetManager.buildCheckpoint(taskName)
+    val allCheckpointOffsets = new java.util.HashMap[SystemStreamPartition, String]()
+    val inputCheckpoint = offsetManager.buildCheckpoint(taskName)
+    if (inputCheckpoint != null) {
+      trace("Got input offsets for taskName: %s as: %s" format(taskName, inputCheckpoint.getOffsets))
+      allCheckpointOffsets.putAll(inputCheckpoint.getOffsets)
+    }
 
     trace("Flushing producers for taskName: %s" format taskName)
     collector.flush
 
-    trace("Flushing state stores for taskName: %s" format taskName)
-    if (storageManager != null) {
-      storageManager.flush
-    }
-
-    trace("Flushing tables for taskName: %s" format taskName)
     if (tableManager != null) {
-      tableManager.flush
+      trace("Flushing tables for taskName: %s" format taskName)
+      tableManager.flush()
     }
 
-    trace("Checkpointing offsets for taskName: %s" format taskName)
+    var newestChangelogOffsets: Map[SystemStreamPartition, Option[String]] = null
+    if (storageManager != null) {
+      trace("Flushing state stores for taskName: %s" format taskName)
+      newestChangelogOffsets = storageManager.flush()
+      trace("Got newest changelog offsets for taskName: %s as: %s " format(taskName, newestChangelogOffsets))
+      newestChangelogOffsets.foreach {case (ssp, newestOffsetOption) =>
+        allCheckpointOffsets.put(ssp, newestOffsetOption.orNull)
+      }
+    }
+
+    val checkpoint = new Checkpoint(allCheckpointOffsets)
+    trace("Got combined checkpoint offsets for taskName: %s as: %s" format (taskName, allCheckpointOffsets))
+
+    var checkpointId: String = null
+    if (storageManager != null && newestChangelogOffsets != null) {
+      trace("Checkpointing stores for taskName: %s" format taskName)
+      checkpointId = storageManager.checkpoint(newestChangelogOffsets.toMap)
+    }
+
     offsetManager.writeCheckpoint(taskName, checkpoint)
 
-    if (checkpoint != null) {
-      checkpoint.getOffsets.asScala
+    if (storageManager != null && checkpointId != null) {
+      trace("Remove old checkpoint stores for taskName: %s" format taskName)
+      storageManager.removeOldCheckpoints(checkpointId)
+    }
+
+    if (inputCheckpoint != null) {
+      trace("Deleting committed input offsets for taskName: %s" format taskName)
+      inputCheckpoint.getOffsets.asScala
         .filter { case (ssp, _) => streamsToDeleteCommittedMessages.contains(ssp.getStream) } // Only delete data of intermediate streams
         .groupBy { case (ssp, _) => ssp.getSystem }
         .foreach { case (systemName: String, offsets: Map[SystemStreamPartition, String]) =>

--- a/samza-core/src/main/scala/org/apache/samza/serializers/CheckpointSerde.scala
+++ b/samza-core/src/main/scala/org/apache/samza/serializers/CheckpointSerde.scala
@@ -63,7 +63,7 @@ class CheckpointSerde extends Serde[Checkpoint] with Logging {
         val partition = m.get("partition")
         require(partition != null, "Partition must be present in JSON-encoded SystemStreamPartition")
         val offset = m.get("offset")
-        require(offset != null, "Offset must be present in JSON-encoded SystemStreamPartition")
+        // allow null offsets, e.g. for changelog ssps
 
         new SystemStreamPartition(system, stream, new Partition(partition.toInt)) -> offset
       }

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -629,7 +629,7 @@ public class ContainerStorageManager {
 
   public void start() throws SamzaException {
     Map<SystemStreamPartition, String> checkpointedChangelogSSPOffsets = new HashMap<>();
-    if (new TaskConfig(config).getTransactionalStateEnabled()) {
+    if (new TaskConfig(config).getTransactionalStateRestoreEnabled()) {
       getTasks(containerModel, TaskMode.Active).forEach((taskName, taskModel) -> {
           if (checkpointManager != null) {
             Set<SystemStream> changelogSystemStreams = new HashSet<>(this.changelogSystemStreams.values());

--- a/samza-core/src/main/scala/org/apache/samza/storage/NonTransactionalStateTaskStorageManager.scala
+++ b/samza-core/src/main/scala/org/apache/samza/storage/NonTransactionalStateTaskStorageManager.scala
@@ -112,6 +112,7 @@ class NonTransactionalStateTaskStorageManager(
       .filterKeys(storeName => persistedStores.contains(storeName))
       .foreach { case (storeName, systemStream) => {
         debug("Writing changelog offset for taskName %s store %s changelog %s." format(taskName, storeName, systemStream))
+        val currentStoreDir = storageManagerUtil.getTaskStoreDir(loggedStoreBaseDir, storeName, taskName, TaskMode.Active)
         try {
           val ssp = new SystemStreamPartition(systemStream.getSystem, systemStream.getStream, partition)
           newestChangelogOffsets(ssp) match {
@@ -119,7 +120,6 @@ class NonTransactionalStateTaskStorageManager(
               debug("Storing newest offset %s for taskName %s store %s changelog %s in OFFSET file."
                 format(newestOffset, taskName, storeName, systemStream))
               // TaskStorageManagers are only created for active tasks
-              val currentStoreDir = storageManagerUtil.getTaskStoreDir(loggedStoreBaseDir, storeName, taskName, TaskMode.Active)
               storageManagerUtil.writeOffsetFile(currentStoreDir, Map(ssp -> newestOffset).asJava, false)
               debug("Successfully stored offset %s for taskName %s store %s changelog %s in OFFSET file."
                 format(newestOffset, taskName, storeName, systemStream))
@@ -128,7 +128,7 @@ class NonTransactionalStateTaskStorageManager(
               // if newestOffset is null, then it means the changelog ssp is (or has become) empty. This could be
               // either because the changelog topic was newly added, repartitioned, or manually deleted and recreated.
               // No need to persist the offset file.
-              storageManagerUtil.deleteOffsetFile(loggedStoreBaseDir, storeName, taskName)
+              storageManagerUtil.deleteOffsetFile(currentStoreDir)
               debug("Deleting OFFSET file for taskName %s store %s changelog ssp %s since the newestOffset is null."
                 format (taskName, storeName, ssp))
             }

--- a/samza-core/src/main/scala/org/apache/samza/storage/TaskStorageManagerFactory.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/TaskStorageManagerFactory.java
@@ -35,9 +35,9 @@ public class TaskStorageManagerFactory {
       Map<String, SystemStream> storeChangelogs, SystemAdmins systemAdmins,
       File loggedStoreBaseDir, Partition changelogPartition,
       Config config, TaskMode taskMode) {
-    if (new TaskConfig(config).getTransactionalStateEnabled()) {
+    if (new TaskConfig(config).getTransactionalStateCheckpointEnabled()) {
       return new TransactionalStateTaskStorageManager(taskName, containerStorageManager, storeChangelogs, systemAdmins,
-          loggedStoreBaseDir, changelogPartition, taskMode);
+          loggedStoreBaseDir, changelogPartition, taskMode, new StorageManagerUtil());
     } else {
       return new NonTransactionalStateTaskStorageManager(taskName, containerStorageManager, storeChangelogs, systemAdmins,
           loggedStoreBaseDir, changelogPartition);

--- a/samza-core/src/main/scala/org/apache/samza/storage/TaskStorageManagerFactory.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/TaskStorageManagerFactory.java
@@ -36,7 +36,8 @@ public class TaskStorageManagerFactory {
       File loggedStoreBaseDir, Partition changelogPartition,
       Config config, TaskMode taskMode) {
     if (new TaskConfig(config).getTransactionalStateEnabled()) {
-      throw new UnsupportedOperationException();
+      return new TransactionalStateTaskStorageManager(taskName, containerStorageManager, storeChangelogs, systemAdmins,
+          loggedStoreBaseDir, changelogPartition, taskMode);
     } else {
       return new NonTransactionalStateTaskStorageManager(taskName, containerStorageManager, storeChangelogs, systemAdmins,
           loggedStoreBaseDir, changelogPartition);

--- a/samza-core/src/main/scala/org/apache/samza/storage/TransactionalStateTaskStorageManager.scala
+++ b/samza-core/src/main/scala/org/apache/samza/storage/TransactionalStateTaskStorageManager.scala
@@ -81,7 +81,7 @@ class TransactionalStateTaskStorageManager(
 
   def removeOldCheckpoints(latestCheckpointId: String): Unit = {
     if (latestCheckpointId != null) {
-      debug("Remove older checkpoints before " + latestCheckpointId)
+      debug("Removing older checkpoints before " + latestCheckpointId)
 
       val files = loggedStoreBaseDir.listFiles()
       if (files != null) {

--- a/samza-core/src/main/scala/org/apache/samza/storage/TransactionalStateTaskStorageManager.scala
+++ b/samza-core/src/main/scala/org/apache/samza/storage/TransactionalStateTaskStorageManager.scala
@@ -1,0 +1,178 @@
+package org.apache.samza.storage
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io._
+import java.nio.file.Path
+
+import com.google.common.annotations.VisibleForTesting
+import com.google.common.collect.ImmutableSet
+import org.apache.commons.io.FileUtils
+import org.apache.commons.io.filefilter.WildcardFileFilter
+import org.apache.samza.{Partition, SamzaException}
+import org.apache.samza.container.TaskName
+import org.apache.samza.job.model.TaskMode
+import org.apache.samza.system._
+import org.apache.samza.util.ScalaJavaUtil.JavaOptionals
+import org.apache.samza.util.Logging
+
+import scala.collection.JavaConverters._
+
+/**
+ * Manage all the storage engines for a given task
+ */
+class TransactionalStateTaskStorageManager(
+  taskName: TaskName,
+  containerStorageManager: ContainerStorageManager,
+  storeChangelogs: Map[String, SystemStream] = Map(),
+  systemAdmins: SystemAdmins,
+  loggedStoreBaseDir: File = new File(System.getProperty("user.dir"), "state"),
+  partition: Partition,
+  taskMode: TaskMode) extends Logging with TaskStorageManager {
+
+  private val storageManagerUtil = new StorageManagerUtil
+
+  def getStore(storeName: String): Option[StorageEngine] =  JavaOptionals.toRichOptional(containerStorageManager.getStore(taskName, storeName)).toOption
+
+  def flush(): Map[SystemStreamPartition, Option[String]] = {
+    debug("Flushing stores.")
+    containerStorageManager.getAllStores(taskName).asScala.values.foreach(_.flush)
+    getNewestChangelogSSPOffsets(taskName, storeChangelogs, partition, systemAdmins)
+  }
+
+  def checkpoint(newestChangelogOffsets: Map[SystemStreamPartition, Option[String]]): String = {
+    debug("Checkpointing stores.")
+
+    val id = System.currentTimeMillis().toString
+    val checkpointPaths = containerStorageManager.getAllStores(taskName).asScala
+      .filter { case (storeName, storeEngine) =>
+        storeEngine.getStoreProperties.isLoggedStore && storeEngine.getStoreProperties.isPersistedToDisk}
+      .flatMap { case (storeName, storeEngine) => {
+        val pathOptional = storeEngine.checkpoint(id)
+        if (pathOptional.isPresent) {
+          Some(storeName, pathOptional.get())
+        } else {
+          None
+        }
+      }}
+      .toMap
+
+    writeChangelogOffsetFiles(checkpointPaths, storeChangelogs, newestChangelogOffsets)
+
+    id
+  }
+
+  def removeOldCheckpoints(latestCheckpointId: String): Unit = {
+    if (latestCheckpointId != null) {
+      debug("Remove older checkpoints before " + latestCheckpointId)
+
+      val files = loggedStoreBaseDir.listFiles()
+      if (files != null) {
+        files
+          .foreach(storeDir => {
+            val storeName = storeDir.getName
+            val taskStoreName = storageManagerUtil.getTaskStoreDir(
+              loggedStoreBaseDir, storeName, taskName, taskMode).getName
+            val fileFilter: FileFilter = new WildcardFileFilter(taskStoreName + "-*")
+            val checkpointDirs = storeDir.listFiles(fileFilter)
+
+            checkpointDirs
+              .filter(!_.getName.contains(latestCheckpointId))
+              .foreach(checkpointDir => {
+                FileUtils.deleteDirectory(checkpointDir)
+              })
+          })
+      }
+    }
+  }
+
+  @VisibleForTesting
+  def stop() {
+    debug("Stopping stores.")
+    containerStorageManager.stopStores()
+  }
+
+  /**
+   * Returns the newest offset for each store changelog SSP for this task. Returned map will
+   * always contain an entry for every changelog SSP.
+   * @return A map of changelog SSPs for this task to their newest offset (or None if ssp is empty)
+   * @throws SamzaException if there was an error fetching newest offset for any SSP
+   */
+  @VisibleForTesting
+  def getNewestChangelogSSPOffsets(taskName: TaskName, storeChangelogs: Map[String, SystemStream],
+      partition: Partition, systemAdmins: SystemAdmins): Map[SystemStreamPartition, Option[String]] = {
+    storeChangelogs
+      .map { case (storeName, systemStream) => {
+        try {
+          debug("Fetching newest offset for taskName %s store %s changelog %s" format (taskName, storeName, systemStream))
+          val ssp = new SystemStreamPartition(systemStream.getSystem, systemStream.getStream, partition)
+          val systemAdmin = systemAdmins.getSystemAdmin(systemStream.getSystem)
+
+          val sspMetadata = Option(systemAdmin.getSSPMetadata(ImmutableSet.of(ssp)).get(ssp))
+            .getOrElse(throw new SamzaException("Received null metadata for ssp: %s" format ssp))
+
+          // newest offset == null implies topic is empty
+          val newestOffsetOption = Option(sspMetadata.getNewestOffset)
+          newestOffsetOption.foreach(newestOffset =>
+            debug("Got newest offset %s for taskName %s store %s changelog %s" format(newestOffset, taskName, storeName, systemStream)))
+
+          (ssp, newestOffsetOption)
+        } catch {
+          case e: Exception =>
+            throw new SamzaException("Error getting newest changelog offset for taskName %s store %s changelog %s."
+              format(taskName, storeName, systemStream), e)
+        }
+      }}
+      .toMap
+  }
+
+  /**
+   * Writes the newest changelog ssp offset for each persistent store the OFFSET file in the checkpoint directory.
+   * These files are used during container startup to ensure transactional state, and to determine whether the
+   * there is any new information in the changelog that is not reflected in the on-disk copy of the store.
+   * If there is any delta, it is replayed from the changelog e.g. This can happen if the job was run on this host,
+   * then another host, and then back to this host.
+   */
+  @VisibleForTesting
+  def writeChangelogOffsetFiles(checkpointPaths: Map[String, Path], storeChangelogs: Map[String, SystemStream], newestChangelogOffsets: Map[SystemStreamPartition, Option[String]]): Unit = {
+    debug("Writing OFFSET files for logged persistent key value stores for task %s." format(checkpointPaths))
+
+    storeChangelogs
+      .filterKeys(storeName => checkpointPaths.contains(storeName))
+      .foreach { case (storeName, systemStream) => {
+        try {
+          val ssp = new SystemStreamPartition(systemStream.getSystem, systemStream.getStream, partition)
+          newestChangelogOffsets(ssp).foreach(newestOffset => {
+            val path = checkpointPaths(storeName)
+            debug("Storing newest offset: %s for taskName: %s store: %s changelog: %s in OFFSET file at path: %s."
+              format(newestOffset, taskName, storeName, systemStream, path))
+            storageManagerUtil.writeOffsetFile(path.toFile, Map(ssp -> newestOffset).asJava, false)
+            debug("Successfully stored offset: %s for taskName: %s store: %s changelog: %s in OFFSET file at path: %s."
+              format(newestOffset, taskName, storeName, systemStream, path))
+          })
+        } catch {
+          case e: Exception =>
+            throw new SamzaException("Error storing offset for taskName %s store %s changelog %s."
+              format(taskName, storeName, systemStream), e)
+        }
+      }}
+    debug("Done writing OFFSET files for logged persistent key value stores for task %s" format(taskName))
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/storage/TestStorageRecovery.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/TestStorageRecovery.java
@@ -38,7 +38,6 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class TestStorageRecovery {
-
   public Config config = null;
   String path = "/tmp/testing";
   private static final String SYSTEM_STREAM_NAME = "changelog";

--- a/samza-core/src/test/java/org/apache/samza/storage/TestTransactionalStateTaskRestoreManager.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/TestTransactionalStateTaskRestoreManager.java
@@ -1,0 +1,1267 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.storage;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ListMultimap;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.samza.Partition;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.MapConfig;
+import org.apache.samza.config.TaskConfig;
+import org.apache.samza.container.TaskName;
+import org.apache.samza.job.model.TaskModel;
+import org.apache.samza.storage.TransactionalStateTaskRestoreManager.StoreActions;
+import org.apache.samza.storage.TransactionalStateTaskRestoreManager.RestoreOffsets;
+import org.apache.samza.system.SSPMetadataCache;
+import org.apache.samza.system.SystemAdmin;
+import org.apache.samza.system.SystemAdmins;
+import org.apache.samza.system.SystemConsumer;
+import org.apache.samza.system.SystemStream;
+import org.apache.samza.system.SystemStreamMetadata.SystemStreamPartitionMetadata;
+import org.apache.samza.system.SystemStreamPartition;
+import org.apache.samza.util.Clock;
+import org.apache.samza.util.FileUtil;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class TestTransactionalStateTaskRestoreManager {
+  @Test
+  public void testGetCurrentChangelogOffsets() {
+    // test gets metadata for all and only task store changelog SSPs
+    // test all changelogs have same partition
+    // test does not change returned ssp metadata
+    TaskModel mockTaskModel = mock(TaskModel.class);
+    when(mockTaskModel.getTaskName()).thenReturn(new TaskName("Partition 0"));
+    Partition taskChangelogPartition = new Partition(0);
+    when(mockTaskModel.getChangelogPartition()).thenReturn(taskChangelogPartition);
+
+    String store1Name = "store1";
+    String changelog1SystemName = "system1";
+    String changelog1StreamName = "store1Changelog";
+    String store2Name = "store2";
+    String changelog2SystemName = "system2";
+    String changelog2StreamName = "store2Changelog";
+
+    SystemStream changelog1SystemStream = new SystemStream(changelog1SystemName, changelog1StreamName);
+    SystemStream changelog2SystemStream = new SystemStream(changelog2SystemName, changelog2StreamName);
+
+    Map<String, SystemStream> mockStoreChangelogs = ImmutableMap.of(
+        store1Name, changelog1SystemStream,
+        store2Name, changelog2SystemStream);
+
+    SSPMetadataCache mockSSPMetadataCache = mock(SSPMetadataCache.class);
+    SystemStreamPartition changelog1SSP = new SystemStreamPartition(changelog1SystemStream, taskChangelogPartition);
+    SystemStreamPartitionMetadata changelog1SSPMetadata = new SystemStreamPartitionMetadata("0", "1", "2");
+    when(mockSSPMetadataCache.getMetadata(eq(changelog1SSP))).thenReturn(changelog1SSPMetadata);
+    SystemStreamPartition changelog2SSP = new SystemStreamPartition(changelog2SystemStream, taskChangelogPartition);
+    SystemStreamPartitionMetadata changelog2SSPMetadata = new SystemStreamPartitionMetadata("1", "2", "3");
+    when(mockSSPMetadataCache.getMetadata(eq(changelog2SSP))).thenReturn(changelog2SSPMetadata);
+
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> currentChangelogOffsets =
+        TransactionalStateTaskRestoreManager.getCurrentChangelogOffsets(
+            mockTaskModel, mockStoreChangelogs, mockSSPMetadataCache);
+
+    verify(mockSSPMetadataCache, times(1)).getMetadata(changelog1SSP);
+    verify(mockSSPMetadataCache, times(1)).getMetadata(changelog2SSP);
+    verifyNoMoreInteractions(mockSSPMetadataCache);
+
+    assertEquals(2, currentChangelogOffsets.size());
+    assertEquals(changelog1SSPMetadata, currentChangelogOffsets.get(changelog1SSP));
+    assertEquals(changelog2SSPMetadata, currentChangelogOffsets.get(changelog2SSP));
+  }
+
+  @Test
+  public void testGetStoreActionsForNonLoggedPersistentStore_AlwaysClearStore() {
+    TaskModel mockTaskModel = mock(TaskModel.class);
+    TaskName taskName = new TaskName("Partition 0");
+    when(mockTaskModel.getTaskName()).thenReturn(taskName);
+    Partition taskChangelogPartition = new Partition(0);
+    when(mockTaskModel.getChangelogPartition()).thenReturn(taskChangelogPartition);
+
+    String store1Name = "store1";
+    StorageEngine store1Engine = mock(StorageEngine.class);
+    StoreProperties mockStore1Properties = mock(StoreProperties.class);
+    when(store1Engine.getStoreProperties()).thenReturn(mockStore1Properties);
+    when(mockStore1Properties.isLoggedStore()).thenReturn(false);
+    when(mockStore1Properties.isPersistedToDisk()).thenReturn(true);
+    Map<String, StorageEngine> mockStoreEngines = ImmutableMap.of(store1Name, store1Engine);
+
+    Map<String, SystemStream> mockStoreChangelogs = ImmutableMap.of();
+
+    Map<SystemStreamPartition, String> mockCheckpointedChangelogOffset = ImmutableMap.of();
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> mockCurrentChangelogOffsets = ImmutableMap.of();
+
+    SystemAdmins mockSystemAdmins = mock(SystemAdmins.class);
+    StorageManagerUtil mockStorageManagerUtil = mock(StorageManagerUtil.class);
+    File mockLoggedStoreBaseDir = mock(File.class);
+    File mockNonLoggedStoreBaseDir = mock(File.class);
+    Config mockConfig = mock(Config.class);
+    Clock mockClock = mock(Clock.class);
+
+    File mockCurrentStoreDir = mock(File.class);
+    when(mockStorageManagerUtil.getTaskStoreDir(eq(mockNonLoggedStoreBaseDir), eq(store1Name), eq(taskName), any()))
+        .thenReturn(mockCurrentStoreDir);
+
+    StoreActions storeActions = TransactionalStateTaskRestoreManager.getStoreActions(
+        mockTaskModel, mockStoreEngines, mockStoreChangelogs, mockCheckpointedChangelogOffset,
+        mockCurrentChangelogOffsets, mockSystemAdmins, mockStorageManagerUtil,
+        mockLoggedStoreBaseDir, mockNonLoggedStoreBaseDir, mockConfig, mockClock);
+
+    assertEquals(1, storeActions.storeDirsToDelete.get(store1Name).size());
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockCurrentStoreDir));
+    // ensure that there is nothing to retain or restore.
+    assertEquals(0, storeActions.storeDirsToRetain.size());
+    assertEquals(0, storeActions.storesToRestore.size());
+  }
+
+  @Test
+  public void testGetStoreActionsForLoggedNonPersistentStore_RestoreToCheckpointedOffset() {
+    TaskModel mockTaskModel = mock(TaskModel.class);
+    TaskName taskName = new TaskName("Partition 0");
+    when(mockTaskModel.getTaskName()).thenReturn(taskName);
+    Partition taskChangelogPartition = new Partition(0);
+    when(mockTaskModel.getChangelogPartition()).thenReturn(taskChangelogPartition);
+
+    String store1Name = "store1";
+    StorageEngine store1Engine = mock(StorageEngine.class);
+    StoreProperties mockStore1Properties = mock(StoreProperties.class);
+    when(store1Engine.getStoreProperties()).thenReturn(mockStore1Properties);
+    when(mockStore1Properties.isLoggedStore()).thenReturn(true);
+    when(mockStore1Properties.isPersistedToDisk()).thenReturn(false); // non-persistent (in memory) store
+    Map<String, StorageEngine> mockStoreEngines = ImmutableMap.of(store1Name, store1Engine);
+
+    String changelog1SystemName = "system1";
+    String changelog1StreamName = "store1Changelog";
+    SystemStream changelog1SystemStream = new SystemStream(changelog1SystemName, changelog1StreamName);
+    SystemStreamPartition changelog1SSP = new SystemStreamPartition(changelog1SystemStream, taskChangelogPartition);
+    SystemStreamPartitionMetadata changelog1SSPMetadata = new SystemStreamPartitionMetadata("0", "10", "11");
+    Map<String, SystemStream> mockStoreChangelogs = ImmutableMap.of(store1Name, changelog1SystemStream);
+
+    String changelog1CheckpointedOffset = "5";
+    ImmutableMap<SystemStreamPartition, String> mockCheckpointedChangelogOffset =
+        ImmutableMap.of(changelog1SSP, changelog1CheckpointedOffset);
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> mockCurrentChangelogOffsets =
+        ImmutableMap.of(changelog1SSP, changelog1SSPMetadata);
+
+    SystemAdmins mockSystemAdmins = mock(SystemAdmins.class);
+    SystemAdmin mockSystemAdmin = mock(SystemAdmin.class);
+    when(mockSystemAdmins.getSystemAdmin(changelog1SSP.getSystem())).thenReturn(mockSystemAdmin);
+    StorageManagerUtil mockStorageManagerUtil = mock(StorageManagerUtil.class);
+    File mockLoggedStoreBaseDir = mock(File.class);
+    File mockNonLoggedStoreBaseDir = mock(File.class);
+    Config mockConfig = mock(Config.class);
+    Clock mockClock = mock(Clock.class);
+
+    Mockito.when(mockSystemAdmin.offsetComparator(anyString(), anyString()))
+        .thenAnswer((Answer<Integer>) invocation -> {
+            String offset1 = (String) invocation.getArguments()[0];
+            String offset2 = (String) invocation.getArguments()[1];
+            return Long.valueOf(offset1).compareTo(Long.valueOf(offset2));
+          });
+
+    StoreActions storeActions = TransactionalStateTaskRestoreManager.getStoreActions(
+        mockTaskModel, mockStoreEngines, mockStoreChangelogs, mockCheckpointedChangelogOffset,
+        mockCurrentChangelogOffsets, mockSystemAdmins, mockStorageManagerUtil,
+        mockLoggedStoreBaseDir, mockNonLoggedStoreBaseDir, mockConfig, mockClock);
+
+    // ensure that there is nothing to delete or retain
+    assertEquals(0, storeActions.storeDirsToDelete.size());
+    // ensure that we restore from the oldest changelog offset to checkpointed changelog offset
+    assertEquals("0", storeActions.storesToRestore.get(store1Name).startingOffset);
+    assertEquals(changelog1CheckpointedOffset, storeActions.storesToRestore.get(store1Name).endingOffset);
+  }
+
+  @Test
+  public void testGetStoreActionsForLoggedNonPersistentStore_FullRestoreIfCheckpointedOffsetNewerThanNewest() {
+    TaskModel mockTaskModel = mock(TaskModel.class);
+    TaskName taskName = new TaskName("Partition 0");
+    when(mockTaskModel.getTaskName()).thenReturn(taskName);
+    Partition taskChangelogPartition = new Partition(0);
+    when(mockTaskModel.getChangelogPartition()).thenReturn(taskChangelogPartition);
+
+    String store1Name = "store1";
+    StorageEngine store1Engine = mock(StorageEngine.class);
+    StoreProperties mockStore1Properties = mock(StoreProperties.class);
+    when(store1Engine.getStoreProperties()).thenReturn(mockStore1Properties);
+    when(mockStore1Properties.isLoggedStore()).thenReturn(true);
+    when(mockStore1Properties.isPersistedToDisk()).thenReturn(false); // non-persistent store
+    Map<String, StorageEngine> mockStoreEngines = ImmutableMap.of(store1Name, store1Engine);
+
+    String changelog1SystemName = "system1";
+    String changelog1StreamName = "store1Changelog";
+    SystemStream changelog1SystemStream = new SystemStream(changelog1SystemName, changelog1StreamName);
+    SystemStreamPartition changelog1SSP = new SystemStreamPartition(changelog1SystemStream, taskChangelogPartition);
+    // checkpointed changelog offset > newest offset (e.g. changelog topic got changed)
+    SystemStreamPartitionMetadata changelog1SSPMetadata = new SystemStreamPartitionMetadata("0", "10", "11");
+    Map<String, SystemStream> mockStoreChangelogs = ImmutableMap.of(store1Name, changelog1SystemStream);
+
+    String changelog1CheckpointedOffset = "21";
+    Map<SystemStreamPartition, String> mockCheckpointedChangelogOffset =
+        new HashMap<SystemStreamPartition, String>() { {
+          put(changelog1SSP, changelog1CheckpointedOffset);
+        } };
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> mockCurrentChangelogOffsets =
+        ImmutableMap.of(changelog1SSP, changelog1SSPMetadata);
+
+    SystemAdmins mockSystemAdmins = mock(SystemAdmins.class);
+    SystemAdmin mockSystemAdmin = mock(SystemAdmin.class);
+    when(mockSystemAdmins.getSystemAdmin(changelog1SSP.getSystem())).thenReturn(mockSystemAdmin);
+    StorageManagerUtil mockStorageManagerUtil = mock(StorageManagerUtil.class);
+    File mockLoggedStoreBaseDir = mock(File.class);
+    File mockNonLoggedStoreBaseDir = mock(File.class);
+    Config mockConfig = mock(Config.class);
+    Clock mockClock = mock(Clock.class);
+
+
+    Mockito.when(mockSystemAdmin.offsetComparator(anyString(), anyString()))
+        .thenAnswer((Answer<Integer>) invocation -> {
+            String offset1 = (String) invocation.getArguments()[0];
+            String offset2 = (String) invocation.getArguments()[1];
+            return Long.valueOf(offset1).compareTo(Long.valueOf(offset2));
+          });
+
+    StoreActions storeActions = TransactionalStateTaskRestoreManager.getStoreActions(
+        mockTaskModel, mockStoreEngines, mockStoreChangelogs, mockCheckpointedChangelogOffset,
+        mockCurrentChangelogOffsets, mockSystemAdmins, mockStorageManagerUtil,
+        mockLoggedStoreBaseDir, mockNonLoggedStoreBaseDir, mockConfig, mockClock);
+
+    // ensure that there is nothing to retain or delete
+    assertEquals(0, storeActions.storeDirsToDelete.size());
+    assertEquals(0, storeActions.storeDirsToRetain.size());
+    // ensure that we mark the store for full restore (from current oldest to current newest)
+    assertEquals("0", storeActions.storesToRestore.get(store1Name).startingOffset);
+    assertEquals("10", storeActions.storesToRestore.get(store1Name).endingOffset);
+  }
+
+  @Test
+  public void testGetStoreActionsForLoggedNonPersistentStore_FullRestoreIfCheckpointedOffsetOlderThanOldest() {
+    TaskModel mockTaskModel = mock(TaskModel.class);
+    TaskName taskName = new TaskName("Partition 0");
+    when(mockTaskModel.getTaskName()).thenReturn(taskName);
+    Partition taskChangelogPartition = new Partition(0);
+    when(mockTaskModel.getChangelogPartition()).thenReturn(taskChangelogPartition);
+
+    String store1Name = "store1";
+    StorageEngine store1Engine = mock(StorageEngine.class);
+    StoreProperties mockStore1Properties = mock(StoreProperties.class);
+    when(store1Engine.getStoreProperties()).thenReturn(mockStore1Properties);
+    when(mockStore1Properties.isLoggedStore()).thenReturn(true);
+    when(mockStore1Properties.isPersistedToDisk()).thenReturn(false); // non-persistent store
+    Map<String, StorageEngine> mockStoreEngines = ImmutableMap.of(store1Name, store1Engine);
+
+    String changelog1SystemName = "system1";
+    String changelog1StreamName = "store1Changelog";
+    SystemStream changelog1SystemStream = new SystemStream(changelog1SystemName, changelog1StreamName);
+    SystemStreamPartition changelog1SSP = new SystemStreamPartition(changelog1SystemStream, taskChangelogPartition);
+    // checkpointed changelog offset > newest offset (e.g. changelog topic got changed)
+    SystemStreamPartitionMetadata changelog1SSPMetadata = new SystemStreamPartitionMetadata("10", "20", "21");
+    Map<String, SystemStream> mockStoreChangelogs = ImmutableMap.of(store1Name, changelog1SystemStream);
+
+    String changelog1CheckpointedOffset = "5";
+    Map<SystemStreamPartition, String> mockCheckpointedChangelogOffset =
+        new HashMap<SystemStreamPartition, String>() { {
+          put(changelog1SSP, changelog1CheckpointedOffset);
+        } };
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> mockCurrentChangelogOffsets =
+        ImmutableMap.of(changelog1SSP, changelog1SSPMetadata);
+
+    SystemAdmins mockSystemAdmins = mock(SystemAdmins.class);
+    SystemAdmin mockSystemAdmin = mock(SystemAdmin.class);
+    when(mockSystemAdmins.getSystemAdmin(changelog1SSP.getSystem())).thenReturn(mockSystemAdmin);
+    StorageManagerUtil mockStorageManagerUtil = mock(StorageManagerUtil.class);
+    File mockLoggedStoreBaseDir = mock(File.class);
+    File mockNonLoggedStoreBaseDir = mock(File.class);
+    Config mockConfig = mock(Config.class);
+    Clock mockClock = mock(Clock.class);
+
+
+    Mockito.when(mockSystemAdmin.offsetComparator(anyString(), anyString()))
+        .thenAnswer((Answer<Integer>) invocation -> {
+            String offset1 = (String) invocation.getArguments()[0];
+            String offset2 = (String) invocation.getArguments()[1];
+            return Long.valueOf(offset1).compareTo(Long.valueOf(offset2));
+          });
+
+    StoreActions storeActions = TransactionalStateTaskRestoreManager.getStoreActions(
+        mockTaskModel, mockStoreEngines, mockStoreChangelogs, mockCheckpointedChangelogOffset,
+        mockCurrentChangelogOffsets, mockSystemAdmins, mockStorageManagerUtil,
+        mockLoggedStoreBaseDir, mockNonLoggedStoreBaseDir, mockConfig, mockClock);
+
+    // ensure that there is nothing to retain or delete
+    assertEquals(0, storeActions.storeDirsToDelete.size());
+    assertEquals(0, storeActions.storeDirsToRetain.size());
+    // ensure that we mark the store for full restore (from current oldest to current newest)
+    assertEquals("10", storeActions.storesToRestore.get(store1Name).startingOffset);
+    assertEquals("20", storeActions.storesToRestore.get(store1Name).endingOffset);
+  }
+
+  @Test
+  public void testGetStoreActionsForLoggedNonPersistentStore_FullTrimIfNullCheckpointedOffsetAndNotRetainExistingState() {
+    TaskModel mockTaskModel = mock(TaskModel.class);
+    TaskName taskName = new TaskName("Partition 0");
+    when(mockTaskModel.getTaskName()).thenReturn(taskName);
+    Partition taskChangelogPartition = new Partition(0);
+    when(mockTaskModel.getChangelogPartition()).thenReturn(taskChangelogPartition);
+
+    String store1Name = "store1";
+    StorageEngine store1Engine = mock(StorageEngine.class);
+    StoreProperties mockStore1Properties = mock(StoreProperties.class);
+    when(store1Engine.getStoreProperties()).thenReturn(mockStore1Properties);
+    when(mockStore1Properties.isLoggedStore()).thenReturn(true);
+    when(mockStore1Properties.isPersistedToDisk()).thenReturn(false); // non-persistent store
+    Map<String, StorageEngine> mockStoreEngines = ImmutableMap.of(store1Name, store1Engine);
+
+    String changelog1SystemName = "system1";
+    String changelog1StreamName = "store1Changelog";
+    SystemStream changelog1SystemStream = new SystemStream(changelog1SystemName, changelog1StreamName);
+    SystemStreamPartition changelog1SSP = new SystemStreamPartition(changelog1SystemStream, taskChangelogPartition);
+    SystemStreamPartitionMetadata changelog1SSPMetadata = new SystemStreamPartitionMetadata("0", "10", "11");
+    Map<String, SystemStream> mockStoreChangelogs = ImmutableMap.of(store1Name, changelog1SystemStream);
+
+    String changelog1CheckpointedOffset = null;
+    Map<SystemStreamPartition, String> mockCheckpointedChangelogOffset =
+        new HashMap<SystemStreamPartition, String>() { {
+          put(changelog1SSP, changelog1CheckpointedOffset);
+        } };
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> mockCurrentChangelogOffsets =
+        ImmutableMap.of(changelog1SSP, changelog1SSPMetadata);
+
+    SystemAdmins mockSystemAdmins = mock(SystemAdmins.class);
+    SystemAdmin mockSystemAdmin = mock(SystemAdmin.class);
+    when(mockSystemAdmins.getSystemAdmin(changelog1SSP.getSystem())).thenReturn(mockSystemAdmin);
+    StorageManagerUtil mockStorageManagerUtil = mock(StorageManagerUtil.class);
+    File mockLoggedStoreBaseDir = mock(File.class);
+    File mockNonLoggedStoreBaseDir = mock(File.class);
+    HashMap<String, String> configMap = new HashMap<>();
+    configMap.put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE, "false");
+    Config mockConfig = new MapConfig(configMap);
+    Clock mockClock = mock(Clock.class);
+
+    Mockito.when(mockSystemAdmin.offsetComparator(anyString(), anyString()))
+        .thenAnswer((Answer<Integer>) invocation -> {
+            String offset1 = (String) invocation.getArguments()[0];
+            String offset2 = (String) invocation.getArguments()[1];
+            return Long.valueOf(offset1).compareTo(Long.valueOf(offset2));
+          });
+
+    StoreActions storeActions = TransactionalStateTaskRestoreManager.getStoreActions(
+        mockTaskModel, mockStoreEngines, mockStoreChangelogs, mockCheckpointedChangelogOffset,
+        mockCurrentChangelogOffsets, mockSystemAdmins, mockStorageManagerUtil,
+        mockLoggedStoreBaseDir, mockNonLoggedStoreBaseDir, mockConfig, mockClock);
+
+    // ensure that there is nothing to delete or retain
+    assertEquals(0, storeActions.storeDirsToDelete.size());
+    assertEquals(0, storeActions.storeDirsToRetain.size());
+    // ensure that we mark the store for restore (full trim == restore from oldest to null)
+    assertEquals("0", storeActions.storesToRestore.get(store1Name).startingOffset);
+    assertNull(storeActions.storesToRestore.get(store1Name).endingOffset);
+  }
+
+  @Test
+  public void testGetStoreActionsForLoggedPersistentStore_RestoreToCheckpointedOffsetIfNoStoreCheckpoints() {
+    TaskModel mockTaskModel = mock(TaskModel.class);
+    TaskName taskName = new TaskName("Partition 0");
+    when(mockTaskModel.getTaskName()).thenReturn(taskName);
+    Partition taskChangelogPartition = new Partition(0);
+    when(mockTaskModel.getChangelogPartition()).thenReturn(taskChangelogPartition);
+
+    String store1Name = "store1";
+    StorageEngine store1Engine = mock(StorageEngine.class);
+    StoreProperties mockStore1Properties = mock(StoreProperties.class);
+    when(store1Engine.getStoreProperties()).thenReturn(mockStore1Properties);
+    when(mockStore1Properties.isLoggedStore()).thenReturn(true);
+    when(mockStore1Properties.isPersistedToDisk()).thenReturn(true);
+    Map<String, StorageEngine> mockStoreEngines = ImmutableMap.of(store1Name, store1Engine);
+
+    String changelog1SystemName = "system1";
+    String changelog1StreamName = "store1Changelog";
+    SystemStream changelog1SystemStream = new SystemStream(changelog1SystemName, changelog1StreamName);
+    SystemStreamPartition changelog1SSP = new SystemStreamPartition(changelog1SystemStream, taskChangelogPartition);
+    SystemStreamPartitionMetadata changelog1SSPMetadata = new SystemStreamPartitionMetadata("0", "10", "11");
+    Map<String, SystemStream> mockStoreChangelogs = ImmutableMap.of(store1Name, changelog1SystemStream);
+
+    String changelog1CheckpointedOffset = "5";
+    ImmutableMap<SystemStreamPartition, String> mockCheckpointedChangelogOffset =
+        ImmutableMap.of(changelog1SSP, changelog1CheckpointedOffset);
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> mockCurrentChangelogOffsets =
+        ImmutableMap.of(changelog1SSP, changelog1SSPMetadata);
+
+    SystemAdmins mockSystemAdmins = mock(SystemAdmins.class);
+    SystemAdmin mockSystemAdmin = mock(SystemAdmin.class);
+    when(mockSystemAdmins.getSystemAdmin(changelog1SSP.getSystem())).thenReturn(mockSystemAdmin);
+    StorageManagerUtil mockStorageManagerUtil = mock(StorageManagerUtil.class);
+    File mockLoggedStoreBaseDir = mock(File.class);
+    File mockNonLoggedStoreBaseDir = mock(File.class);
+    Config mockConfig = mock(Config.class);
+    Clock mockClock = mock(Clock.class);
+
+    File mockCurrentStoreDir = mock(File.class);
+    when(mockStorageManagerUtil.getTaskStoreDir(eq(mockLoggedStoreBaseDir), eq(store1Name), eq(taskName), any()))
+        .thenReturn(mockCurrentStoreDir);
+    Mockito.when(mockSystemAdmin.offsetComparator(anyString(), anyString()))
+        .thenAnswer((Answer<Integer>) invocation -> {
+            String offset1 = (String) invocation.getArguments()[0];
+            String offset2 = (String) invocation.getArguments()[1];
+            return Long.valueOf(offset1).compareTo(Long.valueOf(offset2));
+          });
+
+    StoreActions storeActions = TransactionalStateTaskRestoreManager.getStoreActions(
+        mockTaskModel, mockStoreEngines, mockStoreChangelogs, mockCheckpointedChangelogOffset,
+        mockCurrentChangelogOffsets, mockSystemAdmins, mockStorageManagerUtil,
+        mockLoggedStoreBaseDir, mockNonLoggedStoreBaseDir, mockConfig, mockClock);
+
+    assertEquals(1, storeActions.storeDirsToDelete.get(store1Name).size());
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockCurrentStoreDir));
+    // ensure that we restore from the oldest changelog offset to checkpointed changelog offset
+    assertEquals("0", storeActions.storesToRestore.get(store1Name).startingOffset);
+    assertEquals(changelog1CheckpointedOffset, storeActions.storesToRestore.get(store1Name).endingOffset);
+  }
+
+  @Test
+  public void testGetStoreActionsForLoggedPersistentStore_RestoreToCheckpointedOffsetIfInvalidStoreCheckpoints() {
+    // in these tests, stale == local offset within range of current oldest and newest, but not equal to checkpointed
+    // invalid == store offset is corrupted / store is stale (older than delete retention) etc.
+    // hence in these tests a store checkpoint can be not-stale yet invalid
+    TaskModel mockTaskModel = mock(TaskModel.class);
+    TaskName taskName = new TaskName("Partition 0");
+    when(mockTaskModel.getTaskName()).thenReturn(taskName);
+    Partition taskChangelogPartition = new Partition(0);
+    when(mockTaskModel.getChangelogPartition()).thenReturn(taskChangelogPartition);
+
+    String store1Name = "store1";
+    StorageEngine store1Engine = mock(StorageEngine.class);
+    StoreProperties mockStore1Properties = mock(StoreProperties.class);
+    when(store1Engine.getStoreProperties()).thenReturn(mockStore1Properties);
+    when(mockStore1Properties.isLoggedStore()).thenReturn(true);
+    when(mockStore1Properties.isPersistedToDisk()).thenReturn(true);
+    Map<String, StorageEngine> mockStoreEngines = ImmutableMap.of(store1Name, store1Engine);
+
+    String changelog1SystemName = "system1";
+    String changelog1StreamName = "store1Changelog";
+    SystemStream changelog1SystemStream = new SystemStream(changelog1SystemName, changelog1StreamName);
+    SystemStreamPartition changelog1SSP = new SystemStreamPartition(changelog1SystemStream, taskChangelogPartition);
+    SystemStreamPartitionMetadata changelog1SSPMetadata = new SystemStreamPartitionMetadata("0", "10", "11");
+    Map<String, SystemStream> mockStoreChangelogs = ImmutableMap.of(store1Name, changelog1SystemStream);
+
+    String changelog1CheckpointedOffset = "5";
+    ImmutableMap<SystemStreamPartition, String> mockCheckpointedChangelogOffset =
+        ImmutableMap.of(changelog1SSP, changelog1CheckpointedOffset);
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> mockCurrentChangelogOffsets =
+        ImmutableMap.of(changelog1SSP, changelog1SSPMetadata);
+
+    SystemAdmins mockSystemAdmins = mock(SystemAdmins.class);
+    SystemAdmin mockSystemAdmin = mock(SystemAdmin.class);
+    when(mockSystemAdmins.getSystemAdmin(changelog1SSP.getSystem())).thenReturn(mockSystemAdmin);
+    StorageManagerUtil mockStorageManagerUtil = mock(StorageManagerUtil.class);
+    File mockLoggedStoreBaseDir = mock(File.class);
+    File mockNonLoggedStoreBaseDir = mock(File.class);
+    Config mockConfig = mock(Config.class);
+    Clock mockClock = mock(Clock.class);
+
+    File mockCurrentStoreDir = mock(File.class);
+    File mockStoreNewerCheckpointDir = mock(File.class);
+    String newerCheckpointDirLocalOffset = "5"; // not stale
+    File mockStoreOlderCheckpointDir = mock(File.class);
+    String olderCheckpointDirLocalOffset = "3";
+    when(mockStorageManagerUtil.getTaskStoreDir(eq(mockLoggedStoreBaseDir), eq(store1Name), eq(taskName), any()))
+        .thenReturn(mockCurrentStoreDir);
+    when(mockStorageManagerUtil.getTaskStoreCheckpointDirs(eq(mockLoggedStoreBaseDir), eq(store1Name), eq(taskName), any()))
+        .thenReturn(ImmutableList.of(mockStoreNewerCheckpointDir, mockStoreOlderCheckpointDir));
+    when(mockStorageManagerUtil.isLoggedStoreValid(eq(store1Name), eq(mockStoreNewerCheckpointDir), any(),
+        eq(mockStoreChangelogs), eq(mockTaskModel), any(), eq(mockStoreEngines))).thenReturn(false); // invalid store
+    when(mockStorageManagerUtil.isLoggedStoreValid(eq(store1Name), eq(mockStoreOlderCheckpointDir), any(),
+        eq(mockStoreChangelogs), eq(mockTaskModel), any(), eq(mockStoreEngines))).thenReturn(false); // invalid store
+    Set<SystemStreamPartition> mockChangelogSSPs = ImmutableSet.of(changelog1SSP);
+    when(mockStorageManagerUtil.readOffsetFile(eq(mockStoreNewerCheckpointDir), eq(mockChangelogSSPs), eq(false)))
+        .thenReturn(ImmutableMap.of(changelog1SSP, newerCheckpointDirLocalOffset));
+    when(mockStorageManagerUtil.readOffsetFile(eq(mockStoreOlderCheckpointDir), eq(mockChangelogSSPs), eq(false)))
+        .thenReturn(ImmutableMap.of(changelog1SSP, olderCheckpointDirLocalOffset)); // less than checkpointed offset (5)
+
+    Mockito.when(mockSystemAdmin.offsetComparator(anyString(), anyString()))
+        .thenAnswer((Answer<Integer>) invocation -> {
+            String offset1 = (String) invocation.getArguments()[0];
+            String offset2 = (String) invocation.getArguments()[1];
+            return Long.valueOf(offset1).compareTo(Long.valueOf(offset2));
+          });
+
+    StoreActions storeActions = TransactionalStateTaskRestoreManager.getStoreActions(
+        mockTaskModel, mockStoreEngines, mockStoreChangelogs, mockCheckpointedChangelogOffset,
+        mockCurrentChangelogOffsets, mockSystemAdmins, mockStorageManagerUtil,
+        mockLoggedStoreBaseDir, mockNonLoggedStoreBaseDir, mockConfig, mockClock);
+
+    // ensure that all current dir and checkpoint dirs are marked for deletion
+    assertEquals(3, storeActions.storeDirsToDelete.get(store1Name).size());
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockCurrentStoreDir));
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockStoreOlderCheckpointDir));
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockStoreNewerCheckpointDir));
+    // ensure that no store checkpoint is marked for retention
+    assertEquals(0, storeActions.storeDirsToRetain.size());
+    // ensure that we mark the store for restore from oldest offset to checkpointed offset
+    assertEquals("0", storeActions.storesToRestore.get(store1Name).startingOffset);
+    assertEquals(changelog1CheckpointedOffset, storeActions.storesToRestore.get(store1Name).endingOffset);
+  }
+
+  @Test
+  public void testGetStoreActionsForLoggedPersistentStore_RestoreDeltaIfStaleStoreCheckpoint() {
+    TaskModel mockTaskModel = mock(TaskModel.class);
+    TaskName taskName = new TaskName("Partition 0");
+    when(mockTaskModel.getTaskName()).thenReturn(taskName);
+    Partition taskChangelogPartition = new Partition(0);
+    when(mockTaskModel.getChangelogPartition()).thenReturn(taskChangelogPartition);
+
+    String store1Name = "store1";
+    StorageEngine store1Engine = mock(StorageEngine.class);
+    StoreProperties mockStore1Properties = mock(StoreProperties.class);
+    when(store1Engine.getStoreProperties()).thenReturn(mockStore1Properties);
+    when(mockStore1Properties.isLoggedStore()).thenReturn(true);
+    when(mockStore1Properties.isPersistedToDisk()).thenReturn(true);
+    Map<String, StorageEngine> mockStoreEngines = ImmutableMap.of(store1Name, store1Engine);
+
+    String changelog1SystemName = "system1";
+    String changelog1StreamName = "store1Changelog";
+    SystemStream changelog1SystemStream = new SystemStream(changelog1SystemName, changelog1StreamName);
+    SystemStreamPartition changelog1SSP = new SystemStreamPartition(changelog1SystemStream, taskChangelogPartition);
+    SystemStreamPartitionMetadata changelog1SSPMetadata = new SystemStreamPartitionMetadata("0", "10", "11");
+    Map<String, SystemStream> mockStoreChangelogs = ImmutableMap.of(store1Name, changelog1SystemStream);
+
+    String changelog1CheckpointedOffset = "5";
+    ImmutableMap<SystemStreamPartition, String> mockCheckpointedChangelogOffset =
+        ImmutableMap.of(changelog1SSP, changelog1CheckpointedOffset);
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> mockCurrentChangelogOffsets =
+        ImmutableMap.of(changelog1SSP, changelog1SSPMetadata);
+
+    SystemAdmins mockSystemAdmins = mock(SystemAdmins.class);
+    SystemAdmin mockSystemAdmin = mock(SystemAdmin.class);
+    when(mockSystemAdmins.getSystemAdmin(changelog1SSP.getSystem())).thenReturn(mockSystemAdmin);
+    StorageManagerUtil mockStorageManagerUtil = mock(StorageManagerUtil.class);
+    File mockLoggedStoreBaseDir = mock(File.class);
+    File mockNonLoggedStoreBaseDir = mock(File.class);
+    Config mockConfig = mock(Config.class);
+    Clock mockClock = mock(Clock.class);
+
+    File mockCurrentStoreDir = mock(File.class);
+    File mockStoreNewerCheckpointDir = mock(File.class);
+    String newerCheckpointDirLocalOffset = "4";
+    File mockStoreOlderCheckpointDir = mock(File.class);
+    String olderCheckpointDirLocalOffset = "3";
+    when(mockStorageManagerUtil.getTaskStoreDir(eq(mockLoggedStoreBaseDir), eq(store1Name), eq(taskName), any()))
+        .thenReturn(mockCurrentStoreDir);
+    when(mockStorageManagerUtil.getTaskStoreCheckpointDirs(eq(mockLoggedStoreBaseDir), eq(store1Name), eq(taskName), any()))
+        .thenReturn(ImmutableList.of(mockStoreNewerCheckpointDir, mockStoreOlderCheckpointDir));
+    when(mockStorageManagerUtil.isLoggedStoreValid(eq(store1Name), eq(mockStoreNewerCheckpointDir), any(),
+        eq(mockStoreChangelogs), eq(mockTaskModel), any(), eq(mockStoreEngines))).thenReturn(true);
+    when(mockStorageManagerUtil.isLoggedStoreValid(eq(store1Name), eq(mockStoreOlderCheckpointDir), any(),
+        eq(mockStoreChangelogs), eq(mockTaskModel), any(), eq(mockStoreEngines))).thenReturn(true);
+    Set<SystemStreamPartition> mockChangelogSSPs = ImmutableSet.of(changelog1SSP);
+    when(mockStorageManagerUtil.readOffsetFile(eq(mockStoreNewerCheckpointDir), eq(mockChangelogSSPs), eq(false)))
+        .thenReturn(ImmutableMap.of(changelog1SSP, newerCheckpointDirLocalOffset));
+    when(mockStorageManagerUtil.readOffsetFile(eq(mockStoreOlderCheckpointDir), eq(mockChangelogSSPs), eq(false)))
+        .thenReturn(ImmutableMap.of(changelog1SSP, olderCheckpointDirLocalOffset)); // less than checkpointed offset (5)
+
+    Mockito.when(mockSystemAdmin.offsetComparator(anyString(), anyString()))
+        .thenAnswer((Answer<Integer>) invocation -> {
+            String offset1 = (String) invocation.getArguments()[0];
+            String offset2 = (String) invocation.getArguments()[1];
+            return Long.valueOf(offset1).compareTo(Long.valueOf(offset2));
+          });
+
+    StoreActions storeActions = TransactionalStateTaskRestoreManager.getStoreActions(
+        mockTaskModel, mockStoreEngines, mockStoreChangelogs, mockCheckpointedChangelogOffset,
+        mockCurrentChangelogOffsets, mockSystemAdmins, mockStorageManagerUtil,
+        mockLoggedStoreBaseDir, mockNonLoggedStoreBaseDir, mockConfig, mockClock);
+
+    // ensure that both the current dir and older stale checkpoint dir are marked for deletion
+    assertEquals(2, storeActions.storeDirsToDelete.get(store1Name).size());
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockCurrentStoreDir));
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockStoreOlderCheckpointDir));
+    // ensure that the newer (but still stale) store checkpoint is marked for retention
+    assertEquals(mockStoreNewerCheckpointDir, storeActions.storeDirsToRetain.get(store1Name));
+    // ensure that we mark the store for restore from newer (but still stale) local offset to checkpointed offset
+    assertEquals(newerCheckpointDirLocalOffset, storeActions.storesToRestore.get(store1Name).startingOffset);
+    assertEquals(changelog1CheckpointedOffset, storeActions.storesToRestore.get(store1Name).endingOffset);
+  }
+
+  @Test
+  public void testGetStoreActionsForLoggedPersistentStore_NoRestoreButTrimIfUpToDateStoreCheckpoint() {
+    TaskModel mockTaskModel = mock(TaskModel.class);
+    TaskName taskName = new TaskName("Partition 0");
+    when(mockTaskModel.getTaskName()).thenReturn(taskName);
+    Partition taskChangelogPartition = new Partition(0);
+    when(mockTaskModel.getChangelogPartition()).thenReturn(taskChangelogPartition);
+
+    String store1Name = "store1";
+    StorageEngine store1Engine = mock(StorageEngine.class);
+    StoreProperties mockStore1Properties = mock(StoreProperties.class);
+    when(store1Engine.getStoreProperties()).thenReturn(mockStore1Properties);
+    when(mockStore1Properties.isLoggedStore()).thenReturn(true);
+    when(mockStore1Properties.isPersistedToDisk()).thenReturn(true);
+    Map<String, StorageEngine> mockStoreEngines = ImmutableMap.of(store1Name, store1Engine);
+
+    String changelog1SystemName = "system1";
+    String changelog1StreamName = "store1Changelog";
+    SystemStream changelog1SystemStream = new SystemStream(changelog1SystemName, changelog1StreamName);
+    SystemStreamPartition changelog1SSP = new SystemStreamPartition(changelog1SystemStream, taskChangelogPartition);
+    SystemStreamPartitionMetadata changelog1SSPMetadata = new SystemStreamPartitionMetadata("0", "10", "11");
+    Map<String, SystemStream> mockStoreChangelogs = ImmutableMap.of(store1Name, changelog1SystemStream);
+
+    String changelog1CheckpointedOffset = "5";
+    ImmutableMap<SystemStreamPartition, String> mockCheckpointedChangelogOffset =
+        ImmutableMap.of(changelog1SSP, changelog1CheckpointedOffset);
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> mockCurrentChangelogOffsets =
+        ImmutableMap.of(changelog1SSP, changelog1SSPMetadata);
+
+    SystemAdmins mockSystemAdmins = mock(SystemAdmins.class);
+    SystemAdmin mockSystemAdmin = mock(SystemAdmin.class);
+    when(mockSystemAdmins.getSystemAdmin(changelog1SSP.getSystem())).thenReturn(mockSystemAdmin);
+    StorageManagerUtil mockStorageManagerUtil = mock(StorageManagerUtil.class);
+    File mockLoggedStoreBaseDir = mock(File.class);
+    File mockNonLoggedStoreBaseDir = mock(File.class);
+    Config mockConfig = mock(Config.class);
+    Clock mockClock = mock(Clock.class);
+
+    File mockCurrentStoreDir = mock(File.class);
+    File mockStoreUpToDateCheckpointDir = mock(File.class);
+    File mockStoreOlderCheckpointDir = mock(File.class);
+    when(mockStorageManagerUtil.getTaskStoreDir(eq(mockLoggedStoreBaseDir), eq(store1Name), eq(taskName), any()))
+        .thenReturn(mockCurrentStoreDir);
+    when(mockStorageManagerUtil.getTaskStoreCheckpointDirs(eq(mockLoggedStoreBaseDir), eq(store1Name), eq(taskName), any()))
+        .thenReturn(ImmutableList.of(mockStoreUpToDateCheckpointDir, mockStoreOlderCheckpointDir));
+    when(mockStorageManagerUtil.isLoggedStoreValid(eq(store1Name), eq(mockStoreUpToDateCheckpointDir), any(),
+        eq(mockStoreChangelogs), eq(mockTaskModel), any(), eq(mockStoreEngines))).thenReturn(true);
+    when(mockStorageManagerUtil.isLoggedStoreValid(eq(store1Name), eq(mockStoreOlderCheckpointDir), any(),
+        eq(mockStoreChangelogs), eq(mockTaskModel), any(), eq(mockStoreEngines))).thenReturn(true);
+    Set<SystemStreamPartition> mockChangelogSSPs = ImmutableSet.of(changelog1SSP);
+    when(mockStorageManagerUtil.readOffsetFile(eq(mockStoreUpToDateCheckpointDir), eq(mockChangelogSSPs), eq(false)))
+        .thenReturn(ImmutableMap.of(changelog1SSP, changelog1CheckpointedOffset));
+    when(mockStorageManagerUtil.readOffsetFile(eq(mockStoreOlderCheckpointDir), eq(mockChangelogSSPs), eq(false)))
+        .thenReturn(ImmutableMap.of(changelog1SSP, "3")); // less than checkpointed offset (5)
+
+    Mockito.when(mockSystemAdmin.offsetComparator(anyString(), anyString()))
+        .thenAnswer((Answer<Integer>) invocation -> {
+            String offset1 = (String) invocation.getArguments()[0];
+            String offset2 = (String) invocation.getArguments()[1];
+            return Long.valueOf(offset1).compareTo(Long.valueOf(offset2));
+          });
+
+    StoreActions storeActions = TransactionalStateTaskRestoreManager.getStoreActions(
+        mockTaskModel, mockStoreEngines, mockStoreChangelogs, mockCheckpointedChangelogOffset,
+        mockCurrentChangelogOffsets, mockSystemAdmins, mockStorageManagerUtil,
+        mockLoggedStoreBaseDir, mockNonLoggedStoreBaseDir, mockConfig, mockClock);
+
+    // ensure that both the current dir and older checkpoint dir are marked for deletion
+    assertEquals(2, storeActions.storeDirsToDelete.get(store1Name).size());
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockCurrentStoreDir));
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockStoreOlderCheckpointDir));
+    // ensure that the up-to-date store checkpoint is marked for retention
+    assertEquals(mockStoreUpToDateCheckpointDir, storeActions.storeDirsToRetain.get(store1Name));
+    // ensure that we mark the store for restore even if local offset == checkpointed offset
+    // this is required even if there are no messages to restore, since there may be message we need to trim
+    assertEquals(changelog1CheckpointedOffset, storeActions.storesToRestore.get(store1Name).startingOffset);
+    assertEquals(changelog1CheckpointedOffset, storeActions.storesToRestore.get(store1Name).endingOffset);
+  }
+
+  @Test
+  public void testGetStoreActionsForLoggedPersistentStore_FullRestoreIfNullCheckpointedOffsetAndRetainExistingState() {
+    TaskModel mockTaskModel = mock(TaskModel.class);
+    TaskName taskName = new TaskName("Partition 0");
+    when(mockTaskModel.getTaskName()).thenReturn(taskName);
+    Partition taskChangelogPartition = new Partition(0);
+    when(mockTaskModel.getChangelogPartition()).thenReturn(taskChangelogPartition);
+
+    String store1Name = "store1";
+    StorageEngine store1Engine = mock(StorageEngine.class);
+    StoreProperties mockStore1Properties = mock(StoreProperties.class);
+    when(store1Engine.getStoreProperties()).thenReturn(mockStore1Properties);
+    when(mockStore1Properties.isLoggedStore()).thenReturn(true);
+    when(mockStore1Properties.isPersistedToDisk()).thenReturn(true);
+    Map<String, StorageEngine> mockStoreEngines = ImmutableMap.of(store1Name, store1Engine);
+
+    String changelog1SystemName = "system1";
+    String changelog1StreamName = "store1Changelog";
+    SystemStream changelog1SystemStream = new SystemStream(changelog1SystemName, changelog1StreamName);
+    SystemStreamPartition changelog1SSP = new SystemStreamPartition(changelog1SystemStream, taskChangelogPartition);
+    SystemStreamPartitionMetadata changelog1SSPMetadata = new SystemStreamPartitionMetadata("0", "10", "11");
+    Map<String, SystemStream> mockStoreChangelogs = ImmutableMap.of(store1Name, changelog1SystemStream);
+
+    String changelog1CheckpointedOffset = null;
+    Map<SystemStreamPartition, String> mockCheckpointedChangelogOffset =
+        new HashMap<SystemStreamPartition, String>() { {
+          put(changelog1SSP, changelog1CheckpointedOffset);
+        } };
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> mockCurrentChangelogOffsets =
+        ImmutableMap.of(changelog1SSP, changelog1SSPMetadata);
+
+    SystemAdmins mockSystemAdmins = mock(SystemAdmins.class);
+    SystemAdmin mockSystemAdmin = mock(SystemAdmin.class);
+    when(mockSystemAdmins.getSystemAdmin(changelog1SSP.getSystem())).thenReturn(mockSystemAdmin);
+    StorageManagerUtil mockStorageManagerUtil = mock(StorageManagerUtil.class);
+    File mockLoggedStoreBaseDir = mock(File.class);
+    File mockNonLoggedStoreBaseDir = mock(File.class);
+    HashMap<String, String> configMap = new HashMap<>();
+    configMap.put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE, "true");
+    Config mockConfig = new MapConfig(configMap);
+    Clock mockClock = mock(Clock.class);
+
+    File mockCurrentStoreDir = mock(File.class);
+    File mockStoreNewerCheckpointDir = mock(File.class);
+    File mockStoreOlderCheckpointDir = mock(File.class);
+    String olderCheckpointDirLocalOffset = "3";
+    String newerCheckpointDirLocalOffset = "5";
+    when(mockStorageManagerUtil.getTaskStoreDir(eq(mockLoggedStoreBaseDir), eq(store1Name), eq(taskName), any()))
+        .thenReturn(mockCurrentStoreDir);
+    when(mockStorageManagerUtil.getTaskStoreCheckpointDirs(eq(mockLoggedStoreBaseDir), eq(store1Name), eq(taskName), any()))
+        .thenReturn(ImmutableList.of(mockStoreNewerCheckpointDir, mockStoreOlderCheckpointDir));
+    when(mockStorageManagerUtil.isLoggedStoreValid(eq(store1Name), eq(mockStoreNewerCheckpointDir), any(),
+        eq(mockStoreChangelogs), eq(mockTaskModel), any(), eq(mockStoreEngines))).thenReturn(true);
+    when(mockStorageManagerUtil.isLoggedStoreValid(eq(store1Name), eq(mockStoreOlderCheckpointDir), any(),
+        eq(mockStoreChangelogs), eq(mockTaskModel), any(), eq(mockStoreEngines))).thenReturn(true);
+    Set<SystemStreamPartition> mockChangelogSSPs = ImmutableSet.of(changelog1SSP);
+    when(mockStorageManagerUtil.readOffsetFile(eq(mockStoreNewerCheckpointDir), eq(mockChangelogSSPs), eq(false)))
+        .thenReturn(ImmutableMap.of(changelog1SSP, newerCheckpointDirLocalOffset));
+    when(mockStorageManagerUtil.readOffsetFile(eq(mockStoreOlderCheckpointDir), eq(mockChangelogSSPs), eq(false)))
+        .thenReturn(ImmutableMap.of(changelog1SSP, olderCheckpointDirLocalOffset)); // less than checkpointed offset (5)
+
+    Mockito.when(mockSystemAdmin.offsetComparator(anyString(), anyString()))
+        .thenAnswer((Answer<Integer>) invocation -> {
+            String offset1 = (String) invocation.getArguments()[0];
+            String offset2 = (String) invocation.getArguments()[1];
+            return Long.valueOf(offset1).compareTo(Long.valueOf(offset2));
+          });
+
+    StoreActions storeActions = TransactionalStateTaskRestoreManager.getStoreActions(
+        mockTaskModel, mockStoreEngines, mockStoreChangelogs, mockCheckpointedChangelogOffset,
+        mockCurrentChangelogOffsets, mockSystemAdmins, mockStorageManagerUtil,
+        mockLoggedStoreBaseDir, mockNonLoggedStoreBaseDir, mockConfig, mockClock);
+
+    // ensure that all the store dirs (current or checkpoint) are marked for deletion
+    assertEquals(3, storeActions.storeDirsToDelete.get(store1Name).size());
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockCurrentStoreDir));
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockStoreOlderCheckpointDir));
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockStoreNewerCheckpointDir));
+    // ensure that no directories are retained
+    assertEquals(0, storeActions.storeDirsToRetain.size());
+    // ensure that we mark the store for full restore (from oldest to newest)
+    assertEquals("0", storeActions.storesToRestore.get(store1Name).startingOffset);
+    assertEquals("10", storeActions.storesToRestore.get(store1Name).endingOffset);
+  }
+
+  @Test
+  public void testGetStoreActionsForLoggedPersistentStore_FullTrimIfNullCheckpointedOffsetAndNotRetainExistingState() {
+    TaskModel mockTaskModel = mock(TaskModel.class);
+    TaskName taskName = new TaskName("Partition 0");
+    when(mockTaskModel.getTaskName()).thenReturn(taskName);
+    Partition taskChangelogPartition = new Partition(0);
+    when(mockTaskModel.getChangelogPartition()).thenReturn(taskChangelogPartition);
+
+    String store1Name = "store1";
+    StorageEngine store1Engine = mock(StorageEngine.class);
+    StoreProperties mockStore1Properties = mock(StoreProperties.class);
+    when(store1Engine.getStoreProperties()).thenReturn(mockStore1Properties);
+    when(mockStore1Properties.isLoggedStore()).thenReturn(true);
+    when(mockStore1Properties.isPersistedToDisk()).thenReturn(true);
+    Map<String, StorageEngine> mockStoreEngines = ImmutableMap.of(store1Name, store1Engine);
+
+    String changelog1SystemName = "system1";
+    String changelog1StreamName = "store1Changelog";
+    SystemStream changelog1SystemStream = new SystemStream(changelog1SystemName, changelog1StreamName);
+    SystemStreamPartition changelog1SSP = new SystemStreamPartition(changelog1SystemStream, taskChangelogPartition);
+    SystemStreamPartitionMetadata changelog1SSPMetadata = new SystemStreamPartitionMetadata("0", "10", "11");
+    Map<String, SystemStream> mockStoreChangelogs = ImmutableMap.of(store1Name, changelog1SystemStream);
+
+    String changelog1CheckpointedOffset = null;
+    Map<SystemStreamPartition, String> mockCheckpointedChangelogOffset =
+        new HashMap<SystemStreamPartition, String>() { {
+          put(changelog1SSP, changelog1CheckpointedOffset);
+        } };
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> mockCurrentChangelogOffsets =
+        ImmutableMap.of(changelog1SSP, changelog1SSPMetadata);
+
+    SystemAdmins mockSystemAdmins = mock(SystemAdmins.class);
+    SystemAdmin mockSystemAdmin = mock(SystemAdmin.class);
+    when(mockSystemAdmins.getSystemAdmin(changelog1SSP.getSystem())).thenReturn(mockSystemAdmin);
+    StorageManagerUtil mockStorageManagerUtil = mock(StorageManagerUtil.class);
+    File mockLoggedStoreBaseDir = mock(File.class);
+    File mockNonLoggedStoreBaseDir = mock(File.class);
+    HashMap<String, String> configMap = new HashMap<>();
+    configMap.put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE, "false");
+    Config mockConfig = new MapConfig(configMap);
+    Clock mockClock = mock(Clock.class);
+
+    File mockCurrentStoreDir = mock(File.class);
+    File mockStoreNewerCheckpointDir = mock(File.class);
+    File mockStoreOlderCheckpointDir = mock(File.class);
+    String olderCheckpointDirLocalOffset = "3";
+    String newerCheckpointDirLocalOffset = "5";
+    when(mockStorageManagerUtil.getTaskStoreDir(eq(mockLoggedStoreBaseDir), eq(store1Name), eq(taskName), any()))
+        .thenReturn(mockCurrentStoreDir);
+    when(mockStorageManagerUtil.getTaskStoreCheckpointDirs(eq(mockLoggedStoreBaseDir), eq(store1Name), eq(taskName), any()))
+        .thenReturn(ImmutableList.of(mockStoreNewerCheckpointDir, mockStoreOlderCheckpointDir));
+    when(mockStorageManagerUtil.isLoggedStoreValid(eq(store1Name), eq(mockStoreNewerCheckpointDir), any(),
+        eq(mockStoreChangelogs), eq(mockTaskModel), any(), eq(mockStoreEngines))).thenReturn(true);
+    when(mockStorageManagerUtil.isLoggedStoreValid(eq(store1Name), eq(mockStoreOlderCheckpointDir), any(),
+        eq(mockStoreChangelogs), eq(mockTaskModel), any(), eq(mockStoreEngines))).thenReturn(true);
+    Set<SystemStreamPartition> mockChangelogSSPs = ImmutableSet.of(changelog1SSP);
+    when(mockStorageManagerUtil.readOffsetFile(eq(mockStoreNewerCheckpointDir), eq(mockChangelogSSPs), eq(false)))
+        .thenReturn(ImmutableMap.of(changelog1SSP, newerCheckpointDirLocalOffset));
+    when(mockStorageManagerUtil.readOffsetFile(eq(mockStoreOlderCheckpointDir), eq(mockChangelogSSPs), eq(false)))
+        .thenReturn(ImmutableMap.of(changelog1SSP, olderCheckpointDirLocalOffset)); // less than checkpointed offset (5)
+
+    Mockito.when(mockSystemAdmin.offsetComparator(anyString(), anyString()))
+        .thenAnswer((Answer<Integer>) invocation -> {
+            String offset1 = (String) invocation.getArguments()[0];
+            String offset2 = (String) invocation.getArguments()[1];
+            return Long.valueOf(offset1).compareTo(Long.valueOf(offset2));
+          });
+
+    StoreActions storeActions = TransactionalStateTaskRestoreManager.getStoreActions(
+        mockTaskModel, mockStoreEngines, mockStoreChangelogs, mockCheckpointedChangelogOffset,
+        mockCurrentChangelogOffsets, mockSystemAdmins, mockStorageManagerUtil,
+        mockLoggedStoreBaseDir, mockNonLoggedStoreBaseDir, mockConfig, mockClock);
+
+    // ensure that all the store dirs (current or checkpoint) are marked for deletion
+    assertEquals(3, storeActions.storeDirsToDelete.get(store1Name).size());
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockCurrentStoreDir));
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockStoreOlderCheckpointDir));
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockStoreNewerCheckpointDir));
+    // ensure that no directories are retained
+    assertEquals(0, storeActions.storeDirsToRetain.size());
+    // ensure that we mark the store for restore (full trim == restore from oldest to null)
+    assertEquals("0", storeActions.storesToRestore.get(store1Name).startingOffset);
+    assertNull(storeActions.storesToRestore.get(store1Name).endingOffset);
+  }
+
+  @Test
+  public void testGetStoreActionsForLoggedPersistentStore_FullRestoreIfCheckpointedOffsetOlderThanOldest() {
+    TaskModel mockTaskModel = mock(TaskModel.class);
+    TaskName taskName = new TaskName("Partition 0");
+    when(mockTaskModel.getTaskName()).thenReturn(taskName);
+    Partition taskChangelogPartition = new Partition(0);
+    when(mockTaskModel.getChangelogPartition()).thenReturn(taskChangelogPartition);
+
+    String store1Name = "store1";
+    StorageEngine store1Engine = mock(StorageEngine.class);
+    StoreProperties mockStore1Properties = mock(StoreProperties.class);
+    when(store1Engine.getStoreProperties()).thenReturn(mockStore1Properties);
+    when(mockStore1Properties.isLoggedStore()).thenReturn(true);
+    when(mockStore1Properties.isPersistedToDisk()).thenReturn(true);
+    Map<String, StorageEngine> mockStoreEngines = ImmutableMap.of(store1Name, store1Engine);
+
+    String changelog1SystemName = "system1";
+    String changelog1StreamName = "store1Changelog";
+    SystemStream changelog1SystemStream = new SystemStream(changelog1SystemName, changelog1StreamName);
+    SystemStreamPartition changelog1SSP = new SystemStreamPartition(changelog1SystemStream, taskChangelogPartition);
+    // oldest offset > checkpointed changelog offset
+    SystemStreamPartitionMetadata changelog1SSPMetadata = new SystemStreamPartitionMetadata("11", "20", "21");
+    Map<String, SystemStream> mockStoreChangelogs = ImmutableMap.of(store1Name, changelog1SystemStream);
+
+    String changelog1CheckpointedOffset = "5";
+    Map<SystemStreamPartition, String> mockCheckpointedChangelogOffset =
+        new HashMap<SystemStreamPartition, String>() { {
+          put(changelog1SSP, changelog1CheckpointedOffset);
+        } };
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> mockCurrentChangelogOffsets =
+        ImmutableMap.of(changelog1SSP, changelog1SSPMetadata);
+
+    SystemAdmins mockSystemAdmins = mock(SystemAdmins.class);
+    SystemAdmin mockSystemAdmin = mock(SystemAdmin.class);
+    when(mockSystemAdmins.getSystemAdmin(changelog1SSP.getSystem())).thenReturn(mockSystemAdmin);
+    StorageManagerUtil mockStorageManagerUtil = mock(StorageManagerUtil.class);
+    File mockLoggedStoreBaseDir = mock(File.class);
+    File mockNonLoggedStoreBaseDir = mock(File.class);
+    Config mockConfig = mock(Config.class);
+    Clock mockClock = mock(Clock.class);
+
+    File mockCurrentStoreDir = mock(File.class);
+    File mockStoreNewerCheckpointDir = mock(File.class);
+    File mockStoreOlderCheckpointDir = mock(File.class);
+    String olderCheckpointDirLocalOffset = "3";
+    String newerCheckpointDirLocalOffset = "5";
+    when(mockStorageManagerUtil.getTaskStoreDir(eq(mockLoggedStoreBaseDir), eq(store1Name), eq(taskName), any()))
+        .thenReturn(mockCurrentStoreDir);
+    when(mockStorageManagerUtil.getTaskStoreCheckpointDirs(eq(mockLoggedStoreBaseDir), eq(store1Name), eq(taskName), any()))
+        .thenReturn(ImmutableList.of(mockStoreNewerCheckpointDir, mockStoreOlderCheckpointDir));
+    when(mockStorageManagerUtil.isLoggedStoreValid(eq(store1Name), eq(mockStoreNewerCheckpointDir), any(),
+        eq(mockStoreChangelogs), eq(mockTaskModel), any(), eq(mockStoreEngines))).thenReturn(true);
+    when(mockStorageManagerUtil.isLoggedStoreValid(eq(store1Name), eq(mockStoreOlderCheckpointDir), any(),
+        eq(mockStoreChangelogs), eq(mockTaskModel), any(), eq(mockStoreEngines))).thenReturn(true);
+    Set<SystemStreamPartition> mockChangelogSSPs = ImmutableSet.of(changelog1SSP);
+    when(mockStorageManagerUtil.readOffsetFile(eq(mockStoreNewerCheckpointDir), eq(mockChangelogSSPs), eq(false)))
+        .thenReturn(ImmutableMap.of(changelog1SSP, newerCheckpointDirLocalOffset));
+    when(mockStorageManagerUtil.readOffsetFile(eq(mockStoreOlderCheckpointDir), eq(mockChangelogSSPs), eq(false)))
+        .thenReturn(ImmutableMap.of(changelog1SSP, olderCheckpointDirLocalOffset)); // less than checkpointed offset (5)
+
+    Mockito.when(mockSystemAdmin.offsetComparator(anyString(), anyString()))
+        .thenAnswer((Answer<Integer>) invocation -> {
+            String offset1 = (String) invocation.getArguments()[0];
+            String offset2 = (String) invocation.getArguments()[1];
+            return Long.valueOf(offset1).compareTo(Long.valueOf(offset2));
+          });
+
+    StoreActions storeActions = TransactionalStateTaskRestoreManager.getStoreActions(
+        mockTaskModel, mockStoreEngines, mockStoreChangelogs, mockCheckpointedChangelogOffset,
+        mockCurrentChangelogOffsets, mockSystemAdmins, mockStorageManagerUtil,
+        mockLoggedStoreBaseDir, mockNonLoggedStoreBaseDir, mockConfig, mockClock);
+
+    // ensure that all the store dirs (current or checkpoint) are marked for deletion
+    assertEquals(3, storeActions.storeDirsToDelete.get(store1Name).size());
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockCurrentStoreDir));
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockStoreOlderCheckpointDir));
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockStoreNewerCheckpointDir));
+    // ensure that no directories are retained
+    assertEquals(0, storeActions.storeDirsToRetain.size());
+    // ensure that we mark the store for full restore (from current oldest to current newest)
+    assertEquals("11", storeActions.storesToRestore.get(store1Name).startingOffset);
+    assertEquals("20", storeActions.storesToRestore.get(store1Name).endingOffset);
+  }
+
+  @Test
+  public void testGetStoreActionsForLoggedPersistentStore_FullRestoreIfCheckpointedOffsetNewerThanNewest() {
+    TaskModel mockTaskModel = mock(TaskModel.class);
+    TaskName taskName = new TaskName("Partition 0");
+    when(mockTaskModel.getTaskName()).thenReturn(taskName);
+    Partition taskChangelogPartition = new Partition(0);
+    when(mockTaskModel.getChangelogPartition()).thenReturn(taskChangelogPartition);
+
+    String store1Name = "store1";
+    StorageEngine store1Engine = mock(StorageEngine.class);
+    StoreProperties mockStore1Properties = mock(StoreProperties.class);
+    when(store1Engine.getStoreProperties()).thenReturn(mockStore1Properties);
+    when(mockStore1Properties.isLoggedStore()).thenReturn(true);
+    when(mockStore1Properties.isPersistedToDisk()).thenReturn(true);
+    Map<String, StorageEngine> mockStoreEngines = ImmutableMap.of(store1Name, store1Engine);
+
+    String changelog1SystemName = "system1";
+    String changelog1StreamName = "store1Changelog";
+    SystemStream changelog1SystemStream = new SystemStream(changelog1SystemName, changelog1StreamName);
+    SystemStreamPartition changelog1SSP = new SystemStreamPartition(changelog1SystemStream, taskChangelogPartition);
+    // checkpointed changelog offset > newest offset (e.g. changelog topic got changed)
+    SystemStreamPartitionMetadata changelog1SSPMetadata = new SystemStreamPartitionMetadata("0", "10", "11");
+    Map<String, SystemStream> mockStoreChangelogs = ImmutableMap.of(store1Name, changelog1SystemStream);
+
+    String changelog1CheckpointedOffset = "21";
+    Map<SystemStreamPartition, String> mockCheckpointedChangelogOffset =
+        new HashMap<SystemStreamPartition, String>() { {
+          put(changelog1SSP, changelog1CheckpointedOffset);
+        } };
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> mockCurrentChangelogOffsets =
+        ImmutableMap.of(changelog1SSP, changelog1SSPMetadata);
+
+    SystemAdmins mockSystemAdmins = mock(SystemAdmins.class);
+    SystemAdmin mockSystemAdmin = mock(SystemAdmin.class);
+    when(mockSystemAdmins.getSystemAdmin(changelog1SSP.getSystem())).thenReturn(mockSystemAdmin);
+    StorageManagerUtil mockStorageManagerUtil = mock(StorageManagerUtil.class);
+    File mockLoggedStoreBaseDir = mock(File.class);
+    File mockNonLoggedStoreBaseDir = mock(File.class);
+    Config mockConfig = mock(Config.class);
+    Clock mockClock = mock(Clock.class);
+
+    File mockCurrentStoreDir = mock(File.class);
+    File mockStoreNewerCheckpointDir = mock(File.class);
+    File mockStoreOlderCheckpointDir = mock(File.class);
+    String olderCheckpointDirLocalOffset = "5";
+    String newerCheckpointDirLocalOffset = "15";
+    when(mockStorageManagerUtil.getTaskStoreDir(eq(mockLoggedStoreBaseDir), eq(store1Name), eq(taskName), any()))
+        .thenReturn(mockCurrentStoreDir);
+    when(mockStorageManagerUtil.getTaskStoreCheckpointDirs(eq(mockLoggedStoreBaseDir), eq(store1Name), eq(taskName), any()))
+        .thenReturn(ImmutableList.of(mockStoreNewerCheckpointDir, mockStoreOlderCheckpointDir));
+    when(mockStorageManagerUtil.isLoggedStoreValid(eq(store1Name), eq(mockStoreNewerCheckpointDir), any(),
+        eq(mockStoreChangelogs), eq(mockTaskModel), any(), eq(mockStoreEngines))).thenReturn(true);
+    when(mockStorageManagerUtil.isLoggedStoreValid(eq(store1Name), eq(mockStoreOlderCheckpointDir), any(),
+        eq(mockStoreChangelogs), eq(mockTaskModel), any(), eq(mockStoreEngines))).thenReturn(true);
+    Set<SystemStreamPartition> mockChangelogSSPs = ImmutableSet.of(changelog1SSP);
+    when(mockStorageManagerUtil.readOffsetFile(eq(mockStoreNewerCheckpointDir), eq(mockChangelogSSPs), eq(false)))
+        .thenReturn(ImmutableMap.of(changelog1SSP, newerCheckpointDirLocalOffset));
+    when(mockStorageManagerUtil.readOffsetFile(eq(mockStoreOlderCheckpointDir), eq(mockChangelogSSPs), eq(false)))
+        .thenReturn(ImmutableMap.of(changelog1SSP, olderCheckpointDirLocalOffset)); // less than checkpointed offset (5)
+
+    Mockito.when(mockSystemAdmin.offsetComparator(anyString(), anyString()))
+        .thenAnswer((Answer<Integer>) invocation -> {
+            String offset1 = (String) invocation.getArguments()[0];
+            String offset2 = (String) invocation.getArguments()[1];
+            return Long.valueOf(offset1).compareTo(Long.valueOf(offset2));
+          });
+
+    StoreActions storeActions = TransactionalStateTaskRestoreManager.getStoreActions(
+        mockTaskModel, mockStoreEngines, mockStoreChangelogs, mockCheckpointedChangelogOffset,
+        mockCurrentChangelogOffsets, mockSystemAdmins, mockStorageManagerUtil,
+        mockLoggedStoreBaseDir, mockNonLoggedStoreBaseDir, mockConfig, mockClock);
+
+    // ensure that all the store dirs (current or checkpoint) are marked for deletion
+    assertEquals(3, storeActions.storeDirsToDelete.get(store1Name).size());
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockCurrentStoreDir));
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockStoreOlderCheckpointDir));
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockStoreNewerCheckpointDir));
+    // ensure that no directories are retained
+    assertEquals(0, storeActions.storeDirsToRetain.size());
+    // ensure that we mark the store for full restore (from current oldest to current newest)
+    assertEquals("0", storeActions.storesToRestore.get(store1Name).startingOffset);
+    assertEquals("10", storeActions.storesToRestore.get(store1Name).endingOffset);
+  }
+
+  @Test
+  public void testSetupStoreDirs() {
+    TaskModel mockTaskModel = mock(TaskModel.class);
+    TaskName taskName = new TaskName("Partition 0");
+    when(mockTaskModel.getTaskName()).thenReturn(taskName);
+    Partition taskChangelogPartition = new Partition(0);
+    when(mockTaskModel.getChangelogPartition()).thenReturn(taskChangelogPartition);
+
+    String store1Name = "store1";
+    StorageEngine store1Engine = mock(StorageEngine.class);
+    StoreProperties mockStore1Properties = mock(StoreProperties.class);
+    when(store1Engine.getStoreProperties()).thenReturn(mockStore1Properties);
+    when(mockStore1Properties.isLoggedStore()).thenReturn(true);
+    when(mockStore1Properties.isPersistedToDisk()).thenReturn(true);
+    String store2Name = "store2";
+    StorageEngine store2Engine = mock(StorageEngine.class);
+    StoreProperties mockStore2Properties = mock(StoreProperties.class);
+    when(store2Engine.getStoreProperties()).thenReturn(mockStore2Properties);
+    when(mockStore2Properties.isLoggedStore()).thenReturn(false); // non-logged store
+    when(mockStore2Properties.isPersistedToDisk()).thenReturn(true);
+
+    Map<String, StorageEngine> mockStoreEngines = ImmutableMap.of(
+        store1Name, store1Engine,
+        store2Name, store2Engine);
+
+    File mockStore1DirToRetain = mock(File.class);
+    // there will be no dir to retain for non-logged persistent stores
+    ImmutableMap<String, File> storeDirsToRetain = ImmutableMap.of(store1Name, mockStore1DirToRetain);
+    ListMultimap<String, File> storeDirsToDelete = ArrayListMultimap.create();
+    File mockStore1CurrentDir = mock(File.class);
+    Path mockStore1CurrentDirPath = mock(Path.class);
+    when(mockStore1CurrentDir.toPath()).thenReturn(mockStore1CurrentDirPath);
+    File mockStore2CurrentDir = mock(File.class);
+    Path mockStore2CurrentDirPath = mock(Path.class);
+    when(mockStore2CurrentDir.toPath()).thenReturn(mockStore2CurrentDirPath);
+    File mockStore1DirToDelete1 = mock(File.class);
+    File mockStore1DirToDelete2 = mock(File.class);
+    File mockStore2DirToDelete1 = mock(File.class);
+    File mockStore2DirToDelete2 = mock(File.class);
+    storeDirsToDelete.put(store1Name, mockStore1CurrentDir);
+    storeDirsToDelete.put(store1Name, mockStore1DirToDelete1);
+    storeDirsToDelete.put(store1Name, mockStore1DirToDelete2);
+    storeDirsToDelete.put(store2Name, mockStore2CurrentDir);
+    storeDirsToDelete.put(store2Name, mockStore2DirToDelete1);
+    storeDirsToDelete.put(store2Name, mockStore2DirToDelete2);
+
+    StoreActions storeActions = new StoreActions(storeDirsToRetain, storeDirsToDelete, ImmutableMap.of());
+    StorageManagerUtil mockStorageManagerUtil = mock(StorageManagerUtil.class);
+    FileUtil mockFileUtil = mock(FileUtil.class);
+    File mockLoggedStoreBaseDir = mock(File.class);
+    File mockNonLoggedStoreBaseDir = mock(File.class);
+
+    when(mockStorageManagerUtil.getTaskStoreDir(eq(mockLoggedStoreBaseDir), eq(store1Name), any(), any()))
+        .thenReturn(mockStore1CurrentDir);
+    when(mockStorageManagerUtil.getTaskStoreDir(eq(mockNonLoggedStoreBaseDir), eq(store2Name), any(), any()))
+        .thenReturn(mockStore2CurrentDir);
+    when(mockFileUtil.exists(eq(mockStore1CurrentDirPath)))
+        .thenReturn(false);
+    when(mockFileUtil.exists(eq(mockStore2CurrentDirPath)))
+        .thenReturn(true); // will not be true in reality since current dir is always cleared, but return true for testing
+
+    TransactionalStateTaskRestoreManager.setupStoreDirs(mockTaskModel, mockStoreEngines, storeActions,
+        mockStorageManagerUtil, mockFileUtil, mockLoggedStoreBaseDir, mockNonLoggedStoreBaseDir);
+
+    // verify that store directories to delete are deleted
+    verify(mockFileUtil, times(1)).rm(mockStore1CurrentDir);
+    verify(mockFileUtil, times(1)).rm(mockStore1DirToDelete1);
+    verify(mockFileUtil, times(1)).rm(mockStore1DirToDelete2);
+    verify(mockFileUtil, times(1)).rm(mockStore2CurrentDir);
+    verify(mockFileUtil, times(1)).rm(mockStore2DirToDelete1);
+    verify(mockFileUtil, times(1)).rm(mockStore2DirToDelete2);
+
+    // verify that store checkpoint directories to retain are moved to (empty) current dirs only for store 1
+    // setupStoreDirs doesn't guarantee that the dir is empty by itself, but the dir will be part of dirs to delete.
+    verify(mockStorageManagerUtil, times(1)).moveCheckpointFiles(any(), any());
+    verify(mockFileUtil, times(1)).exists(mockStore1CurrentDirPath);
+    verify(mockFileUtil, times(1)).createDirectories(mockStore1CurrentDirPath);
+    verify(mockFileUtil, times(1)).exists(mockStore2CurrentDirPath);
+    verify(mockFileUtil, never()).createDirectories(mockStore2CurrentDirPath); // should not be called since exists == true
+
+    verifyNoMoreInteractions(mockFileUtil);
+  }
+
+  @Test
+  public void testRegisterStartingOffsets() {
+    TaskModel mockTaskModel = mock(TaskModel.class);
+    TaskName taskName = new TaskName("Partition 0");
+    when(mockTaskModel.getTaskName()).thenReturn(taskName);
+    Partition taskChangelogPartition = new Partition(0);
+    when(mockTaskModel.getChangelogPartition()).thenReturn(taskChangelogPartition);
+
+    String store1Name = "store1";
+    String changelogSystemName = "system";
+    String changelog1StreamName = "store1Changelog";
+    String store2Name = "store2";
+    String changelog2StreamName = "store2Changelog";
+    String store3Name = "store3";
+    String changelog3StreamName = "store3Changelog";
+    String store4Name = "store4";
+    String changelog4StreamName = "store4Changelog";
+
+    // tests restore for store 1 and store 2 but not store 3
+    Map<String, RestoreOffsets> mockRestoreOffsets = ImmutableMap.of(
+        store1Name, new RestoreOffsets("0", "5"), // tests starting offset == oldest (i.e. restore is inclusive)
+        store2Name, new RestoreOffsets("15", "20"), // tests starting offset != oldest (i.e. restore from next offset)
+        store4Name, new RestoreOffsets("31", null)); // tests that null ending offsets are OK (should trim)
+    StoreActions mockStoreActions = new StoreActions(ImmutableMap.of(), ArrayListMultimap.create(), mockRestoreOffsets);
+
+
+    SystemStream changelog1SystemStream = new SystemStream(changelogSystemName, changelog1StreamName);
+    SystemStream changelog2SystemStream = new SystemStream(changelogSystemName, changelog2StreamName);
+    SystemStream changelog3SystemStream = new SystemStream(changelogSystemName, changelog3StreamName);
+    SystemStream changelog4SystemStream = new SystemStream(changelogSystemName, changelog4StreamName);
+
+    Map<String, SystemStream> mockStoreChangelogs = ImmutableMap.of(
+        store1Name, changelog1SystemStream,
+        store2Name, changelog2SystemStream,
+        store3Name, changelog3SystemStream,
+        store4Name, changelog4SystemStream);
+
+    SystemStreamPartition changelog1SSP = new SystemStreamPartition(changelog1SystemStream, taskChangelogPartition);
+    SystemStreamPartitionMetadata changelog1SSPMetadata = new SystemStreamPartitionMetadata("0", "10", "11");
+    SystemStreamPartition changelog2SSP = new SystemStreamPartition(changelog2SystemStream, taskChangelogPartition);
+    SystemStreamPartitionMetadata changelog2SSPMetadata = new SystemStreamPartitionMetadata("11", "20", "21");
+    SystemStreamPartition changelog3SSP = new SystemStreamPartition(changelog3SystemStream, taskChangelogPartition);
+    SystemStreamPartitionMetadata changelog3SSPMetadata = new SystemStreamPartitionMetadata("21", "30", "31");
+    SystemStreamPartition changelog4SSP = new SystemStreamPartition(changelog4SystemStream, taskChangelogPartition);
+    SystemStreamPartitionMetadata changelog4SSPMetadata = new SystemStreamPartitionMetadata("31", "40", "41");
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> mockCurrentChangelogSSPMetadata =
+        ImmutableMap.of(changelog1SSP, changelog1SSPMetadata,
+            changelog2SSP, changelog2SSPMetadata,
+            changelog3SSP, changelog3SSPMetadata,
+            changelog4SSP, changelog4SSPMetadata);
+
+    SystemAdmins mockSystemAdmins = mock(SystemAdmins.class);
+    SystemAdmin mockSystemAdmin = mock(SystemAdmin.class);
+    when(mockSystemAdmins.getSystemAdmin(eq(changelogSystemName))).thenReturn(mockSystemAdmin);
+    Mockito.when(mockSystemAdmin.offsetComparator(anyString(), anyString()))
+        .thenAnswer((Answer<Integer>) invocation -> {
+            String offset1 = (String) invocation.getArguments()[0];
+            String offset2 = (String) invocation.getArguments()[1];
+            return Long.valueOf(offset1).compareTo(Long.valueOf(offset2));
+          });
+    Mockito.when(mockSystemAdmin.getOffsetsAfter(any()))
+        .thenAnswer((Answer<Map<SystemStreamPartition, String>>) invocation -> {
+            Map<SystemStreamPartition, String> offsets = (Map<SystemStreamPartition, String>) invocation.getArguments()[0];
+            Map<SystemStreamPartition, String> nextOffsets = new HashMap<>();
+            offsets.forEach((ssp, offset) -> nextOffsets.put(ssp, Long.toString(Long.valueOf(offset) + 1)));
+            return nextOffsets;
+          });
+
+    SystemConsumer mockSystemConsumer = mock(SystemConsumer.class);
+    Map<String, SystemConsumer> mockStoreConsumers = ImmutableMap.of(
+        store1Name, mockSystemConsumer,
+        store2Name, mockSystemConsumer,
+        store3Name, mockSystemConsumer,
+        store4Name, mockSystemConsumer);
+
+    TransactionalStateTaskRestoreManager.registerStartingOffsets(
+        mockTaskModel, mockStoreActions, mockStoreChangelogs, mockSystemAdmins,
+        mockStoreConsumers, mockCurrentChangelogSSPMetadata);
+
+    // verify that we first register upcoming offsets for each changelog ssp
+    verify(mockSystemConsumer, times(1)).register(changelog1SSP, "11");
+    verify(mockSystemConsumer, times(1)).register(changelog2SSP, "21");
+    verify(mockSystemConsumer, times(1)).register(changelog3SSP, "31");
+    verify(mockSystemConsumer, times(1)).register(changelog4SSP, "41");
+
+    // then verify that we override the starting offsets for changelog 1 and 2
+    verify(mockSystemConsumer, times(1)).register(changelog1SSP, "0"); // ensure that starting offset is inclusive if oldest
+    verify(mockSystemConsumer, times(1)).register(changelog2SSP, "16"); // and that it is next offset if not oldest
+    verify(mockSystemConsumer, times(1)).register(changelog4SSP, "31"); // and that null ending offset is ok
+    verifyNoMoreInteractions(mockSystemConsumer);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testRegisterStartingOffsetsThrowsIfStartingGreaterThanEnding() {
+    TaskModel mockTaskModel = mock(TaskModel.class);
+    TaskName taskName = new TaskName("Partition 0");
+    when(mockTaskModel.getTaskName()).thenReturn(taskName);
+    Partition taskChangelogPartition = new Partition(0);
+    when(mockTaskModel.getChangelogPartition()).thenReturn(taskChangelogPartition);
+
+    // tests starting offset > ending offset
+    Map<String, RestoreOffsets> mockRestoreOffsets = ImmutableMap.of("store1", new RestoreOffsets("5", "0"));
+    StoreActions mockStoreActions = new StoreActions(ImmutableMap.of(), ArrayListMultimap.create(), mockRestoreOffsets);
+
+    String store1Name = "store1";
+    String changelogSystemName = "system";
+    String changelog1StreamName = "store1Changelog";
+
+    SystemStream changelog1SystemStream = new SystemStream(changelogSystemName, changelog1StreamName);
+    Map<String, SystemStream> mockStoreChangelogs = ImmutableMap.of(store1Name, changelog1SystemStream);
+
+    SystemStreamPartition changelog1SSP = new SystemStreamPartition(changelog1SystemStream, taskChangelogPartition);
+    SystemStreamPartitionMetadata changelog1SSPMetadata = new SystemStreamPartitionMetadata("0", "10", "11");
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> mockCurrentChangelogSSPMetadata =
+        ImmutableMap.of(changelog1SSP, changelog1SSPMetadata);
+
+    SystemAdmins mockSystemAdmins = mock(SystemAdmins.class);
+    SystemAdmin mockSystemAdmin = mock(SystemAdmin.class);
+    when(mockSystemAdmins.getSystemAdmin(eq(changelogSystemName))).thenReturn(mockSystemAdmin);
+    Mockito.when(mockSystemAdmin.offsetComparator(anyString(), anyString()))
+        .thenAnswer((Answer<Integer>) invocation -> {
+            String offset1 = (String) invocation.getArguments()[0];
+            String offset2 = (String) invocation.getArguments()[1];
+            return Long.valueOf(offset1).compareTo(Long.valueOf(offset2));
+          });
+    Mockito.when(mockSystemAdmin.getOffsetsAfter(any()))
+        .thenAnswer((Answer<Map<SystemStreamPartition, String>>) invocation -> {
+            Map<SystemStreamPartition, String> offsets = (Map<SystemStreamPartition, String>) invocation.getArguments()[0];
+            Map<SystemStreamPartition, String> nextOffsets = new HashMap<>();
+            offsets.forEach((ssp, offset) -> nextOffsets.put(ssp, Long.toString(Long.valueOf(offset) + 1)));
+            return nextOffsets;
+          });
+
+    SystemConsumer mockSystemConsumer = mock(SystemConsumer.class);
+    Map<String, SystemConsumer> mockStoreConsumers = ImmutableMap.of("store1", mockSystemConsumer);
+
+    TransactionalStateTaskRestoreManager.registerStartingOffsets(
+        mockTaskModel, mockStoreActions, mockStoreChangelogs, mockSystemAdmins,
+        mockStoreConsumers, mockCurrentChangelogSSPMetadata);
+
+    fail("Should have thrown an exception since starting offset > ending offset");
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/storage/TestTransactionalStateTaskRestoreManager.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/TestTransactionalStateTaskRestoreManager.java
@@ -337,7 +337,7 @@ public class TestTransactionalStateTaskRestoreManager {
   }
 
   @Test
-  public void testGetStoreActionsForLoggedNonPersistentStore_FullTrimIfNullCheckpointedOffsetAndNotRetainExistingState() {
+  public void testGetStoreActionsForLoggedNonPersistentStore_FullTrimIfNullCheckpointedOffsetAndNotRetainExistingChangelogState() {
     TaskModel mockTaskModel = mock(TaskModel.class);
     TaskName taskName = new TaskName("Partition 0");
     when(mockTaskModel.getTaskName()).thenReturn(taskName);
@@ -374,7 +374,7 @@ public class TestTransactionalStateTaskRestoreManager {
     File mockLoggedStoreBaseDir = mock(File.class);
     File mockNonLoggedStoreBaseDir = mock(File.class);
     HashMap<String, String> configMap = new HashMap<>();
-    configMap.put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE, "false");
+    configMap.put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_CHANGELOG_STATE, "false");
     Config mockConfig = new MapConfig(configMap);
     Clock mockClock = mock(Clock.class);
 
@@ -702,7 +702,7 @@ public class TestTransactionalStateTaskRestoreManager {
   }
 
   @Test
-  public void testGetStoreActionsForLoggedPersistentStore_FullRestoreIfNullCheckpointedOffsetAndRetainExistingState() {
+  public void testGetStoreActionsForLoggedPersistentStore_FullRestoreIfNullCheckpointedOffsetAndRetainExistingChangelogState() {
     TaskModel mockTaskModel = mock(TaskModel.class);
     TaskName taskName = new TaskName("Partition 0");
     when(mockTaskModel.getTaskName()).thenReturn(taskName);
@@ -739,7 +739,7 @@ public class TestTransactionalStateTaskRestoreManager {
     File mockLoggedStoreBaseDir = mock(File.class);
     File mockNonLoggedStoreBaseDir = mock(File.class);
     HashMap<String, String> configMap = new HashMap<>();
-    configMap.put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE, "true");
+    configMap.put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_CHANGELOG_STATE, "true");
     Config mockConfig = new MapConfig(configMap);
     Clock mockClock = mock(Clock.class);
 
@@ -824,7 +824,7 @@ public class TestTransactionalStateTaskRestoreManager {
     File mockLoggedStoreBaseDir = mock(File.class);
     File mockNonLoggedStoreBaseDir = mock(File.class);
     HashMap<String, String> configMap = new HashMap<>();
-    configMap.put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE, "false");
+    configMap.put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_CHANGELOG_STATE, "false");
     Config mockConfig = new MapConfig(configMap);
     Clock mockClock = mock(Clock.class);
 
@@ -868,6 +868,97 @@ public class TestTransactionalStateTaskRestoreManager {
     assertEquals(0, storeActions.storeDirsToRetain.size());
     // ensure that we mark the store for restore (full trim == restore from oldest to null)
     assertEquals("0", storeActions.storesToRestore.get(store1Name).startingOffset);
+    assertNull(storeActions.storesToRestore.get(store1Name).endingOffset);
+  }
+
+  @Test
+  public void testGetStoreActionsForLoggedPersistentStore_FullRestoreIfNullCheckpointedAndOldestOffset() {
+    // full restore == clear existing state
+    TaskModel mockTaskModel = mock(TaskModel.class);
+    TaskName taskName = new TaskName("Partition 0");
+    when(mockTaskModel.getTaskName()).thenReturn(taskName);
+    Partition taskChangelogPartition = new Partition(0);
+    when(mockTaskModel.getChangelogPartition()).thenReturn(taskChangelogPartition);
+
+    String store1Name = "store1";
+    StorageEngine store1Engine = mock(StorageEngine.class);
+    StoreProperties mockStore1Properties = mock(StoreProperties.class);
+    when(store1Engine.getStoreProperties()).thenReturn(mockStore1Properties);
+    when(mockStore1Properties.isLoggedStore()).thenReturn(true);
+    when(mockStore1Properties.isPersistedToDisk()).thenReturn(true);
+    Map<String, StorageEngine> mockStoreEngines = ImmutableMap.of(store1Name, store1Engine);
+
+    String changelog1SystemName = "system1";
+    String changelog1StreamName = "store1Changelog";
+    SystemStream changelog1SystemStream = new SystemStream(changelog1SystemName, changelog1StreamName);
+    SystemStreamPartition changelog1SSP = new SystemStreamPartition(changelog1SystemStream, taskChangelogPartition);
+    // SSPMetadata contract allows for (and recommends) null as the oldest offset for empty streams.
+    // KafkaSystemAdmin does not follow this convention and returns 0 instead, but we should test for this
+    SystemStreamPartitionMetadata changelog1SSPMetadata = new SystemStreamPartitionMetadata(null, null, null);
+    Map<String, SystemStream> mockStoreChangelogs = ImmutableMap.of(store1Name, changelog1SystemStream);
+
+    String changelog1CheckpointedOffset = null;
+    Map<SystemStreamPartition, String> mockCheckpointedChangelogOffset =
+        new HashMap<SystemStreamPartition, String>() { {
+          put(changelog1SSP, changelog1CheckpointedOffset);
+        } };
+    Map<SystemStreamPartition, SystemStreamPartitionMetadata> mockCurrentChangelogOffsets =
+        ImmutableMap.of(changelog1SSP, changelog1SSPMetadata);
+
+    SystemAdmins mockSystemAdmins = mock(SystemAdmins.class);
+    SystemAdmin mockSystemAdmin = mock(SystemAdmin.class);
+    when(mockSystemAdmins.getSystemAdmin(changelog1SSP.getSystem())).thenReturn(mockSystemAdmin);
+    StorageManagerUtil mockStorageManagerUtil = mock(StorageManagerUtil.class);
+    File mockLoggedStoreBaseDir = mock(File.class);
+    File mockNonLoggedStoreBaseDir = mock(File.class);
+    HashMap<String, String> configMap = new HashMap<>();
+    configMap.put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_CHANGELOG_STATE, "true"); // should not matter
+    Config mockConfig = new MapConfig(configMap);
+    Clock mockClock = mock(Clock.class);
+
+    File mockCurrentStoreDir = mock(File.class);
+    File mockStoreNewerCheckpointDir = mock(File.class);
+    File mockStoreOlderCheckpointDir = mock(File.class);
+    String olderCheckpointDirLocalOffset = "3";
+    String newerCheckpointDirLocalOffset = "5";
+    when(mockStorageManagerUtil.getTaskStoreDir(eq(mockLoggedStoreBaseDir), eq(store1Name), eq(taskName), any()))
+        .thenReturn(mockCurrentStoreDir);
+    when(mockStorageManagerUtil.getTaskStoreCheckpointDirs(eq(mockLoggedStoreBaseDir), eq(store1Name), eq(taskName), any()))
+        .thenReturn(ImmutableList.of(mockStoreNewerCheckpointDir, mockStoreOlderCheckpointDir));
+    when(mockStorageManagerUtil.isLoggedStoreValid(eq(store1Name), eq(mockStoreNewerCheckpointDir), any(),
+        eq(mockStoreChangelogs), eq(mockTaskModel), any(), eq(mockStoreEngines))).thenReturn(true);
+    when(mockStorageManagerUtil.isLoggedStoreValid(eq(store1Name), eq(mockStoreOlderCheckpointDir), any(),
+        eq(mockStoreChangelogs), eq(mockTaskModel), any(), eq(mockStoreEngines))).thenReturn(true);
+    Set<SystemStreamPartition> mockChangelogSSPs = ImmutableSet.of(changelog1SSP);
+    when(mockStorageManagerUtil.readOffsetFile(eq(mockStoreNewerCheckpointDir), eq(mockChangelogSSPs), eq(false)))
+        .thenReturn(ImmutableMap.of(changelog1SSP, newerCheckpointDirLocalOffset));
+    when(mockStorageManagerUtil.readOffsetFile(eq(mockStoreOlderCheckpointDir), eq(mockChangelogSSPs), eq(false)))
+        .thenReturn(ImmutableMap.of(changelog1SSP, olderCheckpointDirLocalOffset)); // less than checkpointed offset (5)
+
+    Mockito.when(mockSystemAdmin.offsetComparator(anyString(), anyString()))
+        .thenAnswer((Answer<Integer>) invocation -> {
+            String offset1 = (String) invocation.getArguments()[0];
+            String offset2 = (String) invocation.getArguments()[1];
+            if (offset1 == null || offset2 == null) {
+              return -1;
+            }
+            return Long.valueOf(offset1).compareTo(Long.valueOf(offset2));
+          });
+
+    StoreActions storeActions = TransactionalStateTaskRestoreManager.getStoreActions(
+        mockTaskModel, mockStoreEngines, mockStoreChangelogs, mockCheckpointedChangelogOffset,
+        mockCurrentChangelogOffsets, mockSystemAdmins, mockStorageManagerUtil,
+        mockLoggedStoreBaseDir, mockNonLoggedStoreBaseDir, mockConfig, mockClock);
+
+    // ensure that all the store dirs (current or checkpoint) are marked for deletion
+    assertEquals(3, storeActions.storeDirsToDelete.get(store1Name).size());
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockCurrentStoreDir));
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockStoreOlderCheckpointDir));
+    assertTrue(storeActions.storeDirsToDelete.get(store1Name).contains(mockStoreNewerCheckpointDir));
+    // ensure that no directories are retained
+    assertEquals(0, storeActions.storeDirsToRetain.size());
+    // ensure that we do a full restore (on the empty topic)
+    assertNull(storeActions.storesToRestore.get(store1Name).startingOffset);
     assertNull(storeActions.storesToRestore.get(store1Name).endingOffset);
   }
 

--- a/samza-core/src/test/scala/org/apache/samza/container/TestTaskInstance.scala
+++ b/samza-core/src/test/scala/org/apache/samza/container/TestTaskInstance.scala
@@ -21,13 +21,13 @@ package org.apache.samza.container
 
 import java.util.Collections
 
-import org.apache.samza.Partition
+import org.apache.samza.{Partition, SamzaException}
 import org.apache.samza.checkpoint.{Checkpoint, OffsetManager}
+import org.apache.samza.config.MapConfig
 import org.apache.samza.context.{TaskContext => _, _}
 import org.apache.samza.job.model.TaskModel
 import org.apache.samza.metrics.Counter
-import org.apache.samza.startpoint.Startpoint
-import org.apache.samza.storage.TaskStorageManager
+import org.apache.samza.storage.NonTransactionalStateTaskStorageManager
 import org.apache.samza.system.{IncomingMessageEnvelope, StreamMetadataCache, SystemAdmin, SystemConsumers, SystemStream, SystemStreamMetadata, _}
 import org.apache.samza.table.TableManager
 import org.apache.samza.task._
@@ -67,7 +67,7 @@ class TestTaskInstance extends AssertionsForJUnit with MockitoSugar {
   @Mock
   private var offsetManager: OffsetManager = null
   @Mock
-  private var taskStorageManager: TaskStorageManager = null
+  private var taskStorageManager: NonTransactionalStateTaskStorageManager = null
   @Mock
   private var taskTableManager: TableManager = null
   // not a mock; using MockTaskInstanceExceptionHandler
@@ -97,6 +97,7 @@ class TestTaskInstance extends AssertionsForJUnit with MockitoSugar {
       Matchers.eq(this.containerContext), any(), Matchers.eq(this.applicationContainerContext)))
       .thenReturn(this.applicationTaskContext)
     when(this.systemAdmins.getSystemAdmin(SYSTEM_NAME)).thenReturn(this.systemAdmin)
+    when(this.jobContext.getConfig).thenReturn(new MapConfig(Collections.singletonMap("task.commit.ms", "-1")))
     setupTaskInstance(Some(this.applicationTaskContextFactory))
   }
 
@@ -212,26 +213,147 @@ class TestTaskInstance extends AssertionsForJUnit with MockitoSugar {
   def testCommitOrder() {
     val commitsCounter = mock[Counter]
     when(this.metrics.commits).thenReturn(commitsCounter)
-    val checkpoint = new Checkpoint(Map(SYSTEM_STREAM_PARTITION -> "4").asJava)
-    when(this.offsetManager.buildCheckpoint(TASK_NAME)).thenReturn(checkpoint)
-
+    val inputOffsets = new Checkpoint(Map(SYSTEM_STREAM_PARTITION -> "4").asJava)
+    val changelogSSP = new SystemStreamPartition(new SystemStream(SYSTEM_NAME, "test-changelog-stream"), new Partition(0))
+    val changelogOffsets = Map(changelogSSP -> Some("5"))
+    val checkpointId = "1234"
+    when(this.offsetManager.buildCheckpoint(TASK_NAME)).thenReturn(inputOffsets)
+    when(this.taskStorageManager.flush()).thenReturn(changelogOffsets)
+    when(this.taskStorageManager.checkpoint(any[Map[SystemStreamPartition, Option[String]]])).thenReturn(checkpointId)
     taskInstance.commit
 
-    val mockOrder = inOrder(this.offsetManager, this.collector, this.taskStorageManager, this.taskTableManager)
+    val mockOrder = inOrder(this.offsetManager, this.collector, this.taskTableManager, this.taskStorageManager)
 
-    // We must first get a snapshot of the checkpoint so it doesn't change while we flush. SAMZA-1384
+    // We must first get a snapshot of the input offsets so it doesn't change while we flush. SAMZA-1384
     mockOrder.verify(this.offsetManager).buildCheckpoint(TASK_NAME)
+
     // Producers must be flushed next and ideally the output would be flushed before the changelog
     // s.t. the changelog and checkpoints (state and inputs) are captured last
     mockOrder.verify(this.collector).flush
-    // Local state is next, to ensure that the state (particularly the offset file) never points to a newer changelog
-    // offset than what is reflected in the on disk state.
-    mockOrder.verify(this.taskStorageManager).flush()
-    // Tables are next
+
+    // Tables should be flushed next
     mockOrder.verify(this.taskTableManager).flush()
-    // Finally, checkpoint the inputs with the snapshotted checkpoint captured at the beginning of commit
-    mockOrder.verify(offsetManager).writeCheckpoint(TASK_NAME, checkpoint)
+
+    // Local state should be flushed next next
+    mockOrder.verify(this.taskStorageManager).flush()
+
+    // Stores checkpoints should be created next with the newest changelog offsets
+    mockOrder.verify(this.taskStorageManager).checkpoint(changelogOffsets)
+
+    // Input checkpoint should be written with the snapshot captured at the beginning of commit and the
+    // newest changelog offset captured during storage manager flush
+    val captor = ArgumentCaptor.forClass(classOf[Checkpoint])
+    mockOrder.verify(offsetManager).writeCheckpoint(any(), captor.capture)
+    val cp = captor.getValue
+    assertEquals("4", cp.getOffsets.get(SYSTEM_STREAM_PARTITION))
+    assertEquals("5", cp.getOffsets.get(changelogSSP))
+
+    // Old checkpointed stores should be cleared
+    mockOrder.verify(this.taskStorageManager).removeOldCheckpoints(checkpointId)
     verify(commitsCounter).inc()
+  }
+
+  @Test
+  def testEmptyChangelogSSPOffsetInCommit() { // e.g. if changelog topic is empty
+    val commitsCounter = mock[Counter]
+    when(this.metrics.commits).thenReturn(commitsCounter)
+
+    val inputOffsets = new Checkpoint(Map(SYSTEM_STREAM_PARTITION -> "4").asJava)
+    val changelogSSP = new SystemStreamPartition(new SystemStream(SYSTEM_NAME, "test-changelog-stream"), new Partition(0))
+    val changelogOffsets = Map(changelogSSP -> None)
+    when(this.offsetManager.buildCheckpoint(TASK_NAME)).thenReturn(inputOffsets)
+    when(this.taskStorageManager.flush()).thenReturn(changelogOffsets)
+    taskInstance.commit
+
+    val captor = ArgumentCaptor.forClass(classOf[Checkpoint])
+    verify(offsetManager).writeCheckpoint(any(), captor.capture)
+    val cp = captor.getValue
+    assertEquals("4", cp.getOffsets.get(SYSTEM_STREAM_PARTITION))
+    assertEquals(null, cp.getOffsets.get(changelogSSP))
+    verify(commitsCounter).inc()
+  }
+
+  @Test
+  def testEmptyChangelogOffsetsInCommit() { // e.g. if stores have no changelogs
+    val commitsCounter = mock[Counter]
+    when(this.metrics.commits).thenReturn(commitsCounter)
+
+    val inputOffsets = new Checkpoint(Map(SYSTEM_STREAM_PARTITION -> "4").asJava)
+    val changelogOffsets = Map[SystemStreamPartition, Option[String]]()
+    when(this.offsetManager.buildCheckpoint(TASK_NAME)).thenReturn(inputOffsets)
+    when(this.taskStorageManager.flush()).thenReturn(changelogOffsets)
+    taskInstance.commit
+
+    val captor = ArgumentCaptor.forClass(classOf[Checkpoint])
+    verify(offsetManager).writeCheckpoint(any(), captor.capture)
+    val cp = captor.getValue
+    assertEquals("4", cp.getOffsets.get(SYSTEM_STREAM_PARTITION))
+    assertEquals(1, cp.getOffsets.size())
+    verify(commitsCounter).inc()
+  }
+
+  @Test
+  def testCommitFailsIfErrorGettingChangelogOffset() { // required for transactional state
+    val commitsCounter = mock[Counter]
+    when(this.metrics.commits).thenReturn(commitsCounter)
+
+    val inputOffsets = new Checkpoint(Map(SYSTEM_STREAM_PARTITION -> "4").asJava)
+    when(this.offsetManager.buildCheckpoint(TASK_NAME)).thenReturn(inputOffsets)
+    when(this.taskStorageManager.flush()).thenThrow(new SamzaException("Error getting changelog offsets"))
+
+    try {
+      taskInstance.commit
+    } catch {
+      case e: SamzaException =>
+        // exception is expected, container should fail if could not get changelog offsets.
+        return
+    }
+
+    fail("Should have failed commit if error getting newest changelog offests")
+  }
+
+  @Test
+  def testCommitFailsIfErrorCreatingStoreCheckpoints() { // required for transactional state
+    val commitsCounter = mock[Counter]
+    when(this.metrics.commits).thenReturn(commitsCounter)
+
+    val inputOffsets = new Checkpoint(Map(SYSTEM_STREAM_PARTITION -> "4").asJava)
+    when(this.offsetManager.buildCheckpoint(TASK_NAME)).thenReturn(inputOffsets)
+    when(this.taskStorageManager.flush()).thenReturn(Map[SystemStreamPartition, Option[String]]())
+    when(this.taskStorageManager.checkpoint(any())).thenThrow(new SamzaException("Error creating store checkpoint"))
+
+    try {
+      taskInstance.commit
+    } catch {
+      case e: SamzaException =>
+        // exception is expected, container should fail if could not get changelog offsets.
+        return
+    }
+
+    fail("Should have failed commit if error getting newest changelog offests")
+  }
+
+  @Test
+  def testCommitFailsIfErrorClearingOldCheckpoints() { // required for transactional state
+    val commitsCounter = mock[Counter]
+    when(this.metrics.commits).thenReturn(commitsCounter)
+
+    val inputOffsets = new Checkpoint(Map(SYSTEM_STREAM_PARTITION -> "4").asJava)
+    when(this.offsetManager.buildCheckpoint(TASK_NAME)).thenReturn(inputOffsets)
+    when(this.taskStorageManager.flush()).thenReturn(Map[SystemStreamPartition, Option[String]]())
+    when(this.taskStorageManager.checkpoint(any())).thenReturn("id")
+    when(this.taskStorageManager.removeOldCheckpoints("id"))
+      .thenThrow(new SamzaException("Error clearing old checkpoints"))
+
+    try {
+      taskInstance.commit
+    } catch {
+      case e: SamzaException =>
+        // exception is expected, container should fail if could not get changelog offsets.
+        return
+    }
+
+    fail("Should have failed commit if error getting newest changelog offests")
   }
 
   /**
@@ -249,7 +371,6 @@ class TestTaskInstance extends AssertionsForJUnit with MockitoSugar {
   def testProducerExceptionsIsPropagated() {
     when(this.metrics.commits).thenReturn(mock[Counter])
     when(this.collector.flush).thenThrow(new SystemProducerException("systemProducerException"))
-
     try {
       taskInstance.commit // Should not swallow the SystemProducerException
     } finally {

--- a/samza-core/src/test/scala/org/apache/samza/processor/StreamProcessorTestUtils.scala
+++ b/samza-core/src/test/scala/org/apache/samza/processor/StreamProcessorTestUtils.scala
@@ -19,6 +19,7 @@
 package org.apache.samza.processor
 
 import java.util
+import java.util.Collections
 
 import org.apache.samza.Partition
 import org.apache.samza.config.MapConfig
@@ -31,6 +32,7 @@ import org.apache.samza.system._
 import org.apache.samza.system.chooser.RoundRobinChooser
 import org.apache.samza.task.{StreamTask, TaskInstanceCollector}
 import org.mockito.Mockito
+import org.mockito.Mockito.when
 
 
 object StreamProcessorTestUtils {
@@ -47,6 +49,9 @@ object StreamProcessorTestUtils {
       new SerdeManager)
     val collector = new TaskInstanceCollector(producerMultiplexer)
     val containerContext = Mockito.mock(classOf[ContainerContext])
+    val jobContext = Mockito.mock(classOf[JobContext])
+    when(jobContext.getConfig).thenReturn(
+      new MapConfig(Collections.singletonMap("task.commit.ms", "-1")))
     val taskInstance: TaskInstance = new TaskInstance(
       streamTask,
       taskModel,
@@ -54,7 +59,7 @@ object StreamProcessorTestUtils {
       adminMultiplexer,
       consumerMultiplexer,
       collector,
-      jobContext = Mockito.mock(classOf[JobContext]),
+      jobContext = jobContext,
       containerContext = containerContext,
       applicationContainerContextOption = None,
       applicationTaskContextFactoryOption = None,

--- a/samza-core/src/test/scala/org/apache/samza/storage/TestContainerStorageManager.java
+++ b/samza-core/src/test/scala/org/apache/samza/storage/TestContainerStorageManager.java
@@ -171,7 +171,7 @@ public class TestContainerStorageManager {
     configMap.put("stores." + STORE_NAME + ".key.serde", "stringserde");
     configMap.put("stores." + STORE_NAME + ".msg.serde", "stringserde");
     configMap.put("serializers.registry.stringserde.class", StringSerdeFactory.class.getName());
-    configMap.put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE, "true");
+    configMap.put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_CHANGELOG_STATE, "true");
     Config config = new MapConfig(configMap);
 
     Map<String, Serde<Object>> serdes = new HashMap<>();

--- a/samza-core/src/test/scala/org/apache/samza/storage/TestTaskStorageManager.scala
+++ b/samza-core/src/test/scala/org/apache/samza/storage/TestTaskStorageManager.scala
@@ -873,7 +873,7 @@ class TaskStorageManagerBuilder extends MockitoSugar {
       "stores.store1.msg.serde" -> classOf[StringSerdeFactory].getCanonicalName,
       "stores.loggedStore1.key.serde" -> classOf[StringSerdeFactory].getCanonicalName,
       "stores.loggedStore1.msg.serde" -> classOf[StringSerdeFactory].getCanonicalName,
-      TaskConfig.TRANSACTIONAL_STATE_ENABLED -> "false").asJava)
+      TaskConfig.TRANSACTIONAL_STATE_RESTORE_ENABLED -> "false").asJava)
 
     var mockSerdes: Map[String, Serde[AnyRef]] = HashMap[String, Serde[AnyRef]]((classOf[StringSerdeFactory].getCanonicalName, Mockito.mock(classOf[Serde[AnyRef]])))
 

--- a/samza-core/src/test/scala/org/apache/samza/storage/TestTransactionalStateTaskStorageManager.java
+++ b/samza-core/src/test/scala/org/apache/samza/storage/TestTransactionalStateTaskStorageManager.java
@@ -1,0 +1,464 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.storage;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import scala.Option;
+import scala.collection.immutable.Map;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Optional;
+import org.apache.samza.Partition;
+import org.apache.samza.SamzaException;
+import org.apache.samza.container.TaskName;
+import org.apache.samza.job.model.TaskMode;
+import org.apache.samza.system.SystemAdmin;
+import org.apache.samza.system.SystemAdmins;
+import org.apache.samza.system.SystemStream;
+import org.apache.samza.system.SystemStreamMetadata.SystemStreamPartitionMetadata;
+import org.apache.samza.system.SystemStreamPartition;
+import org.apache.samza.util.ScalaJavaUtil;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestTransactionalStateTaskStorageManager {
+  @Test
+  public void testFlushOrder() {
+    ContainerStorageManager csm = mock(ContainerStorageManager.class);
+    StorageEngine mockStore = mock(StorageEngine.class);
+    java.util.Map<String, StorageEngine> taskStores = ImmutableMap.of("mockStore", mockStore);
+    when(csm.getAllStores(any())).thenReturn(taskStores);
+
+    TransactionalStateTaskStorageManager tsm = spy(buildTSM(csm, mock(Partition.class)));
+    // stub actual method call
+    doReturn(mock(Map.class)).when(tsm).getNewestChangelogSSPOffsets(any(), any(), any(), any());
+
+    // invoke flush
+    tsm.flush();
+
+    // ensure that stores are flushed before we get newest changelog offsets
+    InOrder inOrder = inOrder(mockStore, tsm);
+    inOrder.verify(mockStore).flush();
+    inOrder.verify(tsm).getNewestChangelogSSPOffsets(any(), any(), any(), any());
+  }
+
+  @Test
+  public void testGetNewestOffsetsReturnsCorrectOffset() {
+    ContainerStorageManager csm = mock(ContainerStorageManager.class);
+    TransactionalStateTaskStorageManager tsm = buildTSM(csm, mock(Partition.class));
+
+    TaskName taskName = mock(TaskName.class);
+    String changelogSystemName = "systemName";
+    String storeName = "storeName";
+    String changelogStreamName = "changelogName";
+    String newestChangelogSSPOffset = "1";
+    SystemStream changelogSystemStream = new SystemStream(changelogSystemName, changelogStreamName);
+    Partition changelogPartition = new Partition(0);
+    SystemStreamPartition changelogSSP = new SystemStreamPartition(changelogSystemStream, changelogPartition);
+
+    Map<String, SystemStream> storeChangelogs =
+        ScalaJavaUtil.toScalaMap(ImmutableMap.of(storeName, changelogSystemStream));
+
+    SystemAdmins systemAdmins = mock(SystemAdmins.class);
+    SystemAdmin systemAdmin = mock(SystemAdmin.class);
+    SystemStreamPartitionMetadata metadata = mock(SystemStreamPartitionMetadata.class);
+
+    when(metadata.getNewestOffset()).thenReturn(newestChangelogSSPOffset);
+    when(systemAdmins.getSystemAdmin(changelogSystemName)).thenReturn(systemAdmin);
+    when(systemAdmin.getSSPMetadata(eq(ImmutableSet.of(changelogSSP)))).thenReturn(ImmutableMap.of(changelogSSP, metadata));
+
+    // invoke the method
+    Map<SystemStreamPartition, Option<String>> offsets =
+        tsm.getNewestChangelogSSPOffsets(
+            taskName, storeChangelogs, changelogPartition, systemAdmins);
+
+    // verify results
+    assertEquals(1, offsets.size());
+    assertEquals(Option.apply(newestChangelogSSPOffset), offsets.apply(changelogSSP));
+  }
+
+  @Test
+  public void testGetNewestOffsetsReturnsNoneForEmptyTopic() {
+    // empty topic == null newest offset
+    ContainerStorageManager csm = mock(ContainerStorageManager.class);
+    TransactionalStateTaskStorageManager tsm = buildTSM(csm, mock(Partition.class));
+
+    TaskName taskName = mock(TaskName.class);
+    String changelogSystemName = "systemName";
+    String storeName = "storeName";
+    String changelogStreamName = "changelogName";
+    String newestChangelogSSPOffset = null;
+    SystemStream changelogSystemStream = new SystemStream(changelogSystemName, changelogStreamName);
+    Partition changelogPartition = new Partition(0);
+    SystemStreamPartition changelogSSP = new SystemStreamPartition(changelogSystemStream, changelogPartition);
+
+    Map<String, SystemStream> storeChangelogs =
+        ScalaJavaUtil.toScalaMap(ImmutableMap.of(storeName, changelogSystemStream));
+
+    SystemAdmins systemAdmins = mock(SystemAdmins.class);
+    SystemAdmin systemAdmin = mock(SystemAdmin.class);
+    SystemStreamPartitionMetadata metadata = mock(SystemStreamPartitionMetadata.class);
+
+    when(metadata.getNewestOffset()).thenReturn(newestChangelogSSPOffset);
+    when(systemAdmins.getSystemAdmin(changelogSystemName)).thenReturn(systemAdmin);
+    when(systemAdmin.getSSPMetadata(eq(ImmutableSet.of(changelogSSP)))).thenReturn(ImmutableMap.of(changelogSSP, metadata));
+
+    // invoke the method
+    Map<SystemStreamPartition, Option<String>> offsets =
+        tsm.getNewestChangelogSSPOffsets(
+            taskName, storeChangelogs, changelogPartition, systemAdmins);
+
+    // verify results
+    assertEquals(1, offsets.size());
+    assertEquals(Option.empty(), offsets.apply(changelogSSP));
+  }
+
+  @Test(expected = SamzaException.class)
+  public void testGetNewestOffsetsThrowsIfNullMetadata() {
+    // empty topic == null newest offset
+    ContainerStorageManager csm = mock(ContainerStorageManager.class);
+    TransactionalStateTaskStorageManager tsm = buildTSM(csm, mock(Partition.class));
+
+    TaskName taskName = mock(TaskName.class);
+    String changelogSystemName = "systemName";
+    String storeName = "storeName";
+    String changelogStreamName = "changelogName";
+    String newestChangelogSSPOffset = null;
+    SystemStream changelogSystemStream = new SystemStream(changelogSystemName, changelogStreamName);
+    Partition changelogPartition = new Partition(0);
+    SystemStreamPartition changelogSSP = new SystemStreamPartition(changelogSystemStream, changelogPartition);
+
+    Map<String, SystemStream> storeChangelogs =
+        ScalaJavaUtil.toScalaMap(ImmutableMap.of(storeName, changelogSystemStream));
+
+    SystemAdmins systemAdmins = mock(SystemAdmins.class);
+    SystemAdmin systemAdmin = mock(SystemAdmin.class);
+    SystemStreamPartitionMetadata metadata = mock(SystemStreamPartitionMetadata.class);
+
+    when(metadata.getNewestOffset()).thenReturn(newestChangelogSSPOffset);
+    when(systemAdmins.getSystemAdmin(changelogSystemName)).thenReturn(systemAdmin);
+    when(systemAdmin.getSSPMetadata(eq(ImmutableSet.of(changelogSSP)))).thenReturn(null);
+
+    // invoke the method
+    Map<SystemStreamPartition, Option<String>> offsets =
+        tsm.getNewestChangelogSSPOffsets(
+            taskName, storeChangelogs, changelogPartition, systemAdmins);
+
+    // verify results
+    fail("Should have thrown an exception if admin didn't return any metadata");
+  }
+
+  @Test(expected = SamzaException.class)
+  public void testGetNewestOffsetsThrowsIfNullSSPMetadata() {
+    // empty topic == null newest offset
+    ContainerStorageManager csm = mock(ContainerStorageManager.class);
+    TransactionalStateTaskStorageManager tsm = buildTSM(csm, mock(Partition.class));
+
+    TaskName taskName = mock(TaskName.class);
+    String changelogSystemName = "systemName";
+    String storeName = "storeName";
+    String changelogStreamName = "changelogName";
+    String newestChangelogSSPOffset = null;
+    SystemStream changelogSystemStream = new SystemStream(changelogSystemName, changelogStreamName);
+    Partition changelogPartition = new Partition(0);
+    SystemStreamPartition changelogSSP = new SystemStreamPartition(changelogSystemStream, changelogPartition);
+
+    Map<String, SystemStream> storeChangelogs =
+        ScalaJavaUtil.toScalaMap(ImmutableMap.of(storeName, changelogSystemStream));
+
+    SystemAdmins systemAdmins = mock(SystemAdmins.class);
+    SystemAdmin systemAdmin = mock(SystemAdmin.class);
+    SystemStreamPartitionMetadata metadata = mock(SystemStreamPartitionMetadata.class);
+
+    when(metadata.getNewestOffset()).thenReturn(newestChangelogSSPOffset);
+    when(systemAdmins.getSystemAdmin(changelogSystemName)).thenReturn(systemAdmin);
+    java.util.Map metadataMap = new HashMap() { {
+        put(changelogSSP, null);
+      } };
+    when(systemAdmin.getSSPMetadata(eq(ImmutableSet.of(changelogSSP)))).thenReturn(metadataMap);
+
+    // invoke the method
+    Map<SystemStreamPartition, Option<String>> offsets =
+        tsm.getNewestChangelogSSPOffsets(
+            taskName, storeChangelogs, changelogPartition, systemAdmins);
+
+    // verify results
+    fail("Should have thrown an exception if admin returned null metadata for changelog SSP");
+  }
+
+  @Test(expected = SamzaException.class)
+  public void testGetNewestOffsetsThrowsIfErrorGettingMetadata() {
+    // empty topic == null newest offset
+    ContainerStorageManager csm = mock(ContainerStorageManager.class);
+    TransactionalStateTaskStorageManager tsm = buildTSM(csm, mock(Partition.class));
+
+    TaskName taskName = mock(TaskName.class);
+    String changelogSystemName = "systemName";
+    String storeName = "storeName";
+    String changelogStreamName = "changelogName";
+    String newestChangelogSSPOffset = null;
+    SystemStream changelogSystemStream = new SystemStream(changelogSystemName, changelogStreamName);
+    Partition changelogPartition = new Partition(0);
+    SystemStreamPartition changelogSSP = new SystemStreamPartition(changelogSystemStream, changelogPartition);
+
+    Map<String, SystemStream> storeChangelogs =
+        ScalaJavaUtil.toScalaMap(ImmutableMap.of(storeName, changelogSystemStream));
+
+    SystemAdmins systemAdmins = mock(SystemAdmins.class);
+    SystemAdmin systemAdmin = mock(SystemAdmin.class);
+    SystemStreamPartitionMetadata metadata = mock(SystemStreamPartitionMetadata.class);
+
+    when(metadata.getNewestOffset()).thenReturn(newestChangelogSSPOffset);
+    when(systemAdmins.getSystemAdmin(changelogSystemName)).thenThrow(new SamzaException("Error getting metadata"));
+    when(systemAdmin.getSSPMetadata(eq(ImmutableSet.of(changelogSSP)))).thenReturn(null);
+
+    // invoke the method
+    Map<SystemStreamPartition, Option<String>> offsets =
+        tsm.getNewestChangelogSSPOffsets(
+            taskName, storeChangelogs, changelogPartition, systemAdmins);
+
+    // verify results
+    fail("Should have thrown an exception if admin had an error getting metadata");
+  }
+
+  @Test
+  public void testCheckpoint() {
+    ContainerStorageManager csm = mock(ContainerStorageManager.class);
+
+    StorageEngine mockLPStore = mock(StorageEngine.class);
+    StoreProperties lpStoreProps = mock(StoreProperties.class);
+    when(mockLPStore.getStoreProperties()).thenReturn(lpStoreProps);
+    when(lpStoreProps.isPersistedToDisk()).thenReturn(true);
+    when(lpStoreProps.isLoggedStore()).thenReturn(true);
+    Path mockPath = mock(Path.class);
+    when(mockLPStore.checkpoint(anyString())).thenReturn(Optional.of(mockPath));
+
+    StorageEngine mockPStore = mock(StorageEngine.class);
+    StoreProperties pStoreProps = mock(StoreProperties.class);
+    when(mockPStore.getStoreProperties()).thenReturn(pStoreProps);
+    when(pStoreProps.isPersistedToDisk()).thenReturn(true);
+    when(pStoreProps.isLoggedStore()).thenReturn(false);
+
+    StorageEngine mockLIStore = mock(StorageEngine.class);
+    StoreProperties liStoreProps = mock(StoreProperties.class);
+    when(mockLIStore.getStoreProperties()).thenReturn(liStoreProps);
+    when(liStoreProps.isPersistedToDisk()).thenReturn(false);
+    when(liStoreProps.isLoggedStore()).thenReturn(true);
+
+    StorageEngine mockIStore = mock(StorageEngine.class);
+    StoreProperties iStoreProps = mock(StoreProperties.class);
+    when(mockIStore.getStoreProperties()).thenReturn(iStoreProps);
+    when(iStoreProps.isPersistedToDisk()).thenReturn(false);
+    when(iStoreProps.isLoggedStore()).thenReturn(false);
+
+    java.util.Map<String, StorageEngine> taskStores = ImmutableMap.of(
+        "loggedPersistentStore", mockLPStore,
+        "persistentStore", mockPStore,
+        "loggedInMemStore", mockLIStore,
+        "inMemStore", mockIStore
+    );
+    when(csm.getAllStores(any())).thenReturn(taskStores);
+
+    TransactionalStateTaskStorageManager tsm = spy(buildTSM(csm, mock(Partition.class)));
+    // stub actual method call
+    ArgumentCaptor<Map> checkpointPathsCaptor = ArgumentCaptor.forClass(Map.class);
+    doNothing().when(tsm).writeChangelogOffsetFiles(any(), any(), any());
+
+    Map<SystemStreamPartition, Option<String>> offsets = ScalaJavaUtil.toScalaMap(
+        ImmutableMap.of(mock(SystemStreamPartition.class), Option.apply("1")));
+
+    // invoke checkpoint
+    tsm.checkpoint(offsets);
+
+    // ensure that checkpoint is never called for non-logged persistent stores since they're
+    // always cleared on restart.
+    verify(mockPStore, never()).checkpoint(anyString());
+    // ensure that checkpoint is never called for in-memory stores since they're not persistent.
+    verify(mockIStore, never()).checkpoint(anyString());
+    verify(mockLIStore, never()).checkpoint(anyString());
+    verify(tsm).writeChangelogOffsetFiles(checkpointPathsCaptor.capture(), any(), eq(offsets));
+    Map<String, Path> checkpointPaths = checkpointPathsCaptor.getValue();
+    assertEquals(1, checkpointPaths.size());
+    assertEquals(mockPath, checkpointPaths.apply("loggedPersistentStore"));
+  }
+
+  @Test(expected = SamzaException.class)
+  public void testCheckpointFailsIfErrorWritingOffsetFiles() {
+    ContainerStorageManager csm = mock(ContainerStorageManager.class);
+
+    StorageEngine mockLPStore = mock(StorageEngine.class);
+    StoreProperties lpStoreProps = mock(StoreProperties.class);
+    when(mockLPStore.getStoreProperties()).thenReturn(lpStoreProps);
+    when(lpStoreProps.isPersistedToDisk()).thenReturn(true);
+    when(lpStoreProps.isLoggedStore()).thenReturn(true);
+    Path mockPath = mock(Path.class);
+    when(mockLPStore.checkpoint(anyString())).thenReturn(Optional.of(mockPath));
+    java.util.Map<String, StorageEngine> taskStores =
+        ImmutableMap.of("loggedPersistentStore", mockLPStore);
+    when(csm.getAllStores(any())).thenReturn(taskStores);
+
+    TransactionalStateTaskStorageManager tsm = spy(buildTSM(csm, mock(Partition.class)));
+    doThrow(new SamzaException("Error writing offset file"))
+        .when(tsm).writeChangelogOffsetFiles(any(), any(), any());
+
+    Map<SystemStreamPartition, Option<String>> offsets = ScalaJavaUtil.toScalaMap(
+        ImmutableMap.of(mock(SystemStreamPartition.class), Option.apply("1")));
+
+    // invoke checkpoint
+    tsm.checkpoint(offsets);
+
+    fail("Should have thrown an exception if error writing offset file");
+  }
+
+  @Test
+  public void testWriteChangelogOffsetFiles() throws IOException {
+    String storeName = "mockStore";
+    ContainerStorageManager csm = mock(ContainerStorageManager.class);
+    StorageEngine mockStore = mock(StorageEngine.class);
+    java.util.Map<String, StorageEngine> taskStores = ImmutableMap.of(storeName, mockStore);
+    when(csm.getAllStores(any())).thenReturn(taskStores);
+
+    Partition changelogPartition = new Partition(0);
+    SystemStream changelogSS = new SystemStream("system", "changelog");
+    SystemStreamPartition changelogSSP = new SystemStreamPartition(changelogSS, changelogPartition);
+    TransactionalStateTaskStorageManager tsm = spy(buildTSM(csm, changelogPartition));
+
+    String changelogNewestOffset = "1";
+    Map<SystemStreamPartition, Option<String>> offsets = ScalaJavaUtil.toScalaMap(
+        ImmutableMap.of(changelogSSP, Option.apply(changelogNewestOffset)));
+
+    Path checkpointPath = Files.createTempDirectory("store-checkpoint-test").toAbsolutePath();
+
+    Map<String, Path> checkpointPaths = ScalaJavaUtil.toScalaMap(
+        ImmutableMap.of(storeName, checkpointPath));
+    Map<String, SystemStream> storeChangelogs = ScalaJavaUtil.toScalaMap(
+        ImmutableMap.of(storeName, changelogSS));
+
+    // invoke method
+    tsm.writeChangelogOffsetFiles(checkpointPaths, storeChangelogs, offsets);
+
+    // verify results
+    java.util.Map<SystemStreamPartition, String> fileOffsets = new StorageManagerUtil()
+        .readOffsetFile(checkpointPath.toFile(), ImmutableSet.of(changelogSSP), false);
+    assertEquals(1, fileOffsets.size());
+    assertEquals(changelogNewestOffset, fileOffsets.get(changelogSSP));
+  }
+
+  @Test
+  public void testWriteChangelogOffsetFilesWithEmptyChangelogTopic() throws IOException {
+    String storeName = "mockStore";
+    ContainerStorageManager csm = mock(ContainerStorageManager.class);
+    StorageEngine mockStore = mock(StorageEngine.class);
+    java.util.Map<String, StorageEngine> taskStores = ImmutableMap.of(storeName, mockStore);
+    when(csm.getAllStores(any())).thenReturn(taskStores);
+
+    Partition changelogPartition = new Partition(0);
+    SystemStream changelogSS = new SystemStream("system", "changelog");
+    SystemStreamPartition changelogSSP = new SystemStreamPartition(changelogSS, changelogPartition);
+    TransactionalStateTaskStorageManager tsm = spy(buildTSM(csm, changelogPartition));
+
+    String changelogNewestOffset = null;
+    Map<SystemStreamPartition, Option<String>> offsets = ScalaJavaUtil.toScalaMap(
+        ImmutableMap.of(changelogSSP, Option.apply(changelogNewestOffset)));
+
+    Path checkpointPath = Files.createTempDirectory("store-checkpoint-test").toAbsolutePath();
+
+    Map<String, Path> checkpointPaths = ScalaJavaUtil.toScalaMap(
+        ImmutableMap.of(storeName, checkpointPath));
+    Map<String, SystemStream> storeChangelogs = ScalaJavaUtil.toScalaMap(
+        ImmutableMap.of(storeName, changelogSS));
+
+    // invoke method
+    tsm.writeChangelogOffsetFiles(checkpointPaths, storeChangelogs, offsets);
+
+    // verify results
+    java.util.Map<SystemStreamPartition, String> fileOffsets = new StorageManagerUtil()
+        .readOffsetFile(checkpointPath.toFile(), ImmutableSet.of(changelogSSP), false);
+    assertEquals(0, fileOffsets.size());
+    assertEquals(changelogNewestOffset, fileOffsets.get(changelogSSP));
+  }
+
+  /**
+   * This should never happen with CheckpointingTaskStorageManager. #getNewestChangelogSSPOffset must
+   * return a key for every changelog SSP. If the SSP is empty, the value should be none. If it could
+   * not fetch metadata, it should throw an exception instead of skipping the SSP.
+   * If this contract is accidentally broken, ensure that we fail the commit
+   */
+  @Test(expected = SamzaException.class)
+  public void testWriteChangelogOffsetFilesWithNoChangelogOffset() throws IOException {
+    String storeName = "mockStore";
+    ContainerStorageManager csm = mock(ContainerStorageManager.class);
+    StorageEngine mockStore = mock(StorageEngine.class);
+    java.util.Map<String, StorageEngine> taskStores = ImmutableMap.of(storeName, mockStore);
+    when(csm.getAllStores(any())).thenReturn(taskStores);
+
+    Partition changelogPartition = new Partition(0);
+    SystemStream changelogSS = new SystemStream("system", "changelog");
+    SystemStreamPartition changelogSSP = new SystemStreamPartition(changelogSS, changelogPartition);
+    TransactionalStateTaskStorageManager tsm = spy(buildTSM(csm, changelogPartition));
+
+    // no mapping present for changelog newest offset
+    Map<SystemStreamPartition, Option<String>> offsets = ScalaJavaUtil.toScalaMap(ImmutableMap.of());
+
+    Path checkpointPath = Files.createTempDirectory("store-checkpoint-test").toAbsolutePath();
+    Map<String, Path> checkpointPaths = ScalaJavaUtil.toScalaMap(
+        ImmutableMap.of(storeName, checkpointPath));
+    Map<String, SystemStream> storeChangelogs = ScalaJavaUtil.toScalaMap(
+        ImmutableMap.of(storeName, changelogSS));
+
+    // invoke method
+    tsm.writeChangelogOffsetFiles(checkpointPaths, storeChangelogs, offsets);
+
+    fail("Should have thrown an exception if no changelog offset found for checkpointed store");
+  }
+
+  private TransactionalStateTaskStorageManager buildTSM(ContainerStorageManager csm, Partition changelogPartition) {
+    TaskName taskName = new TaskName("Partition 0");
+    Map<String, SystemStream> changelogSystemStreams = mock(Map.class);
+    SystemAdmins systemAdmins = mock(SystemAdmins.class);
+    File loggedStoreBaseDir = mock(File.class);
+    TaskMode taskMode = TaskMode.Active;
+
+    return new TransactionalStateTaskStorageManager(
+        taskName, csm, changelogSystemStreams, systemAdmins,
+        loggedStoreBaseDir, changelogPartition, taskMode);
+  }
+}

--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/KeyValueStorageEngine.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/KeyValueStorageEngine.scala
@@ -117,6 +117,7 @@ class KeyValueStorageEngine[K, V](
     var restoredBytes = 0
     var trimmedMessages = 0
     var trimmedBytes = 0
+    var previousMode = ChangelogSSPIterator.Mode.RESTORE
 
     val batch = new java.util.ArrayList[Entry[Array[Byte], Array[Byte]]](batchSize)
     var lastBatchFlushed = false
@@ -128,6 +129,11 @@ class KeyValueStorageEngine[K, V](
       val mode = iterator.getMode
 
       if (mode.equals(ChangelogSSPIterator.Mode.RESTORE)) {
+        if (previousMode == ChangelogSSPIterator.Mode.TRIM) {
+          throw new IllegalStateException(
+            String.format("Illegal ChangelogSSPIterator mode change from TRIM to RESTORE for store: %s " +
+              "in dir: %s with changelog SSP: {}.", storeName, storeDir, changelogSSP))
+        }
         batch.add(new Entry(keyBytes, valBytes))
 
         if (batch.size >= batchSize) {
@@ -152,6 +158,7 @@ class KeyValueStorageEngine[K, V](
           info(restoredMessages + " total entries restored for store: " + storeName + " in directory: " + storeDir.toString + ".")
           if (batch.size > 0) {
             doPutAll(rawStore, batch)
+            batch.clear()
           }
           lastBatchFlushed = true
         }
@@ -174,6 +181,8 @@ class KeyValueStorageEngine[K, V](
           info(restoredMessages + " entries trimmed for store: " + storeName + " in directory: " + storeDir.toString + "...")
         }
       }
+
+      previousMode = mode
     }
 
     // if the last batch isn't flushed yet (e.g., for non transactional state or no messages to trim), flush it now
@@ -181,6 +190,7 @@ class KeyValueStorageEngine[K, V](
       info(restoredMessages + " total entries restored for store: " + storeName + " in directory: " + storeDir.toString + ".")
       if (batch.size > 0) {
         doPutAll(rawStore, batch)
+        batch.clear()
       }
       lastBatchFlushed = true
     }

--- a/samza-test/src/main/resources/log4j.xml
+++ b/samza-test/src/main/resources/log4j.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="console" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.out" />
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] [%X{REQUEST_UUID}] %c{1} [%p] %m%n" />
+    </layout>
+  </appender>
+
+  <logger name="kafka">
+    <level value="off" />
+  </logger>
+  <logger name="org.apache.kafka">
+    <level value="off" />
+  </logger>
+  <logger name="org.apache.samza.system.kafka">
+    <level value="off" />
+  </logger>
+  <logger name="org.apache.zookeeper">
+    <level value="off" />
+  </logger>
+  <root>
+    <priority value="INFO" />
+    <appender-ref ref="console"/>
+  </root>
+</log4j:configuration>

--- a/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateIntegrationTest.java
@@ -88,7 +88,7 @@ public class TransactionalStateIntegrationTest extends StreamApplicationIntegrat
       put(TaskConfig.GROUPER_FACTORY, "org.apache.samza.container.grouper.task.GroupByContainerIdsFactory");
       put(TaskConfig.CHECKPOINT_MANAGER_FACTORY, "org.apache.samza.checkpoint.kafka.KafkaCheckpointManagerFactory");
       put(TaskConfig.COMMIT_MS, "-1"); // manual commit only
-      put(TaskConfig.TRANSACTIONAL_STATE_ENABLED, "true");
+      put(TaskConfig.TRANSACTIONAL_STATE_RESTORE_ENABLED, "true");
       put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_CHANGELOG_STATE, "true");
       put(KafkaConfig.CHECKPOINT_REPLICATION_FACTOR(), "1");
       put(JobConfig.JOB_LOGGED_STORE_BASE_DIR, LOGGED_STORE_BASE_DIR);

--- a/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateIntegrationTest.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.storage.kv;
+
+import com.google.common.collect.ImmutableList;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.samza.application.TaskApplication;
+import org.apache.samza.application.descriptors.TaskApplicationDescriptor;
+import org.apache.samza.config.JobConfig;
+import org.apache.samza.config.JobCoordinatorConfig;
+import org.apache.samza.config.KafkaConfig;
+import org.apache.samza.config.TaskConfig;
+import org.apache.samza.context.Context;
+import org.apache.samza.operators.KV;
+import org.apache.samza.serializers.KVSerde;
+import org.apache.samza.serializers.StringSerde;
+import org.apache.samza.storage.kv.descriptors.RocksDbTableDescriptor;
+import org.apache.samza.system.IncomingMessageEnvelope;
+import org.apache.samza.system.kafka.descriptors.KafkaInputDescriptor;
+import org.apache.samza.system.kafka.descriptors.KafkaSystemDescriptor;
+import org.apache.samza.task.InitableTask;
+import org.apache.samza.task.MessageCollector;
+import org.apache.samza.task.StreamTask;
+import org.apache.samza.task.StreamTaskFactory;
+import org.apache.samza.task.TaskCoordinator;
+import org.apache.samza.test.framework.StreamApplicationIntegrationTestHarness;
+import org.apache.samza.util.FileUtil;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Message format:
+ * "num" -> put (key = num, value = num) and flush
+ * "-num" -> delete (key = num) and flush
+ * ":msg" -> act on msg (including flush) but no commit (may be num, shutdown or crash_once)
+ * "shutdown" -> always shutdown the job
+ * "crash_once" -> shut down the job the first time but ignore on subsequent run
+ */
+@RunWith(value = Parameterized.class)
+public class TransactionalStateIntegrationTest extends StreamApplicationIntegrationTestHarness {
+  @Parameterized.Parameters(name = "hostAffinity={0}")
+  public static Collection<Boolean> data() {
+    return Arrays.asList(true, false);
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(TransactionalStateIntegrationTest.class);
+
+  private static final String INPUT_TOPIC = "inputTopic";
+  private static final String INPUT_SYSTEM = "kafka";
+  private static final String STORE_NAME = "store";
+  private static final String CHANGELOG_TOPIC = "changelog";
+  private static final String LOGGED_STORE_BASE_DIR = new File(System.getProperty("java.io.tmpdir"), "logged-store").getAbsolutePath();
+  private static final Map<String, String> CONFIGS = new HashMap<String, String>() { {
+      put(JobCoordinatorConfig.JOB_COORDINATOR_FACTORY, "org.apache.samza.standalone.PassthroughJobCoordinatorFactory");
+      put(JobConfig.PROCESSOR_ID, "0");
+      put(TaskConfig.GROUPER_FACTORY, "org.apache.samza.container.grouper.task.GroupByContainerIdsFactory");
+      put(TaskConfig.CHECKPOINT_MANAGER_FACTORY, "org.apache.samza.checkpoint.kafka.KafkaCheckpointManagerFactory");
+      put(TaskConfig.COMMIT_MS, "-1"); // manual commit only
+      put(TaskConfig.TRANSACTIONAL_STATE_ENABLED, "true");
+      put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE, "true");
+      put(KafkaConfig.CHECKPOINT_REPLICATION_FACTOR(), "1");
+      put(JobConfig.JOB_LOGGED_STORE_BASE_DIR, LOGGED_STORE_BASE_DIR);
+    } };
+
+  private static List<String> actualInitialStoreContents = new ArrayList<>();
+  private static boolean crashedOnce = false;
+
+  private final boolean hostAffinity;
+
+  public TransactionalStateIntegrationTest(boolean hostAffinity) {
+    this.hostAffinity = hostAffinity;
+  }
+
+  @Before
+  @Override
+  public void setUp() {
+    super.setUp();
+    // reset static state shared with task between each parameterized iteration
+    crashedOnce = false;
+    actualInitialStoreContents = new ArrayList<>();
+    new FileUtil().rm(new File(LOGGED_STORE_BASE_DIR)); // always clear local store on startup
+  }
+
+  @Test
+  public void testStopAndRestart() {
+    List<String> inputMessagesOnInitialRun = Arrays.asList("1", "2", "3", "2", "97", "-97", ":98", ":99", ":crash_once");
+    List<String> expectedChangelogMessagesOnInitialRun = Arrays.asList("1", "2", "3", "2", "97", null, "98", "99");
+    initialRun(inputMessagesOnInitialRun, expectedChangelogMessagesOnInitialRun);
+
+    // first two are reverts for uncommitted messages from last run
+    List<String> expectedChangelogMessagesOnSecondRun =
+        Arrays.asList(null, null, "98", "99", "4", "5", "5");
+    List<String> expectedInitialStoreContentsOnSecondRun = Arrays.asList("1", "2", "3");
+    secondRun(CHANGELOG_TOPIC,
+        expectedChangelogMessagesOnSecondRun, expectedInitialStoreContentsOnSecondRun);
+  }
+
+  @Test
+  public void testWithEmptyChangelogFromInitialRun() {
+    // expected changelog messages will always match since we'll read 0 messages
+    initialRun(ImmutableList.of("crash_once"), Collections.emptyList());
+    secondRun(CHANGELOG_TOPIC, ImmutableList.of("4", "5", "5"), Collections.emptyList());
+  }
+
+  @Test
+  public void testWithNewChangelogAfterInitialRun() {
+    List<String> inputMessagesOnInitialRun = Arrays.asList("1", "2", "3", "2", "97", "-97", ":98", ":99", ":crash_once");
+    List<String> expectedChangelogMessagesOnInitialRun = Arrays.asList("1", "2", "3", "2", "97", null, "98", "99");
+    initialRun(inputMessagesOnInitialRun, expectedChangelogMessagesOnInitialRun);
+
+    // admin client delete topic doesn't seem to work, times out up to 60 seconds.
+    // simulate delete topic by changing the changelog topic instead.
+    String newChangelogTopic = "changelog2";
+    LOG.info("Changing changelog topic to: {}", newChangelogTopic);
+    secondRun(newChangelogTopic, ImmutableList.of("98", "99", "4", "5", "5"), Collections.emptyList());
+  }
+
+  private void initialRun(List<String> inputMessages, List<String> expectedChangelogMessages) {
+    // create input topic and produce the first batch of input messages
+    createTopic(INPUT_TOPIC, 1);
+    inputMessages.forEach(m -> produceMessage(INPUT_TOPIC, 0, m, m));
+
+    // verify that the input messages were produced successfully
+    if (inputMessages.size() > 0) {
+      List<ConsumerRecord<String, String>> inputRecords =
+          consumeMessages(Collections.singletonList(INPUT_TOPIC), inputMessages.size());
+      List<String> readInputMessages = inputRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
+      Assert.assertEquals(inputMessages, readInputMessages);
+    }
+
+    // run the application
+    RunApplicationContext context = runApplication(new MyApplication(CHANGELOG_TOPIC), "myApp", CONFIGS);
+
+    // consume and verify the changelog messages
+    if (expectedChangelogMessages.size() > 0) {
+      List<ConsumerRecord<String, String>> changelogRecords =
+          consumeMessages(Collections.singletonList(CHANGELOG_TOPIC), expectedChangelogMessages.size());
+      List<String> changelogMessages = changelogRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
+      Assert.assertEquals(expectedChangelogMessages, changelogMessages);
+    }
+
+    // wait for the application to finish
+    context.getRunner().waitForFinish();
+    LOG.info("Finished initial run");
+  }
+
+  private void secondRun(String changelogTopic, List<String> expectedChangelogMessages,
+      List<String> expectedInitialStoreContents) {
+    // clear the local store directory
+    if (hostAffinity) {
+      new FileUtil().rm(new File(LOGGED_STORE_BASE_DIR));
+    }
+
+    // produce the second batch of input messages
+
+    List<String> inputMessages = Arrays.asList("4", "5", "5", ":shutdown");
+    inputMessages.forEach(m -> produceMessage(INPUT_TOPIC, 0, m, m));
+
+    // run the application
+    RunApplicationContext context = runApplication(new MyApplication(changelogTopic), "myApp", CONFIGS);
+
+    // wait for the application to finish
+    context.getRunner().waitForFinish();
+
+    // consume and verify any additional changelog messages
+    List<ConsumerRecord<String, String>> changelogRecords =
+        consumeMessages(Collections.singletonList(changelogTopic), expectedChangelogMessages.size());
+    List<String> changelogMessages = changelogRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
+    Assert.assertEquals(expectedChangelogMessages, changelogMessages);
+
+    // verify the store contents during startup (this is after changelog verification to ensure init has completed)
+    Assert.assertEquals(expectedInitialStoreContents, actualInitialStoreContents);
+  }
+
+  static class MyApplication implements TaskApplication {
+    private final String changelogTopic;
+
+    public MyApplication(String changelogTopic) {
+      this.changelogTopic = changelogTopic;
+    }
+
+    @Override
+    public void describe(TaskApplicationDescriptor appDescriptor) {
+      KafkaSystemDescriptor ksd = new KafkaSystemDescriptor(INPUT_SYSTEM);
+      KVSerde<String, String> serde = KVSerde.of(new StringSerde(), new StringSerde());
+
+      KafkaInputDescriptor<KV<String, String>> isd = ksd.getInputDescriptor(INPUT_TOPIC, serde);
+
+      RocksDbTableDescriptor<String, String> td = new RocksDbTableDescriptor<>(STORE_NAME, serde)
+          .withChangelogStream(changelogTopic)
+          .withChangelogReplicationFactor(1);
+
+      appDescriptor
+          .withInputStream(isd)
+          .withTaskFactory((StreamTaskFactory) () -> new MyTask())
+          .withTable(td);
+    }
+  }
+
+  static class MyTask implements StreamTask, InitableTask {
+    private KeyValueStore<String, String> store;
+
+    @Override
+    public void init(Context context) {
+      this.store = (KeyValueStore<String, String>) context.getTaskContext().getStore(STORE_NAME);
+      KeyValueIterator<String, String> storeEntries = store.all();
+      while (storeEntries.hasNext()) {
+        actualInitialStoreContents.add(storeEntries.next().getValue());
+      }
+      storeEntries.close();
+    }
+
+    @Override
+    public void process(IncomingMessageEnvelope envelope,
+        MessageCollector collector, TaskCoordinator coordinator) {
+      String key = (String) envelope.getKey();
+      LOG.info("Received key: {}", key);
+
+      if (key.endsWith("crash_once")) {  // endsWith allows :crash_once and crash_once
+        if (!crashedOnce) {
+          crashedOnce = true;
+          coordinator.shutdown(TaskCoordinator.RequestScope.CURRENT_TASK);
+        } else {
+          return;
+        }
+      } else if (key.endsWith("shutdown")) {
+        coordinator.shutdown(TaskCoordinator.RequestScope.CURRENT_TASK);
+      } else if (key.startsWith("-")) {
+        store.delete(key.substring(1));
+      } else if (key.startsWith(":")) {
+        // write the message and flush, but don't invoke commit later
+        String msg = key.substring(1);
+        store.put(msg, msg);
+      } else {
+        store.put(key, key);
+      }
+      store.flush();
+
+      if (!key.startsWith(":")) {
+        coordinator.commit(TaskCoordinator.RequestScope.CURRENT_TASK);
+      }
+    }
+  }
+}

--- a/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateIntegrationTest.java
@@ -89,7 +89,7 @@ public class TransactionalStateIntegrationTest extends StreamApplicationIntegrat
       put(TaskConfig.CHECKPOINT_MANAGER_FACTORY, "org.apache.samza.checkpoint.kafka.KafkaCheckpointManagerFactory");
       put(TaskConfig.COMMIT_MS, "-1"); // manual commit only
       put(TaskConfig.TRANSACTIONAL_STATE_ENABLED, "true");
-      put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE, "true");
+      put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_CHANGELOG_STATE, "true");
       put(KafkaConfig.CHECKPOINT_REPLICATION_FACTOR(), "1");
       put(JobConfig.JOB_LOGGED_STORE_BASE_DIR, LOGGED_STORE_BASE_DIR);
     } };
@@ -179,7 +179,7 @@ public class TransactionalStateIntegrationTest extends StreamApplicationIntegrat
   private void secondRun(String changelogTopic, List<String> expectedChangelogMessages,
       List<String> expectedInitialStoreContents) {
     // clear the local store directory
-    if (hostAffinity) {
+    if (!hostAffinity) {
       new FileUtil().rm(new File(LOGGED_STORE_BASE_DIR));
     }
 

--- a/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateMultiStoreIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateMultiStoreIntegrationTest.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.storage.kv;
+
+import com.google.common.collect.ImmutableList;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.samza.application.TaskApplication;
+import org.apache.samza.application.descriptors.TaskApplicationDescriptor;
+import org.apache.samza.config.JobConfig;
+import org.apache.samza.config.JobCoordinatorConfig;
+import org.apache.samza.config.KafkaConfig;
+import org.apache.samza.config.TaskConfig;
+import org.apache.samza.context.Context;
+import org.apache.samza.operators.KV;
+import org.apache.samza.serializers.KVSerde;
+import org.apache.samza.serializers.StringSerde;
+import org.apache.samza.storage.kv.descriptors.RocksDbTableDescriptor;
+import org.apache.samza.system.IncomingMessageEnvelope;
+import org.apache.samza.system.kafka.descriptors.KafkaInputDescriptor;
+import org.apache.samza.system.kafka.descriptors.KafkaSystemDescriptor;
+import org.apache.samza.task.InitableTask;
+import org.apache.samza.task.MessageCollector;
+import org.apache.samza.task.StreamTask;
+import org.apache.samza.task.StreamTaskFactory;
+import org.apache.samza.task.TaskCoordinator;
+import org.apache.samza.test.framework.StreamApplicationIntegrationTestHarness;
+import org.apache.samza.util.FileUtil;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs the same tests as {@link TransactionalStateIntegrationTest}, except with an additional
+ * unused store with a changelog. Ensures that the stores are isolated, e.g. if the checkpointed
+ * changelog offset for one is null (no data).
+ */
+@RunWith(value = Parameterized.class)
+public class TransactionalStateMultiStoreIntegrationTest extends StreamApplicationIntegrationTestHarness {
+  @Parameterized.Parameters(name = "hostAffinity={0}")
+  public static Collection<Boolean> data() {
+    return Arrays.asList(true, false);
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(TransactionalStateMultiStoreIntegrationTest.class);
+
+  private static final String INPUT_TOPIC = "inputTopic";
+  private static final String INPUT_SYSTEM = "kafka";
+  private static final String STORE_1_NAME = "store1";
+  private static final String STORE_2_NAME = "store2";
+  private static final String STORE_1_CHANGELOG = "changelog1";
+  private static final String STORE_2_CHANGELOG = "changelog2";
+  private static final String LOGGED_STORE_BASE_DIR = new File(System.getProperty("java.io.tmpdir"), "logged-store").getAbsolutePath();
+  private static final Map<String, String> CONFIGS = new HashMap<String, String>() { {
+      put(JobCoordinatorConfig.JOB_COORDINATOR_FACTORY, "org.apache.samza.standalone.PassthroughJobCoordinatorFactory");
+      put(JobConfig.PROCESSOR_ID, "0");
+      put(TaskConfig.GROUPER_FACTORY, "org.apache.samza.container.grouper.task.GroupByContainerIdsFactory");
+      put(TaskConfig.CHECKPOINT_MANAGER_FACTORY, "org.apache.samza.checkpoint.kafka.KafkaCheckpointManagerFactory");
+      put(TaskConfig.COMMIT_MS, "-1"); // manual commit only
+      put(TaskConfig.TRANSACTIONAL_STATE_ENABLED, "true");
+      put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE, "true");
+      put(KafkaConfig.CHECKPOINT_REPLICATION_FACTOR(), "1");
+      put(JobConfig.JOB_LOGGED_STORE_BASE_DIR, LOGGED_STORE_BASE_DIR);
+    } };
+
+  private static List<String> actualInitialStoreContents = new ArrayList<>();
+  private static boolean crashedOnce = false;
+
+  private final boolean hostAffinity;
+
+  public TransactionalStateMultiStoreIntegrationTest(boolean hostAffinity) {
+    this.hostAffinity = hostAffinity;
+  }
+
+  @Before
+  @Override
+  public void setUp() {
+    super.setUp();
+    // reset static state shared with task between each parameterized iteration
+    crashedOnce = false;
+    actualInitialStoreContents = new ArrayList<>();
+    new FileUtil().rm(new File(LOGGED_STORE_BASE_DIR)); // always clear local store on startup
+  }
+
+  @Test
+  public void testStopAndRestart() {
+    List<String> inputMessagesOnInitialRun = Arrays.asList("1", "2", "3", "2", "97", "-97", ":98", ":99", ":crash_once");
+    List<String> expectedChangelogMessagesOnInitialRun = Arrays.asList("1", "2", "3", "2", "97", null, "98", "99");
+    initialRun(inputMessagesOnInitialRun, expectedChangelogMessagesOnInitialRun);
+
+    // first two are reverts for uncommitted messages from last run
+    List<String> expectedChangelogMessagesOnSecondRun =
+        Arrays.asList(null, null, "98", "99", "4", "5", "5");
+    List<String> expectedInitialStoreContentsOnSecondRun = Arrays.asList("1", "2", "3");
+    secondRun(STORE_1_CHANGELOG,
+        expectedChangelogMessagesOnSecondRun, expectedInitialStoreContentsOnSecondRun);
+  }
+
+  @Test
+  public void testWithEmptyChangelogFromInitialRun() {
+    // expected changelog messages will always match since we'll read 0 messages
+    initialRun(ImmutableList.of("crash_once"), Collections.emptyList());
+    secondRun(STORE_1_CHANGELOG, ImmutableList.of("4", "5", "5"), Collections.emptyList());
+  }
+
+  @Test
+  public void testWithNewChangelogAfterInitialRun() {
+    List<String> inputMessagesOnInitialRun = Arrays.asList("1", "2", "3", "2", "97", "-97", ":98", ":99", ":crash_once");
+    List<String> expectedChangelogMessagesOnInitialRun = Arrays.asList("1", "2", "3", "2", "97", null, "98", "99");
+    initialRun(inputMessagesOnInitialRun, expectedChangelogMessagesOnInitialRun);
+
+    // admin client delete topic doesn't seem to work, times out up to 60 seconds.
+    // simulate delete topic by changing the changelog topic instead.
+    String newChangelogTopic = "changelog3";
+    LOG.info("Changing changelog topic to: {}", newChangelogTopic);
+    secondRun(newChangelogTopic, ImmutableList.of("98", "99", "4", "5", "5"), Collections.emptyList());
+  }
+
+  private void initialRun(List<String> inputMessages, List<String> expectedChangelogMessages) {
+    // create input topic and produce the first batch of input messages
+    createTopic(INPUT_TOPIC, 1);
+    inputMessages.forEach(m -> produceMessage(INPUT_TOPIC, 0, m, m));
+
+    // verify that the input messages were produced successfully
+    if (inputMessages.size() > 0) {
+      List<ConsumerRecord<String, String>> inputRecords =
+          consumeMessages(Collections.singletonList(INPUT_TOPIC), inputMessages.size());
+      List<String> readInputMessages = inputRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
+      Assert.assertEquals(inputMessages, readInputMessages);
+    }
+
+    // run the application
+    RunApplicationContext context = runApplication(new MyApplication(STORE_1_CHANGELOG), "myApp", CONFIGS);
+
+    // consume and verify the changelog messages
+    if (expectedChangelogMessages.size() > 0) {
+      List<ConsumerRecord<String, String>> changelogRecords =
+          consumeMessages(Collections.singletonList(STORE_1_CHANGELOG), expectedChangelogMessages.size());
+      List<String> changelogMessages = changelogRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
+      Assert.assertEquals(expectedChangelogMessages, changelogMessages);
+    }
+
+    // wait for the application to finish
+    context.getRunner().waitForFinish();
+    LOG.info("Finished initial run");
+  }
+
+  private void secondRun(String changelogTopic, List<String> expectedChangelogMessages,
+      List<String> expectedInitialStoreContents) {
+    // clear the local store directory
+    if (hostAffinity) {
+      new FileUtil().rm(new File(LOGGED_STORE_BASE_DIR));
+    }
+
+    // produce the second batch of input messages
+
+    List<String> inputMessages = Arrays.asList("4", "5", "5", ":shutdown");
+    inputMessages.forEach(m -> produceMessage(INPUT_TOPIC, 0, m, m));
+
+    // run the application
+    RunApplicationContext context = runApplication(new MyApplication(changelogTopic), "myApp", CONFIGS);
+
+    // wait for the application to finish
+    context.getRunner().waitForFinish();
+
+    // consume and verify any additional changelog messages
+    List<ConsumerRecord<String, String>> changelogRecords =
+        consumeMessages(Collections.singletonList(changelogTopic), expectedChangelogMessages.size());
+    List<String> changelogMessages = changelogRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
+    Assert.assertEquals(expectedChangelogMessages, changelogMessages);
+
+    // verify the store contents during startup (this is after changelog verification to ensure init has completed)
+    Assert.assertEquals(expectedInitialStoreContents, actualInitialStoreContents);
+  }
+
+  static class MyApplication implements TaskApplication {
+    private final String changelogTopic;
+
+    public MyApplication(String changelogTopic) {
+      this.changelogTopic = changelogTopic;
+    }
+
+    @Override
+    public void describe(TaskApplicationDescriptor appDescriptor) {
+      KafkaSystemDescriptor ksd = new KafkaSystemDescriptor(INPUT_SYSTEM);
+      KVSerde<String, String> serde = KVSerde.of(new StringSerde(), new StringSerde());
+
+      KafkaInputDescriptor<KV<String, String>> isd = ksd.getInputDescriptor(INPUT_TOPIC, serde);
+
+      RocksDbTableDescriptor<String, String> td1 = new RocksDbTableDescriptor<>(STORE_1_NAME, serde)
+          .withChangelogStream(changelogTopic)
+          .withChangelogReplicationFactor(1);
+
+      RocksDbTableDescriptor<String, String> td2 = new RocksDbTableDescriptor<>(STORE_2_NAME, serde)
+          .withChangelogStream(STORE_2_CHANGELOG)
+          .withChangelogReplicationFactor(1);
+
+      appDescriptor
+          .withInputStream(isd)
+          .withTaskFactory((StreamTaskFactory) () -> new MyTask())
+          .withTable(td1)
+          .withTable(td2);
+    }
+  }
+
+  static class MyTask implements StreamTask, InitableTask {
+    private KeyValueStore<String, String> store;
+
+    @Override
+    public void init(Context context) {
+      this.store = (KeyValueStore<String, String>) context.getTaskContext().getStore(STORE_1_NAME);
+      KeyValueIterator<String, String> storeEntries = store.all();
+      while (storeEntries.hasNext()) {
+        actualInitialStoreContents.add(storeEntries.next().getValue());
+      }
+      storeEntries.close();
+    }
+
+    @Override
+    public void process(IncomingMessageEnvelope envelope,
+        MessageCollector collector, TaskCoordinator coordinator) {
+      String key = (String) envelope.getKey();
+      LOG.info("Received key: {}", key);
+
+      if (key.endsWith("crash_once")) {  // endsWith allows :crash_once and crash_once
+        if (!crashedOnce) {
+          crashedOnce = true;
+          coordinator.shutdown(TaskCoordinator.RequestScope.CURRENT_TASK);
+        } else {
+          return;
+        }
+      } else if (key.endsWith("shutdown")) {
+        coordinator.shutdown(TaskCoordinator.RequestScope.CURRENT_TASK);
+      } else if (key.startsWith("-")) {
+        store.delete(key.substring(1));
+      } else if (key.startsWith(":")) {
+        // write the message and flush, but don't invoke commit later
+        String msg = key.substring(1);
+        store.put(msg, msg);
+      } else {
+        store.put(key, key);
+      }
+      store.flush();
+
+      if (!key.startsWith(":")) {
+        coordinator.commit(TaskCoordinator.RequestScope.CURRENT_TASK);
+      }
+    }
+  }
+}

--- a/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateMultiStoreIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateMultiStoreIntegrationTest.java
@@ -88,7 +88,7 @@ public class TransactionalStateMultiStoreIntegrationTest extends StreamApplicati
       put(TaskConfig.CHECKPOINT_MANAGER_FACTORY, "org.apache.samza.checkpoint.kafka.KafkaCheckpointManagerFactory");
       put(TaskConfig.COMMIT_MS, "-1"); // manual commit only
       put(TaskConfig.TRANSACTIONAL_STATE_ENABLED, "true");
-      put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE, "true");
+      put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_CHANGELOG_STATE, "true");
       put(KafkaConfig.CHECKPOINT_REPLICATION_FACTOR(), "1");
       put(JobConfig.JOB_LOGGED_STORE_BASE_DIR, LOGGED_STORE_BASE_DIR);
     } };
@@ -178,7 +178,7 @@ public class TransactionalStateMultiStoreIntegrationTest extends StreamApplicati
   private void secondRun(String changelogTopic, List<String> expectedChangelogMessages,
       List<String> expectedInitialStoreContents) {
     // clear the local store directory
-    if (hostAffinity) {
+    if (!hostAffinity) {
       new FileUtil().rm(new File(LOGGED_STORE_BASE_DIR));
     }
 

--- a/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateMultiStoreIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateMultiStoreIntegrationTest.java
@@ -87,7 +87,7 @@ public class TransactionalStateMultiStoreIntegrationTest extends StreamApplicati
       put(TaskConfig.GROUPER_FACTORY, "org.apache.samza.container.grouper.task.GroupByContainerIdsFactory");
       put(TaskConfig.CHECKPOINT_MANAGER_FACTORY, "org.apache.samza.checkpoint.kafka.KafkaCheckpointManagerFactory");
       put(TaskConfig.COMMIT_MS, "-1"); // manual commit only
-      put(TaskConfig.TRANSACTIONAL_STATE_ENABLED, "true");
+      put(TaskConfig.TRANSACTIONAL_STATE_RESTORE_ENABLED, "true");
       put(TaskConfig.TRANSACTIONAL_STATE_RETAIN_EXISTING_CHANGELOG_STATE, "true");
       put(KafkaConfig.CHECKPOINT_REPLICATION_FACTOR(), "1");
       put(JobConfig.JOB_LOGGED_STORE_BASE_DIR, LOGGED_STORE_BASE_DIR);

--- a/samza-test/src/test/java/org/apache/samza/test/framework/TestStreamApplicationIntegrationTestHarness.java
+++ b/samza-test/src/test/java/org/apache/samza/test/framework/TestStreamApplicationIntegrationTestHarness.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.test.framework;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class TestStreamApplicationIntegrationTestHarness extends StreamApplicationIntegrationTestHarness {
+  private static final String INPUT_TOPIC = "input";
+
+  @Test
+  public void testTheTestHarness() {
+    List<String> inputMessages = Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8", "9", "10");
+    // create input topic and produce the first batch of input messages
+    boolean topicCreated = createTopic(INPUT_TOPIC, 1);
+    if (!topicCreated) {
+      fail("Could not create input topic.");
+    }
+    inputMessages.forEach(m -> produceMessage(INPUT_TOPIC, 0, m, m));
+
+    // verify that the input messages were produced successfully
+    if (inputMessages.size() > 0) {
+      List<ConsumerRecord<String, String>> inputRecords =
+          consumeMessages(Collections.singletonList(INPUT_TOPIC), inputMessages.size());
+      List<String> readInputMessages = inputRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
+      Assert.assertEquals(inputMessages, readInputMessages);
+    }
+  }
+}

--- a/samza-test/src/test/scala/org/apache/samza/test/integration/NonTransactionalStateIntegrationTest.scala
+++ b/samza-test/src/test/scala/org/apache/samza/test/integration/NonTransactionalStateIntegrationTest.scala
@@ -70,7 +70,7 @@ class NonTransactionalStateIntegrationTest extends StreamTaskTestUtil {
   StreamTaskTestUtil(Map(
     "job.name" -> "hello-stateful-world",
     "task.class" -> "org.apache.samza.test.integration.StateStoreTestTask",
-    TaskConfig.TRANSACTIONAL_STATE_ENABLED -> "false",
+    TaskConfig.TRANSACTIONAL_STATE_RESTORE_ENABLED -> "false",
     "stores.mystore.factory" -> "org.apache.samza.storage.kv.RocksDbKeyValueStorageEngineFactory",
     "stores.mystore.key.serde" -> "string",
     "stores.mystore.msg.serde" -> "string",

--- a/samza-test/src/test/scala/org/apache/samza/test/integration/NonTransactionalStateIntegrationTest.scala
+++ b/samza-test/src/test/scala/org/apache/samza/test/integration/NonTransactionalStateIntegrationTest.scala
@@ -19,6 +19,7 @@
 
 package org.apache.samza.test.integration
 
+import org.apache.samza.config.TaskConfig
 import org.apache.samza.context.Context
 import org.apache.samza.storage.kv.KeyValueStore
 import org.apache.samza.system.IncomingMessageEnvelope
@@ -69,6 +70,7 @@ class TestStatefulTask extends StreamTaskTestUtil {
   StreamTaskTestUtil(Map(
     "job.name" -> "hello-stateful-world",
     "task.class" -> "org.apache.samza.test.integration.StateStoreTestTask",
+    TaskConfig.TRANSACTIONAL_STATE_ENABLED -> "false",
     "stores.mystore.factory" -> "org.apache.samza.storage.kv.RocksDbKeyValueStorageEngineFactory",
     "stores.mystore.key.serde" -> "string",
     "stores.mystore.msg.serde" -> "string",

--- a/samza-test/src/test/scala/org/apache/samza/test/integration/NonTransactionalStateShutdownIntegrationTest.scala
+++ b/samza-test/src/test/scala/org/apache/samza/test/integration/NonTransactionalStateShutdownIntegrationTest.scala
@@ -29,7 +29,7 @@ import org.junit.{AfterClass, BeforeClass, Test}
 
 import scala.collection.JavaConverters._
 
-object TestShutdownStatefulTask {
+object NonTransactionalStateShutdownIntegrationTest {
   val STORE_NAME = "loggedstore"
   val STATE_TOPIC_STREAM = "storeChangelog"
 
@@ -52,7 +52,7 @@ object TestShutdownStatefulTask {
  * 4. Start the job again.
  * 5. Validate that the job restored all states (1,2,3,99) to the store, including the pending flushed messages before shutdown
  */
-class TestShutdownStatefulTask extends StreamTaskTestUtil {
+class NonTransactionalStateShutdownIntegrationTest extends StreamTaskTestUtil {
 
   StreamTaskTestUtil(Map(
     "job.name" -> "state-stateful-world",
@@ -116,7 +116,7 @@ class ShutdownStateStoreTask extends TestTask {
 
   override def testInit(context: Context) {
     store = context.getTaskContext
-      .getStore(TestShutdownStatefulTask.STORE_NAME)
+      .getStore(NonTransactionalStateShutdownIntegrationTest.STORE_NAME)
       .asInstanceOf[KeyValueStore[String, String]]
     val iter = store.all
     iter.asScala.foreach( p => restored += (p.getKey -> p.getValue))

--- a/samza-test/src/test/scala/org/apache/samza/test/integration/NonTransactionalStateShutdownIntegrationTest.scala
+++ b/samza-test/src/test/scala/org/apache/samza/test/integration/NonTransactionalStateShutdownIntegrationTest.scala
@@ -19,6 +19,7 @@
 
 package org.apache.samza.test.integration
 
+import org.apache.samza.config.TaskConfig
 import org.apache.samza.context.Context
 import org.apache.samza.storage.kv.KeyValueStore
 import org.apache.samza.system.IncomingMessageEnvelope
@@ -57,6 +58,7 @@ class TestShutdownStatefulTask extends StreamTaskTestUtil {
     "job.name" -> "state-stateful-world",
     "task.class" -> "org.apache.samza.test.integration.ShutdownStateStoreTask",
     "task.commit.ms" -> "-1",
+    TaskConfig.TRANSACTIONAL_STATE_ENABLED -> "false",
     "stores.loggedstore.factory" -> "org.apache.samza.storage.kv.RocksDbKeyValueStorageEngineFactory",
     "stores.loggedstore.key.serde" -> "string",
     "stores.loggedstore.msg.serde" -> "string",

--- a/samza-test/src/test/scala/org/apache/samza/test/integration/NonTransactionalStateShutdownIntegrationTest.scala
+++ b/samza-test/src/test/scala/org/apache/samza/test/integration/NonTransactionalStateShutdownIntegrationTest.scala
@@ -58,7 +58,7 @@ class NonTransactionalStateShutdownIntegrationTest extends StreamTaskTestUtil {
     "job.name" -> "state-stateful-world",
     "task.class" -> "org.apache.samza.test.integration.ShutdownStateStoreTask",
     "task.commit.ms" -> "-1",
-    TaskConfig.TRANSACTIONAL_STATE_ENABLED -> "false",
+    TaskConfig.TRANSACTIONAL_STATE_RESTORE_ENABLED -> "false",
     "stores.loggedstore.factory" -> "org.apache.samza.storage.kv.RocksDbKeyValueStorageEngineFactory",
     "stores.loggedstore.key.serde" -> "string",
     "stores.loggedstore.msg.serde" -> "string",

--- a/samza-test/src/test/scala/org/apache/samza/test/integration/StreamTaskTestUtil.scala
+++ b/samza-test/src/test/scala/org/apache/samza/test/integration/StreamTaskTestUtil.scala
@@ -19,9 +19,10 @@
 
 package org.apache.samza.test.integration
 
+import java.io.File
 import java.time.Duration
 import java.util
-import java.util.{Collections, Properties}
+import java.util.{Collections, Properties, Random}
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 import javax.security.auth.login.Configuration
@@ -75,6 +76,11 @@ object StreamTaskTestUtil {
   val cp1 = new Checkpoint(Map(new SystemStreamPartition("kafka", "topic", new Partition(0)) -> "123").asJava)
   val cp2 = new Checkpoint(Map(new SystemStreamPartition("kafka", "topic", new Partition(0)) -> "12345").asJava)
 
+  // use a random store directory for each run. prevents test failures due to left over state from
+  // previously aborted test runs
+  val random = new Random()
+  val LOGGED_STORE_BASE_DIR = new File(System.getProperty("java.io.tmpdir"), "logged-store-" + random.nextInt()).getAbsolutePath
+
   /*
    * This is the default job configuration. Each test class can override the default configuration below.
    */
@@ -96,7 +102,9 @@ object StreamTaskTestUtil {
     "task.checkpoint.replication.factor" -> "1",
     // However, don't have the inputs use the checkpoint manager
     // since the second part of the test expects to replay the input streams.
-    "systems.kafka.streams.input.samza.reset.offset" -> "false")
+    "systems.kafka.streams.input.samza.reset.offset" -> "false",
+    JobConfig.JOB_LOGGED_STORE_BASE_DIR -> LOGGED_STORE_BASE_DIR
+  )
 
   def apply(map: Map[String, String]): Unit = {
     jobConfig ++= map


### PR DESCRIPTION
Adds implementation and tests for transactional state checkpoint and restore paths.

Changes the existing Task commit path to create and clean up store checkpoint directories, and write the newest changelog offset to the checkpoint.