### PR TITLE
SAMZA-2446: Invoke onCheckpoint only for registered SSPs

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/checkpoint/OffsetManager.scala
+++ b/samza-core/src/main/scala/org/apache/samza/checkpoint/OffsetManager.scala
@@ -353,8 +353,10 @@ class OffsetManager(
         }
       }
 
-      // invoke checkpoint listeners only for SSPs that are registered with the OffsetManager
-      val registeredSSPs = systemStreamPartitions.getOrElse(taskName, immutable.Set[SystemStreamPartition]())
+      // Invoke checkpoint listeners only for SSPs that are registered with the OffsetManager. For example,
+      // changelog SSPs are not registered but may be present in the Checkpoint if transactional state checkpointing
+      // is enabled.
+      val registeredSSPs = systemStreamPartitions.getOrElse(taskName, Set[SystemStreamPartition]())
       checkpoint.getOffsets.asScala
         .filterKeys(registeredSSPs.contains)
         .groupBy { case (ssp, _) => ssp.getSystem }.foreach {


### PR DESCRIPTION
**Symptom:** Since introducing changelog SSP checkpointing in 1.3, onCheckpoint will be invoked for changelog SSPs if job.changelog.system is configured to be the same as an input system which implements CheckpointListener. This can be problematic because the types of checkpoints being written for changelog SSPs and input SSPs are different.
 
**Cause:** OffsetManager.writeCheckpoint is called with a Checkpoint parameter that includes changelog SSP checkpoints.
 
**Changes:** OffsetManager will now only invoke onCheckpoint for SSPs that are registered with it.
 
**Tests:** Wrote a test which attempts to write a Checkpoint with OffsetManager.writeCheckpoint which includes an SSP which was not registered with the OffsetManager. The test verifies that the callback is invoked only for those SSPs that were registered via OffsetManager.register. This test fails without the patch and passes with it.

**API Changes:** None
 
**Upgrade Instructions:** None
 
**Usage Instructions:** None