### PR TITLE
SAMZA-2372:Null pointer exception in LocalApplicationRunner

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
@@ -234,7 +234,11 @@ public class LocalApplicationRunner implements ApplicationRunner {
   public void kill() {
     processors.forEach(sp -> {
         sp.getLeft().stop();    // Stop StreamProcessor
-        sp.getRight().close();  // Close associated coordinator metadata store
+
+        // Coordinator stream isn't required so a null check is necessary
+        if (sp.getRight() != null) {
+          sp.getRight().close();  // Close associated coordinator metadata store
+        }
       });
     cleanup();
   }


### PR DESCRIPTION
Null pointer exception is thrown when calling LocalApplicationRunner.kill() without setting a coordinator stream. My guess that the bug is a result of https://issues.apache.org/jira/browse/SAMZA-2294 forgetting to add the null check everywhere it's required. I added a test that exposes the exception.