### PR TITLE
SAMZA-2386: Get store names should return correct store names in the presence of side inputs

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/StorageConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/StorageConfig.java
@@ -40,6 +40,7 @@ import static com.google.common.base.Preconditions.*;
 public class StorageConfig extends MapConfig {
   private static final String FACTORY_SUFFIX = ".factory";
   private static final String CHANGELOG_SUFFIX = ".changelog";
+  private static final String SIDE_INPUT_PROCESSOR_FACTORY_SUFFIX = ".side.inputs.processor.factory";
   private static final String STORE_PREFIX = "stores.";
 
   public static final String FACTORY = STORE_PREFIX + "%s" + FACTORY_SUFFIX;
@@ -67,7 +68,7 @@ public class StorageConfig extends MapConfig {
   static final String ACCESSLOG_ENABLED = STORE_PREFIX + "%s.accesslog.enabled";
   static final int DEFAULT_ACCESSLOG_SAMPLING_RATIO = 50;
   static final String SIDE_INPUTS = STORE_PREFIX + "%s.side.inputs";
-  static final String SIDE_INPUTS_PROCESSOR_FACTORY = STORE_PREFIX + "%s.side.inputs.processor.factory";
+  static final String SIDE_INPUTS_PROCESSOR_FACTORY = STORE_PREFIX + "%s" + SIDE_INPUT_PROCESSOR_FACTORY_SUFFIX;
   static final String SIDE_INPUTS_PROCESSOR_SERIALIZED_INSTANCE =
       STORE_PREFIX + "%s.side.inputs.processor.serialized.instance";
   static final String INMEMORY_KV_STORAGE_ENGINE_FACTORY =
@@ -84,7 +85,9 @@ public class StorageConfig extends MapConfig {
     Config subConfig = subset(STORE_PREFIX, true);
     List<String> storeNames = new ArrayList<>();
     for (String key : subConfig.keySet()) {
-      if (key.endsWith(FACTORY_SUFFIX)) {
+      if (key.endsWith(SIDE_INPUT_PROCESSOR_FACTORY_SUFFIX)) {
+        storeNames.add(key.substring(0, key.length() - SIDE_INPUT_PROCESSOR_FACTORY_SUFFIX.length()));
+      } else if (key.endsWith(FACTORY_SUFFIX)) {
         storeNames.add(key.substring(0, key.length() - FACTORY_SUFFIX.length()));
       }
     }

--- a/samza-core/src/test/java/org/apache/samza/config/TestStorageConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestStorageConfig.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.samza.SamzaException;
 import org.junit.Test;
@@ -44,6 +45,7 @@ public class TestStorageConfig {
     // empty config, so no stores
     assertEquals(Collections.emptyList(), new StorageConfig(new MapConfig()).getStoreNames());
 
+    Set<String> expectedStoreNames = ImmutableSet.of(STORE_NAME0, STORE_NAME1);
     // has stores
     StorageConfig storageConfig = new StorageConfig(new MapConfig(
         ImmutableMap.of(String.format(StorageConfig.FACTORY, STORE_NAME0), "store0.factory.class",
@@ -51,7 +53,17 @@ public class TestStorageConfig {
     List<String> actual = storageConfig.getStoreNames();
     // ordering shouldn't matter
     assertEquals(2, actual.size());
-    assertEquals(ImmutableSet.of(STORE_NAME0, STORE_NAME1), ImmutableSet.copyOf(actual));
+    assertEquals(expectedStoreNames, ImmutableSet.copyOf(actual));
+
+    //has side input stores
+    StorageConfig config = new StorageConfig(new MapConfig(
+        ImmutableMap.of(String.format(FACTORY, STORE_NAME0), "store0.factory.class",
+            String.format(StorageConfig.SIDE_INPUTS_PROCESSOR_FACTORY, STORE_NAME1), "store1.factory.class")));
+
+    actual = storageConfig.getStoreNames();
+
+    assertEquals(2, actual.size());
+    assertEquals(expectedStoreNames, ImmutableSet.copyOf(actual));
   }
 
   @Test


### PR DESCRIPTION
**Symptom**: Enabling side inputs for low level jobs using configuration will throw an exception during job start up.
**Cause**: `getStoreNames()` uses pattern matching to infer store names from the config. The pattern matching conflicts with `side.inputs.processor.factory` and returns incorrect store names.
**Fix**: Handle side inputs processors factory prefix correctly within `getStoreNames()`
**Tests**: Added unit test for `getStoreNames()`
**API Change**: None
**Usage Instructions**: None
**Upgrade Instructions**: None