### PR TITLE
SAMZA-2423: Heartbeat failure causes incorrect container shutdown

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/container/ContainerHeartbeatMonitor.java
+++ b/samza-core/src/main/java/org/apache/samza/container/ContainerHeartbeatMonitor.java
@@ -52,17 +52,17 @@ public class ContainerHeartbeatMonitor {
     }
     LOG.info("Starting ContainerHeartbeatMonitor");
     scheduler.scheduleAtFixedRate(() -> {
-      ContainerHeartbeatResponse response = containerHeartbeatClient.requestHeartbeat();
-      if (!response.isAlive()) {
-        scheduler.schedule(() -> {
-          // On timeout of container shutting down, force exit.
-          LOG.error("Graceful shutdown timeout expired. Force exiting.");
-          ThreadUtil.logThreadDump("Thread dump at heartbeat monitor shutdown timeout.");
-          System.exit(1);
-        }, SHUTDOWN_TIMOUT_MS, TimeUnit.MILLISECONDS);
-        onContainerExpired.run();
-      }
-    }, 0, SCHEDULE_MS, TimeUnit.MILLISECONDS);
+        ContainerHeartbeatResponse response = containerHeartbeatClient.requestHeartbeat();
+        if (!response.isAlive()) {
+          scheduler.schedule(() -> {
+              // On timeout of container shutting down, force exit.
+              LOG.error("Graceful shutdown timeout expired. Force exiting.");
+              ThreadUtil.logThreadDump("Thread dump at heartbeat monitor shutdown timeout.");
+              System.exit(1);
+            }, SHUTDOWN_TIMOUT_MS, TimeUnit.MILLISECONDS);
+          onContainerExpired.run();
+        }
+      }, 0, SCHEDULE_MS, TimeUnit.MILLISECONDS);
     started = true;
   }
 

--- a/samza-core/src/main/java/org/apache/samza/container/ContainerHeartbeatMonitor.java
+++ b/samza-core/src/main/java/org/apache/samza/container/ContainerHeartbeatMonitor.java
@@ -39,7 +39,7 @@ public class ContainerHeartbeatMonitor {
   private final Runnable onContainerExpired;
   private final ContainerHeartbeatClient containerHeartbeatClient;
   private boolean started = false;
-  private boolean heartbeatExpired = false;
+  private static volatile boolean heartbeatExpired = false;
 
   public ContainerHeartbeatMonitor(Runnable onContainerExpired, ContainerHeartbeatClient containerHeartbeatClient) {
     this.onContainerExpired = onContainerExpired;

--- a/samza-core/src/main/java/org/apache/samza/runtime/ContainerLaunchUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/ContainerLaunchUtil.java
@@ -187,14 +187,14 @@ public class ContainerLaunchUtil {
     if (executionEnvContainerId != null) {
       log.info("Got execution environment container id: {}", executionEnvContainerId);
       return new ContainerHeartbeatMonitor(() -> {
-        try {
-          container.shutdown();
-          containerRunnerException = new SamzaException("Container shutdown due to expired heartbeat");
-        } catch (Exception e) {
-          log.error("Heartbeat monitor failed to shutdown the container gracefully. Exiting process.", e);
-          System.exit(1);
-        }
-      }, new ContainerHeartbeatClient(coordinatorUrl, executionEnvContainerId));
+          try {
+            container.shutdown();
+            containerRunnerException = new SamzaException("Container shutdown due to expired heartbeat");
+          } catch (Exception e) {
+            log.error("Heartbeat monitor failed to shutdown the container gracefully. Exiting process.", e);
+            System.exit(1);
+          }
+        }, new ContainerHeartbeatClient(coordinatorUrl, executionEnvContainerId));
     } else {
       log.warn("Execution environment container id not set. Container heartbeat monitor will not be created");
       return null;


### PR DESCRIPTION
**Symptom:** 
When a container heartbeat fails, the container shutdown
sequence is triggered and the Container is never restarted.

**Cause:**
When a container heartbeat fails, the container shutdown
sequence exists the Container with an exit code of `0` which
marks the container as `Completed` - preventing the JobCoordinator
from restarting the container.
The bug is caused by `containerException` overwritten with the value
returned by `listener.getContainerException` without checking if 
`containerException` was already set by the heartbeat monitor

**Changes:** 
The container can shutdown exceptionally in the following two ways:
1) Exception in the container
2) Heartbeat Expired
In both paths the ContainerLaunchUtil previously expected a
shared static variable to hold the exception. The change introduced
gets rid of the static variable and checks each path explicitly
and exits with code `1` in both cases.