### PR TITLE
SAMZA-2434: Fix the coordinator steam creation workflow

### DIFF
--- a/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaSystemAdmin.java
+++ b/samza-kafka/src/main/java/org/apache/samza/system/kafka/KafkaSystemAdmin.java
@@ -464,19 +464,19 @@ public class KafkaSystemAdmin implements SystemAdmin {
     LOG.info("Creating Kafka topic: {} on system: {}", streamSpec.getPhysicalName(), streamSpec.getSystemName());
     final String REPL_FACTOR = "replication.factor";
 
-    KafkaStreamSpec kSpec = toKafkaSpec(streamSpec);
-    String topicName = kSpec.getPhysicalName();
+    KafkaStreamSpec kafkaStreamSpec = toKafkaSpec(streamSpec);
+    String topicName = kafkaStreamSpec.getPhysicalName();
 
     // create topic.
-    NewTopic newTopic = new NewTopic(topicName, kSpec.getPartitionCount(), (short) kSpec.getReplicationFactor());
+    NewTopic newTopic = new NewTopic(topicName, kafkaStreamSpec.getPartitionCount(), (short) kafkaStreamSpec.getReplicationFactor());
 
     // specify the configs
-    Map<String, String> streamConfig = new HashMap<>(streamSpec.getConfig());
+    Map<String, String> streamConfig = new HashMap<>(kafkaStreamSpec.getConfig());
     // HACK - replication.factor is invalid config for AdminClient.createTopics
     if (streamConfig.containsKey(REPL_FACTOR)) {
       String repl = streamConfig.get(REPL_FACTOR);
       LOG.warn("Configuration {}={} for topic={} is invalid. Using kSpec repl factor {}",
-          REPL_FACTOR, repl, kSpec.getPhysicalName(), kSpec.getReplicationFactor());
+          REPL_FACTOR, repl, kafkaStreamSpec.getPhysicalName(), kafkaStreamSpec.getReplicationFactor());
       streamConfig.remove(REPL_FACTOR);
     }
     newTopic.configs(new MapConfig(streamConfig));


### PR DESCRIPTION
Symptom: Currently the coordinator kafka topic of a samza job is created with cleanup.policy set to 'delete' instead of 'compact' for certain cases. This potentially leads to losing all the metadata(JobModel/Config) stored in coordinator stream for some samza jobs. 

Cause: The control-flow in KafkaSystemAdmin.createStream to build the coordinator stream spec swallows the essential kafka-topic configurations and passes along the empty configuration bag to the kafka-broker when creating the coordinator stream. This issue was introduced in [SAMZA-1868](https://issues.apache.org/jira/browse/SAMZA-1868). 

Changes: Fix the topic-creation control-flow for the coordinator topics and generate the correct topic-configurations.

Tests: Added unit tests to validate that the expected topic configuration bag was generated for the coordinator stream topics.

API Changes: None

Upgrade Instructions: None

Usage Instructions: None

