### PR TITLE
SAMZA-2335: Remove classloader argument from ReflectionUtil

### DIFF
--- a/samza-azure/src/main/java/org/apache/samza/coordinator/AzureJobCoordinator.java
+++ b/samza-azure/src/main/java/org/apache/samza/coordinator/AzureJobCoordinator.java
@@ -300,7 +300,7 @@ public class AzureJobCoordinator implements JobCoordinator {
     JobConfig jobConfig = new JobConfig(config);
     String factoryString = jobConfig.getSystemStreamPartitionGrouperFactory();
     SystemStreamPartitionGrouper grouper =
-        ReflectionUtil.getObj(getClass().getClassLoader(), factoryString, SystemStreamPartitionGrouperFactory.class)
+        ReflectionUtil.getObj(factoryString, SystemStreamPartitionGrouperFactory.class)
             .getSystemStreamPartitionGrouper(jobConfig);
     return grouper;
   }
@@ -367,8 +367,7 @@ public class AzureJobCoordinator implements JobCoordinator {
     // Generate the new JobModel
     GrouperMetadata grouperMetadata = new GrouperMetadataImpl(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
     JobModel newJobModel =
-        JobModelManager.readJobModel(this.config, Collections.emptyMap(), streamMetadataCache, grouperMetadata,
-            getClass().getClassLoader());
+        JobModelManager.readJobModel(this.config, Collections.emptyMap(), streamMetadataCache, grouperMetadata);
     LOG.info("pid=" + processorId + "Generated new Job Model. Version = " + nextJMVersion);
 
     // Publish the new job model

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/AbstractContainerAllocator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/AbstractContainerAllocator.java
@@ -88,11 +88,6 @@ public class AbstractContainerAllocator implements Runnable {
   private final Config config;
 
   /**
-   * Classloader for creating objects from config
-   */
-  private final ClassLoader pluginClassLoader;
-
-  /**
    * A ClusterResourceManager for the allocator to request for resources.
    */
   protected final ClusterResourceManager clusterResourceManager;
@@ -125,7 +120,6 @@ public class AbstractContainerAllocator implements Runnable {
   public AbstractContainerAllocator(ClusterResourceManager clusterResourceManager,
       Config config,
       SamzaApplicationState state,
-      ClassLoader pluginClassLoader,
       boolean hostAffinityEnabled,
       Optional<StandbyContainerManager> standbyContainerManager) {
     ClusterManagerConfig clusterManagerConfig = new ClusterManagerConfig(config);
@@ -137,7 +131,6 @@ public class AbstractContainerAllocator implements Runnable {
     this.taskConfig = new TaskConfig(config);
     this.state = state;
     this.config = config;
-    this.pluginClassLoader = pluginClassLoader;
     this.hostAffinityEnabled = hostAffinityEnabled;
     this.standbyContainerManager = standbyContainerManager;
     this.requestExpiryTimeout = clusterManagerConfig.getContainerRequestTimeout();
@@ -428,8 +421,7 @@ public class AbstractContainerAllocator implements Runnable {
    */
   private CommandBuilder getCommandBuilder(String processorId) {
     String cmdBuilderClassName = taskConfig.getCommandClass(ShellCommandBuilder.class.getName());
-    CommandBuilder cmdBuilder =
-        ReflectionUtil.getObj(this.pluginClassLoader, cmdBuilderClassName, CommandBuilder.class);
+    CommandBuilder cmdBuilder = ReflectionUtil.getObj(cmdBuilderClassName, CommandBuilder.class);
 
     cmdBuilder.setConfig(config).setId(processorId).setUrl(state.jobModelManager.server().getUrl());
     return cmdBuilder;

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterBasedJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterBasedJobCoordinator.java
@@ -181,10 +181,8 @@ public class ClusterBasedJobCoordinator {
 
     // build a JobModelManager and ChangelogStreamManager and perform partition assignments.
     changelogStreamManager = new ChangelogStreamManager(new NamespaceAwareCoordinatorStreamStore(coordinatorStreamStore, SetChangelogMapping.TYPE));
-    ClassLoader classLoader = getClass().getClassLoader();
     jobModelManager =
-        JobModelManager.apply(config, changelogStreamManager.readPartitionMapping(), coordinatorStreamStore,
-            classLoader, metrics);
+        JobModelManager.apply(config, changelogStreamManager.readPartitionMapping(), coordinatorStreamStore, metrics);
 
     hasDurableStores = new StorageConfig(config).hasDurableStores();
     state = new SamzaApplicationState(jobModelManager);
@@ -201,7 +199,7 @@ public class ClusterBasedJobCoordinator {
     jobCoordinatorSleepInterval = clusterManagerConfig.getJobCoordinatorSleepInterval();
 
     // build a container process Manager
-    containerProcessManager = createContainerProcessManager(classLoader);
+    containerProcessManager = createContainerProcessManager();
   }
 
   /**
@@ -233,8 +231,7 @@ public class ClusterBasedJobCoordinator {
 
       //create necessary checkpoint and changelog streams, if not created
       JobModel jobModel = jobModelManager.jobModel();
-      MetadataResourceUtil metadataResourceUtil =
-          new MetadataResourceUtil(jobModel, this.metrics, getClass().getClassLoader(), config);
+      MetadataResourceUtil metadataResourceUtil = new MetadataResourceUtil(jobModel, this.metrics, config);
       metadataResourceUtil.createResources();
 
       // fan out the startpoints
@@ -401,8 +398,8 @@ public class ClusterBasedJobCoordinator {
   }
 
   @VisibleForTesting
-  ContainerProcessManager createContainerProcessManager(ClassLoader classLoader) {
-    return new ContainerProcessManager(config, state, metrics, classLoader);
+  ContainerProcessManager createContainerProcessManager() {
+    return new ContainerProcessManager(config, state, metrics);
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerProcessManager.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerProcessManager.java
@@ -126,22 +126,20 @@ public class ContainerProcessManager implements ClusterResourceManager.Callback 
   private JvmMetrics jvmMetrics;
   private Map<String, MetricsReporter> metricsReporters;
 
-  public ContainerProcessManager(Config config, SamzaApplicationState state, MetricsRegistryMap registry,
-      ClassLoader classLoader) {
+  public ContainerProcessManager(Config config, SamzaApplicationState state, MetricsRegistryMap registry) {
     this.state = state;
     this.clusterManagerConfig = new ClusterManagerConfig(config);
     this.jobConfig = new JobConfig(config);
 
     this.hostAffinityEnabled = clusterManagerConfig.getHostAffinityEnabled();
 
-    ResourceManagerFactory factory = getContainerProcessManagerFactory(clusterManagerConfig, classLoader);
+    ResourceManagerFactory factory = getContainerProcessManagerFactory(clusterManagerConfig);
     this.clusterResourceManager = checkNotNull(factory.getClusterResourceManager(this, state));
 
     // Initialize metrics
     this.containerProcessManagerMetrics = new ContainerProcessManagerMetrics(config, state, registry);
     this.jvmMetrics = new JvmMetrics(registry);
-    this.metricsReporters =
-        MetricsReporterLoader.getMetricsReporters(new MetricsConfig(config), METRICS_SOURCE_NAME, classLoader);
+    this.metricsReporters = MetricsReporterLoader.getMetricsReporters(new MetricsConfig(config), METRICS_SOURCE_NAME);
 
     // Creating diagnostics manager and reporter, and wiring it respectively
     String jobName = new JobConfig(config).getName().get();
@@ -167,7 +165,7 @@ public class ContainerProcessManager implements ClusterResourceManager.Callback 
       this.standbyContainerManager = Optional.empty();
     }
 
-    this.containerAllocator = new AbstractContainerAllocator(this.clusterResourceManager, config, state, classLoader, hostAffinityEnabled, this.standbyContainerManager);
+    this.containerAllocator = new AbstractContainerAllocator(this.clusterResourceManager, config, state, hostAffinityEnabled, this.standbyContainerManager);
     this.allocatorThread = new Thread(this.containerAllocator, "Container Allocator Thread");
     LOG.info("Finished container process manager initialization.");
   }
@@ -177,8 +175,7 @@ public class ContainerProcessManager implements ClusterResourceManager.Callback 
       SamzaApplicationState state,
       MetricsRegistryMap registry,
       ClusterResourceManager resourceManager,
-      Optional<AbstractContainerAllocator> allocator,
-      ClassLoader classLoader) {
+      Optional<AbstractContainerAllocator> allocator) {
     this.state = state;
     this.clusterManagerConfig = clusterManagerConfig;
     this.jobConfig = new JobConfig(clusterManagerConfig);
@@ -189,7 +186,7 @@ public class ContainerProcessManager implements ClusterResourceManager.Callback 
     this.standbyContainerManager = Optional.empty();
     this.diagnosticsManager = Option.empty();
     this.containerAllocator = allocator.orElseGet(
-        () -> new AbstractContainerAllocator(this.clusterResourceManager, clusterManagerConfig, state, classLoader,
+        () -> new AbstractContainerAllocator(this.clusterResourceManager, clusterManagerConfig, state,
             hostAffinityEnabled, this.standbyContainerManager));
     this.allocatorThread = new Thread(this.containerAllocator, "Container Allocator Thread");
     LOG.info("Finished container process manager initialization");
@@ -591,13 +588,12 @@ public class ContainerProcessManager implements ClusterResourceManager.Callback 
    * @param clusterManagerConfig, the cluster manager config to parse.
    *
    */
-  private ResourceManagerFactory getContainerProcessManagerFactory(final ClusterManagerConfig clusterManagerConfig,
-      ClassLoader classLoader) {
+  private ResourceManagerFactory getContainerProcessManagerFactory(final ClusterManagerConfig clusterManagerConfig) {
     final String containerManagerFactoryClass = clusterManagerConfig.getContainerManagerClass();
     final ResourceManagerFactory factory;
 
     try {
-      factory = ReflectionUtil.getObj(classLoader, containerManagerFactoryClass, ResourceManagerFactory.class);
+      factory = ReflectionUtil.getObj(containerManagerFactoryClass, ResourceManagerFactory.class);
     } catch (Exception e) {
       LOG.error("Error creating the cluster resource manager.", e);
       throw new SamzaException(e);

--- a/samza-core/src/main/java/org/apache/samza/config/JobCoordinatorConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobCoordinatorConfig.java
@@ -62,11 +62,11 @@ public class JobCoordinatorConfig extends MapConfig {
     return coordinationUtilsFactory;
   }
 
-  public CoordinationUtilsFactory getCoordinationUtilsFactory(ClassLoader classLoader) {
+  public CoordinationUtilsFactory getCoordinationUtilsFactory() {
     // load the class
     String coordinationUtilsFactoryClass = getJobCoordinationUtilsFactoryClassName();
 
-    return ReflectionUtil.getObj(classLoader, coordinationUtilsFactoryClass, CoordinationUtilsFactory.class);
+    return ReflectionUtil.getObj(coordinationUtilsFactoryClass, CoordinationUtilsFactory.class);
   }
 
   public String getJobCoordinatorFactoryClassName() {

--- a/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
@@ -198,10 +198,10 @@ public class TaskConfig extends MapConfig {
    * @param metricsRegistry Registry of metrics to use. Can be null if not using metrics.
    * @return CheckpointManager object if checkpoint manager factory is configured, otherwise empty.
    */
-  public Optional<CheckpointManager> getCheckpointManager(MetricsRegistry metricsRegistry, ClassLoader classLoader) {
+  public Optional<CheckpointManager> getCheckpointManager(MetricsRegistry metricsRegistry) {
     return Optional.ofNullable(get(CHECKPOINT_MANAGER_FACTORY))
         .filter(StringUtils::isNotBlank)
-        .map(checkpointManagerFactoryName -> ReflectionUtil.getObj(classLoader, checkpointManagerFactoryName,
+        .map(checkpointManagerFactoryName -> ReflectionUtil.getObj(checkpointManagerFactoryName,
             CheckpointManagerFactory.class).getCheckpointManager(this, metricsRegistry));
   }
 

--- a/samza-core/src/main/java/org/apache/samza/container/grouper/stream/SSPGrouperProxy.java
+++ b/samza-core/src/main/java/org/apache/samza/container/grouper/stream/SSPGrouperProxy.java
@@ -51,12 +51,12 @@ public class SSPGrouperProxy {
   private final Set<SystemStreamPartition> broadcastSystemStreamPartitions;
   private final SystemStreamPartitionGrouper grouper;
 
-  public SSPGrouperProxy(Config config, SystemStreamPartitionGrouper grouper, ClassLoader classLoader) {
+  public SSPGrouperProxy(Config config, SystemStreamPartitionGrouper grouper) {
     Preconditions.checkNotNull(config);
     Preconditions.checkNotNull(grouper);
     this.grouper = grouper;
     this.broadcastSystemStreamPartitions = new TaskConfig(config).getBroadcastSystemStreamPartitions();
-    this.systemStreamPartitionMapper = getSystemStreamPartitionMapper(config, classLoader);
+    this.systemStreamPartitionMapper = getSystemStreamPartitionMapper(config);
   }
 
   /**
@@ -171,11 +171,11 @@ public class SSPGrouperProxy {
    * @param config the configuration of the samza job.
    * @return the instantiated {@link SystemStreamPartitionMapper} object.
    */
-  private SystemStreamPartitionMapper getSystemStreamPartitionMapper(Config config, ClassLoader classLoader) {
+  private SystemStreamPartitionMapper getSystemStreamPartitionMapper(Config config) {
     JobConfig jobConfig = new JobConfig(config);
     String systemStreamPartitionMapperClass = jobConfig.getSystemStreamPartitionMapperFactoryName();
     SystemStreamPartitionMapperFactory systemStreamPartitionMapperFactory =
-        ReflectionUtil.getObj(classLoader, systemStreamPartitionMapperClass, SystemStreamPartitionMapperFactory.class);
+        ReflectionUtil.getObj(systemStreamPartitionMapperClass, SystemStreamPartitionMapperFactory.class);
     return systemStreamPartitionMapperFactory.getStreamPartitionMapper(config, new MetricsRegistryMap());
   }
 

--- a/samza-core/src/main/java/org/apache/samza/coordinator/MetadataResourceUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/MetadataResourceUtil.java
@@ -41,11 +41,11 @@ public class MetadataResourceUtil {
    * @param jobModel the loaded {@link JobModel}
    * @param metricsRegistry the registry for reporting metrics.
    */
-  public MetadataResourceUtil(JobModel jobModel, MetricsRegistry metricsRegistry, ClassLoader classLoader, Config config) {
+  public MetadataResourceUtil(JobModel jobModel, MetricsRegistry metricsRegistry, Config config) {
     this.config = config;
     this.jobModel = jobModel;
     TaskConfig taskConfig = new TaskConfig(config);
-    this.checkpointManager = taskConfig.getCheckpointManager(metricsRegistry, classLoader).orElse(null);
+    this.checkpointManager = taskConfig.getCheckpointManager(metricsRegistry).orElse(null);
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/execution/LocalJobPlanner.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/LocalJobPlanner.java
@@ -59,12 +59,11 @@ public class LocalJobPlanner extends JobPlanner {
   private final CoordinationUtils coordinationUtils;
   private final String runId;
 
-  public LocalJobPlanner(ApplicationDescriptorImpl<? extends ApplicationDescriptor> descriptor, String processorId,
-      ClassLoader classLoader) {
+  public LocalJobPlanner(ApplicationDescriptorImpl<? extends ApplicationDescriptor> descriptor, String processorId) {
     super(descriptor);
     this.processorId = processorId;
     JobCoordinatorConfig jcConfig = new JobCoordinatorConfig(userConfig);
-    this.coordinationUtils = jcConfig.getCoordinationUtilsFactory(classLoader)
+    this.coordinationUtils = jcConfig.getCoordinationUtilsFactory()
         .getCoordinationUtils(CoordinationConstants.APPLICATION_RUNNER_PATH_SUFFIX, processorId, userConfig);
     this.runId = null;
   }

--- a/samza-core/src/main/java/org/apache/samza/execution/RemoteJobPlanner.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/RemoteJobPlanner.java
@@ -75,7 +75,7 @@ public class RemoteJobPlanner extends JobPlanner {
       // create the StreamManager to create intermediate streams in the plan
       streamManager = buildAndStartStreamManager(jobConfig);
       if (plan.getApplicationConfig().getAppMode() == ApplicationConfig.ApplicationMode.BATCH) {
-        streamManager.clearStreamsFromPreviousRun(getConfigFromPrevRun(), getClass().getClassLoader());
+        streamManager.clearStreamsFromPreviousRun(getConfigFromPrevRun());
       }
       streamManager.createStreams(plan.getIntermediateStreams());
     } finally {

--- a/samza-core/src/main/java/org/apache/samza/execution/StreamManager.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/StreamManager.java
@@ -104,7 +104,7 @@ public class StreamManager {
    * For batch processing, we always clean up the previous internal streams and create a new set for each run.
    * @param prevConfig config of the previous run
    */
-  public void clearStreamsFromPreviousRun(Config prevConfig, ClassLoader classLoader) {
+  public void clearStreamsFromPreviousRun(Config prevConfig) {
     try {
       ApplicationConfig appConfig = new ApplicationConfig(prevConfig);
       LOGGER.info("run.id from previous run is {}", appConfig.getRunId());
@@ -123,8 +123,7 @@ public class StreamManager {
 
       //Find checkpoint stream and clean up
       TaskConfig taskConfig = new TaskConfig(prevConfig);
-      taskConfig.getCheckpointManager(new MetricsRegistryMap(), classLoader)
-          .ifPresent(CheckpointManager::clearCheckpoints);
+      taskConfig.getCheckpointManager(new MetricsRegistryMap()).ifPresent(CheckpointManager::clearCheckpoints);
 
       //Find changelog streams and remove them
       StorageConfig storageConfig = new StorageConfig(prevConfig);

--- a/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
+++ b/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
@@ -398,14 +398,14 @@ public class StreamProcessor {
         this.taskFactory, JobContextImpl.fromConfigWithDefaults(this.config),
         Option.apply(this.applicationDefinedContainerContextFactoryOptional.orElse(null)),
         Option.apply(this.applicationDefinedTaskContextFactoryOptional.orElse(null)),
-        Option.apply(this.externalContextOptional.orElse(null)), getClass().getClassLoader(), null, startpointManager,
+        Option.apply(this.externalContextOptional.orElse(null)), null, startpointManager,
         diagnosticsManager);
   }
 
   private static JobCoordinator createJobCoordinator(Config config, String processorId, MetricsRegistry metricsRegistry, MetadataStore metadataStore) {
     String jobCoordinatorFactoryClassName = new JobCoordinatorConfig(config).getJobCoordinatorFactoryClassName();
     JobCoordinatorFactory jobCoordinatorFactory =
-        ReflectionUtil.getObj(StreamProcessor.class.getClassLoader(), jobCoordinatorFactoryClassName, JobCoordinatorFactory.class);
+        ReflectionUtil.getObj(jobCoordinatorFactoryClassName, JobCoordinatorFactory.class);
     return jobCoordinatorFactory.getJobCoordinator(processorId, config, metricsRegistry, metadataStore);
   }
 

--- a/samza-core/src/main/java/org/apache/samza/runtime/ContainerLaunchUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/ContainerLaunchUtil.java
@@ -121,7 +121,6 @@ public class ContainerLaunchUtil {
           Option.apply(appDesc.getApplicationContainerContextFactory().orElse(null)),
           Option.apply(appDesc.getApplicationTaskContextFactory().orElse(null)),
           Option.apply(externalContextOptional.orElse(null)),
-          ContainerLaunchUtil.class.getClassLoader(),
           localityManager,
           startpointManager,
           diagnosticsManager);

--- a/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
@@ -114,7 +114,7 @@ public class LocalApplicationRunner implements ApplicationRunner {
   public LocalApplicationRunner(SamzaApplication app, Config config, MetadataStoreFactory metadataStoreFactory) {
     this.appDesc = ApplicationDescriptorUtil.getAppDescriptor(app, config);
     this.isAppModeBatch = new ApplicationConfig(config).getAppMode() == ApplicationConfig.ApplicationMode.BATCH;
-    this.coordinationUtils = getCoordinationUtils(config, getClass().getClassLoader());
+    this.coordinationUtils = getCoordinationUtils(config);
     this.metadataStoreFactory = Optional.ofNullable(metadataStoreFactory);
   }
 
@@ -145,12 +145,12 @@ public class LocalApplicationRunner implements ApplicationRunner {
     return null;
   }
 
-  private Optional<CoordinationUtils> getCoordinationUtils(Config config, ClassLoader classLoader) {
+  private Optional<CoordinationUtils> getCoordinationUtils(Config config) {
     if (!isAppModeBatch) {
       return Optional.empty();
     }
     JobCoordinatorConfig jcConfig = new JobCoordinatorConfig(config);
-    CoordinationUtils coordinationUtils = jcConfig.getCoordinationUtilsFactory(classLoader)
+    CoordinationUtils coordinationUtils = jcConfig.getCoordinationUtilsFactory()
         .getCoordinationUtils(CoordinationConstants.APPLICATION_RUNNER_PATH_SUFFIX, PROCESSOR_ID, config);
     return Optional.ofNullable(coordinationUtils);
   }
@@ -159,10 +159,10 @@ public class LocalApplicationRunner implements ApplicationRunner {
    * @return LocalJobPlanner created
    */
   @VisibleForTesting
-  LocalJobPlanner getPlanner(ClassLoader classLoader) {
+  LocalJobPlanner getPlanner() {
     boolean isAppModeBatch = new ApplicationConfig(appDesc.getConfig()).getAppMode() == ApplicationConfig.ApplicationMode.BATCH;
     if (!isAppModeBatch) {
-      return new LocalJobPlanner(appDesc, PROCESSOR_ID, classLoader);
+      return new LocalJobPlanner(appDesc, PROCESSOR_ID);
     }
     CoordinationUtils coordinationUtils = this.coordinationUtils.orElse(null);
     String runId = this.runId.orElse(null);
@@ -198,7 +198,7 @@ public class LocalApplicationRunner implements ApplicationRunner {
   public void run(ExternalContext externalContext) {
     initializeRunId();
 
-    LocalJobPlanner planner = getPlanner(getClass().getClassLoader());
+    LocalJobPlanner planner = getPlanner();
 
     try {
       List<JobConfig> jobConfigs = planner.prepareJobs();
@@ -333,7 +333,7 @@ public class LocalApplicationRunner implements ApplicationRunner {
       Optional<ExternalContext> externalContextOptional, MetadataStore coordinatorStreamStore) {
     TaskFactory taskFactory = TaskFactoryUtil.getTaskFactory(appDesc);
     Map<String, MetricsReporter> reporters = new HashMap<>();
-    String processorId = createProcessorId(new ApplicationConfig(config), getClass().getClassLoader());
+    String processorId = createProcessorId(new ApplicationConfig(config));
     appDesc.getMetricsReporterFactories().forEach((name, factory) ->
         reporters.put(name, factory.getMetricsReporter(name, processorId, config)));
 
@@ -350,17 +350,16 @@ public class LocalApplicationRunner implements ApplicationRunner {
    * to generate the unique processorId.
    * 3. Else throws the {@see ConfigException} back to the caller.
    * @param appConfig the configuration of the samza application.
-   * @param classLoader classloader for loading processor id generator
    * @throws ConfigException if neither processor.id nor app.processor-id-generator.class is defined in the configuration.
    * @return the generated processor identifier.
    */
   @VisibleForTesting
-  static String createProcessorId(ApplicationConfig appConfig, ClassLoader classLoader) {
+  static String createProcessorId(ApplicationConfig appConfig) {
     if (StringUtils.isNotBlank(appConfig.getProcessorId())) {
       return appConfig.getProcessorId();
     } else if (StringUtils.isNotBlank(appConfig.getAppProcessorIdGeneratorClass())) {
       ProcessorIdGenerator idGenerator =
-          ReflectionUtil.getObj(classLoader, appConfig.getAppProcessorIdGeneratorClass(), ProcessorIdGenerator.class);
+          ReflectionUtil.getObj(appConfig.getAppProcessorIdGeneratorClass(), ProcessorIdGenerator.class);
       return idGenerator.generateProcessorId(appConfig);
     } else {
       throw new ConfigException(String.format("Expected either %s or %s to be configured", ApplicationConfig.PROCESSOR_ID,

--- a/samza-core/src/main/java/org/apache/samza/standalone/PassthroughJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/standalone/PassthroughJobCoordinator.java
@@ -73,8 +73,7 @@ public class PassthroughJobCoordinator implements JobCoordinator {
     this.processorId = processorId;
     this.config = config;
     LocationIdProviderFactory locationIdProviderFactory =
-        ReflectionUtil.getObj(getClass().getClassLoader(), new JobConfig(config).getLocationIdProviderFactory(),
-            LocationIdProviderFactory.class);
+        ReflectionUtil.getObj(new JobConfig(config).getLocationIdProviderFactory(), LocationIdProviderFactory.class);
     LocationIdProvider locationIdProvider = locationIdProviderFactory.getLocationIdProvider(config);
     this.locationId = locationIdProvider.getLocationId();
   }
@@ -86,7 +85,7 @@ public class PassthroughJobCoordinator implements JobCoordinator {
     try {
       jobModel = getJobModel();
       // TODO metrics registry has been null here for a while; is it safe?
-      MetadataResourceUtil metadataResourceUtil = new MetadataResourceUtil(jobModel, null, getClass().getClassLoader(), config);
+      MetadataResourceUtil metadataResourceUtil = new MetadataResourceUtil(jobModel, null, config);
       metadataResourceUtil.createResources();
     } catch (Exception e) {
       LOGGER.error("Exception while trying to getJobModel.", e);
@@ -127,8 +126,7 @@ public class PassthroughJobCoordinator implements JobCoordinator {
     try {
       String containerId = Integer.toString(config.getInt(JobConfig.PROCESSOR_ID));
       GrouperMetadata grouperMetadata = new GrouperMetadataImpl(ImmutableMap.of(String.valueOf(containerId), locationId), Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
-      return JobModelManager.readJobModel(this.config, Collections.emptyMap(), streamMetadataCache, grouperMetadata,
-          getClass().getClassLoader());
+      return JobModelManager.readJobModel(this.config, Collections.emptyMap(), streamMetadataCache, grouperMetadata);
     } finally {
       systemAdmins.stop();
     }

--- a/samza-core/src/main/java/org/apache/samza/storage/StorageRecovery.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/StorageRecovery.java
@@ -132,7 +132,7 @@ public class StorageRecovery extends CommandLine {
       ChangelogStreamManager changelogStreamManager = new ChangelogStreamManager(coordinatorStreamStore);
       JobModelManager jobModelManager =
           JobModelManager.apply(configFromCoordinatorStream, changelogStreamManager.readPartitionMapping(),
-              coordinatorStreamStore, getClass().getClassLoader(), metricsRegistryMap);
+              coordinatorStreamStore, metricsRegistryMap);
       JobModel jobModel = jobModelManager.jobModel();
       containers = jobModel.getContainers();
     } finally {
@@ -161,8 +161,7 @@ public class StorageRecovery extends CommandLine {
 
       Optional<String> factoryClass = config.getStorageFactoryClassName(storeName);
       if (factoryClass.isPresent()) {
-        storageEngineFactories.put(storeName,
-            ReflectionUtil.getObj(getClass().getClassLoader(), factoryClass.get(), StorageEngineFactory.class));
+        storageEngineFactories.put(storeName, ReflectionUtil.getObj(factoryClass.get(), StorageEngineFactory.class));
       } else {
         throw new SamzaException("Missing storage factory for " + storeName + ".");
       }
@@ -191,8 +190,8 @@ public class StorageRecovery extends CommandLine {
         .forEach(serdeName -> {
             String serdeClassName = serializerConfig.getSerdeFactoryClass(serdeName)
               .orElseGet(() -> SerializerConfig.getPredefinedSerdeFactoryName(serdeName));
-            Serde serde = ReflectionUtil.getObj(getClass().getClassLoader(), serdeClassName, SerdeFactory.class)
-                .getSerde(serdeName, serializerConfig);
+            Serde serde =
+                ReflectionUtil.getObj(serdeClassName, SerdeFactory.class).getSerde(serdeName, serializerConfig);
             serdeMap.put(serdeName, serde);
           });
 
@@ -233,8 +232,7 @@ public class StorageRecovery extends CommandLine {
               storeBaseDir,
               maxPartitionNumber,
               null,
-              new SystemClock(),
-              getClass().getClassLoader());
+              new SystemClock());
       this.containerStorageManagers.put(containerModel.getId(), containerStorageManager);
     }
   }

--- a/samza-core/src/main/java/org/apache/samza/table/TableManager.java
+++ b/samza-core/src/main/java/org/apache/samza/table/TableManager.java
@@ -68,9 +68,9 @@ public class TableManager {
    * Construct a table manager instance
    * @param config job configuration
    */
-  public TableManager(Config config, ClassLoader classLoader) {
+  public TableManager(Config config) {
     new JavaTableConfig(config).getTableIds().forEach(tableId -> {
-        addTable(tableId, config, classLoader);
+        addTable(tableId, config);
         logger.debug("Added table " + tableId);
       });
     logger.info(String.format("Added %d tables", tableContexts.size()));
@@ -85,14 +85,14 @@ public class TableManager {
     initialized = true;
   }
 
-  private void addTable(String tableId, Config config, ClassLoader classLoader) {
+  private void addTable(String tableId, Config config) {
     if (tableContexts.containsKey(tableId)) {
       throw new SamzaException("Table " + tableId + " already exists");
     }
     JavaTableConfig tableConfig = new JavaTableConfig(config);
     String providerFactoryClassName = tableConfig.getTableProviderFactory(tableId);
     TableProviderFactory tableProviderFactory =
-        ReflectionUtil.getObj(classLoader, providerFactoryClassName, TableProviderFactory.class);
+        ReflectionUtil.getObj(providerFactoryClassName, TableProviderFactory.class);
     TableCtx ctx = new TableCtx();
     ctx.tableProvider = tableProviderFactory.getTableProvider(tableId);
     tableContexts.put(tableId, ctx);

--- a/samza-core/src/main/java/org/apache/samza/util/MetricsReporterLoader.java
+++ b/samza-core/src/main/java/org/apache/samza/util/MetricsReporterLoader.java
@@ -36,8 +36,7 @@ public class MetricsReporterLoader {
   private MetricsReporterLoader() {
   }
 
-  public static Map<String, MetricsReporter> getMetricsReporters(MetricsConfig metricsConfig, String containerName,
-      ClassLoader classLoader) {
+  public static Map<String, MetricsReporter> getMetricsReporters(MetricsConfig metricsConfig, String containerName) {
     Map<String, MetricsReporter> metricsReporters = new HashMap<>();
 
     String diagnosticsReporterName = MetricsConfig.METRICS_SNAPSHOT_REPORTER_NAME_FOR_DIAGNOSTICS;
@@ -54,7 +53,7 @@ public class MetricsReporterLoader {
           .orElseThrow(() -> new SamzaException(
               String.format("Metrics reporter %s missing .class config", metricsReporterName)));
       MetricsReporterFactory metricsReporterFactory =
-          ReflectionUtil.getObj(classLoader, metricsFactoryClassName, MetricsReporterFactory.class);
+          ReflectionUtil.getObj(metricsFactoryClassName, MetricsReporterFactory.class);
       metricsReporters.put(metricsReporterName,
                            metricsReporterFactory.getMetricsReporter(metricsReporterName,
                                                                      containerName,

--- a/samza-core/src/main/java/org/apache/samza/util/ReflectionUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/util/ReflectionUtil.java
@@ -38,22 +38,14 @@ public class ReflectionUtil {
   /**
    * Create an instance of the specified class with the empty constructor.
    *
-   * Possible recommendations for the classloader to use:
-   * 1) If there is a custom classloader being passed to the caller, consider using that one.
-   * 2) If within instance scope, getClass().getClassLoader() can be used in order to use the same classloader as what
-   * loaded the caller instance.
-   * 3) If within a static scope, the Class object of the caller (e.g. MyClass.class) can be used.
-   *
    * @param <T> type of the object to return
-   * @param classLoader used to load the class; if null, will use the bootstrap classloader (see
-   * {@link Class#forName(String, boolean, ClassLoader)}
    * @param className name of the class
    * @param clazz type of object to return
    * @return instance of the class
    * @throws SamzaException if an exception was thrown while trying to create the class
    */
-  public static <T> T getObj(ClassLoader classLoader, String className, Class<T> clazz) {
-    return doGetObjWithArgs(classLoader, className, clazz);
+  public static <T> T getObj(String className, Class<T> clazz) {
+    return doGetObjWithArgs(className, clazz);
   }
 
   /**
@@ -61,29 +53,20 @@ public class ReflectionUtil {
    * using {@link ConstructorArgument} match the compile-time types of the arguments of the constructor that should be
    * used.
    *
-   * Possible recommendations for the classloader to use:
-   * 1) If there is a custom classloader being passed to the caller, consider using that one.
-   * 2) If within instance scope, getClass().getClassLoader() can be used in order to use the same classloader as what
-   * loaded the caller instance.
-   * 3) If within a static scope, the Class object of the caller (e.g. MyClass.class) can be used.
-   *
    * @param <T> type of the object to return
-   * @param classLoader used to load the class; if null, will use the bootstrap classloader (see
-   * {@link Class#forName(String, boolean, ClassLoader)}
    * @param className name of the class
    * @param clazz type of object to return
    * @param args arguments with types for finding and calling desired constructor to create an instance of className
    * @return instance of the class
    * @throws SamzaException if an exception was thrown while trying to create the class
    */
-  public static <T> T getObjWithArgs(ClassLoader classLoader, String className, Class<T> clazz,
-      ConstructorArgument<?>... args) {
-    return doGetObjWithArgs(classLoader, className, clazz, args);
+  public static <T> T getObjWithArgs(String className, Class<T> clazz, ConstructorArgument<?>... args) {
+    return doGetObjWithArgs(className, clazz, args);
   }
 
   /**
    * Use this to create arguments for when calling
-   * {@link #doGetObjWithArgs(ClassLoader, String, Class, ConstructorArgument[])}
+   * {@link #doGetObjWithArgs(String, Class, ConstructorArgument[])}
    */
   public static <T> ConstructorArgument<T> constructorArgument(T value, Class<T> clazz) {
     return new ConstructorArgument<>(value, clazz);
@@ -95,21 +78,18 @@ public class ReflectionUtil {
    * compile-time types of the arguments of the constructor that should be used.
    *
    * @param <T> type of the object to return
-   * @param classLoader used to load the class; if null, will use the bootstrap classloader (see
-   * {@link Class#forName(String, boolean, ClassLoader)}
    * @param className name of the class
    * @param clazz type of object to return
    * @param args arguments with types for finding and calling desired constructor to create an instance of className
    * @return instance of the class
    * @throws SamzaException if an exception was thrown while trying to create the class
    */
-  private static <T> T doGetObjWithArgs(ClassLoader classLoader, String className, Class<T> clazz,
-      ConstructorArgument<?>... args) {
+  private static <T> T doGetObjWithArgs(String className, Class<T> clazz, ConstructorArgument<?>... args) {
     Validate.notNull(className, "Null class name");
 
     try {
       //noinspection unchecked
-      Class<T> classObj = (Class<T>) Class.forName(className, true, classLoader);
+      Class<T> classObj = (Class<T>) Class.forName(className);
       if (args.length == 0) {
         return classObj.newInstance();
       } else {

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
@@ -149,8 +149,7 @@ public class ZkJobCoordinator implements JobCoordinator {
     systemAdmins = new SystemAdmins(config);
     streamMetadataCache = new StreamMetadataCache(systemAdmins, METADATA_CACHE_TTL_MS, SystemClock.instance());
     LocationIdProviderFactory locationIdProviderFactory =
-        ReflectionUtil.getObj(getClass().getClassLoader(), new JobConfig(config).getLocationIdProviderFactory(),
-            LocationIdProviderFactory.class);
+        ReflectionUtil.getObj(new JobConfig(config).getLocationIdProviderFactory(), LocationIdProviderFactory.class);
     LocationIdProvider locationIdProvider = locationIdProviderFactory.getLocationIdProvider(config);
     this.locationId = locationIdProvider.getLocationId();
     this.coordinatorStreamStore = (CoordinatorStreamStore) coordinatorStreamStore;
@@ -313,7 +312,7 @@ public class ZkJobCoordinator implements JobCoordinator {
   @VisibleForTesting
   void loadMetadataResources(JobModel jobModel) {
     try {
-      MetadataResourceUtil metadataResourceUtil = createMetadataResourceUtil(jobModel, getClass().getClassLoader(), config);
+      MetadataResourceUtil metadataResourceUtil = createMetadataResourceUtil(jobModel, config);
       metadataResourceUtil.createResources();
 
       if (coordinatorStreamStore != null) {
@@ -343,8 +342,8 @@ public class ZkJobCoordinator implements JobCoordinator {
   }
 
   @VisibleForTesting
-  MetadataResourceUtil createMetadataResourceUtil(JobModel jobModel, ClassLoader classLoader, Config config) {
-    return new MetadataResourceUtil(jobModel, metrics.getMetricsRegistry(), classLoader, config);
+  MetadataResourceUtil createMetadataResourceUtil(JobModel jobModel, Config config) {
+    return new MetadataResourceUtil(jobModel, metrics.getMetricsRegistry(), config);
   }
 
   /**
@@ -363,8 +362,7 @@ public class ZkJobCoordinator implements JobCoordinator {
     }
 
     GrouperMetadata grouperMetadata = getGrouperMetadata(zkJobModelVersion, processorNodes);
-    JobModel model = JobModelManager.readJobModel(config, changeLogPartitionMap, streamMetadataCache, grouperMetadata,
-        getClass().getClassLoader());
+    JobModel model = JobModelManager.readJobModel(config, changeLogPartitionMap, streamMetadataCache, grouperMetadata);
     return new JobModel(new MapConfig(), model.getContainers());
   }
 

--- a/samza-core/src/main/scala/org/apache/samza/checkpoint/CheckpointTool.scala
+++ b/samza-core/src/main/scala/org/apache/samza/checkpoint/CheckpointTool.scala
@@ -148,7 +148,6 @@ object CheckpointTool {
 class CheckpointTool(newOffsets: TaskNameToCheckpointMap, coordinatorStreamStore: CoordinatorStreamStore, userDefinedConfig: Config) extends Logging {
 
   def run() {
-    val classLoader = getClass.getClassLoader
     val configFromCoordinatorStream: Config = getConfigFromCoordinatorStream(coordinatorStreamStore)
 
     println("Configuration read from the coordinator stream")
@@ -162,14 +161,14 @@ class CheckpointTool(newOffsets: TaskNameToCheckpointMap, coordinatorStreamStore
     val taskConfig = new TaskConfig(combinedConfig)
     // Instantiate the checkpoint manager with coordinator stream configuration.
     val checkpointManager: CheckpointManager =
-      JavaOptionals.toRichOptional(taskConfig.getCheckpointManager(new MetricsRegistryMap, classLoader))
+      JavaOptionals.toRichOptional(taskConfig.getCheckpointManager(new MetricsRegistryMap))
         .toOption
         .getOrElse(throw new SamzaException("Configuration: task.checkpoint.factory is not defined."))
     try {
       // Find all the TaskNames that would be generated for this job config
       val changelogManager = new ChangelogStreamManager(new NamespaceAwareCoordinatorStreamStore(coordinatorStreamStore, SetChangelogMapping.TYPE))
       val jobModelManager = JobModelManager(combinedConfig, changelogManager.readPartitionMapping(),
-        coordinatorStreamStore, classLoader, new MetricsRegistryMap())
+        coordinatorStreamStore, new MetricsRegistryMap())
       val taskNames = jobModelManager
         .jobModel
         .getContainers

--- a/samza-core/src/main/scala/org/apache/samza/job/local/ProcessJobFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/job/local/ProcessJobFactory.scala
@@ -55,9 +55,8 @@ class ProcessJobFactory extends StreamJobFactory with Logging {
 
     val changelogStreamManager = new ChangelogStreamManager(new NamespaceAwareCoordinatorStreamStore(coordinatorStreamStore, SetChangelogMapping.TYPE))
 
-    val classLoader = getClass.getClassLoader
     val coordinator = JobModelManager(configFromCoordinatorStream, changelogStreamManager.readPartitionMapping(),
-      coordinatorStreamStore, classLoader, metricsRegistry)
+      coordinatorStreamStore, metricsRegistry)
     val jobModel = coordinator.jobModel
 
     val taskPartitionMappings: util.Map[TaskName, Integer] = new util.HashMap[TaskName, Integer]
@@ -70,7 +69,7 @@ class ProcessJobFactory extends StreamJobFactory with Logging {
     changelogStreamManager.writePartitionMapping(taskPartitionMappings)
 
     //create necessary checkpoint and changelog streams
-    val metadataResourceUtil = new MetadataResourceUtil(jobModel, metricsRegistry, classLoader, config)
+    val metadataResourceUtil = new MetadataResourceUtil(jobModel, metricsRegistry, config)
     metadataResourceUtil.createResources()
 
     // fan out the startpoints
@@ -90,7 +89,7 @@ class ProcessJobFactory extends StreamJobFactory with Logging {
     val taskConfig = new TaskConfig(config)
     val commandBuilderClass = taskConfig.getCommandClass(classOf[ShellCommandBuilder].getName)
     info("Using command builder class %s" format commandBuilderClass)
-    val commandBuilder = ReflectionUtil.getObj(classLoader, commandBuilderClass, classOf[CommandBuilder])
+    val commandBuilder = ReflectionUtil.getObj(commandBuilderClass, classOf[CommandBuilder])
 
     // JobCoordinator is stopped by ProcessJob when it exits
     coordinator.start

--- a/samza-core/src/main/scala/org/apache/samza/job/local/ThreadJobFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/job/local/ThreadJobFactory.scala
@@ -56,9 +56,8 @@ class ThreadJobFactory extends StreamJobFactory with Logging {
 
     val changelogStreamManager = new ChangelogStreamManager(new NamespaceAwareCoordinatorStreamStore(coordinatorStreamStore, SetChangelogMapping.TYPE))
 
-    val classLoader = getClass.getClassLoader
     val coordinator = JobModelManager(configFromCoordinatorStream, changelogStreamManager.readPartitionMapping(),
-      coordinatorStreamStore, classLoader, metricsRegistry)
+      coordinatorStreamStore, metricsRegistry)
     val jobModel = coordinator.jobModel
 
     val taskPartitionMappings: mutable.Map[TaskName, Integer] = mutable.Map[TaskName, Integer]()
@@ -71,7 +70,7 @@ class ThreadJobFactory extends StreamJobFactory with Logging {
     changelogStreamManager.writePartitionMapping(taskPartitionMappings)
 
     //create necessary checkpoint and changelog streams
-    val metadataResourceUtil = new MetadataResourceUtil(jobModel, metricsRegistry, classLoader, config)
+    val metadataResourceUtil = new MetadataResourceUtil(jobModel, metricsRegistry, config)
     metadataResourceUtil.createResources()
 
     // fan out the startpoints
@@ -132,8 +131,7 @@ class ThreadJobFactory extends StreamJobFactory with Logging {
         JobContextImpl.fromConfigWithDefaults(config),
         Option(appDesc.getApplicationContainerContextFactory.orElse(null)),
         Option(appDesc.getApplicationTaskContextFactory.orElse(null)),
-        buildExternalContext(config),
-        classLoader
+        buildExternalContext(config)
       )
       container.setContainerListener(containerListener)
 

--- a/samza-core/src/main/scala/org/apache/samza/util/Util.scala
+++ b/samza-core/src/main/scala/org/apache/samza/util/Util.scala
@@ -52,8 +52,7 @@ object Util extends Logging {
   /**
    * Instantiate an object of type T from a given className.
    *
-   * Deprecated: Use [[ReflectionUtil.getObj(ClassLoader, String, Class)]] instead. See javadocs for that method for
-   * recommendations of classloaders to use.
+   * Deprecated: Use [[ReflectionUtil.getObj(String, Class)]] instead.
    */
   @Deprecated
   def getObj[T](className: String, clazz: Class[T]) = {
@@ -103,8 +102,7 @@ object Util extends Logging {
   /**
     * Instantiate an object from given className, and given constructor parameters.
     *
-    * Deprecated: Use [[ReflectionUtil.getObjWithArgs(ClassLoader, String, Class, ConstructorArgument...)]] instead. See
-    * javadocs for that method for recommendations of classloaders to use.
+    * Deprecated: Use [[ReflectionUtil.getObjWithArgs(String, Class, ConstructorArgument...)]] instead.
     */
   @Deprecated
   @throws[ClassNotFoundException]
@@ -174,7 +172,7 @@ object Util extends Logging {
     val rewriterClassName = JavaOptionals.toRichOptional(new JobConfig(config).getConfigRewriterClass(rewriterName))
       .toOption
       .getOrElse(throw new SamzaException("Unable to find class config for config rewriter %s." format rewriterName))
-    val rewriter = ReflectionUtil.getObj(this.getClass.getClassLoader, rewriterClassName, classOf[ConfigRewriter])
+    val rewriter = ReflectionUtil.getObj(rewriterClassName, classOf[ConfigRewriter])
     info("Re-writing config with " + rewriter)
     rewriter.rewrite(rewriterName, config)
   }

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/MockContainerAllocatorWithHostAffinity.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/MockContainerAllocatorWithHostAffinity.java
@@ -31,8 +31,7 @@ public class MockContainerAllocatorWithHostAffinity extends AbstractContainerAll
 
   public MockContainerAllocatorWithHostAffinity(ClusterResourceManager manager,
       Config config, SamzaApplicationState state) {
-    super(manager, config, state,
-        MockContainerAllocatorWithHostAffinity.class.getClassLoader(), true, Optional.empty());
+    super(manager, config, state, true, Optional.empty());
   }
 
   /**

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/MockContainerAllocatorWithoutHostAffinity.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/MockContainerAllocatorWithoutHostAffinity.java
@@ -34,7 +34,7 @@ public class MockContainerAllocatorWithoutHostAffinity extends AbstractContainer
   public MockContainerAllocatorWithoutHostAffinity(ClusterResourceManager manager,
                                 Config config,
                                 SamzaApplicationState state) {
-    super(manager, config, state, MockContainerAllocatorWithoutHostAffinity.class.getClassLoader(), false, Optional.empty());
+    super(manager, config, state, false, Optional.empty());
   }
 
   /**

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestClusterBasedJobCoordinator.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestClusterBasedJobCoordinator.java
@@ -149,8 +149,7 @@ public class TestClusterBasedJobCoordinator {
     // ClusterBasedJobCoordinator will need to be refactored for better mock support.
     doThrow(stopException).when(mockStartpointManager).stop();
 
-    doReturn(mockContainerProcessManager).when(clusterCoordinator)
-        .createContainerProcessManager(getClass().getClassLoader());
+    doReturn(mockContainerProcessManager).when(clusterCoordinator).createContainerProcessManager();
     doReturn(mockStartpointManager).when(clusterCoordinator).createStartpointManager();
     try {
       clusterCoordinator.run();

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithHostAffinity.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithHostAffinity.java
@@ -83,9 +83,7 @@ public class TestContainerAllocatorWithHostAffinity {
 
   @Before
   public void setup() throws Exception {
-    containerAllocator =
-        new AbstractContainerAllocator(clusterResourceManager, config, state,
-            getClass().getClassLoader(), true, Optional.empty());
+    containerAllocator = new AbstractContainerAllocator(clusterResourceManager, config, state, true, Optional.empty());
     requestState = new MockContainerRequestState(clusterResourceManager, true);
     Field requestStateField = containerAllocator.getClass().getDeclaredField("resourceRequestState");
     requestStateField.setAccessible(true);

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithHostAffinity.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithHostAffinity.java
@@ -367,8 +367,8 @@ public class TestContainerAllocatorWithHostAffinity {
       }).when(mockCPM).onResourcesAvailable(anyList());
 
     spyAllocator = Mockito.spy(
-        new AbstractContainerAllocator(new MockClusterResourceManager(mockCPM, state), config, state,
-            getClass().getClassLoader(), true, Optional.empty()));
+        new AbstractContainerAllocator(new MockClusterResourceManager(mockCPM, state), config, state, true,
+            Optional.empty()));
 
     // Request Resources
     spyAllocator.requestResources(new HashMap<String, String>() {
@@ -405,9 +405,7 @@ public class TestContainerAllocatorWithHostAffinity {
   @Test
   public void testExpiredRequestAllocationOnAnyHost() throws Exception {
     MockClusterResourceManager spyManager = spy(new MockClusterResourceManager(callback, state));
-    spyAllocator = Mockito.spy(
-        new AbstractContainerAllocator(spyManager, config, state,
-            getClass().getClassLoader(), true, Optional.empty()));
+    spyAllocator = Mockito.spy(new AbstractContainerAllocator(spyManager, config, state, true, Optional.empty()));
 
     // Request Preferred Resources
     spyAllocator.requestResources(new HashMap<String, String>() {
@@ -449,8 +447,8 @@ public class TestContainerAllocatorWithHostAffinity {
   public void testExpiredRequestAllocationOnSurplusAnyHostWithRunStreamProcessor() throws Exception {
     // Add Extra Resources
     spyAllocator = Mockito.spy(
-        new AbstractContainerAllocator(new MockClusterResourceManager(callback, state), config, state,
-            getClass().getClassLoader(), true, Optional.empty()));
+        new AbstractContainerAllocator(new MockClusterResourceManager(callback, state), config, state, true,
+            Optional.empty()));
 
     spyAllocator.addResource(new SamzaResource(1, 1000, "xyz", "id1"));
     spyAllocator.addResource(new SamzaResource(1, 1000, "zzz", "id2"));

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithoutHostAffinity.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithoutHostAffinity.java
@@ -262,8 +262,8 @@ public class TestContainerAllocatorWithoutHostAffinity {
 
     ClusterResourceManager.Callback mockCPM = mock(ClusterResourceManager.Callback.class);
     spyAllocator = Mockito.spy(
-        new AbstractContainerAllocator(new MockClusterResourceManager(mockCPM, state), config, state,
-            getClass().getClassLoader(), false, Optional.empty()));
+        new AbstractContainerAllocator(new MockClusterResourceManager(mockCPM, state), config, state, false,
+            Optional.empty()));
     // Mock the callback from ClusterManager to add resources to the allocator
     doAnswer((InvocationOnMock invocation) -> {
         SamzaResource resource = (SamzaResource) invocation.getArgumentAt(0, List.class).get(0);

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithoutHostAffinity.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithoutHostAffinity.java
@@ -67,8 +67,7 @@ public class TestContainerAllocatorWithoutHostAffinity {
 
   @Before
   public void setup() throws Exception {
-    containerAllocator = new AbstractContainerAllocator(manager, config, state, getClass().getClassLoader(), false, Optional
-        .empty());
+    containerAllocator = new AbstractContainerAllocator(manager, config, state, false, Optional.empty());
     requestState = new MockContainerRequestState(manager, false);
     Field requestStateField = containerAllocator.getClass().getDeclaredField("resourceRequestState");
     requestStateField.setAccessible(true);

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerProcessManager.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerProcessManager.java
@@ -166,8 +166,7 @@ public class TestContainerProcessManager {
         state,
         new MetricsRegistryMap(),
         clusterResourceManager,
-        Optional.empty(),
-        getClass().getClassLoader()
+        Optional.empty()
     );
 
     allocator =
@@ -621,8 +620,8 @@ public class TestContainerProcessManager {
         state);
 
     ContainerProcessManager manager =
-        new ContainerProcessManager(new ClusterManagerConfig(config), state, new MetricsRegistryMap(), clusterResourceManager,
-            Optional.of(allocator), getClass().getClassLoader());
+        new ContainerProcessManager(new ClusterManagerConfig(config), state, new MetricsRegistryMap(),
+            clusterResourceManager, Optional.of(allocator));
 
     manager.start();
     SamzaResource resource = new SamzaResource(1, 1024, "host1", "resource-1");
@@ -892,7 +891,7 @@ public class TestContainerProcessManager {
 
   private ContainerProcessManager buildContainerProcessManager(ClusterManagerConfig clusterManagerConfig, SamzaApplicationState state,
       ClusterResourceManager clusterResourceManager, Optional<AbstractContainerAllocator> allocator) {
-    return new ContainerProcessManager(clusterManagerConfig, state, new MetricsRegistryMap(), clusterResourceManager, allocator,
-        getClass().getClassLoader());
+    return new ContainerProcessManager(clusterManagerConfig, state, new MetricsRegistryMap(), clusterResourceManager,
+        allocator);
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/config/TestTaskConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestTaskConfig.java
@@ -228,13 +228,13 @@ public class TestTaskConfig {
   public void testGetCheckpointManager() {
     Config config =
         new MapConfig(ImmutableMap.of(TaskConfig.CHECKPOINT_MANAGER_FACTORY, MockCheckpointManagerFactory.class.getName()));
-    assertTrue(new TaskConfig(config).getCheckpointManager(null, getClass().getClassLoader())
+    assertTrue(new TaskConfig(config).getCheckpointManager(null)
         .get() instanceof MockCheckpointManager);
 
     Config configEmptyString = new MapConfig(ImmutableMap.of(TaskConfig.CHECKPOINT_MANAGER_FACTORY, ""));
-    assertFalse(new TaskConfig(configEmptyString).getCheckpointManager(null, getClass().getClassLoader()).isPresent());
+    assertFalse(new TaskConfig(configEmptyString).getCheckpointManager(null).isPresent());
 
-    assertFalse(new TaskConfig(new MapConfig()).getCheckpointManager(null, getClass().getClassLoader()).isPresent());
+    assertFalse(new TaskConfig(new MapConfig()).getCheckpointManager(null).isPresent());
   }
 
   @Test

--- a/samza-core/src/test/java/org/apache/samza/container/grouper/stream/TestGroupByPartition.java
+++ b/samza-core/src/test/java/org/apache/samza/container/grouper/stream/TestGroupByPartition.java
@@ -297,6 +297,6 @@ public class TestGroupByPartition {
   }
 
   private SSPGrouperProxy buildSspGrouperProxy() {
-    return new SSPGrouperProxy(new MapConfig(), new GroupByPartition(new MapConfig()), getClass().getClassLoader());
+    return new SSPGrouperProxy(new MapConfig(), new GroupByPartition(new MapConfig()));
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/container/grouper/stream/TestGroupBySystemStreamPartition.java
+++ b/samza-core/src/test/java/org/apache/samza/container/grouper/stream/TestGroupBySystemStreamPartition.java
@@ -287,7 +287,6 @@ public class TestGroupBySystemStreamPartition {
   }
 
   private static SSPGrouperProxy buildSspGrouperProxy() {
-    return new SSPGrouperProxy(new MapConfig(), new GroupBySystemStreamPartition(new MapConfig()),
-        TestGroupBySystemStreamPartition.class.getClassLoader());
+    return new SSPGrouperProxy(new MapConfig(), new GroupBySystemStreamPartition(new MapConfig()));
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/coordinator/JobModelManagerTestUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/coordinator/JobModelManagerTestUtil.java
@@ -50,10 +50,9 @@ public class JobModelManagerTestUtil {
   }
 
   public static JobModelManager getJobModelManagerUsingReadModel(Config config, StreamMetadataCache streamMetadataCache,
-      HttpServer server, LocalityManager localityManager, Map<String, LocationId> processorLocality,
-      ClassLoader classLoader) {
+      HttpServer server, LocalityManager localityManager, Map<String, LocationId> processorLocality) {
     JobModel jobModel = JobModelManager.readJobModel(config, new HashMap<>(), streamMetadataCache,
-        new GrouperMetadataImpl(processorLocality, new HashMap<>(), new HashMap<>(), new HashMap<>()), classLoader);
+        new GrouperMetadataImpl(processorLocality, new HashMap<>(), new HashMap<>(), new HashMap<>()));
     return new JobModelManager(new JobModel(jobModel.getConfig(), jobModel.getContainers(), localityManager), server, localityManager);
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/coordinator/TestJobModelManager.java
+++ b/samza-core/src/test/java/org/apache/samza/coordinator/TestJobModelManager.java
@@ -126,7 +126,7 @@ public class TestJobModelManager {
     Map<String, LocationId> containerLocality = ImmutableMap.of("0", new LocationId("abc-affinity"));
     this.jobModelManager =
         JobModelManagerTestUtil.getJobModelManagerUsingReadModel(config, mockStreamMetadataCache, server,
-            mockLocalityManager, containerLocality, getClass().getClassLoader());
+            mockLocalityManager, containerLocality);
 
     assertEquals(jobModelManager.jobModel().getAllContainerLocality(), ImmutableMap.of("0", "abc-affinity"));
   }
@@ -160,7 +160,7 @@ public class TestJobModelManager {
 
     this.jobModelManager =
         JobModelManagerTestUtil.getJobModelManagerUsingReadModel(config, mockStreamMetadataCache, server,
-            mockLocalityManager, containerLocality, getClass().getClassLoader());
+            mockLocalityManager, containerLocality);
 
     assertEquals(jobModelManager.jobModel().getAllContainerLocality(), Collections.singletonMap("0", null));
   }

--- a/samza-core/src/test/java/org/apache/samza/coordinator/TestMetadataResourceUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/coordinator/TestMetadataResourceUtil.java
@@ -47,7 +47,7 @@ public class TestMetadataResourceUtil {
   public void testLoadWithCheckpointConfigured() {
     MapConfig mapConfig = new MapConfig(ImmutableMap.of(TaskConfig.CHECKPOINT_MANAGER_FACTORY,
         TestCheckpointManagerFactory.class.getName()));
-    MetadataResourceUtil metadataResourceUtil = Mockito.spy(new MetadataResourceUtil(mockJobModel, mockMetricsRegistry, getClass().getClassLoader(), mapConfig));
+    MetadataResourceUtil metadataResourceUtil = Mockito.spy(new MetadataResourceUtil(mockJobModel, mockMetricsRegistry, mapConfig));
     Mockito.doNothing().when(metadataResourceUtil).createChangelogStreams();
 
     metadataResourceUtil.createResources();
@@ -60,7 +60,7 @@ public class TestMetadataResourceUtil {
   @Test
   public void testLoadWithoutCheckpointConfigured() {
     MapConfig mapConfig = new MapConfig();
-    MetadataResourceUtil metadataResourceUtil = Mockito.spy(new MetadataResourceUtil(mockJobModel, mockMetricsRegistry, getClass().getClassLoader(), mapConfig));
+    MetadataResourceUtil metadataResourceUtil = Mockito.spy(new MetadataResourceUtil(mockJobModel, mockMetricsRegistry, mapConfig));
     Mockito.doNothing().when(metadataResourceUtil).createChangelogStreams();
 
     metadataResourceUtil.createResources();

--- a/samza-core/src/test/java/org/apache/samza/execution/TestLocalJobPlanner.java
+++ b/samza-core/src/test/java/org/apache/samza/execution/TestLocalJobPlanner.java
@@ -89,7 +89,7 @@ public class TestLocalJobPlanner {
 
     CoordinationUtilsFactory coordinationUtilsFactory = mock(CoordinationUtilsFactory.class);
     JobCoordinatorConfig mockJcConfig = mock(JobCoordinatorConfig.class);
-    when(mockJcConfig.getCoordinationUtilsFactory(getClass().getClassLoader())).thenReturn(coordinationUtilsFactory);
+    when(mockJcConfig.getCoordinationUtilsFactory()).thenReturn(coordinationUtilsFactory);
     PowerMockito.whenNew(JobCoordinatorConfig.class).withAnyArguments().thenReturn(mockJcConfig);
 
     localPlanner.prepareJobs();
@@ -120,7 +120,7 @@ public class TestLocalJobPlanner {
     CoordinationUtils coordinationUtils = mock(CoordinationUtils.class);
     CoordinationUtilsFactory coordinationUtilsFactory = mock(CoordinationUtilsFactory.class);
     JobCoordinatorConfig mockJcConfig = mock(JobCoordinatorConfig.class);
-    when(mockJcConfig.getCoordinationUtilsFactory(getClass().getClassLoader())).thenReturn(coordinationUtilsFactory);
+    when(mockJcConfig.getCoordinationUtilsFactory()).thenReturn(coordinationUtilsFactory);
     PowerMockito.whenNew(JobCoordinatorConfig.class).withAnyArguments().thenReturn(mockJcConfig);
 
     DistributedLock lock = mock(DistributedLock.class);

--- a/samza-core/src/test/java/org/apache/samza/execution/TestRemoteJobPlanner.java
+++ b/samza-core/src/test/java/org/apache/samza/execution/TestRemoteJobPlanner.java
@@ -73,7 +73,7 @@ public class TestRemoteJobPlanner {
 
     remotePlanner.prepareJobs();
 
-    verify(streamManager, times(0)).clearStreamsFromPreviousRun(any(), any());
+    verify(streamManager, times(0)).clearStreamsFromPreviousRun(any());
     ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
     verify(streamManager).createStreams(captor.capture());
     List<StreamSpec> streamSpecs = captor.getValue();

--- a/samza-core/src/test/java/org/apache/samza/execution/TestStreamManager.java
+++ b/samza-core/src/test/java/org/apache/samza/execution/TestStreamManager.java
@@ -132,7 +132,7 @@ public class TestStreamManager {
     config.put("stores.test-store.changelog", SYSTEM2 + "." + STREAM2);
 
     StreamManager manager = new StreamManager(systemAdmins);
-    manager.clearStreamsFromPreviousRun(new MapConfig(config), getClass().getClassLoader());
+    manager.clearStreamsFromPreviousRun(new MapConfig(config));
 
     ArgumentCaptor<StreamSpec> captor = ArgumentCaptor.forClass(StreamSpec.class);
     verify(admin1).clearStream(captor.capture());

--- a/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
@@ -367,8 +367,7 @@ public class TestLocalApplicationRunner {
   public void testCreateProcessorIdShouldReturnProcessorIdDefinedInConfiguration() {
     String processorId = "testProcessorId";
     MapConfig configMap = new MapConfig(ImmutableMap.of(ApplicationConfig.PROCESSOR_ID, processorId));
-    String actualProcessorId =
-        LocalApplicationRunner.createProcessorId(new ApplicationConfig(configMap), getClass().getClassLoader());
+    String actualProcessorId = LocalApplicationRunner.createProcessorId(new ApplicationConfig(configMap));
     assertEquals(processorId, actualProcessorId);
   }
 
@@ -376,8 +375,7 @@ public class TestLocalApplicationRunner {
   public void testCreateProcessorIdShouldInvokeProcessorIdGeneratorDefinedInConfiguration() {
     String processorId = "testProcessorId";
     MapConfig configMap = new MapConfig(ImmutableMap.of(ApplicationConfig.APP_PROCESSOR_ID_GENERATOR_CLASS, MockProcessorIdGenerator.class.getCanonicalName()));
-    String actualProcessorId =
-        LocalApplicationRunner.createProcessorId(new ApplicationConfig(configMap), getClass().getClassLoader());
+    String actualProcessorId = LocalApplicationRunner.createProcessorId(new ApplicationConfig(configMap));
     assertEquals(processorId, actualProcessorId);
   }
 
@@ -385,7 +383,7 @@ public class TestLocalApplicationRunner {
   public void testCreateProcessorIdShouldThrowExceptionWhenProcessorIdAndGeneratorAreNotDefined() {
     ApplicationConfig mockConfig = Mockito.mock(ApplicationConfig.class);
     Mockito.when(mockConfig.getProcessorId()).thenReturn(null);
-    LocalApplicationRunner.createProcessorId(mockConfig, getClass().getClassLoader());
+    LocalApplicationRunner.createProcessorId(mockConfig);
   }
 
   private void prepareTest() throws Exception {
@@ -403,7 +401,7 @@ public class TestLocalApplicationRunner {
         ApplicationDescriptorUtil.getAppDescriptor(mockApp, config);
     localPlanner = spy(new LocalJobPlanner(appDesc, coordinationUtils, "FAKE_UID", "FAKE_RUNID"));
     runner = spy(new LocalApplicationRunner(appDesc, Optional.of(coordinationUtils)));
-    doReturn(localPlanner).when(runner).getPlanner(getClass().getClassLoader());
+    doReturn(localPlanner).when(runner).getPlanner();
   }
 
   /**
@@ -476,7 +474,7 @@ public class TestLocalApplicationRunner {
         ApplicationDescriptorUtil.getAppDescriptor(mockApp, config);
     runner = spy(new LocalApplicationRunner(appDesc, Optional.of(coordinationUtils)));
     localPlanner = spy(new LocalJobPlanner(appDesc, coordinationUtils, "FAKE_UID", "FAKE_RUNID"));
-    doReturn(localPlanner).when(runner).getPlanner(getClass().getClassLoader());
+    doReturn(localPlanner).when(runner).getPlanner();
     StreamProcessor sp = mock(StreamProcessor.class);
     CoordinatorStreamStore coordinatorStreamStore = mock(CoordinatorStreamStore.class);
     doReturn(sp).when(runner).createStreamProcessor(anyObject(), anyObject(), anyObject(), anyObject(), any(

--- a/samza-core/src/test/java/org/apache/samza/table/TestTableManager.java
+++ b/samza-core/src/test/java/org/apache/samza/table/TestTableManager.java
@@ -81,14 +81,14 @@ public class TestTableManager {
 
   @Test(expected = IllegalStateException.class)
   public void testInitFailsWithoutInitializingLocalStores() {
-    TableManager tableManager = new TableManager(new MapConfig(new HashMap<>()), getClass().getClassLoader());
+    TableManager tableManager = new TableManager(new MapConfig(new HashMap<>()));
     tableManager.getTable("dummy");
   }
 
   private void doTestInit(Map<String, String> map) {
     Map<String, StorageEngine> storageEngines = new HashMap<>();
     storageEngines.put(TABLE_ID, mock(StorageEngine.class));
-    TableManager tableManager = new TableManager(new MapConfig(map), getClass().getClassLoader());
+    TableManager tableManager = new TableManager(new MapConfig(map));
     tableManager.init(new MockContext());
 
     for (int i = 0; i < 2; i++) {

--- a/samza-core/src/test/java/org/apache/samza/zk/TestZkJobCoordinator.java
+++ b/samza-core/src/test/java/org/apache/samza/zk/TestZkJobCoordinator.java
@@ -271,8 +271,7 @@ public class TestZkJobCoordinator {
     doReturn(mockStartpointManager).when(zkJobCoordinator).createStartpointManager();
 
     MetadataResourceUtil mockMetadataResourceUtil = mock(MetadataResourceUtil.class);
-    doReturn(mockMetadataResourceUtil).when(zkJobCoordinator)
-        .createMetadataResourceUtil(any(), eq(getClass().getClassLoader()), any(Config.class));
+    doReturn(mockMetadataResourceUtil).when(zkJobCoordinator).createMetadataResourceUtil(any(), any(Config.class));
 
     verifyZeroInteractions(mockStartpointManager);
 

--- a/samza-core/src/test/scala/org/apache/samza/coordinator/TestJobCoordinator.scala
+++ b/samza-core/src/test/scala/org/apache/samza/coordinator/TestJobCoordinator.scala
@@ -249,8 +249,7 @@ class TestJobCoordinator extends FlatSpec with PrivateMethodTester {
     val getMatchedInputStreamPartitions = PrivateMethod[immutable.Set[Any]]('getMatchedInputStreamPartitions)
 
     val allSSP = JobModelManager invokePrivate getInputStreamPartitions(config, streamMetadataCache)
-    val matchedSSP =
-      JobModelManager invokePrivate getMatchedInputStreamPartitions(config, streamMetadataCache, getClass.getClassLoader)
+    val matchedSSP = JobModelManager invokePrivate getMatchedInputStreamPartitions(config, streamMetadataCache)
     assertEquals(matchedSSP, allSSP)
   }
 
@@ -283,7 +282,7 @@ class TestJobCoordinator extends FlatSpec with PrivateMethodTester {
     try {
       val changelogPartitionManager = new ChangelogStreamManager(namespaceAwareCoordinatorStore)
       val jobModelManager = JobModelManager(config, changelogPartitionManager.readPartitionMapping(),
-        coordinatorStreamStore, getClass.getClassLoader, new MetricsRegistryMap())
+        coordinatorStreamStore, new MetricsRegistryMap())
       jobModelManager
     } finally {
       coordinatorStreamStore.close()

--- a/samza-core/src/test/scala/org/apache/samza/storage/TestContainerStorageManager.java
+++ b/samza-core/src/test/scala/org/apache/samza/storage/TestContainerStorageManager.java
@@ -220,8 +220,7 @@ public class TestContainerStorageManager {
         DEFAULT_STORE_BASE_DIR,
         2,
         null,
-        new SystemClock(),
-        getClass().getClassLoader());
+        new SystemClock());
   }
 
   @Test

--- a/samza-core/src/test/scala/org/apache/samza/storage/TestTaskStorageManager.scala
+++ b/samza-core/src/test/scala/org/apache/samza/storage/TestTaskStorageManager.scala
@@ -905,8 +905,7 @@ class TaskStorageManagerBuilder extends MockitoSugar {
       TaskStorageManagerBuilder.defaultStoreBaseDir,
       1,
       null,
-      new SystemClock,
-      getClass.getClassLoader)
+      new SystemClock)
     this
   }
 

--- a/samza-elasticsearch/src/main/java/org/apache/samza/system/elasticsearch/ElasticsearchSystemFactory.java
+++ b/samza-elasticsearch/src/main/java/org/apache/samza/system/elasticsearch/ElasticsearchSystemFactory.java
@@ -54,7 +54,7 @@ public class ElasticsearchSystemFactory implements SystemFactory {
     return new ElasticsearchSystemProducer(name,
                                            getBulkProcessorFactory(elasticsearchConfig),
                                            getClient(elasticsearchConfig),
-                                           getIndexRequestFactory(elasticsearchConfig, getClass().getClassLoader()),
+                                           getIndexRequestFactory(elasticsearchConfig),
                                            new ElasticsearchSystemProducerMetrics(name, metricsRegistry));
   }
 
@@ -80,11 +80,9 @@ public class ElasticsearchSystemFactory implements SystemFactory {
     }
   }
 
-  protected static IndexRequestFactory getIndexRequestFactory(ElasticsearchConfig config,
-      ClassLoader classLoader) {
+  protected static IndexRequestFactory getIndexRequestFactory(ElasticsearchConfig config) {
     if (config.getIndexRequestFactoryClassName().isPresent()) {
-      return ReflectionUtil.getObj(classLoader, config.getIndexRequestFactoryClassName().get(),
-          IndexRequestFactory.class);
+      return ReflectionUtil.getObj(config.getIndexRequestFactoryClassName().get(), IndexRequestFactory.class);
     } else {
       return new DefaultIndexRequestFactory();
     }

--- a/samza-kafka/src/test/scala/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.scala
+++ b/samza-kafka/src/test/scala/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.scala
@@ -214,7 +214,7 @@ class TestKafkaCheckpointManager extends KafkaServerTestHarness {
     val systemFactoryClassName = JavaOptionals.toRichOptional(systemConfig.getSystemFactory(systemName)).toOption
       .getOrElse(throw new SamzaException("Missing configuration: " + SystemConfig.SYSTEM_FACTORY_FORMAT format systemName))
 
-    val systemFactory = ReflectionUtil.getObj(getClass.getClassLoader, systemFactoryClassName, classOf[SystemFactory])
+    val systemFactory = ReflectionUtil.getObj(systemFactoryClassName, classOf[SystemFactory])
 
     val spec = new KafkaStreamSpec("id", cpTopic, checkpointSystemName, 1, 1, props)
     new KafkaCheckpointManager(spec, systemFactory, failOnTopicValidation, config, new NoOpMetricsRegistry, serde)

--- a/samza-kv-rocksdb/src/main/java/org/apache/samza/storage/kv/RocksDbKeyValueReader.java
+++ b/samza-kv-rocksdb/src/main/java/org/apache/samza/storage/kv/RocksDbKeyValueReader.java
@@ -57,10 +57,8 @@ public class RocksDbKeyValueReader {
     StorageConfig storageConfig = new StorageConfig(config);
     SerializerConfig serializerConfig = new SerializerConfig(config);
 
-    keySerde = getSerdeFromName(storageConfig.getStorageKeySerde(storeName).orElse(null), serializerConfig,
-        getClass().getClassLoader());
-    valueSerde = getSerdeFromName(storageConfig.getStorageMsgSerde(storeName).orElse(null), serializerConfig,
-        getClass().getClassLoader());
+    keySerde = getSerdeFromName(storageConfig.getStorageKeySerde(storeName).orElse(null), serializerConfig);
+    valueSerde = getSerdeFromName(storageConfig.getStorageMsgSerde(storeName).orElse(null), serializerConfig);
 
     // get db options
     Options options = RocksDbOptionsHelper.options(config, 1, new File(dbPath), StorageEngineFactory.StoreMode.ReadWrite);
@@ -117,9 +115,9 @@ public class RocksDbKeyValueReader {
    * @param serializerConfig serializer config
    * @return a Serde of this serde name
    */
-  private Serde<Object> getSerdeFromName(String name, SerializerConfig serializerConfig, ClassLoader classLoader) {
+  private Serde<Object> getSerdeFromName(String name, SerializerConfig serializerConfig) {
     String serdeClassName =
         serializerConfig.getSerdeFactoryClass(name).orElseGet(() -> SerializerConfig.getPredefinedSerdeFactoryName(name));
-    return ReflectionUtil.getObj(classLoader, serdeClassName, SerdeFactory.class).getSerde(name, serializerConfig);
+    return ReflectionUtil.getObj(serdeClassName, SerdeFactory.class).getSerde(name, serializerConfig);
   }
 }

--- a/samza-log4j/src/main/java/org/apache/samza/logging/log4j/StreamAppender.java
+++ b/samza-log4j/src/main/java/org/apache/samza/logging/log4j/StreamAppender.java
@@ -300,8 +300,7 @@ public class StreamAppender extends AppenderSkeleton {
     String systemFactoryName = log4jSystemConfig.getSystemFactory(systemName)
         .orElseThrow(() -> new SamzaException(
             "Could not figure out \"" + systemName + "\" system factory for log4j StreamAppender to use"));
-    SystemFactory systemFactory =
-        ReflectionUtil.getObj(getClass().getClassLoader(), systemFactoryName, SystemFactory.class);
+    SystemFactory systemFactory = ReflectionUtil.getObj(systemFactoryName, SystemFactory.class);
 
     setSerde(log4jSystemConfig, systemName, streamName);
 
@@ -392,8 +391,7 @@ public class StreamAppender extends AppenderSkeleton {
     }
 
     if (serdeClass != null) {
-      SerdeFactory<LoggingEvent> serdeFactory =
-          ReflectionUtil.getObj(getClass().getClassLoader(), serdeClass, SerdeFactory.class);
+      SerdeFactory<LoggingEvent> serdeFactory = ReflectionUtil.getObj(serdeClass, SerdeFactory.class);
       serde = serdeFactory.getSerde(systemName, config);
     } else {
       String serdeKey = String.format(SerializerConfig.SERDE_FACTORY_CLASS, serdeName);

--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
@@ -321,8 +321,7 @@ public class StreamAppender extends AbstractAppender {
     String systemFactoryName = log4jSystemConfig.getSystemFactory(systemName)
         .orElseThrow(() -> new SamzaException(
             "Could not figure out \"" + systemName + "\" system factory for log4j StreamAppender to use"));
-    SystemFactory systemFactory =
-        ReflectionUtil.getObj(getClass().getClassLoader(), systemFactoryName, SystemFactory.class);
+    SystemFactory systemFactory = ReflectionUtil.getObj(systemFactoryName, SystemFactory.class);
 
     setSerde(log4jSystemConfig, systemName, streamName);
 
@@ -414,8 +413,7 @@ public class StreamAppender extends AbstractAppender {
     }
 
     if (serdeClass != null) {
-      SerdeFactory<LogEvent> serdeFactory =
-          ReflectionUtil.getObj(getClass().getClassLoader(), serdeClass, SerdeFactory.class);
+      SerdeFactory<LogEvent> serdeFactory = ReflectionUtil.getObj(serdeClass, SerdeFactory.class);
       serde = serdeFactory.getSerde(systemName, config);
     } else {
       String serdeKey = String.format(SerializerConfig.SERDE_FACTORY_CLASS, serdeName);

--- a/samza-rest/src/main/java/org/apache/samza/monitor/MonitorLoader.java
+++ b/samza-rest/src/main/java/org/apache/samza/monitor/MonitorLoader.java
@@ -28,11 +28,11 @@ import org.apache.samza.util.ReflectionUtil;
 public class MonitorLoader {
 
   public static Monitor instantiateMonitor(String monitorName, MonitorConfig monitorConfig,
-      MetricsRegistry metricsRegistry, ClassLoader classLoader)
+      MetricsRegistry metricsRegistry)
       throws InstantiationException {
       String factoryClass = monitorConfig.getMonitorFactoryClass();
       try {
-        MonitorFactory monitorFactory = ReflectionUtil.getObj(classLoader, factoryClass, MonitorFactory.class);
+        MonitorFactory monitorFactory = ReflectionUtil.getObj(factoryClass, MonitorFactory.class);
         return monitorFactory.getMonitorInstance(monitorName, monitorConfig, metricsRegistry);
       } catch (Exception e) {
         throw (InstantiationException)

--- a/samza-rest/src/main/java/org/apache/samza/monitor/SamzaMonitorService.java
+++ b/samza-rest/src/main/java/org/apache/samza/monitor/SamzaMonitorService.java
@@ -67,8 +67,7 @@ public class SamzaMonitorService {
                     int monitorSchedulingJitterInMs = (int) (RANDOM.nextInt(schedulingIntervalInMs + 1) * (monitorConfig.getSchedulingJitterPercent() / 100.0));
                     schedulingIntervalInMs += monitorSchedulingJitterInMs;
                     LOGGER.info("Scheduling the monitor: {} to run every {} ms.", monitorName, schedulingIntervalInMs);
-                    scheduler.schedule(getRunnable(
-                        instantiateMonitor(monitorName, monitorConfig, metricsRegistry, getClass().getClassLoader())),
+                    scheduler.schedule(getRunnable(instantiateMonitor(monitorName, monitorConfig, metricsRegistry)),
                         schedulingIntervalInMs);
                 } else {
                   // When MonitorFactoryClass is not defined in the config, ignore the monitor config

--- a/samza-rest/src/main/java/org/apache/samza/rest/SamzaRestApplication.java
+++ b/samza-rest/src/main/java/org/apache/samza/rest/SamzaRestApplication.java
@@ -83,8 +83,7 @@ public class SamzaRestApplication extends ResourceConfig {
   private Collection<? extends Object> instantiateFactoryResources(String factoryClassName, Config config)
       throws InstantiationException {
     try {
-      ResourceFactory factory =
-          ReflectionUtil.getObj(getClass().getClassLoader(), factoryClassName, ResourceFactory.class);
+      ResourceFactory factory = ReflectionUtil.getObj(factoryClassName, ResourceFactory.class);
       return factory.getResourceInstances(config);
     } catch (Exception e) {
       throw (InstantiationException)

--- a/samza-rest/src/main/java/org/apache/samza/rest/SamzaRestService.java
+++ b/samza-rest/src/main/java/org/apache/samza/rest/SamzaRestService.java
@@ -92,8 +92,8 @@ public class SamzaRestService {
       ReadableMetricsRegistry metricsRegistry = new MetricsRegistryMap();
       log.info("Creating new SamzaRestService with config: {}", config);
       MetricsConfig metricsConfig = new MetricsConfig(config);
-      Map<String, MetricsReporter> metricsReporters = MetricsReporterLoader.getMetricsReporters(metricsConfig,
-          Util.getLocalHost().getHostName(), SamzaRestService.class.getClassLoader());
+      Map<String, MetricsReporter> metricsReporters =
+          MetricsReporterLoader.getMetricsReporters(metricsConfig, Util.getLocalHost().getHostName());
       SamzaRestService restService = new SamzaRestService(new Server(config.getPort()), metricsRegistry, metricsReporters,
           new ServletContextHandler(ServletContextHandler.SESSIONS));
 

--- a/samza-rest/src/main/java/org/apache/samza/rest/proxy/job/AbstractJobProxy.java
+++ b/samza-rest/src/main/java/org/apache/samza/rest/proxy/job/AbstractJobProxy.java
@@ -46,11 +46,11 @@ public abstract class AbstractJobProxy implements JobProxy {
    * @param config  the config containing the job proxy factory property.
    * @return        the JobProxy produced by the factory.
    */
-  public static JobProxy fromFactory(JobsResourceConfig config, ClassLoader classLoader) {
+  public static JobProxy fromFactory(JobsResourceConfig config) {
     String jobProxyFactoryClassName = config.getJobProxyFactory();
     if (jobProxyFactoryClassName != null && !jobProxyFactoryClassName.isEmpty()) {
       try {
-        JobProxyFactory factory = ReflectionUtil.getObj(classLoader, jobProxyFactoryClassName, JobProxyFactory.class);
+        JobProxyFactory factory = ReflectionUtil.getObj(jobProxyFactoryClassName, JobProxyFactory.class);
         return factory.getJobProxy(config);
       } catch (Exception e) {
         throw new SamzaException(e);

--- a/samza-rest/src/main/java/org/apache/samza/rest/proxy/job/SimpleYarnJobProxy.java
+++ b/samza-rest/src/main/java/org/apache/samza/rest/proxy/job/SimpleYarnJobProxy.java
@@ -50,7 +50,7 @@ public class SimpleYarnJobProxy extends ScriptJobProxy {
   public SimpleYarnJobProxy(JobsResourceConfig config) throws Exception {
     super(config);
     this.installFinder = new SimpleInstallationFinder(config.getInstallationsPath(),
-        ReflectionUtil.getObj(getClass().getClassLoader(), config.getJobConfigFactory(), ConfigFactory.class));
+        ReflectionUtil.getObj(config.getJobConfigFactory(), ConfigFactory.class));
     this.statusProvider = new YarnRestJobStatusProvider(config);
   }
 

--- a/samza-rest/src/main/java/org/apache/samza/rest/proxy/job/SimpleYarnJobProxyFactory.java
+++ b/samza-rest/src/main/java/org/apache/samza/rest/proxy/job/SimpleYarnJobProxyFactory.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Factory to produce SimpleJobProxy instances.
  *
- * See {@link AbstractJobProxy#fromFactory(JobsResourceConfig, ClassLoader)}
+ * See {@link AbstractJobProxy#fromFactory(JobsResourceConfig)}
  */
 public class SimpleYarnJobProxyFactory implements JobProxyFactory {
 

--- a/samza-rest/src/main/java/org/apache/samza/rest/proxy/task/SamzaTaskProxy.java
+++ b/samza-rest/src/main/java/org/apache/samza/rest/proxy/task/SamzaTaskProxy.java
@@ -118,8 +118,7 @@ public class SamzaTaskProxy implements TaskProxy {
     try {
       InstallationRecord record = installFinder.getAllInstalledJobs().get(jobInstance);
       ConfigFactory configFactory =
-          ReflectionUtil.getObj(getClass().getClassLoader(), taskResourceConfig.getJobConfigFactory(),
-              ConfigFactory.class);
+          ReflectionUtil.getObj(taskResourceConfig.getJobConfigFactory(), ConfigFactory.class);
       Config config = configFactory.getConfig(new URI(String.format("file://%s", record.getConfigFilePath())));
       Map<String, String> configMap = ImmutableMap.of(JobConfig.JOB_ID, jobInstance.getJobId(),
                                                       JobConfig.JOB_NAME, jobInstance.getJobName());

--- a/samza-rest/src/main/java/org/apache/samza/rest/proxy/task/SamzaTaskProxyFactory.java
+++ b/samza-rest/src/main/java/org/apache/samza/rest/proxy/task/SamzaTaskProxyFactory.java
@@ -44,8 +44,7 @@ public class SamzaTaskProxyFactory implements TaskProxyFactory {
                                 String.format("Config param %s is not defined.", BaseResourceConfig.CONFIG_JOB_INSTALLATIONS_PATH));
     String configFactoryClass = config.getJobConfigFactory();
     try {
-      ConfigFactory configFactory =
-          ReflectionUtil.getObj(getClass().getClassLoader(), configFactoryClass, ConfigFactory.class);
+      ConfigFactory configFactory = ReflectionUtil.getObj(configFactoryClass, ConfigFactory.class);
       InstallationFinder installFinder = new SimpleInstallationFinder(installationsPath, configFactory);
       return new SamzaTaskProxy(config, installFinder);
     } catch (Exception e) {

--- a/samza-rest/src/main/java/org/apache/samza/rest/resources/JobsResource.java
+++ b/samza-rest/src/main/java/org/apache/samza/rest/resources/JobsResource.java
@@ -56,7 +56,7 @@ public class JobsResource {
    * @param config  the configuration containing the {@link JobProxyFactory} class.
    */
   public JobsResource(JobsResourceConfig config) {
-    jobProxy = AbstractJobProxy.fromFactory(config, getClass().getClassLoader());
+    jobProxy = AbstractJobProxy.fromFactory(config);
   }
 
   /**

--- a/samza-rest/src/main/java/org/apache/samza/rest/resources/TasksResource.java
+++ b/samza-rest/src/main/java/org/apache/samza/rest/resources/TasksResource.java
@@ -59,8 +59,7 @@ public class TasksResource {
     Preconditions.checkArgument(StringUtils.isNotEmpty(taskProxyFactoryClassName),
                                 String.format("Missing config: %s", TaskResourceConfig.CONFIG_TASK_PROXY_FACTORY));
     try {
-      TaskProxyFactory factory =
-          ReflectionUtil.getObj(getClass().getClassLoader(), taskProxyFactoryClassName, TaskProxyFactory.class);
+      TaskProxyFactory factory = ReflectionUtil.getObj(taskProxyFactoryClassName, TaskProxyFactory.class);
       taskProxy = factory.getTaskProxy(config);
     } catch (Exception e) {
       LOG.error(String.format("Exception in building TasksResource with config: %s.", config), e);

--- a/samza-rest/src/test/java/org/apache/samza/monitor/TestMonitorService.java
+++ b/samza-rest/src/test/java/org/apache/samza/monitor/TestMonitorService.java
@@ -57,7 +57,7 @@ public class TestMonitorService {
         Monitor monitor = null;
         try {
             monitor = MonitorLoader.instantiateMonitor("testMonitor", new MonitorConfig(new MapConfig(configMap)),
-                METRICS_REGISTRY, getClass().getClassLoader());
+                METRICS_REGISTRY);
         } catch (InstantiationException e) {
             fail();
         }

--- a/samza-sql/src/main/java/org/apache/samza/sql/data/SamzaSqlExecutionContext.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/data/SamzaSqlExecutionContext.java
@@ -70,7 +70,7 @@ public class SamzaSqlExecutionContext implements Cloneable {
   public ScalarUdf createInstance(String clazz, String udfName, Context context) {
     // Configs should be same for all the UDF methods within a UDF. Hence taking the first one.
     Config udfConfig = udfMetadata.get(udfName).get(0).getUdfConfig();
-    ScalarUdf scalarUdf = ReflectionUtil.getObj(getClass().getClassLoader(), clazz, ScalarUdf.class);
+    ScalarUdf scalarUdf = ReflectionUtil.getObj(clazz, ScalarUdf.class);
     scalarUdf.init(udfConfig, context);
     return scalarUdf;
   }

--- a/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationConfig.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/runner/SamzaSqlApplicationConfig.java
@@ -178,7 +178,7 @@ public class SamzaSqlApplicationConfig {
     Config pluginConfig = staticConfig.subset(pluginDomain);
     String factoryName = pluginConfig.getOrDefault(CFG_FACTORY, "");
     Validate.notEmpty(factoryName, String.format("Factory is not set for %s", plugin));
-    Object factory = ReflectionUtil.getObj(SamzaSqlApplicationConfig.class.getClassLoader(), factoryName, Object.class);
+    Object factory = ReflectionUtil.getObj(factoryName, Object.class);
     LOG.info("Instantiating {} using factory {} with props {}", pluginName, factoryName, pluginConfig);
     return factoryInvoker.apply(factory, pluginConfig);
   }

--- a/samza-test/src/main/scala/org/apache/samza/test/performance/TestKeyValuePerformance.scala
+++ b/samza-test/src/main/scala/org/apache/samza/test/performance/TestKeyValuePerformance.scala
@@ -124,7 +124,7 @@ object TestKeyValuePerformance extends Logging {
         val storageFactoryClassName =
           JavaOptionals.toRichOptional(storageConfig.getStorageFactoryClassName(storeName)).toOption
                 .getOrElse(throw new SamzaException("Missing storage factory for %s." format storeName))
-        (storeName, ReflectionUtil.getObj(getClass.getClassLoader, storageFactoryClassName,
+        (storeName, ReflectionUtil.getObj(storageFactoryClassName,
           classOf[StorageEngineFactory[Array[Byte], Array[Byte]]]))
     })
 

--- a/samza-test/src/test/java/org/apache/samza/processor/TestZkStreamProcessorBase.java
+++ b/samza-test/src/test/java/org/apache/samza/processor/TestZkStreamProcessorBase.java
@@ -133,10 +133,8 @@ public class TestZkStreamProcessorBase extends IntegrationTestHarness {
     map.put(ApplicationConfig.PROCESSOR_ID, pId);
     Config config = new MapConfig(map);
     String jobCoordinatorFactoryClassName = new JobCoordinatorConfig(config).getJobCoordinatorFactoryClassName();
-    JobCoordinator jobCoordinator =
-        ReflectionUtil.getObj(getClass().getClassLoader(), jobCoordinatorFactoryClassName, JobCoordinatorFactory.class)
-            .getJobCoordinator(pId, config, new MetricsRegistryMap(), Mockito.mock(
-                CoordinatorStreamStore.class));
+    JobCoordinator jobCoordinator = ReflectionUtil.getObj(jobCoordinatorFactoryClassName, JobCoordinatorFactory.class)
+        .getJobCoordinator(pId, config, new MetricsRegistryMap(), Mockito.mock(CoordinatorStreamStore.class));
 
     ProcessorLifecycleListener listener = new ProcessorLifecycleListener() {
       @Override

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
@@ -725,8 +725,7 @@ public class TestZkLocalApplicationRunner extends IntegrationTestHarness {
 
   private MapConfig getConfigFromCoordinatorStream(Config config) {
     MetadataStoreFactory metadataStoreFactory =
-        ReflectionUtil.getObj(getClass().getClassLoader(), new JobConfig(config).getMetadataStoreFactory(),
-            MetadataStoreFactory.class);
+        ReflectionUtil.getObj(new JobConfig(config).getMetadataStoreFactory(), MetadataStoreFactory.class);
     MetadataStore metadataStore = metadataStoreFactory.getMetadataStore("set-config", config, new MetricsRegistryMap());
     metadataStore.init();
     Map<String, String> configMap = new HashMap<>();

--- a/samza-test/src/test/scala/org/apache/samza/test/integration/StreamTaskTestUtil.scala
+++ b/samza-test/src/test/scala/org/apache/samza/test/integration/StreamTaskTestUtil.scala
@@ -275,8 +275,8 @@ class StreamTaskTestUtil {
     jobModel.maxChangeLogStreamPartitions = 1
 
     val taskConfig = new TaskConfig(jobModel.getConfig)
-    val checkpointManagerOption = JavaOptionals.toRichOptional(taskConfig.getCheckpointManager(new MetricsRegistryMap(),
-      getClass.getClassLoader)).toOption
+    val checkpointManagerOption =
+      JavaOptionals.toRichOptional(taskConfig.getCheckpointManager(new MetricsRegistryMap())).toOption
     checkpointManagerOption match {
       case Some(checkpointManager) =>
         checkpointManager.createResources()

--- a/samza-tools/src/main/java/org/apache/samza/tools/benchmark/AbstractSamzaBench.java
+++ b/samza-tools/src/main/java/org/apache/samza/tools/benchmark/AbstractSamzaBench.java
@@ -125,7 +125,7 @@ public abstract class AbstractSamzaBench {
     String systemFactory = config.get(String.format(CFG_SYSTEM_FACTORY, systemName));
     physicalStreamName = config.get(String.format(CFG_PHYSICAL_STREAM_NAME, streamId));
 
-    factory = ReflectionUtil.getObj(getClass().getClassLoader(), systemFactory, SystemFactory.class);
+    factory = ReflectionUtil.getObj(systemFactory, SystemFactory.class);
   }
 
   /**

--- a/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnClusterResourceManager.java
+++ b/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnClusterResourceManager.java
@@ -161,7 +161,7 @@ public class YarnClusterResourceManager extends ClusterResourceManager implement
     );
 
     MetricsRegistryMap registry = new MetricsRegistryMap();
-    metrics = new SamzaAppMasterMetrics(config, samzaAppState, registry, getClass().getClassLoader());
+    metrics = new SamzaAppMasterMetrics(config, samzaAppState, registry);
 
     // parse configs from the Yarn environment
     String containerIdStr = System.getenv(ApplicationConstants.Environment.CONTAINER_ID.toString());

--- a/samza-yarn/src/main/java/org/apache/samza/validation/YarnJobValidationTool.java
+++ b/samza-yarn/src/main/java/org/apache/samza/validation/YarnJobValidationTool.java
@@ -166,7 +166,7 @@ public class YarnJobValidationTool {
       ChangelogStreamManager changelogStreamManager = new ChangelogStreamManager(coordinatorStreamStore);
       JobModelManager jobModelManager =
           JobModelManager.apply(configFromCoordinatorStream, changelogStreamManager.readPartitionMapping(),
-              coordinatorStreamStore, getClass().getClassLoader(), metricsRegistry);
+              coordinatorStreamStore, metricsRegistry);
       validator.init(config);
       Map<String, String> jmxUrls = jobModelManager.jobModel().getAllContainerToHostValues(SetContainerHostMapping.JMX_TUNNELING_URL_KEY);
       for (Map.Entry<String, String> entry : jmxUrls.entrySet()) {

--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/SamzaAppMasterMetrics.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/SamzaAppMasterMetrics.scala
@@ -39,12 +39,10 @@ object SamzaAppMasterMetrics {
  */
 class SamzaAppMasterMetrics(val config: Config,
   val state: SamzaApplicationState,
-  val registry: ReadableMetricsRegistry,
-  val classLoader: ClassLoader) extends MetricsHelper with Logging {
+  val registry: ReadableMetricsRegistry) extends MetricsHelper with Logging {
 
   private val metricsConfig = new MetricsConfig(config)
-  val reporters =
-    MetricsReporterLoader.getMetricsReporters(metricsConfig, SamzaAppMasterMetrics.sourceName, classLoader).asScala
+  val reporters = MetricsReporterLoader.getMetricsReporters(metricsConfig, SamzaAppMasterMetrics.sourceName).asScala
   reporters.values.foreach(_.register(SamzaAppMasterMetrics.sourceName, registry))
 
   def start() {

--- a/samza-yarn/src/test/java/org/apache/samza/webapp/TestApplicationMasterRestClient.java
+++ b/samza-yarn/src/test/java/org/apache/samza/webapp/TestApplicationMasterRestClient.java
@@ -304,8 +304,7 @@ public class TestApplicationMasterRestClient {
   }
 
   private void assignMetricValues(SamzaApplicationState samzaAppState, MetricsRegistryMap registry) {
-    SamzaAppMasterMetrics metrics =
-        new SamzaAppMasterMetrics(new MapConfig(), samzaAppState, registry, getClass().getClassLoader());
+    SamzaAppMasterMetrics metrics = new SamzaAppMasterMetrics(new MapConfig(), samzaAppState, registry);
     metrics.start();
     samzaAppState.runningProcessors.put("dummyContainer",
         new SamzaResource(1, 2, AM_HOST_NAME, "dummyResourceId")); // 1 container

--- a/samza-yarn/src/test/scala/org/apache/samza/job/yarn/TestSamzaYarnAppMasterService.scala
+++ b/samza-yarn/src/test/scala/org/apache/samza/job/yarn/TestSamzaYarnAppMasterService.scala
@@ -108,7 +108,7 @@ class TestSamzaYarnAppMasterService {
     try {
       val changelogPartitionManager = new ChangelogStreamManager(namespaceAwareCoordinatorStore)
       val jobModelManager = JobModelManager(getDummyConfig, changelogPartitionManager.readPartitionMapping(),
-        coordinatorStreamStore, getClass.getClassLoader, new MetricsRegistryMap())
+        coordinatorStreamStore, new MetricsRegistryMap())
       jobModelManager
     } finally {
       coordinatorStreamStore.close()


### PR DESCRIPTION
SAMZA-2204 added a ReflectionUtil class for some reflection-based helpers, and SAMZA-2210 started to replace the usage of Util.getObj with those ReflectionUtil methods.
The intended purpose of those changes was to be able to explicitly choose a classloader for loading pluggable classes, but it is no longer necessary to explicitly pass it in. This ticket cleans up that explicit classloader argument.
We are able to use the default classloader propagation to properly pass around the classloader to use.