### PR TITLE
SAMZA-2346: Fixing Test timeouts for Allocator testing

### DIFF
--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithHostAffinity.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithHostAffinity.java
@@ -420,7 +420,7 @@ public class TestContainerAllocatorWithHostAffinity {
     spyAllocatorThread.start();
 
     // Let the request expire, expiration timeout is 3 ms
-    Thread.sleep(10);
+    Thread.sleep(100);
 
     // Verify that all the request that were created as preferred host requests expired
     assertTrue(state.preferredHostRequests.get() == 2);
@@ -456,8 +456,8 @@ public class TestContainerAllocatorWithHostAffinity {
     // Request Preferred Resources
     spyAllocator.requestResources(new HashMap<String, String>() {
       {
-        put("0", "abc");
-        put("1", "def");
+        put("0", "hostname-0");
+        put("1", "hostname-1");
       }
     });
 
@@ -466,13 +466,13 @@ public class TestContainerAllocatorWithHostAffinity {
     spyAllocatorThread.start();
 
     // Let the request expire, expiration timeout is 3 ms
-    Thread.sleep(10);
+    Thread.sleep(100);
 
     // Verify that all the request that were created as preferred host requests expired
-    assertTrue(state.expiredPreferredHostRequests.get() == 2);
-    verify(spyAllocator, times(1)).handleExpiredRequest(eq("0"), eq("abc"),
+    assertEquals(state.expiredPreferredHostRequests.get(), 2);
+    verify(spyAllocator, times(1)).handleExpiredRequest(eq("0"), eq("hostname-0"),
         any(SamzaResourceRequest.class));
-    verify(spyAllocator, times(1)).handleExpiredRequest(eq("1"), eq("def"),
+    verify(spyAllocator, times(1)).handleExpiredRequest(eq("1"), eq("hostname-1"),
         any(SamzaResourceRequest.class));
 
     // Verify that runStreamProcessor was invoked with already available ANY_HOST requests

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithoutHostAffinity.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithoutHostAffinity.java
@@ -312,7 +312,7 @@ public class TestContainerAllocatorWithoutHostAffinity {
     spyThread.start();
 
     // Let the request expire, expiration timeout is 3 ms
-    Thread.sleep(20);
+    Thread.sleep(100);
 
     // Verify that all the request that were created as ANY_HOST host
     // and all created requests expired


### PR DESCRIPTION
Some of these tests were failing due to expiry timeouts on some machines and being flaky. To fix this we have just increased the thread sleep time to ensure expiry of requests on allocator thread gets triggered. 

 