### PR TITLE
Update rocksdb to 6.4.6 version

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -40,7 +40,7 @@
   metricsVersion = "2.2.0"
   mockitoVersion = "1.10.19"
   powerMockVersion = "1.6.6"
-  rocksdbVersion = "5.7.3"
+  rocksdbVersion = "6.4.6"
   scalaTestVersion = "3.0.1"
   slf4jVersion = "1.7.7"
   yarnVersion = "2.6.1"


### PR DESCRIPTION
PR to upgrade the rocksdb version from 5.7.3 to 6.4.6 as there was an issue using a lower version of rocksdb here (https://github.com/tensorflow/tensorflow/issues/22307)

Tested with:
./gradlew clean build
./gradlew clean test
mint build and pcl through internal Linkedin samza
Creating a test build and running Bkonold's test-store-workload in the automated release testing. 

