### PR TITLE
SAMZA-2443: Upgrade Jetty version to prevent AM file descriptor leak

### DIFF
--- a/gradle/dependency-versions-scala-2.11.gradle
+++ b/gradle/dependency-versions-scala-2.11.gradle
@@ -25,5 +25,4 @@ ext {
   // -language:reflectiveCalls: Allow the automatic use of reflection to access fields without warning or library import
   scalaOptions = ["-feature", "-language:implicitConversions", "-language:reflectiveCalls"]
   scalatraVersion = "2.5.0"
-  jettyVersion = "9.2.7.v20150116"
 }

--- a/gradle/dependency-versions-scala-2.12.gradle
+++ b/gradle/dependency-versions-scala-2.12.gradle
@@ -25,5 +25,4 @@ ext {
   // -language:reflectiveCalls: Allow the automatic use of reflection to access fields without warning or library import
   scalaOptions = ["-feature", "-language:implicitConversions", "-language:reflectiveCalls"]
   scalatraVersion = "2.5.0"
-  jettyVersion = "9.2.7.v20150116"
 }

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -34,6 +34,7 @@
   httpClientVersion = "4.4.1"
   jacksonVersion = "1.9.13"
   jerseyVersion = "2.22.1"
+  jettyVersion = "9.4.20.v20190813"
   jodaTimeVersion = "2.2"
   joptSimpleVersion = "3.2"
   junitVersion = "4.12"


### PR DESCRIPTION
Symptom: AM Process runs out of file descriptors and gets stuck during deployment of jobs with a large number of containers. Containers are unable to start since they can’t fetch the JobModel and configs from the AM endpoint.

Cause: This seems to be a Jetty bug that’s fixed in the latest versions. For more details, see: https://docs.google.com/document/d/1RFf_3_lJHHdoZHQlikSDHcm55GYbp7ObA8qVUwr-6p0/edit#

Changes: Bump Jetty version to 9.4.20.v20190813

Tests: Reproduced locally using the test harness in https://github.com/prateekm/samza/commit/6d7e01b5b9d0d38a7766357a870ba7daeadd828e. All unit and integration tests pass with the version bump. Verified that Samza jobs are able to deploy correctly on a YARN cluster with the version bump.

API Changes: Jetty version upgraded from 9.2.7.v20150116 to 9.4.20.v20190813.

Upgrade Instructions: None.
 
Usage Instructions: None.