### PR TITLE
SAMZA-2416 : Adding null-check before incrementing metrics for bytesSerialized

### DIFF
--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/SerializedKeyValueStore.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/SerializedKeyValueStore.scala
@@ -136,7 +136,9 @@ class SerializedKeyValueStore[K, V](
     null
   } else {
     val bytes = serde.toBytes(t)
-    metrics.bytesSerialized.inc(bytes.size)
+    if (bytes != null) {
+      metrics.bytesSerialized.inc(bytes.size)
+    }
     bytes
   }
 


### PR DESCRIPTION
Adding null-check before incrementing metrics for bytesSerialized

Symptom: User serde-serialization logic can choose to serialize non-null objects to a null, which implies delete the value. In this case, current code tries to increment the metrics using the size of the null and fails with an NPE.

Cause: Current code tries to increment the bytesSerialized metrics using the size of the null and fails with an NPE.

Fix: Added logic to skip metric value update if serde returns null.

