### PR TITLE
SAMZA-2459: Upgrade Jackson-core dependency for samza-azure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -216,7 +216,7 @@ project(":samza-azure_$scalaSuffix") {
     compile "com.azure:azure-storage-blob:12.0.1"
     compile "com.microsoft.azure:azure-storage:5.3.1"
     compile "com.microsoft.azure:azure-eventhubs:1.0.1"
-    compile "com.fasterxml.jackson.core:jackson-core:2.8.8"
+    compile "com.fasterxml.jackson.core:jackson-core:2.10.0"
     compile "io.dropwizard.metrics:metrics-core:3.1.2"
     compile "org.apache.avro:avro:$avroVersion"
     compile project(':samza-api')


### PR DESCRIPTION
**Symptom:**

Samza job using the new AzureBlobSystemProducer requires to explicitly pin  jackson-core dependency to be 2.10.0. Other wise, NoClassDefFoundError is thrown for com.fasterxml.jackson.core.TSFBuilder needed by com.azure.storage.blob.BlobServiceClientBuilder.buildAsyncClient which is used by the SystemProducer to setUpAzureContainer.

**Cause:**
samza-azure's build gradle has jackson-core:2.8.8. Without this explicit pinning, sample samza job's maven resolves jackson-core to 2.6.0 that is pulled in by com.microsoft.azure:azure-storage:5.3.1. However, azure-storage-blob:12.0.1 used by the SystemProducer needs jackson-core:2.10.0. 

**Changes:**
Upgrade jackson-core to 2.10.0

**Tests:** Sample High level job in hello-samza (apache/samza-hello-samza#71) works correctly with these changes and without needing to specify any jackson dependencies.