### PR TITLE
SAMZA-2431: Fix the checkpoint and changelog topic auto-creation.

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/system/StreamSpec.java
+++ b/samza-api/src/main/java/org/apache/samza/system/StreamSpec.java
@@ -19,6 +19,8 @@
 
 package org.apache.samza.system;
 
+import com.google.common.base.Joiner;
+
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
@@ -269,6 +271,6 @@ public class StreamSpec implements Serializable {
 
   @Override
   public String toString() {
-    return String.format("StreamSpec: id=%s, systemName=%s, pName=%s, partCount=%d.", id, systemName, physicalName, partitionCount);
+    return String.format("StreamSpec: id=%s, systemName=%s, pName=%s, partCount=%d, config=%s.", id, systemName, physicalName, partitionCount, Joiner.on(",").withKeyValueSeparator("=").join(config));
   }
 }

--- a/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaSystemAdmin.java
+++ b/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaSystemAdmin.java
@@ -541,8 +541,8 @@ public class KafkaSystemAdmin implements SystemAdmin {
           new KafkaStreamSpec(spec.getId(), spec.getPhysicalName(), systemName, 1, coordinatorStreamReplicationFactor,
               coordinatorStreamProperties);
     } else if (spec.isCheckpointStream()) {
-      kafkaSpec = KafkaStreamSpec.fromSpec(StreamSpec.createCheckpointStreamSpec(spec.getPhysicalName(), systemName))
-              .copyWithReplicationFactor(Integer.parseInt(new KafkaConfig(config).getCheckpointReplicationFactor().get()));
+      kafkaSpec = KafkaStreamSpec.fromSpec(spec)
+                                 .copyWithReplicationFactor(Integer.parseInt(new KafkaConfig(config).getCheckpointReplicationFactor().get()));
     } else if (intermediateStreamProperties.containsKey(spec.getId())) {
       kafkaSpec = KafkaStreamSpec.fromSpec(spec);
       Properties properties = kafkaSpec.getProperties();

--- a/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaSystemAdmin.java
+++ b/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaSystemAdmin.java
@@ -541,8 +541,11 @@ public class KafkaSystemAdmin implements SystemAdmin {
           new KafkaStreamSpec(spec.getId(), spec.getPhysicalName(), systemName, 1, coordinatorStreamReplicationFactor,
               coordinatorStreamProperties);
     } else if (spec.isCheckpointStream()) {
-      kafkaSpec = KafkaStreamSpec.fromSpec(spec)
-                                 .copyWithReplicationFactor(Integer.parseInt(new KafkaConfig(config).getCheckpointReplicationFactor().get()));
+      Properties checkpointTopicProperties = new Properties();
+      checkpointTopicProperties.putAll(spec.getConfig());
+      kafkaSpec = KafkaStreamSpec.fromSpec(StreamSpec.createCheckpointStreamSpec(spec.getPhysicalName(), spec.getSystemName()))
+              .copyWithReplicationFactor(Integer.parseInt(new KafkaConfig(config).getCheckpointReplicationFactor().get()))
+              .copyWithProperties(checkpointTopicProperties);
     } else if (intermediateStreamProperties.containsKey(spec.getId())) {
       kafkaSpec = KafkaStreamSpec.fromSpec(spec);
       Properties properties = kafkaSpec.getProperties();

--- a/samza-kafka/src/main/scala/org/apache/samza/config/KafkaConfig.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/config/KafkaConfig.scala
@@ -322,8 +322,7 @@ class KafkaConfig(config: Config) extends ScalaMapConfig(config) {
     // Adjust changelog topic setting, when TTL is set on a RocksDB store
     //  - Disable log compaction on Kafka changelog topic
     //  - Set topic TTL to be the same as RocksDB TTL
-    val storeTTLkey = "stores.%s.rocksdb.ttl.ms" format name
-    Option(config.get(storeTTLkey)) match {
+    Option(config.get("stores.%s.rocksdb.ttl.ms" format name)) match {
       case Some(rocksDbTtl) =>
         if (!rocksDbTtl.isEmpty && rocksDbTtl.toInt < 0) {
           kafkaChangeLogProperties.setProperty("cleanup.policy", "compact")

--- a/samza-kafka/src/main/scala/org/apache/samza/config/KafkaConfig.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/config/KafkaConfig.scala
@@ -325,8 +325,9 @@ class KafkaConfig(config: Config) extends ScalaMapConfig(config) {
     val storeTTLkey = "stores.%s.rocksdb.ttl.ms" format name
     Option(config.get(storeTTLkey)) match {
       case Some(rocksDbTtl) =>
-        if (config.getInt(storeTTLkey, 0) < 0) {
+        if (!rocksDbTtl.isEmpty && rocksDbTtl.toInt < 0) {
           kafkaChangeLogProperties.setProperty("cleanup.policy", "compact")
+          kafkaChangeLogProperties.setProperty("max.message.bytes", getChangelogStreamMaxMessageByte(name))
         } else if (!config.containsKey("stores.%s.changelog.kafka.cleanup.policy" format name)) {
           kafkaChangeLogProperties.setProperty("cleanup.policy", "delete")
           if (!config.containsKey("stores.%s.changelog.kafka.retention.ms" format name)) {

--- a/samza-kafka/src/test/java/org/apache/samza/system/kafka/TestKafkaSystemAdminJava.java
+++ b/samza-kafka/src/test/java/org/apache/samza/system/kafka/TestKafkaSystemAdminJava.java
@@ -115,6 +115,32 @@ public class TestKafkaSystemAdminJava extends TestKafkaSystemAdmin {
   }
 
   @Test
+  public void testToKafkaSpecForCheckpointStreamShouldReturnTheCorrectStreamSpecByPreservingTheConfig() {
+    String topicName = "testStream";
+    String streamId = "samza-internal-checkpoint-stream-id";
+    int partitionCount = 2;
+    Map<String, String> map = new HashMap<>();
+    map.put("cleanup.policy", "compact");
+    map.put("replication.factor", "3");
+    map.put("segment.bytes", "536870912");
+    map.put("delete.retention.ms", "86400000");
+
+    Config config = new MapConfig(map);
+
+    StreamSpec spec = new StreamSpec(streamId, topicName, SYSTEM, partitionCount, config);
+    KafkaSystemAdmin kafkaSystemAdmin = systemAdmin();
+    KafkaStreamSpec kafkaStreamSpec = kafkaSystemAdmin.toKafkaSpec(spec);
+    System.out.println(kafkaStreamSpec);
+    assertEquals(streamId, kafkaStreamSpec.getId());
+    assertEquals(topicName, kafkaStreamSpec.getPhysicalName());
+    assertEquals(partitionCount, kafkaStreamSpec.getPartitionCount());
+    assertEquals(3, kafkaStreamSpec.getReplicationFactor());
+    assertEquals("compact", kafkaStreamSpec.getConfig().get("cleanup.policy"));
+    assertEquals("536870912", kafkaStreamSpec.getConfig().get("segment.bytes"));
+    assertEquals("86400000", kafkaStreamSpec.getConfig().get("delete.retention.ms"));
+  }
+
+  @Test
   public void testToKafkaSpec() {
     String topicName = "testStream";
 

--- a/samza-kafka/src/test/java/org/apache/samza/system/kafka/TestKafkaSystemAdminJava.java
+++ b/samza-kafka/src/test/java/org/apache/samza/system/kafka/TestKafkaSystemAdminJava.java
@@ -118,7 +118,7 @@ public class TestKafkaSystemAdminJava extends TestKafkaSystemAdmin {
   public void testToKafkaSpecForCheckpointStreamShouldReturnTheCorrectStreamSpecByPreservingTheConfig() {
     String topicName = "testStream";
     String streamId = "samza-internal-checkpoint-stream-id";
-    int partitionCount = 2;
+    int partitionCount = 1;
     Map<String, String> map = new HashMap<>();
     map.put("cleanup.policy", "compact");
     map.put("replication.factor", "3");

--- a/samza-kafka/src/test/scala/org/apache/samza/config/TestKafkaConfig.scala
+++ b/samza-kafka/src/test/scala/org/apache/samza/config/TestKafkaConfig.scala
@@ -22,14 +22,14 @@ package org.apache.samza.config
 import java.util.Properties
 import java.util.concurrent.TimeUnit
 
-import org.apache.samza.config.factories.PropertiesConfigFactory
 import org.junit.Assert._
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 
 import scala.collection.JavaConverters._
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.apache.kafka.clients.producer.ProducerConfig
-import org.junit.Before
 
 class TestKafkaConfig {
 
@@ -47,6 +47,10 @@ class TestKafkaConfig {
     props.setProperty(JobConfig.JOB_NAME, "jobName")
   }
 
+  @After
+  def clearUpProperties(): Unit = {
+    props.clear()
+  }
 
   @Test
   def testStreamLevelFetchSizeOverride() {
@@ -79,6 +83,43 @@ class TestKafkaConfig {
     val mapConfig4 = new MapConfig(props.asScala.asJava)
     val kafkaConfig4 = new KafkaConfig(mapConfig4)
     assertEquals("65536", kafkaConfig4.getConsumerFetchThresholdBytes("kafka").get)
+  }
+
+  @Test
+  def testChangeLogPropertiesShouldReturnCorrectTopicConfigurationForInfiniteTTLStores(): Unit = {
+    val props = new Properties
+    props.setProperty(KAFKA_PRODUCER_PROPERTY_PREFIX + "bootstrap.servers", "localhost:9092")
+    props.setProperty("systems." + SYSTEM_NAME + ".consumer.zookeeper.connect", "localhost:2181/")
+    props.setProperty(JobConfig.JOB_NAME, "jobName")
+
+    props.setProperty("stores.test1.changelog", "kafka.mychangelog1")
+    props.setProperty("stores.test1.rocksdb.ttl.ms", "-1")
+
+    val mapConfig = new MapConfig(props.asScala.asJava)
+    val kafkaConfig = new KafkaConfig(mapConfig)
+    val kafkaProperties = kafkaConfig.getChangelogKafkaProperties("test1")
+    assertEquals("compact", kafkaProperties.getProperty("cleanup.policy"))
+    assertEquals("536870912", kafkaProperties.getProperty("segment.bytes"))
+    assertEquals("86400000", kafkaProperties.getProperty("delete.retention.ms"))
+  }
+
+  @Test
+  def testChangeLogPropertiesShouldReturnCorrectTopicConfigurationForStoresWithEmptyRocksDBTTL(): Unit = {
+    val props = new Properties
+    props.setProperty(KAFKA_PRODUCER_PROPERTY_PREFIX + "bootstrap.servers", "localhost:9092")
+    props.setProperty("systems." + SYSTEM_NAME + ".consumer.zookeeper.connect", "localhost:2181/")
+    props.setProperty(JobConfig.JOB_NAME, "jobName")
+
+    props.setProperty("stores.test1.changelog", "kafka.mychangelog1")
+
+    val mapConfig = new MapConfig(props.asScala.asJava)
+    val kafkaConfig = new KafkaConfig(mapConfig)
+    val kafkaProperties = kafkaConfig.getChangelogKafkaProperties("test1")
+    assertEquals("compact", kafkaProperties.getProperty("cleanup.policy"))
+    assertEquals("536870912", kafkaProperties.getProperty("segment.bytes"))
+    assertEquals("86400000", kafkaProperties.getProperty("delete.retention.ms"))
+    assertEquals("1000012", kafkaProperties.getProperty("max.message.bytes"))
+
   }
 
   @Test

--- a/samza-kafka/src/test/scala/org/apache/samza/config/TestKafkaConfig.scala
+++ b/samza-kafka/src/test/scala/org/apache/samza/config/TestKafkaConfig.scala
@@ -100,6 +100,7 @@ class TestKafkaConfig {
     val kafkaProperties = kafkaConfig.getChangelogKafkaProperties("test1")
     assertEquals("compact", kafkaProperties.getProperty("cleanup.policy"))
     assertEquals("536870912", kafkaProperties.getProperty("segment.bytes"))
+    assertEquals("1000012", kafkaProperties.getProperty("max.message.bytes"))
     assertEquals("86400000", kafkaProperties.getProperty("delete.retention.ms"))
   }
 


### PR DESCRIPTION
Symptom: Checkpoint and changelog kafka topics of a samza job may be created with cleanup.policy set to 'delete' instead of 'compact' for certain cases.

Cause: 
- *Checkpoint:* The control-flow in KafkaStreamSpec to build checkpoint spec swallows the essential kafka-topic configuration rather it passes empty configuration bag to kafka-broker. This behavior was introduced in SAMZA-2339. 
- *Changelog:* The change-log topic configurations were incorrectly generated when the RocksDB store TTL is set to -1 by the user. This behavior was introduced in SAMZA-1929.

Changes: Fix the topic-creation control-flow for the metadata topics and generate the correct topic-configurations.

Tests: Added unit tests to validate that the expected topic configuration bag was generated for both checkpoint and changelog topics.

API Changes: None

Upgrade Instructions: None

Usage Instructions: None

