### PR TITLE
KafkaCheckPointManager -> Move log line so it does not have a forward…

### DIFF
--- a/samza-kafka/src/main/scala/org/apache/samza/checkpoint/kafka/KafkaCheckpointManager.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/checkpoint/kafka/KafkaCheckpointManager.scala
@@ -58,11 +58,12 @@ class KafkaCheckpointManager(checkpointSpec: KafkaStreamSpec,
 
   var MaxRetryDurationInMillis: Long = TimeUnit.MINUTES.toMillis(15)
 
+  val checkpointSystem: String = checkpointSpec.getSystemName
+  val checkpointTopic: String = checkpointSpec.getPhysicalName
+
   info(s"Creating KafkaCheckpointManager for checkpointTopic:$checkpointTopic, systemName:$checkpointSystem " +
     s"validateCheckpoints:$validateCheckpoint")
 
-  val checkpointSystem: String = checkpointSpec.getSystemName
-  val checkpointTopic: String = checkpointSpec.getPhysicalName
   val checkpointSsp: SystemStreamPartition = new SystemStreamPartition(checkpointSystem, checkpointTopic, new Partition(0))
   val expectedGrouperFactory: String = new JobConfig(config).getSystemStreamPartitionGrouperFactory
 


### PR DESCRIPTION
There is a forward reference in the first info log, line 61. It will always state checkpointTopic and checkpointSystem are null.