### PR TITLE
SAMZA-2305: Stream processor should ensure previous container is stopped during a rebalance

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/storage/StorageEngine.java
+++ b/samza-api/src/main/java/org/apache/samza/storage/StorageEngine.java
@@ -43,11 +43,15 @@ public interface StorageEngine {
    * provided in one {@link java.util.Iterator} and not deserialized for
    * efficiency, allowing the implementation to optimize replay, if possible.
    *
+   * The implementers are expected to handle interrupt signals to the restoration thread and rethrow the exception to
+   * upstream so that {@code TaskRestoreManager} can accordingly notify the container.
+   *
    * @param envelopes
    *          An iterator of envelopes that the storage engine can read from to
    *          restore its state on startup.
+   * @throws InterruptedException when received interrupts during restoration
    */
-  void restore(ChangelogSSPIterator envelopes);
+  void restore(ChangelogSSPIterator envelopes) throws InterruptedException;
 
   /**
    * Flush any cached messages

--- a/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
+++ b/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
@@ -85,16 +85,18 @@ import scala.Option;
  *
  * Describes the valid state transitions of the {@link StreamProcessor}.
  *
- *
- *                                                                                                   ────────────────────────────────
- *                                                                                                  │                               │
- *                                                                                                  │                               │
- *                                                                                                  │                               │
- *                                                                                                  │                               │
- *     New                                StreamProcessor.start()          Rebalance triggered      V        Receives JobModel      │
- *  StreamProcessor ──────────▶   NEW ───────────────────────────▶ STARTED ──────────────────▶ IN_REBALANCE ─────────────────────▶ RUNNING
- *   Creation                      │                                 │     by group leader          │     and starts Container      │
- *                                 │                                 │                              │                               │
+ *                                                                                                     Receives another re-balance request when the container
+ *                                                                                                     from the previous re-balance is still in INIT phase
+ *                                                                                                   ────────────────────────────────────────────────
+ *                                                                                                  │                               │                │
+ *                                                                                                  │                               │                │
+ *                                                                                                  │                               │                │
+ *                                                                                                  │                               │                │
+ *     New                                StreamProcessor.start()          Rebalance triggered      V        Receives JobModel      │                │
+ *  StreamProcessor ──────────▶   NEW ───────────────────────────▶ STARTED ──────────────────▶ IN_REBALANCE ─────────────────────▶ RUNNING           │
+ *   Creation                      │                                 │     by group leader          │     and starts │Container     │                │
+ *                                 │                                 │                              │                │              │                │
+ *                                 │                                 │                              │                 ───────────────────────────────
  *                             Stre│amProcessor.stop()           Stre│amProcessor.stop()        Stre│amProcessor.stop()         Stre│amProcessor.stop()
  *                                 │                                 │                              │                               │
  *                                 │                                 │                              │                               │

--- a/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
+++ b/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
@@ -491,8 +491,6 @@ public class StreamProcessor {
                 state = State.STOPPING;
                 jobCoordinator.stop();
               } else {
-                Preconditions.checkState(containerExecutorService.isShutdown(),
-                    "Executor service did not shutdown cleanly.");
                 containerExecutorService = createExecutorService();
               }
             } else {

--- a/samza-core/src/main/java/org/apache/samza/storage/NonTransactionalStateTaskRestoreManager.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/NonTransactionalStateTaskRestoreManager.java
@@ -316,7 +316,7 @@ class NonTransactionalStateTaskRestoreManager implements TaskRestoreManager {
    * Restore each store in taskStoresToRestore sequentially
    */
   @Override
-  public void restore() {
+  public void restore() throws InterruptedException {
     for (String storeName : taskStoresToRestore) {
       LOG.info("Restoring store: {} for task: {}", storeName, taskModel.getTaskName());
       SystemConsumer systemConsumer = storeConsumers.get(storeName);

--- a/samza-core/src/main/java/org/apache/samza/storage/StorageRecovery.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/StorageRecovery.java
@@ -120,6 +120,8 @@ public class StorageRecovery extends CommandLine {
         try {
           containerStorageManager.start();
         } catch (InterruptedException e) {
+          // we can ignore the exception since its only used in the context of a command line tool and bubbling the
+          // exception upstream isn't needed.
           LOG.warn("Received an interrupt during store restoration for container {}."
               + " Proceeding with the next container", containerName);
         }

--- a/samza-core/src/main/java/org/apache/samza/storage/StorageRecovery.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/StorageRecovery.java
@@ -117,7 +117,12 @@ public class StorageRecovery extends CommandLine {
 
     systemAdmins.start();
     this.containerStorageManagers.forEach((containerName, containerStorageManager) -> {
-        containerStorageManager.start();
+        try {
+          containerStorageManager.start();
+        } catch (InterruptedException e) {
+          LOG.warn("Received an interrupt during store restoration for container {}."
+              + " Proceeding with the next container", containerName);
+        }
       });
     this.containerStorageManagers.forEach((containerName, containerStorageManager) -> {
         containerStorageManager.shutdown();

--- a/samza-core/src/main/java/org/apache/samza/storage/TaskRestoreManager.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/TaskRestoreManager.java
@@ -36,7 +36,7 @@ public interface TaskRestoreManager {
   /**
    * Restore state from checkpoints, state snapshots and changelog.
    */
-  void restore();
+  void restore() throws InterruptedException;
 
   /**
    * Stop all persistent stores after restoring.

--- a/samza-core/src/main/java/org/apache/samza/storage/TaskRestoreManager.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/TaskRestoreManager.java
@@ -35,6 +35,15 @@ public interface TaskRestoreManager {
 
   /**
    * Restore state from checkpoints, state snapshots and changelog.
+   * Currently, store restoration happens on a separate thread pool within {@code ContainerStorageManager}. In case of
+   * interrupt/shutdown signals from {@code SamzaContainer}, {@code ContainerStorageManager} may interrupt the restore
+   * thread.
+   *
+   * Note: Typically, interrupt signals don't bubble up as {@link InterruptedException} unless the restore thread is
+   * waiting on IO/network. In case of busy looping, implementors are expected to check the interrupt status of the
+   * thread periodically and shutdown gracefully before throwing {@link InterruptedException} upstream.
+   * {@code SamzaContainer} will not wait for clean up and the interrupt signal is the best effort by the container
+   * to notify that its shutting down.
    */
   void restore() throws InterruptedException;
 

--- a/samza-core/src/main/java/org/apache/samza/storage/TransactionalStateTaskRestoreManager.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/TransactionalStateTaskRestoreManager.java
@@ -117,7 +117,7 @@ public class TransactionalStateTaskRestoreManager implements TaskRestoreManager 
   }
 
   @Override
-  public void restore() {
+  public void restore() throws InterruptedException {
     Map<String, RestoreOffsets> storesToRestore = storeActions.storesToRestore;
 
     for (Map.Entry<String, RestoreOffsets> entry : storesToRestore.entrySet()) {

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -771,7 +771,7 @@ class SamzaContainer(
       case e: InterruptedException =>
         /*
          * We don't want to categorize interrupts as failure since the only place the container thread gets interrupted within
-         * our code is inside stream processor is during the following two scenarios
+         * our code inside stream processor is during the following two scenarios
          *    1. During a re-balance, if the container has not started or hasn't reported start status to StreamProcessor.
          *       Subsequently stream processor attempts to interrupt the container thread before proceeding to join the barrier
          *       to agree on the new work assignment.

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -938,6 +938,12 @@ public class ContainerStorageManager {
         LOG.info("Starting stores in task instance {}", this.taskName.getTaskName());
         taskRestoreManager.restore();
       } catch (InterruptedException e) {
+        /*
+         * The container thread is the only external source to trigger an interrupt to the restoration thread and thus
+         * it is okay to swallow this exception and not propagate it upstream. If the container is interrupted during
+         * the store restoration, ContainerStorageManager signals the restore workers to abandon restoration and then
+         * finally propagates the exception upstream to trigger container shutdown.
+         */
         LOG.warn("Received an interrupt during store restoration for task: {}.", this.taskName.getTaskName());
       } finally {
         // Stop all persistent stores after restoring. Certain persistent stores opened in BulkLoad mode are compacted

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -632,7 +632,7 @@ public class ContainerStorageManager {
     return this.sideInputStorageManagers.values().stream().collect(Collectors.toSet());
   }
 
-  public void start() throws SamzaException {
+  public void start() throws SamzaException, InterruptedException {
     Map<SystemStreamPartition, String> checkpointedChangelogSSPOffsets = new HashMap<>();
     if (new TaskConfig(config).getTransactionalStateRestoreEnabled()) {
       getTasks(containerModel, TaskMode.Active).forEach((taskName, taskModel) -> {
@@ -657,7 +657,8 @@ public class ContainerStorageManager {
   }
 
   // Restoration of all stores, in parallel across tasks
-  private void restoreStores(Map<SystemStreamPartition, String> checkpointedChangelogSSPOffsets) {
+  private void restoreStores(Map<SystemStreamPartition, String> checkpointedChangelogSSPOffsets)
+      throws InterruptedException {
     LOG.info("Store Restore started");
 
     // initialize each TaskStorageManager
@@ -665,7 +666,7 @@ public class ContainerStorageManager {
        taskStorageManager.init(checkpointedChangelogSSPOffsets));
 
     // Start each store consumer once
-    this.storeConsumers.values().stream().distinct().forEach(systemConsumer -> systemConsumer.start());
+    this.storeConsumers.values().stream().distinct().forEach(SystemConsumer::start);
 
     // Create a thread pool for parallel restores (and stopping of persistent stores)
     ExecutorService executorService = Executors.newFixedThreadPool(this.parallelRestoreThreadPoolSize,
@@ -684,6 +685,11 @@ public class ContainerStorageManager {
     for (Future future : taskRestoreFutures) {
       try {
         future.get();
+      } catch (InterruptedException e) {
+        LOG.warn("Received an interrupt during store restoration. Issuing interrupts to the store restoration workers to exit "
+            + "prematurely without restoring full state.");
+        executorService.shutdownNow();
+        throw e;
       } catch (Exception e) {
         LOG.error("Exception when restoring ", e);
         throw new SamzaException("Exception when restoring ", e);
@@ -693,7 +699,7 @@ public class ContainerStorageManager {
     executorService.shutdown();
 
     // Stop each store consumer once
-    this.storeConsumers.values().stream().distinct().forEach(systemConsumer -> systemConsumer.stop());
+    this.storeConsumers.values().stream().distinct().forEach(SystemConsumer::stop);
 
     // Now re-create persistent stores in read-write mode, leave non-persistent stores as-is
     recreatePersistentTaskStoresInReadWriteMode(this.containerModel, jobContext, containerContext,
@@ -791,6 +797,14 @@ public class ContainerStorageManager {
       }
 
     } catch (InterruptedException e) {
+      LOG.warn("Received an interrupt during side inputs store restoration."
+          + " Exiting prematurely without completing store restore.");
+      /*
+       * We want to stop side input restoration and rethrow the exception upstream. Container should handle the
+       * interrupt exception and shutdown the components and cleaning up the resource. We don't want to clean up the
+       * resources prematurely here.
+       */
+      shouldShutdown = true; // todo: should we cancel the flush future right away or wait for container to handle it as part of shutdown sequence?
       throw new SamzaException("Side inputs read was interrupted", e);
     }
 
@@ -920,22 +934,26 @@ public class ContainerStorageManager {
     @Override
     public Void call() {
       long startTime = System.currentTimeMillis();
-      LOG.info("Starting stores in task instance {}", this.taskName.getTaskName());
-      taskRestoreManager.restore();
+      try {
+        LOG.info("Starting stores in task instance {}", this.taskName.getTaskName());
+        taskRestoreManager.restore();
+      } catch (InterruptedException e) {
+        LOG.warn("Received an interrupt during store restoration for task: {}.", this.taskName.getTaskName());
+      } finally {
+        // Stop all persistent stores after restoring. Certain persistent stores opened in BulkLoad mode are compacted
+        // on stop, so paralleling stop() also parallelizes their compaction (a time-intensive operation).
+        taskRestoreManager.stopPersistentStores();
+        long timeToRestore = System.currentTimeMillis() - startTime;
 
-      // Stop all persistent stores after restoring. Certain persistent stores opened in BulkLoad mode are compacted
-      // on stop, so paralleling stop() also parallelizes their compaction (a time-intensive operation).
-      taskRestoreManager.stopPersistentStores();
+        if (this.samzaContainerMetrics != null) {
+          Gauge taskGauge = this.samzaContainerMetrics.taskStoreRestorationMetrics().getOrDefault(this.taskName, null);
 
-      long timeToRestore = System.currentTimeMillis() - startTime;
-
-      if (this.samzaContainerMetrics != null) {
-        Gauge taskGauge = this.samzaContainerMetrics.taskStoreRestorationMetrics().getOrDefault(this.taskName, null);
-
-        if (taskGauge != null) {
-          taskGauge.set(timeToRestore);
+          if (taskGauge != null) {
+            taskGauge.set(timeToRestore);
+          }
         }
       }
+
       return null;
     }
   }

--- a/samza-core/src/main/scala/org/apache/samza/system/SystemConsumers.scala
+++ b/samza-core/src/main/scala/org/apache/samza/system/SystemConsumers.scala
@@ -204,6 +204,10 @@ class SystemConsumers (
       consumers.values.foreach(_.stop)
 
       chooser.stop
+
+      started = false
+    } else {
+      debug("Ignoring the consumers stop request since it never started.")
     }
   }
 

--- a/samza-core/src/main/scala/org/apache/samza/system/SystemConsumers.scala
+++ b/samza-core/src/main/scala/org/apache/samza/system/SystemConsumers.scala
@@ -138,6 +138,13 @@ class SystemConsumers (
   private val emptySystemStreamPartitionsBySystem = new HashMap[String, Set[SystemStreamPartition]]()
 
   /**
+    * Denotes if the SystemConsumers have started. The flag is useful in the event of shutting down since interrupt
+    * on Samza Container will shutdown components and container currently doesn't track what components have started
+    * successfully.
+    */
+  private var started = false
+
+  /**
    * Default timeout to noNewMessagesTimeout. Every time SystemConsumers
    * receives incoming messages, it sets timeout to 0. Every time
    * SystemConsumers receives no new incoming messages from the MessageChooser,
@@ -185,15 +192,19 @@ class SystemConsumers (
 
     chooser.start
 
+    started = true
+
     refresh
   }
 
   def stop {
-    debug("Stopping consumers.")
+    if (started) {
+      debug("Stopping consumers.")
 
-    consumers.values.foreach(_.stop)
+      consumers.values.foreach(_.stop)
 
-    chooser.stop
+      chooser.stop
+    }
   }
 
 

--- a/samza-core/src/main/scala/org/apache/samza/system/SystemProducers.scala
+++ b/samza-core/src/main/scala/org/apache/samza/system/SystemProducers.scala
@@ -35,16 +35,21 @@ class SystemProducers(
    */
   dropSerializationError: Boolean = false) extends Logging {
 
+  private var started = false
+
   def start {
     debug("Starting producers.")
 
     producers.values.foreach(_.start)
+    started = true
   }
 
   def stop {
-    debug("Stopping producers.")
+    if (started) {
+      debug("Stopping producers.")
 
-    producers.values.foreach(_.stop)
+      producers.values.foreach(_.stop)
+    }
   }
 
   def register(source: String) {

--- a/samza-core/src/main/scala/org/apache/samza/system/SystemProducers.scala
+++ b/samza-core/src/main/scala/org/apache/samza/system/SystemProducers.scala
@@ -35,6 +35,11 @@ class SystemProducers(
    */
   dropSerializationError: Boolean = false) extends Logging {
 
+  /**
+    * Denotes if the SystemConsumers have started. The flag is useful in the event of shutting down since interrupt
+    * on Samza Container will shutdown components and container currently doesn't track what components have started
+    * successfully.
+    */
   private var started = false
 
   def start {

--- a/samza-core/src/main/scala/org/apache/samza/system/SystemProducers.scala
+++ b/samza-core/src/main/scala/org/apache/samza/system/SystemProducers.scala
@@ -54,6 +54,9 @@ class SystemProducers(
       debug("Stopping producers.")
 
       producers.values.foreach(_.stop)
+      started = false
+    } else {
+      debug("Ignoring the producers stop request since it never started.")
     }
   }
 

--- a/samza-core/src/test/java/org/apache/samza/processor/TestStreamProcessor.java
+++ b/samza-core/src/test/java/org/apache/samza/processor/TestStreamProcessor.java
@@ -55,7 +55,10 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;

--- a/samza-core/src/test/java/org/apache/samza/processor/TestStreamProcessor.java
+++ b/samza-core/src/test/java/org/apache/samza/processor/TestStreamProcessor.java
@@ -485,7 +485,6 @@ public class TestStreamProcessor {
     assertEquals(State.IN_REBALANCE, streamProcessor.state);
     assertNotEquals(mockExecutorService, streamProcessor.containerExecutorService);
     Mockito.verify(mockExecutorService, Mockito.times(1)).shutdownNow();
-    Mockito.verify(mockExecutorService, Mockito.times(1)).isShutdown();
   }
 
   @Test
@@ -502,7 +501,6 @@ public class TestStreamProcessor {
     assertEquals(State.STOPPING, streamProcessor.state);
     assertEquals(mockExecutorService, streamProcessor.containerExecutorService);
     Mockito.verify(mockExecutorService, Mockito.times(1)).shutdownNow();
-    Mockito.verify(mockExecutorService, Mockito.times(0)).isShutdown();
     Mockito.verify(mockJobCoordinator, Mockito.times(1)).stop();
   }
 

--- a/samza-core/src/test/scala/org/apache/samza/storage/TestContainerStorageManager.java
+++ b/samza-core/src/test/scala/org/apache/samza/storage/TestContainerStorageManager.java
@@ -101,7 +101,7 @@ public class TestContainerStorageManager {
    * Method to create a containerStorageManager with mocked dependencies
    */
   @Before
-  public void setUp() {
+  public void setUp() throws InterruptedException {
     taskRestoreMetricGauges = new HashMap<>();
     this.tasks = new HashMap<>();
     this.taskInstanceMetrics = new HashMap<>();
@@ -243,7 +243,7 @@ public class TestContainerStorageManager {
   }
 
   @Test
-  public void testParallelismAndMetrics() {
+  public void testParallelismAndMetrics() throws InterruptedException {
     this.containerStorageManager.start();
     this.containerStorageManager.shutdown();
 

--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/KeyValueStorageEngine.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/KeyValueStorageEngine.scala
@@ -202,7 +202,7 @@ class KeyValueStorageEngine[K, V](
     flush() // TODO HIGH pmaheshw SAMZA-2338: Need a way to flush changelog producers. This only flushes the stores.
 
     if (Thread.currentThread().isInterrupted) {
-      warn("Received an interrupt during store restoration. Exiting without restore the full state.")
+      warn("Received an interrupt during store restoration. Exiting without restoring the full state.")
       throw new InterruptedException("Received an interrupt during store restoration.")
     }
   }

--- a/samza-kv/src/test/scala/org/apache/samza/storage/kv/TestKeyValueStorageEngine.scala
+++ b/samza-kv/src/test/scala/org/apache/samza/storage/kv/TestKeyValueStorageEngine.scala
@@ -201,13 +201,13 @@ class TestKeyValueStorageEngine {
     try {
       val restoreFuture = executorService.submit(restore)
       restoreFuture.get()
+      fail("Expected execution exception during restoration")
     } catch {
       case e: ExecutionException => {
         assertTrue(e.getCause.isInstanceOf[InterruptedException])
         // Make sure we don't restore any more records and bail out
         assertEquals(2, metrics.restoredMessagesGauge.getValue)
       }
-      case _: Throwable => fail("Expected execution exception during restoration")
     }
   }
 


### PR DESCRIPTION
**Symptom**: Duplicate processing, Inconsistent checkpoints for inputs, Inconsistent changelog state
**Cause**: We have a bug in the state machine inside stream processor that can result in processors running containers with old job model version after rebalances in Standalone deployment model. 
**Fix**: We interrupt the container and wait for container to shutdown gracefully within a timeout (task.shutdown.ms) and fail the stream processor if the container doesn’t shut down within the timeout
**Tests**: Added unit tests for StreamProcessor and SamzaContainer. Working on integration tests.
**API Changes** `restore`  methods on `TaskRestoreManager` and `StorageEngine` now throws `InterruptedException`. Please refer to java docs to get additional implementation notes. 
**Upgrade Instructions** Standalone jobs w/ external monitoring service to restart your application should follow the External monitoring section in the document below to tune debounce time to account for monitoring service latency and container startup time.
**Usage Instructions** None
More details about the bug can be found [here](https://docs.google.com/document/d/1gWjKsbNoRwuSexjAxgqw_1R9MaJEckMIZY0cX2_NoaY/edit#).