### PR TITLE
SAMZA-2447: Checkpoint dir removal should only search in valid store dirs

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/storage/TransactionalStateTaskStorageManager.scala
+++ b/samza-core/src/main/scala/org/apache/samza/storage/TransactionalStateTaskStorageManager.scala
@@ -90,11 +90,13 @@ class TransactionalStateTaskStorageManager(
             val fileFilter: FileFilter = new WildcardFileFilter(taskStoreName + "-*")
             val checkpointDirs = storeDir.listFiles(fileFilter)
 
-            checkpointDirs
-              .filter(!_.getName.contains(latestCheckpointId.toString))
-              .foreach(checkpointDir => {
-                FileUtils.deleteDirectory(checkpointDir)
-              })
+            if (checkpointDirs != null) {
+              checkpointDirs
+                .filter(!_.getName.contains(latestCheckpointId.toString))
+                .foreach(checkpointDir => {
+                  FileUtils.deleteDirectory(checkpointDir)
+                })
+            }
           })
       }
     }

--- a/samza-core/src/test/scala/org/apache/samza/storage/TestTransactionalStateTaskStorageManager.java
+++ b/samza-core/src/test/scala/org/apache/samza/storage/TestTransactionalStateTaskStorageManager.java
@@ -22,7 +22,6 @@ package org.apache.samza.storage;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.io.FileFilter;
-import org.apache.commons.io.filefilter.WildcardFileFilter;
 import scala.Option;
 import scala.collection.immutable.Map;
 

--- a/samza-core/src/test/scala/org/apache/samza/storage/TestTransactionalStateTaskStorageManager.java
+++ b/samza-core/src/test/scala/org/apache/samza/storage/TestTransactionalStateTaskStorageManager.java
@@ -507,7 +507,7 @@ public class TestTransactionalStateTaskStorageManager {
     File mockStoreDir = mock(File.class);
     String mockStoreDirName = "notDirectory";
 
-    when(loggedStoreBaseDir.listFiles()).thenReturn(new File[] { mockStoreDir });
+    when(loggedStoreBaseDir.listFiles()).thenReturn(new File[] {mockStoreDir});
     when(mockStoreDir.getName()).thenReturn(mockStoreDirName);
     when(storageManagerUtil.getTaskStoreDir(eq(loggedStoreBaseDir), eq(mockStoreDirName), eq(taskName), eq(taskMode))).thenReturn(mockStoreDir);
     // null here can happen if listFiles is called on a non-directory

--- a/samza-core/src/test/scala/org/apache/samza/storage/TestTransactionalStateTaskStorageManager.java
+++ b/samza-core/src/test/scala/org/apache/samza/storage/TestTransactionalStateTaskStorageManager.java
@@ -494,7 +494,7 @@ public class TestTransactionalStateTaskStorageManager {
   }
 
   @Test
-  public void testRemoveOldCheckpoints() {
+  public void testRemoveOldCheckpointsWhenBaseDirContainsRegularFiles() {
     TaskName taskName = new TaskName("Partition 0");
     ContainerStorageManager containerStorageManager = mock(ContainerStorageManager.class);
     Map<String, SystemStream> changelogSystemStreams = mock(Map.class);


### PR DESCRIPTION
**Symptom:** NPE when attempting to remove old checkpoint directories.
 
**Cause:** Removal of old checkpoints assumes every file in the logged store base directory is also a directory, which may not be true if the user has configured it to a path that is not exclusive to store contents.
 
**Changes:** Check that the result of `listFiles` is non-null before attempting to delete.
 
**Tests:** Wrote a test to mimic the behavior of a non-directory file in the logged store base directory. Test fails without the patch, passes with it.

**API Changes:** None
 
**Upgrade Instructions:** None
 
**Usage Instructions:** None