### PR TITLE
SAMZA-2339 : Update KafkaSystemAdmin to adhere to the checkpoint replication factor

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/system/StreamSpec.java
+++ b/samza-api/src/main/java/org/apache/samza/system/StreamSpec.java
@@ -226,6 +226,10 @@ public class StreamSpec implements Serializable {
     return id.equals(COORDINATOR_STREAM_ID);
   }
 
+  public boolean isCheckpointStream() {
+    return id.equals(CHECKPOINT_STREAM_ID);
+  }
+
   private void validateLogicalIdentifier(String identifierName, String identifierValue) {
     if (identifierValue == null || !identifierValue.matches("[A-Za-z0-9_-]+")) {
       throw new IllegalArgumentException(String.format("Identifier '%s' is '%s'. It must match the expression [A-Za-z0-9_-]+", identifierName, identifierValue));

--- a/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaSystemAdmin.java
+++ b/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaSystemAdmin.java
@@ -540,6 +540,9 @@ public class KafkaSystemAdmin implements SystemAdmin {
       kafkaSpec =
           new KafkaStreamSpec(spec.getId(), spec.getPhysicalName(), systemName, 1, coordinatorStreamReplicationFactor,
               coordinatorStreamProperties);
+    } else if (spec.isCheckpointStream()) {
+      kafkaSpec = KafkaStreamSpec.fromSpec(StreamSpec.createCheckpointStreamSpec(spec.getPhysicalName(), systemName))
+              .copyWithReplicationFactor(Integer.parseInt(new KafkaConfig(config).getCheckpointReplicationFactor().get()));
     } else if (intermediateStreamProperties.containsKey(spec.getId())) {
       kafkaSpec = KafkaStreamSpec.fromSpec(spec);
       Properties properties = kafkaSpec.getProperties();

--- a/samza-kafka/src/test/scala/org/apache/samza/system/kafka/TestKafkaSystemAdmin.scala
+++ b/samza-kafka/src/test/scala/org/apache/samza/system/kafka/TestKafkaSystemAdmin.scala
@@ -272,6 +272,23 @@ class TestKafkaSystemAdmin {
   }
 
   @Test
+  def testShouldCreateCheckpointStream {
+    val topic = "test-checkpoint-stream"
+    val expectedReplicationFactor = 1
+    val map = new java.util.HashMap[String, String]()
+    map.put(org.apache.samza.config.KafkaConfig.CHECKPOINT_REPLICATION_FACTOR, expectedReplicationFactor.toString)
+    val systemAdmin = createSystemAdmin(SYSTEM, map)
+
+    val spec = StreamSpec.createCheckpointStreamSpec(topic, "kafka")
+    val actualReplicationFactor = systemAdmin.toKafkaSpec(spec).getReplicationFactor
+    // Ensure we respect the replication factor passed to system admin
+    assertEquals(expectedReplicationFactor, actualReplicationFactor)
+
+    systemAdmin.createStream(spec)
+    validateTopic(topic, 1)
+  }
+
+  @Test
   def testGetNewestOffset {
     createTopic(TOPIC2, 16)
     validateTopic(TOPIC2, 16)


### PR DESCRIPTION
As part of this PR: https://github.com/apache/samza/pull/789/files#diff-52d8a92e9c8e3d26c4e595919566326aR519 the replicationFactor value defined in the config was dropped since with the kafka client update it cannot be passed to the configs. 

To preserve this config it should be passed to the checkpoint topic spec; this PR adds the change to preserve the value set by the config `task.checkpoint.replication.factor` in the checkpoint kafka topic spec.