### PR TITLE
SAMZA-2441: Update ApplicationRunnerMain#ApplicationRunnerCommandLine not to load local file

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/job/JobRunner.scala
+++ b/samza-core/src/main/scala/org/apache/samza/job/JobRunner.scala
@@ -20,25 +20,33 @@
 package org.apache.samza.job
 
 
+import joptsimple.{OptionSet, OptionSpec}
 import org.apache.samza.SamzaException
 import org.apache.samza.config._
-import org.apache.samza.coordinator.stream.{CoordinatorStreamSystemConsumer, CoordinatorStreamSystemProducer}
-import org.apache.samza.coordinator.stream.messages.{Delete, SetConfig}
-import org.apache.samza.metrics.MetricsRegistryMap
-import org.apache.samza.runtime.ApplicationRunnerMain.ApplicationRunnerCommandLine
 import org.apache.samza.runtime.ApplicationRunnerOperation
-import org.apache.samza.system.{StreamSpec, SystemAdmins}
 import org.apache.samza.util.ScalaJavaUtil.JavaOptionals
 import org.apache.samza.util._
-
-import scala.collection.JavaConverters._
 
 
 object JobRunner extends Logging {
   val SOURCE = "job-runner"
 
+  class JobRunnerCommandLine extends CommandLine {
+    var operationOpt: OptionSpec[String] =
+      parser.accepts("operation", "The operation to perform; run, status, kill.")
+        .withRequiredArg
+        .ofType(classOf[String])
+        .describedAs("operation=run")
+        .defaultsTo("run")
+
+    def getOperation(options: OptionSet): ApplicationRunnerOperation = {
+      val rawOp = options.valueOf(operationOpt)
+      ApplicationRunnerOperation.fromString(rawOp)
+    }
+  }
+
   def main(args: Array[String]) {
-    val cmdline = new ApplicationRunnerCommandLine
+    val cmdline = new JobRunnerCommandLine
     val options = cmdline.parser.parse(args: _*)
     val config = cmdline.loadConfig(options)
     val operation = cmdline.getOperation(options)

--- a/samza-core/src/test/java/org/apache/samza/runtime/TestApplicationRunnerMain.java
+++ b/samza-core/src/test/java/org/apache/samza/runtime/TestApplicationRunnerMain.java
@@ -18,6 +18,7 @@
  */
 package org.apache.samza.runtime;
 
+import com.google.common.collect.ImmutableMap;
 import java.time.Duration;
 import joptsimple.OptionSet;
 import org.apache.samza.application.MockStreamApplication;
@@ -26,6 +27,7 @@ import org.apache.samza.config.ApplicationConfig;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.ConfigLoaderFactory;
 import org.apache.samza.config.JobConfig;
+import org.apache.samza.config.MapConfig;
 import org.apache.samza.context.ExternalContext;
 import org.apache.samza.job.ApplicationStatus;
 import org.junit.Test;
@@ -95,13 +97,13 @@ public class TestApplicationRunnerMain {
 
     Config actual = cmdLine.loadConfig(options);
 
-    assertEquals(4, actual.size());
-    assertEquals("org.apache.samza.config.loaders.PropertiesConfigLoaderFactory", actual.get(JobConfig.CONFIG_LOADER_FACTORY));
-    assertEquals(
-        getClass().getResource("/test.properties").getPath(),
-        actual.get(ConfigLoaderFactory.CONFIG_LOADER_PROPERTIES_PREFIX + "path"));
-    assertEquals(MockStreamApplication.class.getName(), actual.get(ApplicationConfig.APP_CLASS));
-    assertEquals(TestApplicationRunnerInvocationCounts.class.getName(), actual.get("app.runner.class"));
+    Config expected = new MapConfig(ImmutableMap.of(
+        JobConfig.CONFIG_LOADER_FACTORY, "org.apache.samza.config.loaders.PropertiesConfigLoaderFactory",
+        ConfigLoaderFactory.CONFIG_LOADER_PROPERTIES_PREFIX + "path", getClass().getResource("/test.properties").getPath(),
+        ApplicationConfig.APP_CLASS, MockStreamApplication.class.getName(),
+        "app.runner.class", TestApplicationRunnerInvocationCounts.class.getName()));
+
+    assertEquals(expected, actual);
   }
 
   public static class TestApplicationRunnerInvocationCounts implements ApplicationRunner {


### PR DESCRIPTION
Design:
https://cwiki.apache.org/confluence/display/SAMZA/SEP-23%3A+Simplify+Job+Runner

Changes:
1. Override ApplicationRunnerCommandLine#loadConfig not to invoke config loader as ApplicationRunners handles initial config and full job config themselves.
2. Add JobRunnerCommandLine to load full job config for JobRunner to keep consistent with previous behavior as it still needs full job config for special use cases.

API Changes:
None

Upgrade Instructions:
None

Usage Instructions:
None

Tests:
1. Unit Tests