### PR TITLE
SAMZA-2438: Fix the change log topic properties generation.

### DIFF
--- a/samza-kafka/src/main/scala/org/apache/samza/config/KafkaConfig.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/config/KafkaConfig.scala
@@ -324,7 +324,7 @@ class KafkaConfig(config: Config) extends ScalaMapConfig(config) {
     //  - Set topic TTL to be the same as RocksDB TTL
     Option(config.get("stores.%s.rocksdb.ttl.ms" format name)) match {
       case Some(rocksDbTtl) =>
-        if (!rocksDbTtl.isEmpty && rocksDbTtl.toInt < 0) {
+        if (!rocksDbTtl.isEmpty && rocksDbTtl.toLong < 0) {
           kafkaChangeLogProperties.setProperty("cleanup.policy", "compact")
           kafkaChangeLogProperties.setProperty("max.message.bytes", getChangelogStreamMaxMessageByte(name))
         } else if (!config.containsKey("stores.%s.changelog.kafka.cleanup.policy" format name)) {


### PR DESCRIPTION
Symptom: Launching a stateful samza job with high RocksDB TTL(around 28 days) results in the following exception:

```java
Exception in thread "main" org.apache.samza.SamzaException: Failed to run application
        at org.apache.samza.runtime.RemoteApplicationRunner.run(RemoteApplicationRunner.java:79)
        at org.apache.samza.runtime.ApplicationRunnerUtil.invoke(ApplicationRunnerUtil.java:54)
        at org.apache.samza.runtime.ApplicationRunnerMain.main(ApplicationRunnerMain.java:53)
Caused by: java.lang.NumberFormatException: For input string: "2419200000"
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
        at java.lang.Integer.parseInt(Integer.java:583)
        at java.lang.Integer.parseInt(Integer.java:615)
        at scala.collection.immutable.StringLike$class.toInt(StringLike.scala:272)
        at scala.collection.immutable.StringOps.toInt(StringOps.scala:29)
        at org.apache.samza.config.KafkaConfig.getChangelogKafkaProperties(KafkaConfig.scala:331)
        at org.apache.samza.system.kafka.KafkaSystemAdmin.<init>(KafkaSystemAdmin.java:159)
        at com.linkedin.samza.system.kafka.SamzaLiKafkaSystemAdmin.<init>(SamzaLiKafkaSystemAdmin.java:40)
        at com.linkedin.samza.system.kafka.SamzaLiKafkaSystemFactory.getAdmin(SamzaLiKafkaSystemFactory.java:141)
        at org.apache.samza.config.SystemConfig.lambda$getSystemAdmins$0(SystemConfig.java:97)
        at java.util.stream.Collectors.lambda$toMap$58(Collectors.java:1321)
        at java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
        at java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1696)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
```
Cause: RocksDB TTL can be set to very high value, but the validation-checks in changelog topic config generation was casting the RocksDB TTL value to `int` type.

Tests: Added unit tests to validate that change-log topic configuration gets correctly generated for stores with high TTL(> INT_MAX)

API Changes: None

Upgrade Instructions: None

Usage Instructions: None
