### PR TITLE
SAMZA-2452 : Adding internal autosizing related configs

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/ClusterManagerConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ClusterManagerConfig.java
@@ -144,7 +144,9 @@ public class ClusterManagerConfig extends MapConfig {
   }
 
   public int getNumCores() {
-    if (containsKey(CLUSTER_MANAGER_MAX_CORES)) {
+    if (getBoolean(JobConfig.JOB_AUTOSIZING_ENABLED, false) && containsKey(JobConfig.JOB_AUTOSIZING_CONTAINER_MAX_CORES)) {
+      return getInt(JobConfig.JOB_AUTOSIZING_CONTAINER_MAX_CORES);
+    } else if (containsKey(CLUSTER_MANAGER_MAX_CORES)) {
       return getInt(CLUSTER_MANAGER_MAX_CORES);
     } else if (containsKey(CONTAINER_MAX_CPU_CORES)) {
       log.info("Configuration {} is deprecated. Please use {}", CONTAINER_MAX_CPU_CORES, CLUSTER_MANAGER_MAX_CORES);
@@ -155,7 +157,9 @@ public class ClusterManagerConfig extends MapConfig {
   }
 
   public int getContainerMemoryMb() {
-    if (containsKey(CLUSTER_MANAGER_MEMORY_MB)) {
+    if (getBoolean(JobConfig.JOB_AUTOSIZING_ENABLED, false) && containsKey(JobConfig.JOB_AUTOSIZING_CONTAINER_MEMORY_MB)) {
+      return getInt(JobConfig.JOB_AUTOSIZING_CONTAINER_MEMORY_MB);
+    } else if (containsKey(CLUSTER_MANAGER_MEMORY_MB)) {
       return getInt(CLUSTER_MANAGER_MEMORY_MB);
     } else if (containsKey(CONTAINER_MAX_MEMORY_MB)) {
       log.info("Configuration {} is deprecated. Please use {}", CONTAINER_MAX_MEMORY_MB, CLUSTER_MANAGER_MEMORY_MB);

--- a/samza-core/src/main/java/org/apache/samza/config/ClusterManagerConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ClusterManagerConfig.java
@@ -143,6 +143,11 @@ public class ClusterManagerConfig extends MapConfig {
     }
   }
 
+  /**
+   * Return the value of CLUSTER_MANAGER_MAX_CORES or CONTAINER_MAX_CPU_CORES (in that order) if autosizing is not enabled,
+   * otherwise returns the value of JOB_AUTOSIZING_CONTAINER_MAX_CORES.
+   * @return
+   */
   public int getNumCores() {
     if (getBoolean(JobConfig.JOB_AUTOSIZING_ENABLED, false) && containsKey(JobConfig.JOB_AUTOSIZING_CONTAINER_MAX_CORES)) {
       return getInt(JobConfig.JOB_AUTOSIZING_CONTAINER_MAX_CORES);
@@ -156,6 +161,11 @@ public class ClusterManagerConfig extends MapConfig {
     }
   }
 
+  /**
+   * Return the value of CLUSTER_MANAGER_MEMORY_MB or CONTAINER_MAX_MEMORY_MB (in that order) if autosizing is not enabled,
+   * otherwise returns the value of JOB_AUTOSIZING_CONTAINER_MEMORY_MB.
+   * @return
+   */
   public int getContainerMemoryMb() {
     if (getBoolean(JobConfig.JOB_AUTOSIZING_ENABLED, false) && containsKey(JobConfig.JOB_AUTOSIZING_CONTAINER_MEMORY_MB)) {
       return getInt(JobConfig.JOB_AUTOSIZING_CONTAINER_MEMORY_MB);

--- a/samza-core/src/main/java/org/apache/samza/config/ClusterManagerConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ClusterManagerConfig.java
@@ -149,7 +149,7 @@ public class ClusterManagerConfig extends MapConfig {
    * @return
    */
   public int getNumCores() {
-    if (getBoolean(JobConfig.JOB_AUTOSIZING_ENABLED, false) && containsKey(JobConfig.JOB_AUTOSIZING_CONTAINER_MAX_CORES)) {
+    if (new JobConfig(this).getAutosizingEnabled() && containsKey(JobConfig.JOB_AUTOSIZING_CONTAINER_MAX_CORES)) {
       return getInt(JobConfig.JOB_AUTOSIZING_CONTAINER_MAX_CORES);
     } else if (containsKey(CLUSTER_MANAGER_MAX_CORES)) {
       return getInt(CLUSTER_MANAGER_MAX_CORES);
@@ -167,7 +167,7 @@ public class ClusterManagerConfig extends MapConfig {
    * @return
    */
   public int getContainerMemoryMb() {
-    if (getBoolean(JobConfig.JOB_AUTOSIZING_ENABLED, false) && containsKey(JobConfig.JOB_AUTOSIZING_CONTAINER_MEMORY_MB)) {
+    if (new JobConfig(this).getAutosizingEnabled() && containsKey(JobConfig.JOB_AUTOSIZING_CONTAINER_MEMORY_MB)) {
       return getInt(JobConfig.JOB_AUTOSIZING_CONTAINER_MEMORY_MB);
     } else if (containsKey(CLUSTER_MANAGER_MEMORY_MB)) {
       return getInt(CLUSTER_MANAGER_MEMORY_MB);

--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -130,6 +130,15 @@ public class JobConfig extends MapConfig {
   public static final String CONTAINER_METADATA_FILENAME_FORMAT = "%s.metadata"; // Filename: <containerID>.metadata
   public static final String CONTAINER_METADATA_DIRECTORY_SYS_PROPERTY = "samza.log.dir";
 
+  // Auto-sizing related configs tthat ake precedence over respective sizing confings job.container.count, etc,
+  // *only* when job.autosizing.enabled is true. Otherwise current behavior is maintained.
+  public static final String JOB_AUTOSIZING_ENABLED = "job.autosizing.enabled";
+  public static final String JOB_AUTOSIZING_CONTAINER_COUNT = "job.autosizing.container.count";
+  public static final String JOB_AUTOSIZING_CONTAINER_THREAD_POOL_SIZE = "job.autosizing.container.thread.pool.size";
+  public static final String JOB_AUTOSIZING_CONTAINER_MAX_HEAP_MB = "job.autosizing.container.maxheap.mb";
+  public static final String JOB_AUTOSIZING_CONTAINER_MEMORY_MB = "job.autosizing.container.memory.mb";
+  public static final String JOB_AUTOSIZING_CONTAINER_MAX_CORES = "job.autosizing.container.cpu.cores";
+
   public static final String COORDINATOR_STREAM_FACTORY = "job.coordinatorstream.config.factory";
   public static final String DEFAULT_COORDINATOR_STREAM_CONFIG_FACTORY = "org.apache.samza.util.DefaultCoordinatorStreamConfigFactory";
 
@@ -166,8 +175,12 @@ public class JobConfig extends MapConfig {
   }
 
   public int getContainerCount() {
+    Optional<String> autoscalingContainerCountValue = Optional.ofNullable(get(JOB_AUTOSIZING_CONTAINER_COUNT));
     Optional<String> jobContainerCountValue = Optional.ofNullable(get(JOB_CONTAINER_COUNT));
-    if (jobContainerCountValue.isPresent()) {
+
+    if (getAutosizingEnabled() && autoscalingContainerCountValue.isPresent()) {
+      return Integer.parseInt(autoscalingContainerCountValue.get());
+    } else if (jobContainerCountValue.isPresent()) {
       return Integer.parseInt(jobContainerCountValue.get());
     } else {
       // To maintain backwards compatibility, honor yarn.container.count for now.
@@ -287,7 +300,13 @@ public class JobConfig extends MapConfig {
   }
 
   public int getThreadPoolSize() {
-    return getInt(JOB_CONTAINER_THREAD_POOL_SIZE, 0);
+    Optional<String> autoscalingContainerThreadPoolSize = Optional.ofNullable(get(
+        JOB_AUTOSIZING_CONTAINER_THREAD_POOL_SIZE));
+    if (getAutosizingEnabled() && autoscalingContainerThreadPoolSize.isPresent()) {
+      return Integer.parseInt(autoscalingContainerThreadPoolSize.get());
+    } else {
+      return getInt(JOB_CONTAINER_THREAD_POOL_SIZE, 0);
+    }
   }
 
   public int getDebounceTimeMs() {
@@ -308,6 +327,23 @@ public class JobConfig extends MapConfig {
 
   public boolean getDiagnosticsEnabled() {
     return getBoolean(JOB_DIAGNOSTICS_ENABLED, false);
+  }
+
+  public boolean getAutosizingEnabled() {
+    return getBoolean(JOB_AUTOSIZING_ENABLED, false);
+  }
+
+  public boolean isAutosizingConfig(String configParam) {
+    switch (configParam) {
+      case JOB_AUTOSIZING_CONTAINER_COUNT:
+      case JOB_AUTOSIZING_CONTAINER_MAX_CORES:
+      case JOB_AUTOSIZING_CONTAINER_MAX_HEAP_MB:
+      case JOB_AUTOSIZING_CONTAINER_MEMORY_MB:
+      case JOB_AUTOSIZING_CONTAINER_THREAD_POOL_SIZE:
+        return true;
+      default:
+        return false;
+    }
   }
 
   public boolean getJMXEnabled() {

--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -130,7 +130,7 @@ public class JobConfig extends MapConfig {
   public static final String CONTAINER_METADATA_FILENAME_FORMAT = "%s.metadata"; // Filename: <containerID>.metadata
   public static final String CONTAINER_METADATA_DIRECTORY_SYS_PROPERTY = "samza.log.dir";
 
-  // Auto-sizing related configs tthat ake precedence over respective sizing confings job.container.count, etc,
+  // Auto-sizing related configs that ake precedence over respective sizing confings job.container.count, etc,
   // *only* when job.autosizing.enabled is true. Otherwise current behavior is maintained.
   private static final String JOB_AUTOSIZING_CONFIG_PREFIX = "job.autosizing."; // used to determine if a config is related to autosizing
   public static final String JOB_AUTOSIZING_ENABLED = JOB_AUTOSIZING_CONFIG_PREFIX + "enabled";

--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -174,6 +174,11 @@ public class JobConfig extends MapConfig {
     return Optional.ofNullable(get(JOB_DEFAULT_SYSTEM));
   }
 
+  /**
+   * Return the value of JOB_CONTAINER_COUNT or "yarn.container.count" (in that order) if autosizing is not enabled,
+   * otherwise returns the value of JOB_AUTOSIZING_CONTAINER_COUNT.
+   * @return
+   */
   public int getContainerCount() {
     Optional<String> autoscalingContainerCountValue = Optional.ofNullable(get(JOB_AUTOSIZING_CONTAINER_COUNT));
     Optional<String> jobContainerCountValue = Optional.ofNullable(get(JOB_CONTAINER_COUNT));
@@ -299,6 +304,11 @@ public class JobConfig extends MapConfig {
     return get(SSP_MATCHER_CONFIG_JOB_FACTORY_REGEX, DEFAULT_SSP_MATCHER_CONFIG_JOB_FACTORY_REGEX);
   }
 
+  /**
+   * Return the value of JOB_CONTAINER_THREAD_POOL_SIZE if autosizing is not enabled,
+   * otherwise returns the value of JOB_AUTOSIZING_CONTAINER_THREAD_POOL_SIZE.
+   * @return
+   */
   public int getThreadPoolSize() {
     Optional<String> autoscalingContainerThreadPoolSize = Optional.ofNullable(get(
         JOB_AUTOSIZING_CONTAINER_THREAD_POOL_SIZE));

--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -132,12 +132,13 @@ public class JobConfig extends MapConfig {
 
   // Auto-sizing related configs tthat ake precedence over respective sizing confings job.container.count, etc,
   // *only* when job.autosizing.enabled is true. Otherwise current behavior is maintained.
-  public static final String JOB_AUTOSIZING_ENABLED = "job.autosizing.enabled";
-  public static final String JOB_AUTOSIZING_CONTAINER_COUNT = "job.autosizing.container.count";
-  public static final String JOB_AUTOSIZING_CONTAINER_THREAD_POOL_SIZE = "job.autosizing.container.thread.pool.size";
-  public static final String JOB_AUTOSIZING_CONTAINER_MAX_HEAP_MB = "job.autosizing.container.maxheap.mb";
-  public static final String JOB_AUTOSIZING_CONTAINER_MEMORY_MB = "job.autosizing.container.memory.mb";
-  public static final String JOB_AUTOSIZING_CONTAINER_MAX_CORES = "job.autosizing.container.cpu.cores";
+  private static final String JOB_AUTOSIZING_CONFIG_PREFIX = "job.autosizing."; // used to determine if a config is related to autosizing
+  public static final String JOB_AUTOSIZING_ENABLED = JOB_AUTOSIZING_CONFIG_PREFIX + "enabled";
+  public static final String JOB_AUTOSIZING_CONTAINER_COUNT = JOB_AUTOSIZING_CONFIG_PREFIX + "container.count";
+  public static final String JOB_AUTOSIZING_CONTAINER_THREAD_POOL_SIZE = JOB_AUTOSIZING_CONFIG_PREFIX + "container.thread.pool.size";
+  public static final String JOB_AUTOSIZING_CONTAINER_MAX_HEAP_MB = JOB_AUTOSIZING_CONFIG_PREFIX + "container.maxheap.mb";
+  public static final String JOB_AUTOSIZING_CONTAINER_MEMORY_MB = JOB_AUTOSIZING_CONFIG_PREFIX + "container.memory.mb";
+  public static final String JOB_AUTOSIZING_CONTAINER_MAX_CORES = JOB_AUTOSIZING_CONFIG_PREFIX + "container.cpu.cores";
 
   public static final String COORDINATOR_STREAM_FACTORY = "job.coordinatorstream.config.factory";
   public static final String DEFAULT_COORDINATOR_STREAM_CONFIG_FACTORY = "org.apache.samza.util.DefaultCoordinatorStreamConfigFactory";
@@ -180,11 +181,11 @@ public class JobConfig extends MapConfig {
    * @return
    */
   public int getContainerCount() {
-    Optional<String> autoscalingContainerCountValue = Optional.ofNullable(get(JOB_AUTOSIZING_CONTAINER_COUNT));
+    Optional<String> autosizingContainerCountValue = Optional.ofNullable(get(JOB_AUTOSIZING_CONTAINER_COUNT));
     Optional<String> jobContainerCountValue = Optional.ofNullable(get(JOB_CONTAINER_COUNT));
 
-    if (getAutosizingEnabled() && autoscalingContainerCountValue.isPresent()) {
-      return Integer.parseInt(autoscalingContainerCountValue.get());
+    if (getAutosizingEnabled() && autosizingContainerCountValue.isPresent()) {
+      return Integer.parseInt(autosizingContainerCountValue.get());
     } else if (jobContainerCountValue.isPresent()) {
       return Integer.parseInt(jobContainerCountValue.get());
     } else {
@@ -310,10 +311,10 @@ public class JobConfig extends MapConfig {
    * @return
    */
   public int getThreadPoolSize() {
-    Optional<String> autoscalingContainerThreadPoolSize = Optional.ofNullable(get(
+    Optional<String> autosizingContainerThreadPoolSize = Optional.ofNullable(get(
         JOB_AUTOSIZING_CONTAINER_THREAD_POOL_SIZE));
-    if (getAutosizingEnabled() && autoscalingContainerThreadPoolSize.isPresent()) {
-      return Integer.parseInt(autoscalingContainerThreadPoolSize.get());
+    if (getAutosizingEnabled() && autosizingContainerThreadPoolSize.isPresent()) {
+      return Integer.parseInt(autosizingContainerThreadPoolSize.get());
     } else {
       return getInt(JOB_CONTAINER_THREAD_POOL_SIZE, 0);
     }
@@ -343,17 +344,14 @@ public class JobConfig extends MapConfig {
     return getBoolean(JOB_AUTOSIZING_ENABLED, false);
   }
 
+  /**
+   * Check if a given config parameter is an internal autosizing related config, based on
+   * its name having the prefix "job.autosizing"
+   * @param configParam the config param to determine
+   * @return true if the config is related to autosizing, false otherwise
+   */
   public boolean isAutosizingConfig(String configParam) {
-    switch (configParam) {
-      case JOB_AUTOSIZING_CONTAINER_COUNT:
-      case JOB_AUTOSIZING_CONTAINER_MAX_CORES:
-      case JOB_AUTOSIZING_CONTAINER_MAX_HEAP_MB:
-      case JOB_AUTOSIZING_CONTAINER_MEMORY_MB:
-      case JOB_AUTOSIZING_CONTAINER_THREAD_POOL_SIZE:
-        return true;
-      default:
-        return false;
-    }
+    return configParam.startsWith(JOB_AUTOSIZING_CONFIG_PREFIX);
   }
 
   public boolean getJMXEnabled() {

--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -130,7 +130,7 @@ public class JobConfig extends MapConfig {
   public static final String CONTAINER_METADATA_FILENAME_FORMAT = "%s.metadata"; // Filename: <containerID>.metadata
   public static final String CONTAINER_METADATA_DIRECTORY_SYS_PROPERTY = "samza.log.dir";
 
-  // Auto-sizing related configs that ake precedence over respective sizing confings job.container.count, etc,
+  // Auto-sizing related configs that take precedence over respective sizing confings job.container.count, etc,
   // *only* when job.autosizing.enabled is true. Otherwise current behavior is maintained.
   private static final String JOB_AUTOSIZING_CONFIG_PREFIX = "job.autosizing."; // used to determine if a config is related to autosizing
   public static final String JOB_AUTOSIZING_ENABLED = JOB_AUTOSIZING_CONFIG_PREFIX + "enabled";

--- a/samza-core/src/main/java/org/apache/samza/util/DiagnosticsUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/util/DiagnosticsUtil.java
@@ -139,7 +139,7 @@ public class DiagnosticsUtil {
           new DiagnosticsManager(jobName, jobId, jobModel.getContainers(), containerMemoryMb, containerNumCores,
               new StorageConfig(config).getNumPersistentStores(), maxHeapSizeBytes, containerThreadPoolSize, containerId, execEnvContainerId.orElse(""),
               taskClassVersion, samzaVersion, hostName, diagnosticsSystemStream, systemProducer,
-              Duration.ofMillis(new TaskConfig(config).getShutdownMs()));
+              Duration.ofMillis(new TaskConfig(config).getShutdownMs()), jobConfig.getAutosizingEnabled());
 
       Option<String> blacklist = ScalaJavaUtil.JavaOptionals$.MODULE$.toRichOptional(
           metricsConfig.getMetricsSnapshotReporterBlacklist(diagnosticsReporterName)).toOption();

--- a/samza-core/src/main/scala/org/apache/samza/diagnostics/DiagnosticsManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/diagnostics/DiagnosticsManager.java
@@ -67,7 +67,7 @@ public class DiagnosticsManager {
   private final long maxHeapSizeBytes;
   private final int containerThreadPoolSize;
   private final Map<String, ContainerModel> containerModels;
-  private final boolean autoscalingEnabled;
+  private final boolean autosizingEnabled;
   private boolean jobParamsEmitted = false;
 
   private final SystemProducer systemProducer; // SystemProducer for writing diagnostics data
@@ -93,12 +93,12 @@ public class DiagnosticsManager {
       String hostname,
       SystemStream diagnosticSystemStream,
       SystemProducer systemProducer,
-      Duration terminationDuration, boolean autoscalingEnabled) {
+      Duration terminationDuration, boolean autosizingEnabled) {
 
     this(jobName, jobId, containerModels, containerMemoryMb, containerNumCores, numPersistentStores, maxHeapSizeBytes, containerThreadPoolSize,
         containerId, executionEnvContainerId, taskClassVersion, samzaVersion, hostname, diagnosticSystemStream, systemProducer,
         terminationDuration, Executors.newSingleThreadScheduledExecutor(
-            new ThreadFactoryBuilder().setNameFormat(PUBLISH_THREAD_NAME).setDaemon(true).build()), autoscalingEnabled);
+            new ThreadFactoryBuilder().setNameFormat(PUBLISH_THREAD_NAME).setDaemon(true).build()), autosizingEnabled);
   }
 
   @VisibleForTesting
@@ -118,7 +118,7 @@ public class DiagnosticsManager {
       SystemStream diagnosticSystemStream,
       SystemProducer systemProducer,
       Duration terminationDuration,
-      ScheduledExecutorService executorService, boolean autoscalingEnabled) {
+      ScheduledExecutorService executorService, boolean autosizingEnabled) {
     this.jobName = jobName;
     this.jobId = jobId;
     this.containerModels = containerModels;
@@ -139,7 +139,7 @@ public class DiagnosticsManager {
     this.processorStopEvents = new ConcurrentLinkedQueue<>();
     this.exceptions = new BoundedList<>("exceptions"); // Create a BoundedList with default size and time parameters
     this.scheduler = executorService;
-    this.autoscalingEnabled = autoscalingEnabled;
+    this.autosizingEnabled = autosizingEnabled;
 
     resetTime = Instant.now();
 
@@ -204,7 +204,7 @@ public class DiagnosticsManager {
           diagnosticsStreamMessage.addContainerModels(containerModels);
           diagnosticsStreamMessage.addMaxHeapSize(maxHeapSizeBytes);
           diagnosticsStreamMessage.addContainerThreadPoolSize(containerThreadPoolSize);
-          diagnosticsStreamMessage.addAutosizingEnabled(autoscalingEnabled);
+          diagnosticsStreamMessage.addAutosizingEnabled(autosizingEnabled);
         }
 
         // Add stop event list to the message

--- a/samza-core/src/main/scala/org/apache/samza/diagnostics/DiagnosticsStreamMessage.java
+++ b/samza-core/src/main/scala/org/apache/samza/diagnostics/DiagnosticsStreamMessage.java
@@ -252,8 +252,8 @@ public class DiagnosticsStreamMessage {
       diagnosticsStreamMessage.addContainerModels(deserializeContainerModelMap((String) diagnosticsManagerGroupMap.get(CONTAINER_MODELS_METRIC_NAME)));
       diagnosticsStreamMessage.addMaxHeapSize((Long) diagnosticsManagerGroupMap.get(CONTAINER_MAX_CONFIGURED_HEAP_METRIC_NAME));
       diagnosticsStreamMessage.addContainerThreadPoolSize((Integer) diagnosticsManagerGroupMap.get(CONTAINER_THREAD_POOL_SIZE_METRIC_NAME));
-
       diagnosticsStreamMessage.addProcessorStopEvents((List<ProcessorStopEvent>) diagnosticsManagerGroupMap.get(STOP_EVENT_LIST_METRIC_NAME));
+      diagnosticsStreamMessage.addAutosizingEnabled((Boolean) diagnosticsManagerGroupMap.get(AUTOSIZING_ENABLED_METRIC_NAME));
     }
 
     if (containerMetricsGroupMap != null && containerMetricsGroupMap.containsKey(EXCEPTION_LIST_METRIC_NAME)) {

--- a/samza-core/src/main/scala/org/apache/samza/diagnostics/DiagnosticsStreamMessage.java
+++ b/samza-core/src/main/scala/org/apache/samza/diagnostics/DiagnosticsStreamMessage.java
@@ -59,6 +59,7 @@ public class DiagnosticsStreamMessage {
   private static final String CONTAINER_MAX_CONFIGURED_HEAP_METRIC_NAME = "maxHeap";
   private static final String CONTAINER_THREAD_POOL_SIZE_METRIC_NAME = "containerThreadPoolSize";
   private static final String CONTAINER_MODELS_METRIC_NAME = "containerModels";
+  private static final String AUTOSIZING_ENABLED_METRIC_NAME = "autosizingEnabled";
 
   private final MetricsHeader metricsHeader;
   private final Map<String, Map<String, Object>> metricsMessage;
@@ -124,6 +125,14 @@ public class DiagnosticsStreamMessage {
       addToMetricsMessage(GROUP_NAME_FOR_DIAGNOSTICS_MANAGER, CONTAINER_MODELS_METRIC_NAME,
           serializeContainerModelMap(containerModelMap));
     }
+  }
+
+  /**
+   * Add the current auto-scaling setting.
+   * @param autosizingEnabled the parameter value.
+   */
+  public void addAutosizingEnabled(Boolean autosizingEnabled) {
+    addToMetricsMessage(GROUP_NAME_FOR_DIAGNOSTICS_MANAGER, AUTOSIZING_ENABLED_METRIC_NAME, autosizingEnabled);
   }
 
   /**
@@ -213,6 +222,10 @@ public class DiagnosticsStreamMessage {
 
   public Map<String, ContainerModel> getContainerModels() {
     return deserializeContainerModelMap((String) getFromMetricsMessage(GROUP_NAME_FOR_DIAGNOSTICS_MANAGER, CONTAINER_MODELS_METRIC_NAME));
+  }
+
+  public Boolean getAutosizingEnabled() {
+    return (Boolean) getFromMetricsMessage(GROUP_NAME_FOR_DIAGNOSTICS_MANAGER, AUTOSIZING_ENABLED_METRIC_NAME);
   }
 
   // Helper method to get a {@link DiagnosticsStreamMessage} from a {@link MetricsSnapshot}.

--- a/samza-core/src/test/java/org/apache/samza/config/TestJobConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestJobConfig.java
@@ -20,6 +20,7 @@ package org.apache.samza.config;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -31,6 +32,7 @@ import org.apache.samza.container.grouper.stream.GroupByPartitionFactory;
 import org.apache.samza.container.grouper.stream.HashSystemStreamPartitionMapperFactory;
 import org.apache.samza.coordinator.metadatastore.CoordinatorStreamMetadataStoreFactory;
 import org.apache.samza.runtime.DefaultLocationIdProviderFactory;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -581,5 +583,29 @@ public class TestJobConfig {
 
     jobConfig = new JobConfig(new MapConfig(ImmutableMap.of(JobConfig.COORDINATOR_STREAM_FACTORY, "specific_coordinator_stream")));
     assertEquals(jobConfig.getCoordinatorStreamFactory(), "specific_coordinator_stream");
+  }
+
+  @Test
+  public void testAutosizingConfig() {
+    Map<String, String> config = new HashMap<>();
+    config.put("job.autosizing.enabled", "true");
+    config.put("job.container.count", "1");
+    config.put("job.autosizing.container.count", "2");
+    config.put("job.container.thread.pool.size", "1");
+    config.put("job.autosizing.container.thread.pool.size", "3");
+    config.put("job.autosizing.container.maxheap.mb", "500");
+
+    config.put("cluster-manager.container.memory.mb", "500");
+    config.put("job.autosizing.container.memory.mb", "900");
+    config.put("cluster-manager.container.cpu.cores", "1");
+    config.put("job.autosizing.container.cpu.cores", "2");
+    JobConfig jobConfig = new JobConfig(new MapConfig(config));
+    Assert.assertTrue(jobConfig.getAutosizingEnabled());
+    Assert.assertEquals(2, jobConfig.getContainerCount());
+    Assert.assertEquals(3, jobConfig.getThreadPoolSize());
+
+    ClusterManagerConfig clusterManagerConfig = new ClusterManagerConfig(new MapConfig(config));
+    Assert.assertEquals(900, clusterManagerConfig.getContainerMemoryMb());
+    Assert.assertEquals(2, clusterManagerConfig.getNumCores());
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/config/TestJobConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestJobConfig.java
@@ -607,5 +607,11 @@ public class TestJobConfig {
     ClusterManagerConfig clusterManagerConfig = new ClusterManagerConfig(new MapConfig(config));
     Assert.assertEquals(900, clusterManagerConfig.getContainerMemoryMb());
     Assert.assertEquals(2, clusterManagerConfig.getNumCores());
+
+    ShellCommandConfig shellCommandConfig = new ShellCommandConfig(new MapConfig(ImmutableMap.of("task.opts", "-Xmx100m")));
+    Assert.assertEquals("Xmx param should match task.opts parameter with autosizing off", shellCommandConfig.getTaskOpts().get(), "-Xmx100m");
+
+    shellCommandConfig = new ShellCommandConfig(new MapConfig(config));
+    Assert.assertEquals("Xmx param should match job.autosizing.container.maxheap.mb value", "-Xmx500m", shellCommandConfig.getTaskOpts().get());
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/config/TestJobConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestJobConfig.java
@@ -610,11 +610,6 @@ public class TestJobConfig {
     ShellCommandConfig shellCommandConfig =
         new ShellCommandConfig(new MapConfig(ImmutableMap.of(JobConfig.JOB_AUTOSIZING_ENABLED, "false")));
     assertEquals(Option.empty(), shellCommandConfig.getTaskOpts());
-
-    String taskOpts = "-Dproperty=value";
-    shellCommandConfig = new ShellCommandConfig(new MapConfig(
-        ImmutableMap.of(ShellCommandConfig.TASK_JVM_OPTS(), taskOpts, JobConfig.JOB_AUTOSIZING_ENABLED, "false")));
-    assertEquals(Option.apply(taskOpts), shellCommandConfig.getTaskOpts());
   }
 
   @Test

--- a/samza-core/src/test/java/org/apache/samza/config/TestJobConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestJobConfig.java
@@ -610,6 +610,11 @@ public class TestJobConfig {
     ShellCommandConfig shellCommandConfig =
         new ShellCommandConfig(new MapConfig(ImmutableMap.of(JobConfig.JOB_AUTOSIZING_ENABLED, "false")));
     assertEquals(Option.empty(), shellCommandConfig.getTaskOpts());
+
+    String taskOpts = "-Dproperty=value";
+    shellCommandConfig = new ShellCommandConfig(new MapConfig(
+        ImmutableMap.of(ShellCommandConfig.TASK_JVM_OPTS(), taskOpts, JobConfig.JOB_AUTOSIZING_ENABLED, "false")));
+    assertEquals(Option.apply(taskOpts), shellCommandConfig.getTaskOpts());
   }
 
   @Test
@@ -625,16 +630,16 @@ public class TestJobConfig {
         ImmutableMap.of(ShellCommandConfig.TASK_JVM_OPTS(), taskOpts, JobConfig.JOB_AUTOSIZING_ENABLED, "true")));
     assertEquals(Option.apply(taskOpts), shellCommandConfig.getTaskOpts());
 
-    // opts not set, autosizing max heap set
+    // opts set with Xmx, autosizing max heap set
     shellCommandConfig = new ShellCommandConfig(new MapConfig(
         ImmutableMap.of(JobConfig.JOB_AUTOSIZING_ENABLED, "true", JobConfig.JOB_AUTOSIZING_CONTAINER_MAX_HEAP_MB,
-            "1024")));
-    assertEquals(Option.apply("-Xmx1024m"), shellCommandConfig.getTaskOpts());
+            "1024", "task.opts", "-Xmx10m -Dproperty=value")));
+    assertEquals(Option.apply("-Xmx1024m -Dproperty=value"), shellCommandConfig.getTaskOpts());
 
     // opts set without -Xmx, autosizing max heap set
     shellCommandConfig = new ShellCommandConfig(new MapConfig(
         ImmutableMap.of(JobConfig.JOB_AUTOSIZING_ENABLED, "true", JobConfig.JOB_AUTOSIZING_CONTAINER_MAX_HEAP_MB,
-            "1024")));
-    assertEquals(Option.apply("-Xmx1024m"), shellCommandConfig.getTaskOpts());
+            "1024", "task.opts", "-Dproperty=value")));
+    assertEquals(Option.apply("-Dproperty=value -Xmx1024m"), shellCommandConfig.getTaskOpts());
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/diagnostics/TestDiagnosticsManager.java
+++ b/samza-core/src/test/java/org/apache/samza/diagnostics/TestDiagnosticsManager.java
@@ -57,6 +57,7 @@ public class TestDiagnosticsManager {
   private long maxHeapSize = 900;
   private int numPersistentStores = 2;
   private int containerNumCores = 2;
+  private boolean autosizingEnabled = false;
   private Map<String, ContainerModel> containerModels = TestDiagnosticsStreamMessage.getSampleContainerModels();
   private Collection<DiagnosticsExceptionEvent> exceptionEventList = TestDiagnosticsStreamMessage.getExceptionList();
 
@@ -78,7 +79,7 @@ public class TestDiagnosticsManager {
     this.diagnosticsManager =
         new DiagnosticsManager(jobName, jobId, containerModels, containerMb, containerNumCores, numPersistentStores, maxHeapSize, containerThreadPoolSize,
             "0", executionEnvContainerId, taskClassVersion, samzaVersion, hostname, diagnosticsSystemStream,
-            mockSystemProducer, Duration.ofSeconds(1), mockExecutorService);
+            mockSystemProducer, Duration.ofSeconds(1), mockExecutorService, autosizingEnabled);
 
     exceptionEventList.forEach(
         diagnosticsExceptionEvent -> this.diagnosticsManager.addExceptionEvent(diagnosticsExceptionEvent));
@@ -212,6 +213,7 @@ public class TestDiagnosticsManager {
     Assert.assertEquals(containerModels, diagnosticsStreamMessage.getContainerModels());
     Assert.assertEquals(containerNumCores, diagnosticsStreamMessage.getContainerNumCores().intValue());
     Assert.assertEquals(numPersistentStores, diagnosticsStreamMessage.getNumPersistentStores().intValue());
+    Assert.assertEquals(autosizingEnabled, diagnosticsStreamMessage.getAutosizingEnabled());
   }
 
   private class MockSystemProducer implements SystemProducer {


### PR DESCRIPTION
Adding internal autosizing related configs, can be used by an external controller. 
These sizing-related configs (e.g., container-count, etc) take precedence when job.autosizing.enabled is set, otherwise existing behavior is retained.

Symptom: Sizing configs set by a controller need to be different from user-facing configs.

Cause: --
Fix: Added internal configs for sizing related configs. Added tests. 
The enabled config is also needs to be emitted by the DiagnosticsManager.
API Changes: Adding internal autosizing related configs (job.autosizing.enabled, job.autosizing.container.count, job.autosizing.container.thread.pool.size, job.autosizing.maxheap.mb, job.autosizing.cpu.cores) , can be used by an external controller. These sizing-related configs (e.g., container-count, etc) take precedence when job.autosizing.enabled is set, otherwise existing behavior is retained. 