### PR TITLE
SAMZA-2415: Fix AvroRelConverter to only consider cached schema while populating SamzaSqlRelRecord for all the nested records.

### DIFF
--- a/samza-sql/src/main/java/org/apache/samza/sql/avro/AvroRelConverter.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/avro/AvroRelConverter.java
@@ -125,18 +125,11 @@ public class AvroRelConverter implements SamzaRelConverter {
         .collect(Collectors.toList()));
   }
 
-  private static SamzaSqlRelRecord convertToRelRecord(IndexedRecord avroRecord) {
+  private static SamzaSqlRelRecord convertToRelRecord(IndexedRecord avroRecord, Schema schema) {
     List<Object> fieldValues = new ArrayList<>();
     List<String> fieldNames = new ArrayList<>();
     if (avroRecord != null) {
-      fieldNames.addAll(
-          avroRecord.getSchema().getFields().stream().map(Schema.Field::name).collect(Collectors.toList()));
-      fieldValues.addAll(avroRecord.getSchema()
-          .getFields()
-          .stream()
-          .map(f -> convertToJavaObject(avroRecord.get(avroRecord.getSchema().getField(f.name()).pos()),
-              getNonNullUnionSchema(avroRecord.getSchema().getField(f.name()).schema())))
-          .collect(Collectors.toList()));
+      fetchFieldNamesAndValuesFromIndexedRecord(avroRecord, fieldNames, fieldValues, schema);
     } else {
       String msg = "Avro Record is null";
       LOG.error(msg);
@@ -231,7 +224,7 @@ public class AvroRelConverter implements SamzaRelConverter {
     }
     switch (schema.getType()) {
       case RECORD:
-        return convertToRelRecord((IndexedRecord) avroObj);
+        return convertToRelRecord((IndexedRecord) avroObj, schema);
       case ARRAY: {
         ArrayList<Object> retVal = new ArrayList<>();
         List<Object> avroArray;

--- a/samza-sql/src/main/java/org/apache/samza/sql/interfaces/SqlIOConfig.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/interfaces/SqlIOConfig.java
@@ -81,13 +81,11 @@ public class SqlIOConfig {
     this.streamId = String.format("%s-%s", systemName, streamName);
 
     samzaRelConverterName = streamConfigs.get(CFG_SAMZA_REL_CONVERTER);
-    Validate.notEmpty(samzaRelConverterName, String.format("System %s is unknown. %s is not set or empty for this"
-        + " system", systemName, CFG_SAMZA_REL_CONVERTER));
+    Validate.notEmpty(samzaRelConverterName, String.format("System %s is not supported. Please check if the system name is provided correctly.", systemName));
 
     if (isRemoteTable()) {
       samzaRelTableKeyConverterName = streamConfigs.get(CFG_SAMZA_REL_TABLE_KEY_CONVERTER);
-      Validate.notEmpty(samzaRelTableKeyConverterName, String.format("System %s is unknown. %s is not set or empty for"
-          + " this system", systemName, CFG_SAMZA_REL_CONVERTER));
+      Validate.notEmpty(samzaRelTableKeyConverterName, String.format("System %s is not supported. Please check if the system name is provided correctly.", systemName));
     } else {
       samzaRelTableKeyConverterName = "";
     }

--- a/samza-sql/src/main/java/org/apache/samza/sql/util/SamzaSqlQueryParser.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/util/SamzaSqlQueryParser.java
@@ -53,7 +53,6 @@ import org.apache.calcite.tools.Planner;
 import org.apache.samza.SamzaException;
 import org.apache.samza.sql.interfaces.SamzaSqlDriver;
 import org.apache.samza.sql.interfaces.SamzaSqlJavaTypeFactoryImpl;
-import org.apache.samza.sql.planner.QueryPlanner;
 import org.apache.samza.sql.planner.SamzaSqlValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
Currently, relRecord is populated with cached schema only at the top-level fields while the nested fields are populated with the schema of the incoming record. This ticket is to fix that inconsistency and always consider cached schema (schema that is fetched when the job starts).

As a by-product of considering only cached schema, Sql job will keep running even though the input schema has evolved, let's say a new field is added. We will keep dropping the new field. As a separate effort, we need to consider adding metrics to flag whenever we detect that the input schema has evolved.

**Symptom**: Container sometimes fails with exception when the schema of input stream(s) evolves.
**Cause**: Currently, relRecord is populated with cached schema only at the top-level fields while the nested fields are populated with the schema of the incoming record. 
**Fix**: This ticket is to fix the above inconsistency and always consider cached schema (schema that is fetched when the job starts).
**Tests**: This happened with a sql on an input kafka stream where the job went down when the schema evolved. Was able to repro with shell and verify the fix on it. Automated tests are planned to be tackled as a separate effort for schema evolution.
