### PR TITLE
Refactor LocalApplicationRunner

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
@@ -110,8 +110,7 @@ public class LocalApplicationRunner implements ApplicationRunner {
    * @param config configuration for the application
    * @param metadataStoreFactory the instance of {@link MetadataStoreFactory} to read and write to coordinator stream.
    */
-  @VisibleForTesting
-  LocalApplicationRunner(SamzaApplication app, Config config, MetadataStoreFactory metadataStoreFactory) {
+  public LocalApplicationRunner(SamzaApplication app, Config config, MetadataStoreFactory metadataStoreFactory) {
     this(ApplicationDescriptorUtil.getAppDescriptor(app, config), getCoordinationUtils(config), metadataStoreFactory);
   }
 

--- a/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
@@ -76,9 +76,9 @@ public class LocalApplicationRunner implements ApplicationRunner {
 
   private static final Logger LOG = LoggerFactory.getLogger(LocalApplicationRunner.class);
   private static final String PROCESSOR_ID = UUID.randomUUID().toString();
-  private final  static String RUN_ID_METADATA_STORE = "RunIdCoordinationStore";
+  private static final String RUN_ID_METADATA_STORE = "RunIdCoordinationStore";
   private static final String METADATA_STORE_FACTORY_CONFIG = "metadata.store.factory";
-  public final static String DEFAULT_METADATA_STORE_FACTORY = ZkMetadataStoreFactory.class.getName();
+  private static final String DEFAULT_METADATA_STORE_FACTORY = ZkMetadataStoreFactory.class.getName();
 
   private final ApplicationDescriptorImpl<? extends ApplicationDescriptor> appDesc;
   private final Set<Pair<StreamProcessor, MetadataStore>> processors = ConcurrentHashMap.newKeySet();
@@ -88,9 +88,9 @@ public class LocalApplicationRunner implements ApplicationRunner {
   private final boolean isAppModeBatch;
   private final Optional<CoordinationUtils> coordinationUtils;
   private final Optional<MetadataStoreFactory> metadataStoreFactory;
+
   private Optional<String> runId = Optional.empty();
   private Optional<RunIdGenerator> runIdGenerator = Optional.empty();
-
   private ApplicationStatus appStatus = ApplicationStatus.New;
 
   /**
@@ -110,11 +110,9 @@ public class LocalApplicationRunner implements ApplicationRunner {
    * @param config configuration for the application
    * @param metadataStoreFactory the instance of {@link MetadataStoreFactory} to read and write to coordinator stream.
    */
-  public LocalApplicationRunner(SamzaApplication app, Config config, MetadataStoreFactory metadataStoreFactory) {
-    this.appDesc = ApplicationDescriptorUtil.getAppDescriptor(app, config);
-    this.isAppModeBatch = new ApplicationConfig(config).getAppMode() == ApplicationConfig.ApplicationMode.BATCH;
-    this.coordinationUtils = getCoordinationUtils(config);
-    this.metadataStoreFactory = Optional.ofNullable(metadataStoreFactory);
+  @VisibleForTesting
+  LocalApplicationRunner(SamzaApplication app, Config config, MetadataStoreFactory metadataStoreFactory) {
+    this(ApplicationDescriptorUtil.getAppDescriptor(app, config), getCoordinationUtils(config), metadataStoreFactory);
   }
 
   /**
@@ -122,12 +120,20 @@ public class LocalApplicationRunner implements ApplicationRunner {
    */
   @VisibleForTesting
   LocalApplicationRunner(ApplicationDescriptorImpl<? extends ApplicationDescriptor> appDesc, Optional<CoordinationUtils> coordinationUtils) {
-    this.appDesc = appDesc;
-    this.isAppModeBatch = new ApplicationConfig(appDesc.getConfig()).getAppMode() == ApplicationConfig.ApplicationMode.BATCH;
-    this.coordinationUtils = coordinationUtils;
-    this.metadataStoreFactory = Optional.ofNullable(getDefaultCoordinatorStreamStoreFactory(new JobConfig(appDesc.getConfig())));
+    this(appDesc, coordinationUtils, getDefaultCoordinatorStreamStoreFactory(new JobConfig(appDesc.getConfig())));
   }
 
+  private LocalApplicationRunner(
+      ApplicationDescriptorImpl<? extends ApplicationDescriptor> appDesc,
+      Optional<CoordinationUtils> coordinationUtils,
+      MetadataStoreFactory metadataStoreFactory) {
+    this.appDesc = appDesc;
+    this.isAppModeBatch = isAppModeBatch(appDesc.getConfig());
+    this.coordinationUtils = coordinationUtils;
+    this.metadataStoreFactory = Optional.ofNullable(metadataStoreFactory);
+  }
+
+  @VisibleForTesting
   static MetadataStoreFactory getDefaultCoordinatorStreamStoreFactory(JobConfig jobConfig) {
     String coordinatorSystemName = jobConfig.getCoordinatorSystemNameOrNull();
     JobCoordinatorConfig jobCoordinatorConfig = new JobCoordinatorConfig(jobConfig);
@@ -144,14 +150,18 @@ public class LocalApplicationRunner implements ApplicationRunner {
     return null;
   }
 
-  private Optional<CoordinationUtils> getCoordinationUtils(Config config) {
-    if (!isAppModeBatch) {
+  private static Optional<CoordinationUtils> getCoordinationUtils(Config config) {
+    if (!isAppModeBatch(config)) {
       return Optional.empty();
     }
     JobCoordinatorConfig jcConfig = new JobCoordinatorConfig(config);
     CoordinationUtils coordinationUtils = jcConfig.getCoordinationUtilsFactory()
         .getCoordinationUtils(CoordinationConstants.APPLICATION_RUNNER_PATH_SUFFIX, PROCESSOR_ID, config);
     return Optional.ofNullable(coordinationUtils);
+  }
+
+  private static boolean isAppModeBatch(Config config) {
+    return new ApplicationConfig(config).getAppMode() == ApplicationConfig.ApplicationMode.BATCH;
   }
 
   /**
@@ -185,7 +195,7 @@ public class LocalApplicationRunner implements ApplicationRunner {
       runIdGenerator = Optional.of(new RunIdGenerator(coordinationUtils.get(), metadataStore));
       runId = runIdGenerator.flatMap(RunIdGenerator::getRunId);
     } catch (Exception e) {
-      LOG.warn("Failed to generate run id. Will continue execution without a run id. Caused by {}", e);
+      LOG.warn("Failed to generate run id. Will continue execution without a run id.", e);
     }
   }
 
@@ -278,7 +288,7 @@ public class LocalApplicationRunner implements ApplicationRunner {
 
   @VisibleForTesting
   protected Set<StreamProcessor> getProcessors() {
-    return processors.stream().map(sp -> sp.getLeft()).collect(Collectors.toSet());
+    return processors.stream().map(Pair::getLeft).collect(Collectors.toSet());
   }
 
   @VisibleForTesting
@@ -340,10 +350,8 @@ public class LocalApplicationRunner implements ApplicationRunner {
     appDesc.getMetricsReporterFactories().forEach((name, factory) ->
         reporters.put(name, factory.getMetricsReporter(name, processorId, config)));
 
-    StreamProcessor streamProcessor = new StreamProcessor(processorId, config, reporters, taskFactory, appDesc.getApplicationContainerContextFactory(),
+    return new StreamProcessor(processorId, config, reporters, taskFactory, appDesc.getApplicationContainerContextFactory(),
           appDesc.getApplicationTaskContextFactory(), externalContextOptional, listenerFactory, null, coordinatorStreamStore);
-
-    return streamProcessor;
   }
 
   /**


### PR DESCRIPTION
Issues: LocalApplicationRunner has multiple constructors and follows different initialization logic.

Changes:

1. Refactor all constructors to end up with the same private constructor.
2. Align "static final" and "final static" to "static final"
3. Group class variales based on accessibility
4. Minor fixs on inconsistent styling, return etc.

API Changes:
None

Upgrade Instructions: 
None
 
Usage Instructions:
None

Tests:
Unit Tests