### PR TITLE
SAMZA-2429: Update LocalApplicatoinRunner to load full job config from config loader when present.

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
@@ -133,7 +133,7 @@ public class LocalApplicationRunner implements ApplicationRunner {
     this.isAppModeBatch = isAppModeBatch(config);
     this.coordinationUtils = context.coordinationUtils.isPresent()
         ? context.coordinationUtils
-        : getCoordinationUtils(appDesc.getConfig());
+        : getCoordinationUtils(config);
     this.metadataStoreFactory = context.metadataStoreFactory.isPresent()
         ? context.metadataStoreFactory
         : getDefaultCoordinatorStreamStoreFactory(config);

--- a/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
@@ -143,6 +143,10 @@ public class LocalApplicationRunner implements ApplicationRunner {
 
   @VisibleForTesting
   static MetadataStoreFactory getDefaultCoordinatorStreamStoreFactory(JobConfig jobConfig) {
+    if (jobConfig.getConfigLoaderFactory().isPresent()) {
+      jobConfig = new JobConfig(ConfigUtil.loadConfig(jobConfig));
+    }
+
     String coordinatorSystemName = jobConfig.getCoordinatorSystemNameOrNull();
     JobCoordinatorConfig jobCoordinatorConfig = new JobCoordinatorConfig(jobConfig);
     String jobCoordinatorFactoryClassName = jobCoordinatorConfig.getJobCoordinatorFactoryClassName();
@@ -159,6 +163,10 @@ public class LocalApplicationRunner implements ApplicationRunner {
   }
 
   private static Optional<CoordinationUtils> getCoordinationUtils(Config config) {
+    if (new JobConfig(config).getConfigLoaderFactory().isPresent()) {
+      config = ConfigUtil.loadConfig(config);
+    }
+
     if (!isAppModeBatch(config)) {
       return Optional.empty();
     }

--- a/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
@@ -20,7 +20,6 @@
 package org.apache.samza.runtime;
 
 import com.google.common.collect.ImmutableMap;
-import com.sun.glass.ui.Application;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
@@ -58,7 +57,6 @@ import org.apache.samza.standalone.PassthroughJobCoordinatorFactory;
 import org.apache.samza.system.SystemAdmins;
 import org.apache.samza.task.IdentityStreamTask;
 import org.apache.samza.util.ConfigUtil;
-import org.apache.samza.util.TestConfigUtil;
 import org.apache.samza.zk.ZkMetadataStore;
 import org.apache.samza.zk.ZkMetadataStoreFactory;
 import org.junit.Before;

--- a/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
@@ -66,10 +66,22 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({LocalJobPlanner.class, LocalApplicationRunner.class, ZkMetadataStoreFactory.class})

--- a/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
@@ -542,7 +542,7 @@ public class TestLocalApplicationRunner {
   public void testGetCoordinatorStreamStoreFactoryWithDefaultSystem() {
     Optional<MetadataStoreFactory> metadataStoreFactory =
         LocalApplicationRunner.getDefaultCoordinatorStreamStoreFactory(new MapConfig(ImmutableMap.of(JobConfig.JOB_DEFAULT_SYSTEM, "test-system")));
-    assertFalse(metadataStoreFactory.isPresent());
+    assertTrue(metadataStoreFactory.isPresent());
   }
 
   /**
@@ -557,7 +557,7 @@ public class TestLocalApplicationRunner {
             JobCoordinatorConfig.JOB_COORDINATOR_FACTORY, PassthroughJobCoordinatorFactory.class.getName()));
     Optional<MetadataStoreFactory> metadataStoreFactory =
         LocalApplicationRunner.getDefaultCoordinatorStreamStoreFactory(mapConfig);
-    assertTrue(metadataStoreFactory.isPresent());
+    assertFalse(metadataStoreFactory.isPresent());
   }
 
   /**


### PR DESCRIPTION
Design:
https://cwiki.apache.org/confluence/display/SAMZA/SEP-23%3A+Simplify+Job+Runner

Changes:
1. Update unit test only public constructor of LocalApplicationRunner to take SamzaApplication and Config as well to be consistent with other constructors.
2. Update private constructor of LocalApplicationRunner to take SamzaApplication and Config.
3. Update private constructor of LocalApplicationRunner to load full job config when config loader is present.

API Changes:
LocalApplicationRunner's constructor now allows initial config/job submission config only instead of full job config, this is backward compatible as full job config is still supported.

Upgrade Instructions:
This is part of a series PRs, detailed information will be provided in the last/main PR.

Usage Instructions:
This is part of a series PRs, detailed information will be provided in the last/main PR.

Tests
Unit tests