### PR TITLE
SAMZA-2409: Update YarnJob to construct job submission env varible

### DIFF
--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/YarnJob.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/YarnJob.scala
@@ -178,7 +178,7 @@ object YarnJob extends Logging {
       envMapBuilder += ShellCommandConfig.ENV_SUBMISSION_CONFIG ->
         Util.envVarEscape(SamzaObjectMapper.getObjectMapper.writeValueAsString(config))
     } else {
-      // TODO: Clean this up once SAMZA-2405 is completed when legacy flow is removed.
+      // TODO SAMZA-2432: Clean this up once SAMZA-2405 is completed when legacy flow is removed.
       val coordinatorSystemConfig = CoordinatorStreamUtil.buildCoordinatorStreamConfig(config)
       envMapBuilder += ShellCommandConfig.ENV_COORDINATOR_SYSTEM_CONFIG ->
         Util.envVarEscape(SamzaObjectMapper.getObjectMapper.writeValueAsString(coordinatorSystemConfig))

--- a/samza-yarn/src/test/java/org/apache/samza/job/yarn/TestYarnJob.java
+++ b/samza-yarn/src/test/java/org/apache/samza/job/yarn/TestYarnJob.java
@@ -111,4 +111,24 @@ public class TestYarnJob {
     assertEquals(expected, JavaConverters.mapAsJavaMapConverter(
         YarnJob$.MODULE$.buildEnvironment(config, new YarnConfig(config), new JobConfig(config))).asJava());
   }
+
+  @Test
+  public void testBuildJobSubmissionEnvironment() throws IOException {
+    Config config = new MapConfig(new ImmutableMap.Builder<String, String>()
+        .put(JobConfig.JOB_NAME, "jobName")
+        .put(JobConfig.JOB_ID, "jobId")
+        .put(JobConfig.CONFIG_LOADER_FACTORY, "org.apache.samza.config.loaders.PropertiesConfigLoaderFactory")
+        .put(YarnConfig.AM_JVM_OPTIONS, "")
+        .put(JobConfig.CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED, "true")
+        .build());
+    String expectedSubmissionConfig = Util.envVarEscape(SamzaObjectMapper.getObjectMapper()
+        .writeValueAsString(config));
+    Map<String, String> expected = ImmutableMap.of(
+        ShellCommandConfig.ENV_SUBMISSION_CONFIG(), expectedSubmissionConfig,
+        ShellCommandConfig.ENV_JAVA_OPTS(), "",
+        ShellCommandConfig.ENV_CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED(), "true",
+        ShellCommandConfig.ENV_APPLICATION_LIB_DIR(), "./__package/lib");
+    assertEquals(expected, JavaConverters.mapAsJavaMapConverter(
+        YarnJob$.MODULE$.buildEnvironment(config, new YarnConfig(config), new JobConfig(config))).asJava());
+  }
 }


### PR DESCRIPTION
Design:
https://cwiki.apache.org/confluence/display/SAMZA/SEP-23%3A+Simplify+Job+Runner

Changes:
1. Depending the on the existence of job.config.loader.factory, YarnJob will alternatively wraps job submission configs to Yarn.
2. In a separate PR, ClusterBasedJobCoordinator will be updated to read full job config from loader or coordinator stream based on the existence of submission config environment variable.

API Changes:
N/A. This is part of a series PRs, detailed information will be provided in the last/main PR.

Upgrade Instructions:
N/A. This is part of a series PRs, detailed information will be provided in the last/main PR.

Usage Instructions:
N/A. This is part of a series PRs, detailed information will be provided in the last/main PR.

Tests:
Unit Tests