### PR TITLE
SAMZA-2352: Use min.compaction.lag.ms to avoid compacting the Kafka changelog topic

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/StorageConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/StorageConfig.java
@@ -52,6 +52,9 @@ public class StorageConfig extends MapConfig {
   public static final boolean DEFAULT_DISALLOW_LARGE_MESSAGES = false;
   public static final String DROP_LARGE_MESSAGES = STORE_PREFIX + "%s.drop.large.messages";
   public static final boolean DEFAULT_DROP_LARGE_MESSAGES = false;
+  // The log compaction lag time for transactional state change log
+  public static final String CHANGELOG_MIN_COMPACTION_LAG_MS = STORE_PREFIX + "%s.kafka.changelog.replication.factor";
+  public static final long DEFAULT_CHANGELOG_MIN_COMPACTION_LAG_MS = TimeUnit.HOURS.toMillis(4);
 
   static final String CHANGELOG_SYSTEM = "job.changelog.system";
   static final String CHANGELOG_DELETE_RETENTION_MS = STORE_PREFIX + "%s.changelog.delete.retention.ms";
@@ -205,6 +208,10 @@ public class StorageConfig extends MapConfig {
 
   public boolean getDropLargeMessages(String storeName) {
     return getBoolean(String.format(DROP_LARGE_MESSAGES, storeName), DEFAULT_DROP_LARGE_MESSAGES);
+  }
+
+  public long getChangelogMinCompactionLagMs(String storeName) {
+    return getLong(String.format(CHANGELOG_MIN_COMPACTION_LAG_MS, storeName), DEFAULT_CHANGELOG_MIN_COMPACTION_LAG_MS);
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/config/StorageConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/StorageConfig.java
@@ -53,7 +53,7 @@ public class StorageConfig extends MapConfig {
   public static final String DROP_LARGE_MESSAGES = STORE_PREFIX + "%s.drop.large.messages";
   public static final boolean DEFAULT_DROP_LARGE_MESSAGES = false;
   // The log compaction lag time for transactional state change log
-  public static final String CHANGELOG_MIN_COMPACTION_LAG_MS = STORE_PREFIX + "%s.kafka.changelog.replication.factor";
+  public static final String CHANGELOG_MIN_COMPACTION_LAG_MS = STORE_PREFIX + "%s.changelog.kafka.min.compaction.lag.ms";
   public static final long DEFAULT_CHANGELOG_MIN_COMPACTION_LAG_MS = TimeUnit.HOURS.toMillis(4);
 
   static final String CHANGELOG_SYSTEM = "job.changelog.system";

--- a/samza-core/src/main/java/org/apache/samza/config/StorageConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/StorageConfig.java
@@ -31,6 +31,8 @@ import org.apache.samza.SamzaException;
 import org.apache.samza.execution.StreamManager;
 import org.apache.samza.util.StreamUtil;
 
+import static com.google.common.base.Preconditions.*;
+
 
 /**
  * Config helper methods related to storage.
@@ -45,6 +47,7 @@ public class StorageConfig extends MapConfig {
   public static final String MSG_SERDE = STORE_PREFIX + "%s.msg.serde";
   public static final String CHANGELOG_STREAM = STORE_PREFIX + "%s" + CHANGELOG_SUFFIX;
   public static final String ACCESSLOG_STREAM_SUFFIX = "access-log";
+  // TODO: setting replication.factor seems not working as in KafkaConfig.
   public static final String CHANGELOG_REPLICATION_FACTOR = STORE_PREFIX + "%s.changelog.replication.factor";
   public static final String CHANGELOG_MAX_MSG_SIZE_BYTES = STORE_PREFIX + "%s.changelog.max.message.size.bytes";
   public static final int DEFAULT_CHANGELOG_MAX_MSG_SIZE_BYTES = 1048576;
@@ -53,7 +56,8 @@ public class StorageConfig extends MapConfig {
   public static final String DROP_LARGE_MESSAGES = STORE_PREFIX + "%s.drop.large.messages";
   public static final boolean DEFAULT_DROP_LARGE_MESSAGES = false;
   // The log compaction lag time for transactional state change log
-  public static final String CHANGELOG_MIN_COMPACTION_LAG_MS = STORE_PREFIX + "%s.changelog.kafka.min.compaction.lag.ms";
+  public static final String MIN_COMPACTION_LAG_MS = "min.compaction.lag.ms";
+  public static final String CHANGELOG_MIN_COMPACTION_LAG_MS = STORE_PREFIX + "%s.changelog." + MIN_COMPACTION_LAG_MS;
   public static final long DEFAULT_CHANGELOG_MIN_COMPACTION_LAG_MS = TimeUnit.HOURS.toMillis(4);
 
   static final String CHANGELOG_SYSTEM = "job.changelog.system";
@@ -211,7 +215,12 @@ public class StorageConfig extends MapConfig {
   }
 
   public long getChangelogMinCompactionLagMs(String storeName) {
-    return getLong(String.format(CHANGELOG_MIN_COMPACTION_LAG_MS, storeName), DEFAULT_CHANGELOG_MIN_COMPACTION_LAG_MS);
+    String minCompactLagConfigName = String.format(CHANGELOG_MIN_COMPACTION_LAG_MS, storeName);
+    // Avoid the inconsistency of overriding using stores.x.changelog.kafka...
+    checkArgument(get("stores." + storeName + ".changelog.kafka." + MIN_COMPACTION_LAG_MS) == null,
+        "Use " + minCompactLagConfigName + " to set kafka min.compaction.lag.ms property.");
+
+    return getLong(minCompactLagConfigName, DEFAULT_CHANGELOG_MIN_COMPACTION_LAG_MS);
   }
 
   /**

--- a/samza-core/src/test/java/org/apache/samza/config/TestStorageConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestStorageConfig.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.util.concurrent.TimeUnit;
 import org.apache.samza.SamzaException;
 import org.junit.Test;
 
@@ -295,5 +296,18 @@ public class TestStorageConfig {
     StorageConfig storageConfig = new StorageConfig(
         new MapConfig(ImmutableMap.of(String.format(StorageConfig.DROP_LARGE_MESSAGES, STORE_NAME0), "true")));
     assertEquals(true, storageConfig.getDropLargeMessages(STORE_NAME0));
+  }
+
+  @Test
+  public void testGetChangelogMinCompactionLagMs() {
+    // empty config, return default lag ms
+    assertEquals(DEFAULT_CHANGELOG_MIN_COMPACTION_LAG_MS,
+        new StorageConfig(new MapConfig()).getChangelogMinCompactionLagMs(STORE_NAME0));
+
+    long lagOverride = TimeUnit.HOURS.toMillis(6);
+    StorageConfig storageConfig = new StorageConfig(
+        new MapConfig(ImmutableMap.of(String.format(CHANGELOG_MIN_COMPACTION_LAG_MS, STORE_NAME0),
+            String.valueOf(lagOverride))));
+    assertEquals(lagOverride, storageConfig.getChangelogMinCompactionLagMs(STORE_NAME0));
   }
 }

--- a/samza-kafka/src/main/scala/org/apache/samza/config/KafkaConfig.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/config/KafkaConfig.scala
@@ -88,7 +88,7 @@ object KafkaConfig {
 
   val DEFAULT_RETENTION_MS_FOR_BATCH = TimeUnit.DAYS.toMillis(1)
 
-  val MIN_COMPACTION_LOG_MS = "min.compaction.lag.ms"
+  val MIN_COMPACTION_LAG_MS = "min.compaction.lag.ms"
 
   implicit def Config2Kafka(config: Config) = new KafkaConfig(config)
 }
@@ -345,7 +345,7 @@ class KafkaConfig(config: Config) extends ScalaMapConfig(config) {
     // (the messages after last checkpoint) being log-compacted so we can trim the rest of the updates.
     // We use min.compaction.log.ms to control the compaction time.
     if (new TaskConfig(this).getTransactionalStateRestoreEnabled) {
-      kafkaChangeLogProperties.setProperty(KafkaConfig.MIN_COMPACTION_LOG_MS,
+      kafkaChangeLogProperties.setProperty(KafkaConfig.MIN_COMPACTION_LAG_MS,
         String.valueOf(StorageConfig.DEFAULT_CHANGELOG_MIN_COMPACTION_LAG_MS))
     }
 

--- a/samza-kafka/src/main/scala/org/apache/samza/config/KafkaConfig.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/config/KafkaConfig.scala
@@ -56,8 +56,6 @@ object KafkaConfig {
   // The default segment size to use for changelog topics
   val CHANGELOG_DEFAULT_SEGMENT_SIZE = "536870912"
   val CHANGELOG_MAX_MESSAGE_BYTES = "stores.%s.changelog." + MAX_MESSAGE_BYTES
-  // The default log compaction lag time for transactional state change log
-  val CHANGELOG_DEFAULT_MIN_COMPACTION_LAG_MS = TimeUnit.HOURS.toMillis(4)
 
   // Helper regular expression definitions to extract/match configurations
   val CHANGELOG_STREAM_NAMES_REGEX = "stores\\.(.*)\\.changelog$"
@@ -89,6 +87,8 @@ object KafkaConfig {
   val CONSUMER_FETCH_THRESHOLD_BYTES = SystemConfig.SYSTEM_ID_PREFIX + "samza.fetch.threshold.bytes"
 
   val DEFAULT_RETENTION_MS_FOR_BATCH = TimeUnit.DAYS.toMillis(1)
+
+  val MIN_COMPACTION_LOG_MS = "min.compaction.lag.ms"
 
   implicit def Config2Kafka(config: Config) = new KafkaConfig(config)
 }
@@ -345,8 +345,8 @@ class KafkaConfig(config: Config) extends ScalaMapConfig(config) {
     // (the messages after last checkpoint) being log-compacted so we can trim the rest of the updates.
     // We use min.compaction.log.ms to control the compaction time.
     if (new TaskConfig(this).getTransactionalStateRestoreEnabled) {
-      kafkaChangeLogProperties.setProperty("min.compaction.lag.ms",
-        String.valueOf(KafkaConfig.CHANGELOG_DEFAULT_MIN_COMPACTION_LAG_MS))
+      kafkaChangeLogProperties.setProperty(KafkaConfig.MIN_COMPACTION_LOG_MS,
+        String.valueOf(StorageConfig.DEFAULT_CHANGELOG_MIN_COMPACTION_LAG_MS))
     }
 
     filteredConfigs.asScala.foreach { kv => kafkaChangeLogProperties.setProperty(kv._1, kv._2) }

--- a/samza-kafka/src/main/scala/org/apache/samza/config/KafkaConfig.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/config/KafkaConfig.scala
@@ -88,8 +88,6 @@ object KafkaConfig {
 
   val DEFAULT_RETENTION_MS_FOR_BATCH = TimeUnit.DAYS.toMillis(1)
 
-  val MIN_COMPACTION_LAG_MS = "min.compaction.lag.ms"
-
   implicit def Config2Kafka(config: Config) = new KafkaConfig(config)
 }
 
@@ -338,15 +336,16 @@ class KafkaConfig(config: Config) extends ScalaMapConfig(config) {
         kafkaChangeLogProperties.setProperty("max.message.bytes", getChangelogStreamMaxMessageByte(name))
     }
 
+    val storageConfig = new StorageConfig(config)
     kafkaChangeLogProperties.setProperty("segment.bytes", KafkaConfig.CHANGELOG_DEFAULT_SEGMENT_SIZE)
-    kafkaChangeLogProperties.setProperty("delete.retention.ms", String.valueOf(new StorageConfig(config).getChangeLogDeleteRetentionInMs(name)))
+    kafkaChangeLogProperties.setProperty("delete.retention.ms", String.valueOf(storageConfig.getChangeLogDeleteRetentionInMs(name)))
 
     // To enable transactional state, we will need to avoid the head of the changelog
     // (the messages after last checkpoint) being log-compacted so we can trim the rest of the updates.
     // We use min.compaction.log.ms to control the compaction time.
     if (new TaskConfig(this).getTransactionalStateRestoreEnabled) {
-      kafkaChangeLogProperties.setProperty(KafkaConfig.MIN_COMPACTION_LAG_MS,
-        String.valueOf(StorageConfig.DEFAULT_CHANGELOG_MIN_COMPACTION_LAG_MS))
+      kafkaChangeLogProperties.setProperty(StorageConfig.MIN_COMPACTION_LAG_MS,
+        String.valueOf(storageConfig.getChangelogMinCompactionLagMs(name)))
     }
 
     filteredConfigs.asScala.foreach { kv => kafkaChangeLogProperties.setProperty(kv._1, kv._2) }

--- a/samza-kafka/src/test/scala/org/apache/samza/config/TestKafkaConfig.scala
+++ b/samza-kafka/src/test/scala/org/apache/samza/config/TestKafkaConfig.scala
@@ -144,7 +144,7 @@ class TestKafkaConfig {
     // test compaction config for transactional state
     val lagOverride = String.valueOf(TimeUnit.HOURS.toMillis(6))
     props.setProperty(TaskConfig.TRANSACTIONAL_STATE_RESTORE_ENABLED, "true")
-    props.setProperty("stores.test2.changelog.kafka.min.compaction.lag.ms", lagOverride)
+    props.setProperty("stores.test2.changelog.min.compaction.lag.ms", lagOverride)
     val tsMapConfig = new MapConfig(props.asScala.asJava)
     val tsKafkaConfig = new KafkaConfig(tsMapConfig)
     assertEquals(String.valueOf(StorageConfig.DEFAULT_CHANGELOG_MIN_COMPACTION_LAG_MS),

--- a/samza-kafka/src/test/scala/org/apache/samza/config/TestKafkaConfig.scala
+++ b/samza-kafka/src/test/scala/org/apache/samza/config/TestKafkaConfig.scala
@@ -142,14 +142,14 @@ class TestKafkaConfig {
       KafkaConfig.DEFAULT_LOG_COMPACT_TOPIC_MAX_MESSAGE_BYTES)
 
     // test compaction config for transactional state
+    val lagOverride = String.valueOf(TimeUnit.HOURS.toMillis(6))
     props.setProperty(TaskConfig.TRANSACTIONAL_STATE_RESTORE_ENABLED, "true")
-    props.setProperty("stores.test2.changelog.kafka.min.compaction.lag.ms",
-      String.valueOf(TimeUnit.HOURS.toMillis(6)))
+    props.setProperty("stores.test2.changelog.kafka.min.compaction.lag.ms", lagOverride)
     val tsMapConfig = new MapConfig(props.asScala.asJava)
     val tsKafkaConfig = new KafkaConfig(tsMapConfig)
-    assertEquals(KafkaConfig.CHANGELOG_DEFAULT_MIN_COMPACTION_LAG_MS.toString,
+    assertEquals(String.valueOf(StorageConfig.DEFAULT_CHANGELOG_MIN_COMPACTION_LAG_MS),
       tsKafkaConfig.getChangelogKafkaProperties("test1").getProperty("min.compaction.lag.ms"))
-    assertEquals(String.valueOf(TimeUnit.HOURS.toMillis(6)),
+    assertEquals(lagOverride,
       tsKafkaConfig.getChangelogKafkaProperties("test2").getProperty("min.compaction.lag.ms"))
   }
 


### PR DESCRIPTION
To enable transactional state, we will need to avoid the head of the changelog (the ones after last checkpoint) not being log-compacted so we can trim the rest of the updates. We use min.compaction.log.ms to control the compaction time.