### PR TITLE
SAMZA-2319: [2/2] Simplify Container Allocation logic : Rename AbstractContainerAllocator to ContainerAllocator

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerAllocator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerAllocator.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * {@link AbstractContainerAllocator} makes requests for physical resources to the resource manager and also runs
+ * {@link ContainerAllocator} makes requests for physical resources to the resource manager and also runs
  * a processor on an allocated physical resource.
  *
  * <ul>
@@ -69,9 +69,9 @@ import org.slf4j.LoggerFactory;
  *
  * This class is not thread-safe. This class is used in the refactored code path as called by run-jc.sh
  */
-public class AbstractContainerAllocator implements Runnable {
+public class ContainerAllocator implements Runnable {
 
-  private static final Logger LOG = LoggerFactory.getLogger(AbstractContainerAllocator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ContainerAllocator.class);
 
   /* State that controls the lifecycle of the allocator thread */
   private volatile boolean isRunning = true;
@@ -122,7 +122,7 @@ public class AbstractContainerAllocator implements Runnable {
 
   private final Optional<StandbyContainerManager> standbyContainerManager;
 
-  public AbstractContainerAllocator(ClusterResourceManager clusterResourceManager,
+  public ContainerAllocator(ClusterResourceManager clusterResourceManager,
       Config config,
       SamzaApplicationState state,
       ClassLoader pluginClassLoader,

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerProcessManager.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerProcessManager.java
@@ -60,7 +60,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *      - Identifying the cause of container failure and re-requesting containers from the cluster manager by adding request to the
  *        internal requestQueue in {@link ResourceRequestState}
  *  - The allocator thread that assigns the allocated containers to pending requests
- *    (See {@link org.apache.samza.clustermanager.AbstractContainerAllocator} or {@link org.apache.samza.clustermanager.AbstractContainerAllocator})
+ *    (See {@link org.apache.samza.clustermanager.ContainerAllocator} or {@link org.apache.samza.clustermanager.ContainerAllocator})
  *
  */
 public class ContainerProcessManager implements ClusterResourceManager.Callback   {
@@ -92,7 +92,7 @@ public class ContainerProcessManager implements ClusterResourceManager.Callback 
   /**
    * The Allocator matches requests to resources and executes processes.
    */
-  private final AbstractContainerAllocator containerAllocator;
+  private final ContainerAllocator containerAllocator;
   private final Thread allocatorThread;
 
   // The StandbyContainerManager manages standby-aware allocation and failover of containers
@@ -167,7 +167,7 @@ public class ContainerProcessManager implements ClusterResourceManager.Callback 
       this.standbyContainerManager = Optional.empty();
     }
 
-    this.containerAllocator = new AbstractContainerAllocator(this.clusterResourceManager, config, state, classLoader, hostAffinityEnabled, this.standbyContainerManager);
+    this.containerAllocator = new ContainerAllocator(this.clusterResourceManager, config, state, classLoader, hostAffinityEnabled, this.standbyContainerManager);
     this.allocatorThread = new Thread(this.containerAllocator, "Container Allocator Thread");
     LOG.info("Finished container process manager initialization.");
   }
@@ -177,7 +177,7 @@ public class ContainerProcessManager implements ClusterResourceManager.Callback 
       SamzaApplicationState state,
       MetricsRegistryMap registry,
       ClusterResourceManager resourceManager,
-      Optional<AbstractContainerAllocator> allocator,
+      Optional<ContainerAllocator> allocator,
       ClassLoader classLoader) {
     this.state = state;
     this.clusterManagerConfig = clusterManagerConfig;
@@ -189,7 +189,7 @@ public class ContainerProcessManager implements ClusterResourceManager.Callback 
     this.standbyContainerManager = Optional.empty();
     this.diagnosticsManager = Option.empty();
     this.containerAllocator = allocator.orElseGet(
-        () -> new AbstractContainerAllocator(this.clusterResourceManager, clusterManagerConfig, state, classLoader,
+        () -> new ContainerAllocator(this.clusterResourceManager, clusterManagerConfig, state, classLoader,
             hostAffinityEnabled, this.standbyContainerManager));
     this.allocatorThread = new Thread(this.containerAllocator, "Container Allocator Thread");
     LOG.info("Finished container process manager initialization");

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/StandbyContainerManager.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/StandbyContainerManager.java
@@ -83,7 +83,7 @@ public class StandbyContainerManager {
    * @param containerAllocator the container allocator
    */
   public void handleContainerStop(String containerID, String resourceID, String preferredHost, int exitStatus,
-      AbstractContainerAllocator containerAllocator, Duration preferredHostRetryDelay) {
+      ContainerAllocator containerAllocator, Duration preferredHostRetryDelay) {
 
     if (StandbyTaskUtil.isStandbyContainer(containerID)) {
       handleStandbyContainerStop(containerID, resourceID, preferredHost, containerAllocator, preferredHostRetryDelay);
@@ -116,7 +116,7 @@ public class StandbyContainerManager {
    * @param containerID the ID of the container that has failed
    */
   public void handleContainerLaunchFail(String containerID, String resourceID,
-      AbstractContainerAllocator containerAllocator) {
+      ContainerAllocator containerAllocator) {
 
     if (StandbyTaskUtil.isStandbyContainer(containerID)) {
       log.info("Handling launch fail for standby-container {}, requesting resource on any host {}", containerID);
@@ -137,7 +137,7 @@ public class StandbyContainerManager {
    * @param preferredHost Preferred host of the standby container
    */
   private void handleStandbyContainerStop(String standbyContainerID, String resourceID, String preferredHost,
-      AbstractContainerAllocator containerAllocator, Duration preferredHostRetryDelay) {
+      ContainerAllocator containerAllocator, Duration preferredHostRetryDelay) {
 
     // if this standbyContainerResource was stopped for a failover, we will find a metadata entry
     Optional<StandbyContainerManager.FailoverMetadata> failoverMetadata = this.checkIfUsedForFailover(resourceID);
@@ -173,7 +173,7 @@ public class StandbyContainerManager {
    * @param resourceID  the samza-resource-ID of the container when it failed (used to index failover-state)
    */
   private void initiateStandbyAwareAllocation(String activeContainerID, String resourceID,
-      AbstractContainerAllocator containerAllocator) {
+      ContainerAllocator containerAllocator) {
 
     String standbyHost = this.selectStandbyHost(activeContainerID, resourceID);
 
@@ -371,7 +371,7 @@ public class StandbyContainerManager {
    * @param samzaResource the resource candidate
    */
   public void checkStandbyConstraintsAndRunStreamProcessor(SamzaResourceRequest request, String preferredHost,
-      SamzaResource samzaResource, AbstractContainerAllocator containerAllocator,
+      SamzaResource samzaResource, ContainerAllocator containerAllocator,
       ResourceRequestState resourceRequestState) {
     String containerID = request.getProcessorId();
 
@@ -414,7 +414,7 @@ public class StandbyContainerManager {
    * @param resourceRequestState used to cancel resource requests if required.
    */
   public void handleExpiredResourceRequest(String containerID, SamzaResourceRequest request,
-      Optional<SamzaResource> alternativeResource, AbstractContainerAllocator containerAllocator,
+      Optional<SamzaResource> alternativeResource, ContainerAllocator containerAllocator,
       ResourceRequestState resourceRequestState) {
 
     if (StandbyTaskUtil.isStandbyContainer(containerID)) {
@@ -427,7 +427,7 @@ public class StandbyContainerManager {
 
   // Handle an expired resource request that was made for placing a standby container
   private void handleExpiredRequestForStandbyContainer(String containerID, SamzaResourceRequest request,
-      Optional<SamzaResource> alternativeResource, AbstractContainerAllocator containerAllocator,
+      Optional<SamzaResource> alternativeResource, ContainerAllocator containerAllocator,
       ResourceRequestState resourceRequestState) {
 
     if (alternativeResource.isPresent()) {
@@ -447,7 +447,7 @@ public class StandbyContainerManager {
 
   // Handle an expired resource request that was made for placing an active container
   private void handleExpiredRequestForActiveContainer(String containerID, SamzaResourceRequest request,
-      AbstractContainerAllocator containerAllocator, ResourceRequestState resourceRequestState) {
+      ContainerAllocator containerAllocator, ResourceRequestState resourceRequestState) {
 
     log.info("Handling expired request for active container {}", containerID);
     Optional<FailoverMetadata> failoverMetadata = getFailoverMetadata(request);

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/MockContainerAllocatorWithHostAffinity.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/MockContainerAllocatorWithHostAffinity.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
-public class MockContainerAllocatorWithHostAffinity extends AbstractContainerAllocator {
+public class MockContainerAllocatorWithHostAffinity extends ContainerAllocator {
   private Semaphore semaphore = new Semaphore(0);
 
   public MockContainerAllocatorWithHostAffinity(ClusterResourceManager manager,
@@ -55,7 +55,7 @@ public class MockContainerAllocatorWithHostAffinity extends AbstractContainerAll
   }
 
   public ResourceRequestState getContainerRequestState() throws Exception {
-    Field field = AbstractContainerAllocator.class.getDeclaredField("resourceRequestState");
+    Field field = ContainerAllocator.class.getDeclaredField("resourceRequestState");
     field.setAccessible(true);
 
     return (ResourceRequestState) field.get(this);

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/MockContainerAllocatorWithoutHostAffinity.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/MockContainerAllocatorWithoutHostAffinity.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
-public class MockContainerAllocatorWithoutHostAffinity extends AbstractContainerAllocator {
+public class MockContainerAllocatorWithoutHostAffinity extends ContainerAllocator {
   public int requestedContainers = 0;
   private Semaphore semaphore = new Semaphore(0);
 
@@ -58,7 +58,7 @@ public class MockContainerAllocatorWithoutHostAffinity extends AbstractContainer
   }
 
   public ResourceRequestState getContainerRequestState() throws Exception {
-    Field field = AbstractContainerAllocator.class.getDeclaredField("resourceRequestState");
+    Field field = ContainerAllocator.class.getDeclaredField("resourceRequestState");
     field.setAccessible(true);
 
     return (ResourceRequestState) field.get(this);

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithHostAffinity.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithHostAffinity.java
@@ -74,8 +74,8 @@ public class TestContainerAllocatorWithHostAffinity {
         new MockHttpServer("/", 7777, null, new ServletHolder(DefaultServlet.class)));
   }
 
-  private AbstractContainerAllocator containerAllocator;
-  private AbstractContainerAllocator spyAllocator;
+  private ContainerAllocator containerAllocator;
+  private ContainerAllocator spyAllocator;
   private final int timeoutMillis = 1000;
   private MockContainerRequestState requestState;
   private Thread allocatorThread;
@@ -84,7 +84,7 @@ public class TestContainerAllocatorWithHostAffinity {
   @Before
   public void setup() throws Exception {
     containerAllocator =
-        new AbstractContainerAllocator(clusterResourceManager, config, state,
+        new ContainerAllocator(clusterResourceManager, config, state,
             getClass().getClassLoader(), true, Optional.empty());
     requestState = new MockContainerRequestState(clusterResourceManager, true);
     Field requestStateField = containerAllocator.getClass().getDeclaredField("resourceRequestState");
@@ -369,7 +369,7 @@ public class TestContainerAllocatorWithHostAffinity {
       }).when(mockCPM).onResourcesAvailable(anyList());
 
     spyAllocator = Mockito.spy(
-        new AbstractContainerAllocator(new MockClusterResourceManager(mockCPM, state), config, state,
+        new ContainerAllocator(new MockClusterResourceManager(mockCPM, state), config, state,
             getClass().getClassLoader(), true, Optional.empty()));
 
     // Request Resources
@@ -408,7 +408,7 @@ public class TestContainerAllocatorWithHostAffinity {
   public void testExpiredRequestAllocationOnAnyHost() throws Exception {
     MockClusterResourceManager spyManager = spy(new MockClusterResourceManager(callback, state));
     spyAllocator = Mockito.spy(
-        new AbstractContainerAllocator(spyManager, config, state,
+        new ContainerAllocator(spyManager, config, state,
             getClass().getClassLoader(), true, Optional.empty()));
 
     // Request Preferred Resources
@@ -451,7 +451,7 @@ public class TestContainerAllocatorWithHostAffinity {
   public void testExpiredRequestAllocationOnSurplusAnyHostWithRunStreamProcessor() throws Exception {
     // Add Extra Resources
     spyAllocator = Mockito.spy(
-        new AbstractContainerAllocator(new MockClusterResourceManager(callback, state), config, state,
+        new ContainerAllocator(new MockClusterResourceManager(callback, state), config, state,
             getClass().getClassLoader(), true, Optional.empty()));
 
     spyAllocator.addResource(new SamzaResource(1, 1000, "xyz", "id1"));

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithoutHostAffinity.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithoutHostAffinity.java
@@ -58,16 +58,16 @@ public class TestContainerAllocatorWithoutHostAffinity {
   private final SamzaApplicationState state = new SamzaApplicationState(jobModelManager);
   private final MockClusterResourceManager manager = new MockClusterResourceManager(callback, state);
 
-  private AbstractContainerAllocator containerAllocator;
+  private ContainerAllocator containerAllocator;
   private MockContainerRequestState requestState;
   private Thread allocatorThread;
 
   private Thread spyThread;
-  private AbstractContainerAllocator spyAllocator;
+  private ContainerAllocator spyAllocator;
 
   @Before
   public void setup() throws Exception {
-    containerAllocator = new AbstractContainerAllocator(manager, config, state, getClass().getClassLoader(), false, Optional
+    containerAllocator = new ContainerAllocator(manager, config, state, getClass().getClassLoader(), false, Optional
         .empty());
     requestState = new MockContainerRequestState(manager, false);
     Field requestStateField = containerAllocator.getClass().getDeclaredField("resourceRequestState");
@@ -263,7 +263,7 @@ public class TestContainerAllocatorWithoutHostAffinity {
 
     ClusterResourceManager.Callback mockCPM = mock(ClusterResourceManager.Callback.class);
     spyAllocator = Mockito.spy(
-        new AbstractContainerAllocator(new MockClusterResourceManager(mockCPM, state), config, state,
+        new ContainerAllocator(new MockClusterResourceManager(mockCPM, state), config, state,
             getClass().getClassLoader(), false, Optional.empty()));
     // Mock the callback from ClusterManager to add resources to the allocator
     doAnswer((InvocationOnMock invocation) -> {

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerProcessManager.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerProcessManager.java
@@ -146,9 +146,9 @@ public class TestContainerProcessManager {
     ContainerProcessManager cpm =
         buildContainerProcessManager(new ClusterManagerConfig(new MapConfig(conf)), state, clusterResourceManager, Optional.empty());
 
-    AbstractContainerAllocator allocator =
-        (AbstractContainerAllocator) getPrivateFieldFromCpm("containerAllocator", cpm).get(cpm);
-    assertEquals(AbstractContainerAllocator.class, allocator.getClass());
+    ContainerAllocator allocator =
+        (ContainerAllocator) getPrivateFieldFromCpm("containerAllocator", cpm).get(cpm);
+    assertEquals(ContainerAllocator.class, allocator.getClass());
     // Asserts that samza exposed container configs is honored by allocator thread
     assertEquals(500, allocator.containerMemoryMb);
     assertEquals(5, allocator.containerNumCpuCores);
@@ -171,8 +171,8 @@ public class TestContainerProcessManager {
     );
 
     allocator =
-        (AbstractContainerAllocator) getPrivateFieldFromCpm("containerAllocator", cpm).get(cpm);
-    assertEquals(AbstractContainerAllocator.class, allocator.getClass());
+        (ContainerAllocator) getPrivateFieldFromCpm("containerAllocator", cpm).get(cpm);
+    assertEquals(ContainerAllocator.class, allocator.getClass());
     // Asserts that samza exposed container configs is honored by allocator thread
     assertEquals(500, allocator.containerMemoryMb);
     assertEquals(5, allocator.containerNumCpuCores);
@@ -891,7 +891,7 @@ public class TestContainerProcessManager {
   }
 
   private ContainerProcessManager buildContainerProcessManager(ClusterManagerConfig clusterManagerConfig, SamzaApplicationState state,
-      ClusterResourceManager clusterResourceManager, Optional<AbstractContainerAllocator> allocator) {
+      ClusterResourceManager clusterResourceManager, Optional<ContainerAllocator> allocator) {
     return new ContainerProcessManager(clusterManagerConfig, state, new MetricsRegistryMap(), clusterResourceManager, allocator,
         getClass().getClassLoader());
   }


### PR DESCRIPTION
Summary: This PR just renames AbstractContainerAllocator to ContainerAllocator

Note: This is a stacked PR on: https://github.com/apache/samza/pull/1152

*For the ease of reviewing, please review this PR from commit onwards:*
https://github.com/apache/samza/commit/439f0bc7305d4ad1cb50821df60f9c97ae84b20e
