### PR TITLE
Adding metric that is 0 when container-starting, 1 when started.

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -764,6 +764,7 @@ class SamzaContainer(
         containerListener.afterStart()
       }
       metrics.containerStartupTime.set((System.nanoTime() - startTime)/1000000)
+      metrics.containerStarted.set(1)
       if (taskInstances.size > 0)
         runLoop.run
       else

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
@@ -46,6 +46,7 @@ class SamzaContainerMetrics(
   val diskQuotaBytes = newGauge("disk-quota-bytes", Long.MaxValue)
   val executorWorkFactor = newGauge("executor-work-factor", 1.0)
   val physicalMemoryMb = newGauge[Double]("physical-memory-mb", 0.0F)
+  val containerStarted = newCounter("container-started")
 
   val taskStoreRestorationMetrics: util.Map[TaskName, Gauge[Long]] = new util.HashMap[TaskName, Gauge[Long]]()
 


### PR DESCRIPTION
Adding metric that is 0 when container-starting, 1 when started.

Symptom: External monitoring and control (e.g., autosizing) require a way to know when a container has started (e.g., state-restore has completed). Currently, they have to rely on restore-time or container-startup-time metrics, which are a bit tricky to use.

Cause: None

Fix: Added a new metric, a counter, which is 0 and remains at 0 after the container has started. A Gauge on the other hand will go to 0 if its not updated.

Tests: Samza test job with and without state.