### PR TITLE
SAMZA-2406: Add ConfigLoader, ConfigLoaderFactory interface and default PropertiesConfigLoader as well as PropertiesConfigLoaderFactory implementations.

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/config/ConfigLoader.java
+++ b/samza-api/src/main/java/org/apache/samza/config/ConfigLoader.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.config;
+
+/**
+ * The primary means of fetching {@link org.apache.samza.config.Config} on Application Master during start up.
+ */
+public interface ConfigLoader {
+  Config getConfig();
+}

--- a/samza-api/src/main/java/org/apache/samza/config/ConfigLoader.java
+++ b/samza-api/src/main/java/org/apache/samza/config/ConfigLoader.java
@@ -20,7 +20,8 @@
 package org.apache.samza.config;
 
 /**
- * The primary means of fetching full job {@link org.apache.samza.config.Config} on cluster based job coordinator during start up.
+ * The primary means of fetching full job {@link org.apache.samza.config.Config} on
+ * LocalApplicationRunner and ClusterBasedJobCoordinator during start up.
  */
 public interface ConfigLoader {
   Config getConfig();

--- a/samza-api/src/main/java/org/apache/samza/config/ConfigLoader.java
+++ b/samza-api/src/main/java/org/apache/samza/config/ConfigLoader.java
@@ -20,7 +20,7 @@
 package org.apache.samza.config;
 
 /**
- * The primary means of fetching {@link org.apache.samza.config.Config} on Application Master during start up.
+ * The primary means of fetching full job {@link org.apache.samza.config.Config} on cluster based job coordinator during start up.
  */
 public interface ConfigLoader {
   Config getConfig();

--- a/samza-api/src/main/java/org/apache/samza/config/ConfigLoaderFactory.java
+++ b/samza-api/src/main/java/org/apache/samza/config/ConfigLoaderFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.config;
+
+/**
+ * The factory for an {@link ConfigLoader} instance to loader job config.
+ */
+public interface ConfigLoaderFactory {
+  /**
+   * Get an instance of {@link ConfigLoader}
+   *
+   * @param config start up config which specifies properties needed for the loader to load config.
+   * @return a config loader instance.
+   */
+  ConfigLoader getLoader(Config config);
+}

--- a/samza-api/src/main/java/org/apache/samza/config/ConfigLoaderFactory.java
+++ b/samza-api/src/main/java/org/apache/samza/config/ConfigLoaderFactory.java
@@ -20,13 +20,13 @@
 package org.apache.samza.config;
 
 /**
- * The factory for an {@link ConfigLoader} instance to loader job config.
+ * The factory for an {@link ConfigLoader} instance to load full job config.
  */
 public interface ConfigLoaderFactory {
   /**
    * Get an instance of {@link ConfigLoader}
    *
-   * @param config start up config which specifies properties needed for the loader to load config.
+   * @param config start up config which specifies properties needed for the loader to load full job config.
    * @return a config loader instance.
    */
   ConfigLoader getLoader(Config config);

--- a/samza-api/src/main/java/org/apache/samza/config/MapConfig.java
+++ b/samza-api/src/main/java/org/apache/samza/config/MapConfig.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 
 /**

--- a/samza-api/src/main/java/org/apache/samza/config/MapConfig.java
+++ b/samza-api/src/main/java/org/apache/samza/config/MapConfig.java
@@ -42,17 +42,6 @@ public class MapConfig extends Config {
     this(Collections.singletonList(map));
   }
 
-  /**
-   * Build a {@link MapConfig} from {@link Properties}
-   *
-   * @param properties to build MapConfig
-   */
-  public MapConfig(Properties properties) {
-    this.map = new HashMap<>();
-    // Per Properties JavaDoc, all its keys and values are of type String
-    properties.forEach((key, value) -> this.map.put(key.toString(), value.toString()));
-  }
-
   public MapConfig(List<Map<String, String>> maps) {
     this.map = new HashMap<>();
     for (Map<String, String> m: maps) {

--- a/samza-api/src/main/java/org/apache/samza/config/MapConfig.java
+++ b/samza-api/src/main/java/org/apache/samza/config/MapConfig.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 /**
@@ -39,6 +40,17 @@ public class MapConfig extends Config {
 
   public MapConfig(Map<String, String> map) {
     this(Collections.singletonList(map));
+  }
+
+  /**
+   * Build a {@link MapConfig} from {@link Properties}
+   *
+   * @param properties to build MapConfig
+   */
+  public MapConfig(Properties properties) {
+    this.map = new HashMap<>();
+    // Per Properties JavaDoc, all its keys and values are of type String
+    properties.forEach((key, value) -> this.map.put(key.toString(), value.toString()));
   }
 
   public MapConfig(List<Map<String, String>> maps) {

--- a/samza-core/src/main/java/org/apache/samza/config/loaders/PropertiesConfigLoader.java
+++ b/samza-core/src/main/java/org/apache/samza/config/loaders/PropertiesConfigLoader.java
@@ -22,6 +22,8 @@ package org.apache.samza.config.loaders;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import org.apache.samza.SamzaException;
 import org.apache.samza.config.Config;
@@ -33,6 +35,9 @@ import org.slf4j.LoggerFactory;
 import static java.util.Objects.requireNonNull;
 
 
+/**
+ * ConfigLoader to load full job configs from a local properties file given its path.
+ */
 public class PropertiesConfigLoader implements ConfigLoader {
   private static final Logger LOG = LoggerFactory.getLogger(PropertiesConfigLoader.class);
 
@@ -51,11 +56,15 @@ public class PropertiesConfigLoader implements ConfigLoader {
       props.load(in);
       in.close();
 
-      LOG.debug("got config {} from config {}", props, path);
+      LOG.debug("got config {} from path {}", props, path);
 
-      return new MapConfig(props);
+      Map<String, String> config = new HashMap<>(props.size());
+      // Per Properties JavaDoc, all its keys and values are of type String
+      props.forEach((key, value) -> config.put(key.toString(), value.toString()));
+
+      return new MapConfig(config);
     } catch (IOException e) {
-      throw new SamzaException("Failed to read from");
+      throw new SamzaException("Failed to read from " + path);
     }
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/config/loaders/PropertiesConfigLoader.java
+++ b/samza-core/src/main/java/org/apache/samza/config/loaders/PropertiesConfigLoader.java
@@ -43,6 +43,11 @@ public class PropertiesConfigLoader implements ConfigLoader {
 
   private final String path;
 
+  /**
+   * @param path Absolute or relative file path where the properties file locates. For example,
+   *             in <a href="https://samza.apache.org/startup/hello-samza/1.0.0/">Hello Samza</a>,
+   *             it will be set to /__package/config/wikipedia-feed.properties
+   */
   public PropertiesConfigLoader(String path) {
     this.path = requireNonNull(path);
   }

--- a/samza-core/src/main/java/org/apache/samza/config/loaders/PropertiesConfigLoader.java
+++ b/samza-core/src/main/java/org/apache/samza/config/loaders/PropertiesConfigLoader.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.config.loaders;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import org.apache.samza.SamzaException;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.ConfigLoader;
+import org.apache.samza.config.MapConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.Objects.requireNonNull;
+
+
+public class PropertiesConfigLoader implements ConfigLoader {
+  private static final Logger LOG = LoggerFactory.getLogger(PropertiesConfigLoader.class);
+
+  private final String path;
+
+  public PropertiesConfigLoader(String path) {
+    this.path = requireNonNull(path);
+  }
+
+  @Override
+  public Config getConfig() {
+    try {
+      InputStream in = new FileInputStream(path);
+      Properties props = new Properties();
+
+      props.load(in);
+      in.close();
+
+      LOG.debug("got config {} from config {}", props, path);
+
+      return new MapConfig(props);
+    } catch (IOException e) {
+      throw new SamzaException("Failed to read from");
+    }
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/config/loaders/PropertiesConfigLoaderFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/config/loaders/PropertiesConfigLoaderFactory.java
@@ -25,6 +25,10 @@ import org.apache.samza.config.ConfigLoader;
 import org.apache.samza.config.ConfigLoaderFactory;
 
 
+/**
+ * ConfigLoaderFactory which initialize {@link PropertiesConfigLoader} with properties file path specified in
+ * job.config.loader.properties.path.
+ */
 public class PropertiesConfigLoaderFactory implements ConfigLoaderFactory {
   private static final String KEY = "path";
 

--- a/samza-core/src/main/java/org/apache/samza/config/loaders/PropertiesConfigLoaderFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/config/loaders/PropertiesConfigLoaderFactory.java
@@ -1,0 +1,22 @@
+package org.apache.samza.config.loaders;
+
+import org.apache.samza.SamzaException;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.ConfigLoader;
+import org.apache.samza.config.ConfigLoaderFactory;
+
+
+public class PropertiesConfigLoaderFactory implements ConfigLoaderFactory {
+  private static final String KEY = "path";
+
+  @Override
+  public ConfigLoader getLoader(Config config) {
+    String path = config.get(KEY);
+
+    if (path == null) {
+      throw new SamzaException("path is required to read config from properties file");
+    }
+
+    return new PropertiesConfigLoader(path);
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/config/loaders/PropertiesConfigLoaderFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/config/loaders/PropertiesConfigLoaderFactory.java
@@ -30,11 +30,11 @@ import org.apache.samza.config.ConfigLoaderFactory;
  * job.config.loader.properties.path.
  */
 public class PropertiesConfigLoaderFactory implements ConfigLoaderFactory {
-  private static final String KEY = "path";
+  private static final String PATH_KEY = "path";
 
   @Override
   public ConfigLoader getLoader(Config config) {
-    String path = config.get(KEY);
+    String path = config.get(PATH_KEY);
 
     if (path == null) {
       throw new SamzaException("path is required to read config from properties file");

--- a/samza-core/src/main/java/org/apache/samza/config/loaders/PropertiesConfigLoaderFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/config/loaders/PropertiesConfigLoaderFactory.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.samza.config.loaders;
 
 import org.apache.samza.SamzaException;

--- a/samza-core/src/test/java/org/apache/samza/config/loaders/TestPropertiesConfigLoader.java
+++ b/samza-core/src/test/java/org/apache/samza/config/loaders/TestPropertiesConfigLoader.java
@@ -1,0 +1,33 @@
+package org.apache.samza.config.loaders;
+
+import java.util.Collections;
+import org.apache.samza.SamzaException;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.ConfigLoader;
+import org.apache.samza.config.MapConfig;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class TestPropertiesConfigLoader {
+  @Test
+  public void testCanReadPropertiesConfigFiles() {
+    ConfigLoader loader = new PropertiesConfigLoaderFactory().getLoader(
+        new MapConfig(Collections.singletonMap("path", getClass().getResource("/test.properties").getPath())));
+
+    Config config = loader.getConfig();
+    assertEquals("bar", config.get("foo"));
+  }
+
+  @Test
+  public void testCanNotReadWithoutPath() {
+    try {
+      ConfigLoader loader = new PropertiesConfigLoaderFactory().getLoader(new MapConfig());
+      loader.getConfig();
+      fail("should have gotten a samza exception");
+    } catch (SamzaException e) {
+      // Do nothing
+    }
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/config/loaders/TestPropertiesConfigLoader.java
+++ b/samza-core/src/test/java/org/apache/samza/config/loaders/TestPropertiesConfigLoader.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.samza.config.loaders;
 
 import java.util.Collections;

--- a/samza-core/src/test/java/org/apache/samza/config/loaders/TestPropertiesConfigLoader.java
+++ b/samza-core/src/test/java/org/apache/samza/config/loaders/TestPropertiesConfigLoader.java
@@ -26,7 +26,7 @@ import org.apache.samza.config.ConfigLoader;
 import org.apache.samza.config.MapConfig;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 
 public class TestPropertiesConfigLoader {
@@ -39,14 +39,9 @@ public class TestPropertiesConfigLoader {
     assertEquals("bar", config.get("foo"));
   }
 
-  @Test
+  @Test(expected = SamzaException.class)
   public void testCanNotReadWithoutPath() {
-    try {
-      ConfigLoader loader = new PropertiesConfigLoaderFactory().getLoader(new MapConfig());
-      loader.getConfig();
-      fail("should have gotten a samza exception");
-    } catch (SamzaException e) {
-      // Do nothing
-    }
+    ConfigLoader loader = new PropertiesConfigLoaderFactory().getLoader(new MapConfig());
+    loader.getConfig();
   }
 }


### PR DESCRIPTION
Add ConfigLoader, ConfigLoaderFactory interface and default PropertiesConfigLoader as well as PropertiesConfigLoaderFactory implementations, which will be used on AM to fetch configs. It will also be used on LocalApplicationRunner to fetch configs as well.

The existing ConfigFactory interface will be deprecated and removed as we do not fetch configs on start up script run-app.sh anymore.

Design:
https://cwiki.apache.org/confluence/display/SAMZA/SEP-23%3A+Simplify+Job+Runner

Changes:

1. Add ConfigLoader interface which will be used in job coordinator to retrieve config from.
2. Add ConfigLoaderFactory interface which will be used to create an instance of ConfigLoader.
3. Add PropertiesConfigLoader which is a default implementation of ConfigLoader that reads a local properties file given the file path.
4. Add PropertiesConfigLoaderFactory which is a default implementation of ConfigLoaderFactory that reads properties file path from start up config and creates a PropertiesConfigLoader with the provided path.

API Changes:

  N/A. This is part of a series PRs, detailed information will be provided in the last/main PR.
Upgrade Instructions:
  N/A. This is part of a series PRs, detailed information will be provided in the last/main PR.
Usage Instructions:
  N/A. This is part of a series PRs, detailed information will be provided in the last/main PR.

Tests:

Add TestPropertiesConfigLoader to unit test PropertiesConfigLoader.