### PR TITLE
SAMZA-2275: Azure Blob System Producer: fixes for high level jobs

### DIFF
--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobConfig.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobConfig.java
@@ -40,10 +40,10 @@ public class AzureBlobConfig extends MapConfig {
 
   // Azure Storage Account name under which the Azure container representing this system is.
   // System name = Azure container name (https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names)
-  public static final String SYSTEM_AZURE_ACCOUNT_NAME = SYSTEM_AZUREBLOB_PREFIX + "account.name";
+  public static final String SYSTEM_AZURE_ACCOUNT_NAME = Config.SENSITIVE_PREFIX + SYSTEM_AZUREBLOB_PREFIX + "account.name";
 
   // Azure Storage Account key associated with the Azure Storage Account
-  public static final String SYSTEM_AZURE_ACCOUNT_KEY  = SYSTEM_AZUREBLOB_PREFIX + "account.key";
+  public static final String SYSTEM_AZURE_ACCOUNT_KEY  = Config.SENSITIVE_PREFIX + SYSTEM_AZUREBLOB_PREFIX + "account.key";
 
   // Whether to use proxy while connecting to Azure Storage
   public static final String SYSTEM_AZURE_USE_PROXY  = SYSTEM_AZUREBLOB_PREFIX + "proxy.use";

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobSystemAdmin.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobSystemAdmin.java
@@ -19,6 +19,7 @@
 
 package org.apache.samza.system.azureblob;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import org.apache.samza.system.SystemAdmin;
@@ -35,7 +36,8 @@ public class AzureBlobSystemAdmin implements SystemAdmin {
   }
 
   public Map<String, SystemStreamMetadata> getSystemStreamMetadata(Set<String> streamNames) {
-    throw new UnsupportedOperationException("getSystemStreamMetadata not supported for AzureBlobSystemAdmin");
+    return new HashMap<>();
+    //throw new UnsupportedOperationException("getSystemStreamMetadata not supported for AzureBlobSystemAdmin");
   }
 
   public Integer offsetComparator(String offset1, String offset2) {

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobSystemAdmin.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobSystemAdmin.java
@@ -37,7 +37,6 @@ public class AzureBlobSystemAdmin implements SystemAdmin {
 
   public Map<String, SystemStreamMetadata> getSystemStreamMetadata(Set<String> streamNames) {
     return new HashMap<>();
-    //throw new UnsupportedOperationException("getSystemStreamMetadata not supported for AzureBlobSystemAdmin");
   }
 
   public Integer offsetComparator(String offset1, String offset2) {

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobSystemAdmin.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobSystemAdmin.java
@@ -35,6 +35,21 @@ public class AzureBlobSystemAdmin implements SystemAdmin {
     throw new UnsupportedOperationException("getOffsetsAfter not supported for AzureBlobSystemAdmin");
   }
 
+  /**
+   * SystemAdmin.getSystemStreamMetadata is directly or indirectly used for the following purposes
+   * 1. Get number of partitions which is then used to validate joins or calculate intermediate streams
+   * 2. CoordinatorStream purposes, offsets for SystemConsumer, changelog offsets or cache of SSP metadata
+   * The (2) category of usages are not relevant for AzureBlob as it has no consumer.
+   * The (1) usage is again not relevant for AzureBlob as it can not be an input to join
+   * or affect an intermediate stream as it is currently supporting only an output stream.
+   * Additionally, AzureBlob has no concept of a partition and
+   * SystemStreamMetadata gives oldest, newest and upcoming offsets for a stream which are not relevant for an Azure Blob.
+   * Hence, returning empty map is acceptable.
+   * @param streamNames
+   *          The streams to to fetch metadata for.
+   * @return map of streamName to {@link org.apache.samza.system.SystemStreamMetadata}
+   *         returns an empty map.
+   */
   public Map<String, SystemStreamMetadata> getSystemStreamMetadata(Set<String> streamNames) {
     return new HashMap<>();
   }


### PR DESCRIPTION
**Symptom**: 
1. Samza High level job using this SystemProducer gets UnsupportedOperationException from AzureBlobSystemAdmin.
2. Azure account details of the samza job are logged. 

**Cause**:
1. getSystemStreamMetadata throws unsupported exception. 
2. Account details configs are not marked sensitive.

**Changes**
1. getSystemStreamMetadata returns an empty map.
2. "sensitive" prefixed to the account details configs.

**Tests**: Sample High level job in hello-samza (https://github.com/apache/samza-hello-samza/pull/71) works correctly with these changes. 