### PR TITLE
Samza-2331: Fix java doc of table descriptor for default rate limiter

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
+++ b/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
@@ -225,7 +225,9 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
    * it is invalid to call {@link RemoteTableDescriptor#withRateLimiter(RateLimiter,
    * TableRateLimiter.CreditFunction, TableRateLimiter.CreditFunction)}
    * and vice versa.
-   * @param creditsPerSec rate limit for read operations; must be positive
+   * Note that this is the total credit of rate limit for the entire job, each task will get a per task
+   * credit of creditsPerSec/tasksCount. Hence creditsPerSec should be greater than total number of tasks.
+   * @param creditsPerSec rate limit for read operations; must be positive and greater than total number tasks
    * @return this table descriptor instance
    */
   public RemoteTableDescriptor<K, V> withReadRateLimit(int creditsPerSec) {
@@ -239,7 +241,9 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
    * it is invalid to call {@link RemoteTableDescriptor#withRateLimiter(RateLimiter,
    * TableRateLimiter.CreditFunction, TableRateLimiter.CreditFunction)}
    * and vice versa.
-   * @param creditsPerSec rate limit for write operations; must be positive
+   * Note that this is the total credit of rate limit for the entire job, each task will get a per task
+   * credit of creditsPerSec/tasksCount. Hence creditsPerSec should be greater than total number of tasks.
+   * @param creditsPerSec rate limit for write operations; must be positive and greater than total number tasks
    * @return this table descriptor instance
    */
   public RemoteTableDescriptor<K, V> withWriteRateLimit(int creditsPerSec) {

--- a/samza-core/src/main/java/org/apache/samza/util/EmbeddedTaggedRateLimiter.java
+++ b/samza-core/src/main/java/org/apache/samza/util/EmbeddedTaggedRateLimiter.java
@@ -115,6 +115,8 @@ public class EmbeddedTaggedRateLimiter implements RateLimiter {
             int numTasks = jobModel.getContainers().values().stream()
                 .mapToInt(cm -> cm.getTasks().size())
                 .sum();
+            Preconditions.checkArgument(e.getValue() >= numTasks,
+                    String.format("rate limit count (%d) must be greater than number of tasks (%d)", e.getValue(), numTasks));
             int effectiveRate = e.getValue() / numTasks;
             TaskName taskName = context.getTaskContext().getTaskModel().getTaskName();
             LOGGER.info(String.format("Effective rate limit for task %s and tag %s is %d", taskName, tag,

--- a/samza-core/src/main/java/org/apache/samza/util/EmbeddedTaggedRateLimiter.java
+++ b/samza-core/src/main/java/org/apache/samza/util/EmbeddedTaggedRateLimiter.java
@@ -120,8 +120,8 @@ public class EmbeddedTaggedRateLimiter implements RateLimiter {
             LOGGER.info(String.format("Effective rate limit for task %s and tag %s is %f", taskName, tag,
                 effectiveRate));
             if (effectiveRate < 1.0) {
-                LOGGER.warn(String.format("Effective limit rate (%f) is very low. "
-                        + "Total rate limit is %d while number of tasks is %d. Consider increasing the rate limit.",
+              LOGGER.warn(String.format("Effective limit rate (%f) is very low. "
+                              + "Total rate limit is %d while number of tasks is %d. Consider increasing the rate limit.",
                         effectiveRate, e.getValue(), numTasks));
             }
             return new ImmutablePair<>(tag, com.google.common.util.concurrent.RateLimiter.create(effectiveRate));


### PR DESCRIPTION
Existing java doc is confusing about what the actual behavior is for the default rate limiter. We should explicitly note that it is for the entire job and per task credit needs to divide that by number of tasks.