### PR TITLE
SAMZA-2444: JobModel save in CoordinatorStreamStore resulting flush for each message

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/clustermanager/container/placement/ContainerPlacementMetadataStore.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/container/placement/ContainerPlacementMetadataStore.java
@@ -119,6 +119,7 @@ public class ContainerPlacementMetadataStore {
     try {
       containerPlacementMessageStore.put(toContainerPlacementMessageKey(message.getUuid(), message.getClass()),
           objectMapper.writeValueAsBytes(message));
+      containerPlacementMessageStore.flush();
     } catch (Exception ex) {
       throw new SamzaException(
           String.format("ContainerPlacementRequestMessage might have been not written to metastore %s", message), ex);
@@ -137,6 +138,7 @@ public class ContainerPlacementMetadataStore {
     try {
       containerPlacementMessageStore.put(toContainerPlacementMessageKey(message.getUuid(), message.getClass()),
           objectMapper.writeValueAsBytes(message));
+      containerPlacementMessageStore.flush();
     } catch (Exception ex) {
       throw new SamzaException(
           String.format("ContainerPlacementResponseMessage might have been not written to metastore %s", message), ex);
@@ -199,6 +201,7 @@ public class ContainerPlacementMetadataStore {
     Preconditions.checkState(!stopped, "Underlying metadata store not available");
     Preconditions.checkNotNull(uuid, "uuid cannot be null");
     containerPlacementMessageStore.delete(toContainerPlacementMessageKey(uuid, ContainerPlacementRequestMessage.class));
+    containerPlacementMessageStore.flush();
   }
 
   /**
@@ -209,6 +212,7 @@ public class ContainerPlacementMetadataStore {
     Preconditions.checkState(!stopped, "Underlying metadata store not available");
     Preconditions.checkNotNull(uuid, "uuid cannot be null");
     containerPlacementMessageStore.delete(toContainerPlacementMessageKey(uuid, ContainerPlacementResponseMessage.class));
+    containerPlacementMessageStore.flush();
   }
 
   /**
@@ -230,6 +234,7 @@ public class ContainerPlacementMetadataStore {
     for (String key : requestKeys) {
       containerPlacementMessageStore.delete(key);
     }
+    containerPlacementMessageStore.flush();
   }
 
   static String toContainerPlacementMessageKey(UUID uuid, Class<?> messageType) {

--- a/samza-core/src/main/java/org/apache/samza/container/LocalityManager.java
+++ b/samza-core/src/main/java/org/apache/samza/container/LocalityManager.java
@@ -94,6 +94,7 @@ public class LocalityManager {
     }
 
     metadataStore.put(containerId, valueSerde.toBytes(hostName));
+    metadataStore.flush();
   }
 
   public void close() {

--- a/samza-core/src/main/java/org/apache/samza/container/grouper/task/TaskAssignmentManager.java
+++ b/samza-core/src/main/java/org/apache/samza/container/grouper/task/TaskAssignmentManager.java
@@ -119,6 +119,8 @@ public class TaskAssignmentManager {
       taskModeMappingMetadataStore.put(taskName, taskModeSerde.toBytes(taskMode.toString()));
       taskNameToContainerId.put(taskName, containerId);
     }
+    taskContainerMappingMetadataStore.flush();
+    taskModeMappingMetadataStore.flush();
   }
 
   /**
@@ -132,6 +134,8 @@ public class TaskAssignmentManager {
       taskModeMappingMetadataStore.delete(taskName);
       taskNameToContainerId.remove(taskName);
     }
+    taskContainerMappingMetadataStore.flush();
+    taskModeMappingMetadataStore.flush();
   }
 
   public void close() {

--- a/samza-core/src/main/java/org/apache/samza/container/grouper/task/TaskPartitionAssignmentManager.java
+++ b/samza-core/src/main/java/org/apache/samza/container/grouper/task/TaskPartitionAssignmentManager.java
@@ -73,7 +73,6 @@ public class TaskPartitionAssignmentManager {
   public void writeTaskPartitionAssignments(Map<SystemStreamPartition, List<String>> sspToTaskNameMapping) {
     for (SystemStreamPartition partition: sspToTaskNameMapping.keySet()) {
       List<String> taskNames = sspToTaskNameMapping.get(partition);
-      LOG.info("Storing ssp: {} and task: {} into metadata store", partition, taskNames);
       // For broadcast streams, a input system stream partition will be mapped to more than one tasks in a
       // SamzaContainer. Rather than storing taskName to list of SystemStreamPartitions in metadata store, here
       // systemStreamPartition to list of taskNames is stored. This was done due to 1 MB limit on value size in kafka.

--- a/samza-core/src/main/java/org/apache/samza/container/grouper/task/TaskPartitionAssignmentManager.java
+++ b/samza-core/src/main/java/org/apache/samza/container/grouper/task/TaskPartitionAssignmentManager.java
@@ -88,6 +88,7 @@ public class TaskPartitionAssignmentManager {
         throw new SamzaException("Exception occurred when writing task to partition assignment.", e);
       }
     }
+    metadataStore.flush();
   }
 
   /**
@@ -120,6 +121,7 @@ public class TaskPartitionAssignmentManager {
       String serializedSSPAsJson = serializeSSPToJson(systemStreamPartition);
       metadataStore.delete(serializedSSPAsJson);
     }
+    metadataStore.flush();
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/coordinator/RunIdGenerator.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/RunIdGenerator.java
@@ -84,6 +84,7 @@ public class RunIdGenerator {
               String.valueOf(System.currentTimeMillis()) + "-" + UUID.randomUUID().toString().substring(0, 8);
           LOG.info("Writing the run id for this run as {}", runId);
           metadataStore.put(CoordinationConstants.RUNID_STORE_KEY, runId.getBytes("UTF-8"));
+          metadataStore.flush();
         } else {
           runId = new String(metadataStore.get(CoordinationConstants.RUNID_STORE_KEY));
           LOG.info("Read the run id for this run as {}", runId);

--- a/samza-core/src/main/java/org/apache/samza/coordinator/metadatastore/CoordinatorStreamStore.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/metadatastore/CoordinatorStreamStore.java
@@ -137,13 +137,6 @@ public class CoordinatorStreamStore implements MetadataStore {
   }
 
   @Override
-  public void putAll(Map<String, byte[]> entries) {
-    for (Map.Entry<String, byte[]> entry : entries.entrySet()) {
-      put(entry.getKey(), entry.getValue());
-    }
-  }
-
-  @Override
   public void delete(String namespacedKey) {
     // Since kafka doesn't support individual message deletion, store value as null for a namespacedKey to delete.
     put(namespacedKey, null);

--- a/samza-core/src/main/java/org/apache/samza/execution/LocalJobPlanner.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/LocalJobPlanner.java
@@ -190,6 +190,7 @@ public class LocalJobPlanner extends JobPlanner {
           streamManager.createStreams(intStreams);
           String streamCreatedMessage = "Streams created by processor " + processorId;
           metadataStore.put(String.format(STREAM_CREATED_STATE_KEY, lockId), streamCreatedMessage.getBytes("UTF-8"));
+          metadataStore.flush();
           distributedLock.unlock();
           break;
         } else {

--- a/samza-core/src/main/java/org/apache/samza/job/model/JobModelUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/job/model/JobModelUtil.java
@@ -80,6 +80,7 @@ public class JobModelUtil {
       byte[] jobModelSerializedAsBytes = jobModelSerializedAsString.getBytes(UTF_8);
       String metadataStoreKey = getJobModelKey(jobModelVersion);
       metadataStore.put(metadataStoreKey, jobModelSerializedAsBytes);
+      metadataStore.flush();
     } catch (Exception e) {
       throw new SamzaException(String.format("Exception occurred when storing JobModel: %s with version: %s.", jobModel, jobModelVersion), e);
     }

--- a/samza-core/src/main/java/org/apache/samza/startpoint/StartpointManager.java
+++ b/samza-core/src/main/java/org/apache/samza/startpoint/StartpointManager.java
@@ -145,6 +145,7 @@ public class StartpointManager {
 
     try {
       readWriteStore.put(toReadWriteStoreKey(ssp, taskName), objectMapper.writeValueAsBytes(startpoint));
+      readWriteStore.flush();
     } catch (Exception ex) {
       throw new SamzaException(String.format(
           "Startpoint for SSP: %s and task: %s may not have been written to the metadata store.", ssp, taskName), ex);
@@ -208,6 +209,7 @@ public class StartpointManager {
     Preconditions.checkNotNull(ssp, "SystemStreamPartition cannot be null");
 
     readWriteStore.delete(toReadWriteStoreKey(ssp, taskName));
+    readWriteStore.flush();
   }
 
   /**
@@ -218,6 +220,7 @@ public class StartpointManager {
     for (String key : readWriteKeys) {
       readWriteStore.delete(key);
     }
+    readWriteStore.flush();
   }
 
   /**
@@ -273,6 +276,7 @@ public class StartpointManager {
       StartpointFanOutPerTask newFanOut = fanOuts.get(taskName);
       fanOutStore.put(fanOutKey, objectMapper.writeValueAsBytes(newFanOut));
     }
+    fanOutStore.flush();
 
     for (SystemStreamPartition ssp : deleteKeys.keySet()) {
       for (TaskName taskName : deleteKeys.get(ssp)) {
@@ -314,6 +318,7 @@ public class StartpointManager {
     Preconditions.checkNotNull(taskName, "TaskName cannot be null");
 
     fanOutStore.delete(toFanOutStoreKey(taskName));
+    fanOutStore.flush();
   }
 
   /**
@@ -324,6 +329,7 @@ public class StartpointManager {
     for (String key : fanOutKeys) {
       fanOutStore.delete(key);
     }
+    fanOutStore.flush();
   }
 
   @VisibleForTesting

--- a/samza-core/src/main/java/org/apache/samza/storage/ChangelogStreamManager.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/ChangelogStreamManager.java
@@ -102,6 +102,7 @@ public class ChangelogStreamManager {
         metadataStore.delete(taskName);
       }
     }
+    metadataStore.flush();
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
@@ -324,6 +324,7 @@ public class ZkJobCoordinator implements JobCoordinator {
           byte[] serializedValue = jsonSerde.toBytes(entry.getValue());
           configStore.put(entry.getKey(), serializedValue);
         }
+        configStore.flush();
 
         // fan out the startpoints
         StartpointManager startpointManager = createStartpointManager();

--- a/samza-core/src/main/scala/org/apache/samza/coordinator/JobModelManager.scala
+++ b/samza-core/src/main/scala/org/apache/samza/coordinator/JobModelManager.scala
@@ -240,10 +240,12 @@ object JobModelManager extends Logging {
     // taskName to SystemStreamPartitions is done here to wire-in the data to {@see JobModel}.
     val sspToTaskNameMap: util.Map[SystemStreamPartition, util.List[String]] = new util.HashMap[SystemStreamPartition, util.List[String]]()
 
+    val taskContainerMappings: util.Map[String, util.Map[String, TaskMode]] = new util.HashMap[String, util.Map[String, TaskMode]]()
+
     for (container <- jobModel.getContainers.values()) {
       for ((taskName, taskModel) <- container.getTasks) {
-        info ("Storing task: %s and container ID: %s into metadata store" format(taskName.getTaskName, container.getId))
-        taskAssignmentManager.writeTaskContainerMapping(taskName.getTaskName, container.getId, container.getTasks.get(taskName).getTaskMode)
+        taskContainerMappings.putIfAbsent(container.getId, new util.HashMap[String, TaskMode]())
+        taskContainerMappings.get(container.getId).put(taskName.getTaskName, container.getTasks.get(taskName).getTaskMode)
         for (partition <- taskModel.getSystemStreamPartitions) {
           if (!sspToTaskNameMap.containsKey(partition)) {
             sspToTaskNameMap.put(partition, new util.ArrayList[String]())
@@ -253,10 +255,8 @@ object JobModelManager extends Logging {
       }
     }
 
-    for ((ssp, taskNames) <- sspToTaskNameMap) {
-      info ("Storing ssp: %s and task: %s into metadata store" format(ssp, taskNames))
-      taskPartitionAssignmentManager.writeTaskPartitionAssignment(ssp, taskNames)
-    }
+    taskAssignmentManager.writeTaskContainerMappings(taskContainerMappings)
+    taskPartitionAssignmentManager.writeTaskPartitionAssignments(sspToTaskNameMap);
   }
 
   /**

--- a/samza-core/src/test/java/org/apache/samza/container/grouper/task/TestTaskAssignmentManager.java
+++ b/samza-core/src/test/java/org/apache/samza/container/grouper/task/TestTaskAssignmentManager.java
@@ -60,10 +60,13 @@ public class TestTaskAssignmentManager {
   @Test
   public void testTaskAssignmentManager() {
     Map<String, String> expectedMap = ImmutableMap.of("Task0", "0", "Task1", "1", "Task2", "2", "Task3", "0", "Task4", "1");
+    Map<String, Map<String, TaskMode>> taskContainerMappings = ImmutableMap.of(
+        "0", ImmutableMap.of("Task0", TaskMode.Active, "Task3", TaskMode.Active),
+        "1", ImmutableMap.of("Task1", TaskMode.Active, "Task4", TaskMode.Active),
+        "2", ImmutableMap.of("Task2", TaskMode.Active)
+    );
 
-    for (Map.Entry<String, String> entry : expectedMap.entrySet()) {
-      taskAssignmentManager.writeTaskContainerMapping(entry.getKey(), entry.getValue(), TaskMode.Active);
-    }
+    taskAssignmentManager.writeTaskContainerMappings(taskContainerMappings);
 
     Map<String, String> localMap = taskAssignmentManager.readTaskAssignment();
 
@@ -75,10 +78,12 @@ public class TestTaskAssignmentManager {
   @Test
   public void testDeleteMappings() {
     Map<String, String> expectedMap = ImmutableMap.of("Task0", "0", "Task1", "1");
+    Map<String, Map<String, TaskMode>> taskContainerMappings = ImmutableMap.of(
+        "0", ImmutableMap.of("Task0", TaskMode.Active),
+        "1", ImmutableMap.of("Task1", TaskMode.Active)
+    );
 
-    for (Map.Entry<String, String> entry : expectedMap.entrySet()) {
-      taskAssignmentManager.writeTaskContainerMapping(entry.getKey(), entry.getValue(), TaskMode.Active);
-    }
+    taskAssignmentManager.writeTaskContainerMappings(taskContainerMappings);
 
     Map<String, String> localMap = taskAssignmentManager.readTaskAssignment();
     assertEquals(expectedMap, localMap);

--- a/samza-core/src/test/java/org/apache/samza/container/grouper/task/TestTaskPartitionAssignmentManager.java
+++ b/samza-core/src/test/java/org/apache/samza/container/grouper/task/TestTaskPartitionAssignmentManager.java
@@ -20,7 +20,6 @@ package org.apache.samza.container.grouper.task;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.samza.config.Config;

--- a/samza-core/src/test/java/org/apache/samza/container/grouper/task/TestTaskPartitionAssignmentManager.java
+++ b/samza-core/src/test/java/org/apache/samza/container/grouper/task/TestTaskPartitionAssignmentManager.java
@@ -20,6 +20,7 @@ package org.apache.samza.container.grouper.task;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.samza.config.Config;
@@ -63,7 +64,7 @@ public class TestTaskPartitionAssignmentManager {
   @Test
   public void testReadAfterWrite() {
     List<String> testTaskNames = ImmutableList.of("test-task1", "test-task2", "test-task3");
-    taskPartitionAssignmentManager.writeTaskPartitionAssignment(testSystemStreamPartition, testTaskNames);
+    taskPartitionAssignmentManager.writeTaskPartitionAssignments(ImmutableMap.of(testSystemStreamPartition, testTaskNames));
 
     Map<SystemStreamPartition, List<String>> expectedMapping = ImmutableMap.of(testSystemStreamPartition, testTaskNames);
     Map<SystemStreamPartition, List<String>> actualMapping = taskPartitionAssignmentManager.readTaskPartitionAssignments();
@@ -74,7 +75,7 @@ public class TestTaskPartitionAssignmentManager {
   @Test
   public void testDeleteAfterWrite() {
     List<String> testTaskNames = ImmutableList.of("test-task1", "test-task2", "test-task3");
-    taskPartitionAssignmentManager.writeTaskPartitionAssignment(testSystemStreamPartition, testTaskNames);
+    taskPartitionAssignmentManager.writeTaskPartitionAssignments(ImmutableMap.of(testSystemStreamPartition, testTaskNames));
 
     Map<SystemStreamPartition, List<String>> actualMapping = taskPartitionAssignmentManager.readTaskPartitionAssignments();
     Assert.assertEquals(1, actualMapping.size());
@@ -94,12 +95,13 @@ public class TestTaskPartitionAssignmentManager {
     SystemStreamPartition testSystemStreamPartition3 = new SystemStreamPartition(TEST_SYSTEM, "stream-3", PARTITION);
     List<String> testTaskNames3 = ImmutableList.of("test-task6", "test-task7", "test-task8");
 
-    taskPartitionAssignmentManager.writeTaskPartitionAssignment(testSystemStreamPartition1, testTaskNames1);
-    taskPartitionAssignmentManager.writeTaskPartitionAssignment(testSystemStreamPartition2, testTaskNames2);
-    taskPartitionAssignmentManager.writeTaskPartitionAssignment(testSystemStreamPartition3, testTaskNames3);
+    taskPartitionAssignmentManager.writeTaskPartitionAssignments(
+        ImmutableMap.of(testSystemStreamPartition1, testTaskNames1, testSystemStreamPartition2, testTaskNames2,
+            testSystemStreamPartition3, testTaskNames3));
 
-    Map<SystemStreamPartition, List<String>> expectedMapping = ImmutableMap.of(testSystemStreamPartition1, testTaskNames1,
-            testSystemStreamPartition2, testTaskNames2, testSystemStreamPartition3, testTaskNames3);
+    Map<SystemStreamPartition, List<String>> expectedMapping =
+        ImmutableMap.of(testSystemStreamPartition1, testTaskNames1, testSystemStreamPartition2, testTaskNames2,
+            testSystemStreamPartition3, testTaskNames3);
     Map<SystemStreamPartition, List<String>> actualMapping = taskPartitionAssignmentManager.readTaskPartitionAssignments();
 
     Assert.assertEquals(expectedMapping, actualMapping);
@@ -108,14 +110,11 @@ public class TestTaskPartitionAssignmentManager {
   @Test
   public void testMultipleUpdatesReturnsTheMostRecentValue() {
     List<String> testTaskNames1 = ImmutableList.of("test-task1", "test-task2", "test-task3");
-
-    taskPartitionAssignmentManager.writeTaskPartitionAssignment(testSystemStreamPartition, testTaskNames1);
-
+    taskPartitionAssignmentManager.writeTaskPartitionAssignments(ImmutableMap.of(testSystemStreamPartition, testTaskNames1));
     List<String> testTaskNames2 = ImmutableList.of("test-task4", "test-task5");
-    taskPartitionAssignmentManager.writeTaskPartitionAssignment(testSystemStreamPartition, testTaskNames2);
-
+    taskPartitionAssignmentManager.writeTaskPartitionAssignments(ImmutableMap.of(testSystemStreamPartition, testTaskNames2));
     List<String> testTaskNames3 = ImmutableList.of("test-task6", "test-task7", "test-task8");
-    taskPartitionAssignmentManager.writeTaskPartitionAssignment(testSystemStreamPartition, testTaskNames3);
+    taskPartitionAssignmentManager.writeTaskPartitionAssignments(ImmutableMap.of(testSystemStreamPartition, testTaskNames3));
 
     Map<SystemStreamPartition, List<String>> expectedMapping = ImmutableMap.of(testSystemStreamPartition, testTaskNames3);
     Map<SystemStreamPartition, List<String>> actualMapping = taskPartitionAssignmentManager.readTaskPartitionAssignments();

--- a/samza-core/src/test/java/org/apache/samza/coordinator/TestJobModelManager.java
+++ b/samza-core/src/test/java/org/apache/samza/coordinator/TestJobModelManager.java
@@ -270,7 +270,7 @@ public class TestJobModelManager {
 
     when(mockJobModel.getContainers()).thenReturn(containerMapping);
     when(mockGrouperMetadata.getPreviousTaskToProcessorAssignment()).thenReturn(new HashMap<>());
-    Mockito.doNothing().when(mockTaskAssignmentManager).writeTaskContainerMapping(Mockito.any(), Mockito.any(), Mockito.any());
+    Mockito.doNothing().when(mockTaskAssignmentManager).writeTaskContainerMappings(Mockito.any());
 
     JobModelManager.updateTaskAssignments(mockJobModel, mockTaskAssignmentManager, mockTaskPartitionAssignmentManager, mockGrouperMetadata);
 
@@ -289,18 +289,18 @@ public class TestJobModelManager {
     // Verifications
     Mockito.verify(mockJobModel, atLeast(1)).getContainers();
     Mockito.verify(mockTaskAssignmentManager).deleteTaskContainerMappings(Mockito.any());
-    Mockito.verify(mockTaskAssignmentManager).writeTaskContainerMapping("task-1", "test-container-id", TaskMode.Active);
-    Mockito.verify(mockTaskAssignmentManager).writeTaskContainerMapping("task-2", "test-container-id", TaskMode.Active);
-    Mockito.verify(mockTaskAssignmentManager).writeTaskContainerMapping("task-3", "test-container-id", TaskMode.Active);
-    Mockito.verify(mockTaskAssignmentManager).writeTaskContainerMapping("task-4", "test-container-id", TaskMode.Active);
+    Mockito.verify(mockTaskAssignmentManager).writeTaskContainerMappings(ImmutableMap.of("test-container-id",
+        ImmutableMap.of("task-1", TaskMode.Active, "task-2", TaskMode.Active, "task-3", TaskMode.Active, "task-4", TaskMode.Active)));
 
     // Verify that the old, stale partition mappings had been purged in the coordinator stream.
     Mockito.verify(mockTaskPartitionAssignmentManager).delete(systemStreamPartitions);
 
     // Verify that the new task to partition assignment is stored in the coordinator stream.
-    Mockito.verify(mockTaskPartitionAssignmentManager).writeTaskPartitionAssignment(testSystemStreamPartition1, ImmutableList.of("task-1"));
-    Mockito.verify(mockTaskPartitionAssignmentManager).writeTaskPartitionAssignment(testSystemStreamPartition2, ImmutableList.of("task-2"));
-    Mockito.verify(mockTaskPartitionAssignmentManager).writeTaskPartitionAssignment(testSystemStreamPartition3, ImmutableList.of("task-3"));
-    Mockito.verify(mockTaskPartitionAssignmentManager).writeTaskPartitionAssignment(testSystemStreamPartition4, ImmutableList.of("task-4"));
+    Mockito.verify(mockTaskPartitionAssignmentManager).writeTaskPartitionAssignments(ImmutableMap.of(
+        testSystemStreamPartition1, ImmutableList.of("task-1"),
+        testSystemStreamPartition2, ImmutableList.of("task-2"),
+        testSystemStreamPartition3, ImmutableList.of("task-3"),
+        testSystemStreamPartition4, ImmutableList.of("task-4")
+    ));
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/coordinator/TestRunIdGenerator.java
+++ b/samza-core/src/test/java/org/apache/samza/coordinator/TestRunIdGenerator.java
@@ -51,6 +51,7 @@ public class TestRunIdGenerator {
     verify(membership, Mockito.times(1)).registerProcessor();
     verify(membership, Mockito.times(1)).getNumberOfProcessors();
     verify(metadataStore, Mockito.times(1)).put(eq(CoordinationConstants.RUNID_STORE_KEY), any(byte[].class));
+    verify(metadataStore, Mockito.times(1)).flush();
   }
 
   @Test

--- a/samza-core/src/test/java/org/apache/samza/coordinator/metadatastore/TestCoordinatorStreamStore.java
+++ b/samza-core/src/test/java/org/apache/samza/coordinator/metadatastore/TestCoordinatorStreamStore.java
@@ -105,7 +105,6 @@ public class TestCoordinatorStreamStore {
     Assert.assertEquals(value3, spyCoordinatorStreamStore.get(key3));
     Assert.assertEquals(value4, spyCoordinatorStreamStore.get(key4));
     Assert.assertEquals(value5, spyCoordinatorStreamStore.get(key5));
-    Mockito.verify(spyCoordinatorStreamStore).flush(); // verify flush called only once during putAll
   }
 
   @Test

--- a/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
@@ -497,7 +497,7 @@ public class TestLocalApplicationRunner {
     verify(coordinationUtils, Mockito.times(0)).getClusterMembership();
     verify(clusterMembership, Mockito.times(0)).getNumberOfProcessors();
     verify(metadataStore, Mockito.times(0)).put(eq(CoordinationConstants.RUNID_STORE_KEY), any(byte[].class));
-    verify(metadataStore, Mockito.times(1)).flush();
+    verify(metadataStore, Mockito.times(0)).flush();
   }
 
   private void prepareTestForRunId() throws Exception {

--- a/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestLocalApplicationRunner.java
@@ -469,6 +469,7 @@ public class TestLocalApplicationRunner {
     verify(coordinationUtils, Mockito.times(1)).getLock(CoordinationConstants.RUNID_LOCK_ID);
     verify(clusterMembership, Mockito.times(1)).getNumberOfProcessors();
     verify(metadataStore, Mockito.times(1)).put(eq(CoordinationConstants.RUNID_STORE_KEY), any(byte[].class));
+    verify(metadataStore, Mockito.times(1)).flush();
   }
 
   /**
@@ -496,6 +497,7 @@ public class TestLocalApplicationRunner {
     verify(coordinationUtils, Mockito.times(0)).getClusterMembership();
     verify(clusterMembership, Mockito.times(0)).getNumberOfProcessors();
     verify(metadataStore, Mockito.times(0)).put(eq(CoordinationConstants.RUNID_STORE_KEY), any(byte[].class));
+    verify(metadataStore, Mockito.times(1)).flush();
   }
 
   private void prepareTestForRunId() throws Exception {


### PR DESCRIPTION
## Symptom

When Samza's job creates lots of tasks/partitions, it can take over a long time for AM to save the metadata in a run which may cause timeout exception.
We observed if the Samza's job has over 37k tasks/partitions, it takes over 10 min for AM to save it in a run.

## Cause

JobModelManager uses CoordinatorStreamStore.put() to save job metadata information which does flush for each message, and the flush operation is heavy especially when the remote server suffering the performance issues. 

## Changes

- [x] Separate `flush` from `put/putAll/delete` functions in `CoordinatorStreamStore`.
- [x] Explicity call `flush` after call `put/putAll/delete` in related classes
- [x] Batch write task partition assignments information to metadata store.
- [x] Batch write task container information to metadata store.

## Tests

- [x] All unit tests and integration tests are passed

## API Changes

- [x] Replace `writeTaskPartitionAssignment` with new batch write method `writeTaskPartitionAssignments` in `TaskPartitionAssignmentManager`
- [x] Replace `writeTaskContainerMapping` with  new batch write method `writeTaskContainerMappings` in `TaskAssignmentManager`.

## Upgrade Instructions
None

## Usage Instructions
None
