### PR TITLE
SAMZA-2382: User specified side input processor should take precedence over the identity processor

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -554,7 +554,7 @@ public class ContainerStorageManager {
             // if this is a standby-task and the store is a non-side-input changelog store
             // we creating identity sideInputProcessor for stores of standbyTasks
             // have to use the right serde because the sideInput stores are created
-            
+
             Serde keySerde = serdes.get(config.getStorageKeySerde(storeName)
                 .orElseThrow(() -> new SamzaException("Could not find storage key serde for store: " + storeName)));
             Serde msgSerde = serdes.get(config.getStorageMsgSerde(storeName)
@@ -572,6 +572,7 @@ public class ContainerStorageManager {
                 }
               }
             };
+            LOG.info("Using identitty side-inputs-processor for store: {}, task: {}", storeName, taskName);
           }
 
           sideInputStoresToProcessors.get(taskName).put(storeName, sideInputsProcessor);

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -572,7 +572,7 @@ public class ContainerStorageManager {
                 }
               }
             };
-            LOG.info("Using identitty side-inputs-processor for store: {}, task: {}", storeName, taskName);
+            LOG.info("Using identity side-inputs-processor for store: {}, task: {}", storeName, taskName);
           }
 
           sideInputStoresToProcessors.get(taskName).put(storeName, sideInputsProcessor);

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -548,15 +548,13 @@ public class ContainerStorageManager {
             sideInputsProcessor = sideInputsProcessorFactory.getSideInputsProcessor(config, taskInstanceMetrics.get(taskName).registry());
             LOG.info("Using side-inputs-processor from factory: {} for store: {}, task: {}", config.getSideInputsProcessorFactory(storeName).get(), storeName, taskName);
 
-          } else if (!config.getSideInputsProcessorFactory(storeName).isPresent() && taskMode.equals(TaskMode.Active)) {
-
-            // this is a active-task with a side-input store but no sideinput-processor-factory defined in config
-            throw new SamzaException(String.format("Could not find sideInputs processor factory for store: %s", storeName));
           } else {
-            // this is a standby-task and the store is a non-side-input changelog store
+            // if this is a active-task with a side-input store but no sideinput-processor-factory defined in config, we rely on upstream validations to fail the deploy
 
-            // creating identity sideInputProcessor for stores of standbyTasks
+            // if this is a standby-task and the store is a non-side-input changelog store
+            // we creating identity sideInputProcessor for stores of standbyTasks
             // have to use the right serde because the sideInput stores are created
+            
             Serde keySerde = serdes.get(config.getStorageKeySerde(storeName)
                 .orElseThrow(() -> new SamzaException("Could not find storage key serde for store: " + storeName)));
             Serde msgSerde = serdes.get(config.getStorageMsgSerde(storeName)


### PR DESCRIPTION
User specified side input processor should take precedence over the identity processor

Symptom: Standby containers on jobs using side-inputs will run into deserialization exceptions when side-inputs use a custom serde (while changelog uses byte serde).

Cause: If the changelog doesnt use byte serde, the custom serde and processor should be respected.

Fix: Added logic that enables user specified side input processor to take precedence over the identity processor.

Tests: Samza test job that uses standby containers with side-inputs, with side-inputs using a custom serde.