### PR TITLE
SAMZA-2324: Adding KV store metrics for rocksdb

### DIFF
--- a/samza-kv-rocksdb/src/main/scala/org/apache/samza/storage/kv/RocksDbKeyValueStore.scala
+++ b/samza-kv-rocksdb/src/main/scala/org/apache/samza/storage/kv/RocksDbKeyValueStore.scala
@@ -25,7 +25,6 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import java.util.{Comparator, Optional}
 
-import org.apache.commons.io.FileUtils
 import org.apache.samza.SamzaException
 import org.apache.samza.checkpoint.CheckpointId
 import org.apache.samza.config.Config
@@ -101,8 +100,6 @@ object RocksDbKeyValueStore extends Logging {
             "0"
           }
         ))
-
-      metrics.newGauge("rocksdb.size-on-disk", () => FileUtils.sizeOfDirectory(new File(dir.getAbsolutePath)))
 
       rocksDb
     } catch {

--- a/samza-kv-rocksdb/src/main/scala/org/apache/samza/storage/kv/RocksDbKeyValueStore.scala
+++ b/samza-kv-rocksdb/src/main/scala/org/apache/samza/storage/kv/RocksDbKeyValueStore.scala
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import java.util.{Comparator, Optional}
 
+import org.apache.commons.io.FileUtils
 import org.apache.samza.SamzaException
 import org.apache.samza.checkpoint.CheckpointId
 import org.apache.samza.config.Config
@@ -100,6 +101,8 @@ object RocksDbKeyValueStore extends Logging {
             "0"
           }
         ))
+
+      metrics.newGauge("rocksdb.size-on-disk", () -> FileUtils.sizeOfDirectory(new File(dir.getAbsolutePath)))
 
       rocksDb
     } catch {

--- a/samza-kv-rocksdb/src/main/scala/org/apache/samza/storage/kv/RocksDbKeyValueStore.scala
+++ b/samza-kv-rocksdb/src/main/scala/org/apache/samza/storage/kv/RocksDbKeyValueStore.scala
@@ -102,7 +102,7 @@ object RocksDbKeyValueStore extends Logging {
           }
         ))
 
-      metrics.newGauge("rocksdb.size-on-disk", () -> FileUtils.sizeOfDirectory(new File(dir.getAbsolutePath)))
+      metrics.newGauge("rocksdb.size-on-disk", () => FileUtils.sizeOfDirectory(new File(dir.getAbsolutePath)))
 
       rocksDb
     } catch {

--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/SerializedKeyValueStoreMetrics.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/SerializedKeyValueStoreMetrics.scala
@@ -35,6 +35,7 @@ class SerializedKeyValueStoreMetrics(
   val flushes = newCounter("flushes")
   val bytesSerialized = newCounter("bytes-serialized")
   val bytesDeserialized = newCounter("bytes-deserialized")
+  val maxRecordSizeBytes = newGauge("max-record-size-bytes", 0L)
 
   override def getPrefix = storeName + "-"
 }


### PR DESCRIPTION
**Design:** Adding a metric to track the maximum serialized value size written to rocksdb. This provides value to customers using logged stores backed by kafka. As kafka has configurable message size limits, the addition of this metric will allow users to understand how their records are approaching that limit.
**Changes:** Adds a new metric "max-record-size-bytes" to SerializedKeyValueStoreMetrics, which is tracked in SerializedKeyValueStore.
**Tests:** Built a version of samza locally which included this commit, then ran a test job that wrote consistently sized records to rocksdb and verified that the metric emitted matched that size.

**API Changes:** none
**Upgrade Instructions:** No manual steps other than upgrading to the samza version containing this commit. Once upgraded the new record size metric will be emitted.
**Usage Instructions:** None. New metric will be emitted automatically on upgrading version.
