### PR TITLE
SAMZA-2458: Update ProcessJobFactory and ThreadJobFactory to load full job config

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/job/local/ProcessJobFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/job/local/ProcessJobFactory.scala
@@ -105,7 +105,7 @@ class ProcessJobFactory extends StreamJobFactory with Logging {
     info("Using command builder class %s" format commandBuilderClass)
     val commandBuilder = ReflectionUtil.getObj(commandBuilderClass, classOf[CommandBuilder])
 
-    // JobCoordinator is stopped by ProcessJob when it exits
+    // Start JobModelManager which will be stopped by ProcessJob when it exits
     jobModelManager.start
 
     commandBuilder

--- a/samza-core/src/main/scala/org/apache/samza/job/local/ProcessJobFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/job/local/ProcessJobFactory.scala
@@ -40,7 +40,7 @@ import org.apache.samza.util.{ConfigUtil, CoordinatorStreamUtil, DiagnosticsUtil
 import scala.collection.JavaConversions._
 
 /**
- * Creates a stand alone ProcessJob with the specified config.
+ * Creates a ProcessJob with the specified config.
  */
 class ProcessJobFactory extends StreamJobFactory with Logging {
   def getJob(submissionConfig: Config): StreamJob = {
@@ -71,8 +71,8 @@ class ProcessJobFactory extends StreamJobFactory with Logging {
     coordinatorStreamStore.init()
 
     val changelogStreamManager = new ChangelogStreamManager(new NamespaceAwareCoordinatorStreamStore(coordinatorStreamStore, SetChangelogMapping.TYPE))
-    val coordinator = JobModelManager(config, changelogStreamManager.readPartitionMapping(), coordinatorStreamStore, metricsRegistry)
-    val jobModel = coordinator.jobModel
+    val jobModelManager = JobModelManager(config, changelogStreamManager.readPartitionMapping(), coordinatorStreamStore, metricsRegistry)
+    val jobModel = jobModelManager.jobModel
     val taskPartitionMappings: util.Map[TaskName, Integer] = new util.HashMap[TaskName, Integer]
 
     for (containerModel <- jobModel.getContainers.values) {
@@ -102,13 +102,13 @@ class ProcessJobFactory extends StreamJobFactory with Logging {
     val commandBuilder = ReflectionUtil.getObj(commandBuilderClass, classOf[CommandBuilder])
 
     // JobCoordinator is stopped by ProcessJob when it exits
-    coordinator.start
+    jobModelManager.start
 
     commandBuilder
       .setConfig(config)
       .setId("0")
-      .setUrl(coordinator.server.getUrl)
+      .setUrl(jobModelManager.server.getUrl)
 
-    new ProcessJob(commandBuilder, coordinator)
+    new ProcessJob(commandBuilder, jobModelManager)
   }
 }

--- a/samza-core/src/main/scala/org/apache/samza/job/local/ThreadJobFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/job/local/ThreadJobFactory.scala
@@ -49,21 +49,24 @@ import scala.collection.mutable
 class ThreadJobFactory extends StreamJobFactory with Logging {
   def getJob(submissionConfig: Config): StreamJob = {
     info("Creating a ThreadJob, which is only meant for debugging.")
-    val originalConfig = ConfigUtil.loadConfig(submissionConfig)
+    var config = submissionConfig
+    if (new JobConfig(submissionConfig).getConfigLoaderFactory.isPresent) {
+      val originalConfig = ConfigUtil.loadConfig(submissionConfig)
 
-    // Execute planning
-    val planner = new RemoteJobPlanner(ApplicationDescriptorUtil.getAppDescriptor(ApplicationUtil.fromConfig(originalConfig), originalConfig))
-    val jobConfigs = planner.prepareJobs
+      // Execute planning
+      val planner = new RemoteJobPlanner(ApplicationDescriptorUtil.getAppDescriptor(ApplicationUtil.fromConfig(originalConfig), originalConfig))
+      val jobConfigs = planner.prepareJobs
 
-    if (jobConfigs.size != 1) {
-      throw new SamzaException("Only single stage job is supported.")
+      if (jobConfigs.size != 1) {
+        throw new SamzaException("Only single stage job is supported.")
+      }
+
+      // This is the full job config
+      config = jobConfigs.get(0)
+      // This needs to be consistent with RemoteApplicationRunner#run where JobRunner#submit to be called instead of JobRunner#run
+      CoordinatorStreamUtil.writeConfigToCoordinatorStream(config)
+      DiagnosticsUtil.createDiagnosticsStream(config)
     }
-
-    // This is the full job config
-    val config = jobConfigs.get(0)
-    // This needs to be consistent with RemoteApplicationRunner#run where JobRunner#submit to be called instead of JobRunner#run
-    CoordinatorStreamUtil.writeConfigToCoordinatorStream(config)
-    DiagnosticsUtil.createDiagnosticsStream(config)
 
     val metricsRegistry = new MetricsRegistryMap()
     val coordinatorStreamStore: CoordinatorStreamStore = new CoordinatorStreamStore(config, new MetricsRegistryMap())

--- a/samza-core/src/main/scala/org/apache/samza/job/local/ThreadJobFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/job/local/ThreadJobFactory.scala
@@ -19,16 +19,18 @@
 
 package org.apache.samza.job.local
 
+import org.apache.samza.SamzaException
 import org.apache.samza.application.ApplicationUtil
 import org.apache.samza.application.descriptors.ApplicationDescriptorUtil
 import org.apache.samza.config.JobConfig._
 import org.apache.samza.config.ShellCommandConfig._
-import org.apache.samza.config.{Config, JobConfig, TaskConfig}
+import org.apache.samza.config.{Config, JobConfig}
 import org.apache.samza.container.{SamzaContainer, SamzaContainerListener, TaskName}
 import org.apache.samza.context.{ExternalContext, JobContextImpl}
-import org.apache.samza.coordinator.{JobModelManager, MetadataResourceUtil}
 import org.apache.samza.coordinator.metadatastore.{CoordinatorStreamStore, NamespaceAwareCoordinatorStreamStore}
 import org.apache.samza.coordinator.stream.messages.SetChangelogMapping
+import org.apache.samza.coordinator.{JobModelManager, MetadataResourceUtil}
+import org.apache.samza.execution.RemoteJobPlanner
 import org.apache.samza.job.model.JobModelUtil
 import org.apache.samza.job.{StreamJob, StreamJobFactory}
 import org.apache.samza.metrics.{JmxServer, MetricsRegistryMap, MetricsReporter}
@@ -36,7 +38,7 @@ import org.apache.samza.runtime.ProcessorContext
 import org.apache.samza.startpoint.StartpointManager
 import org.apache.samza.storage.ChangelogStreamManager
 import org.apache.samza.task.{TaskFactory, TaskFactoryUtil}
-import org.apache.samza.util.{CoordinatorStreamUtil, Logging}
+import org.apache.samza.util.{ConfigUtil, CoordinatorStreamUtil, DiagnosticsUtil, Logging}
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable
@@ -45,18 +47,31 @@ import scala.collection.mutable
   * Creates a new Thread job with the given config
   */
 class ThreadJobFactory extends StreamJobFactory with Logging {
-  def getJob(config: Config): StreamJob = {
+  def getJob(submissionConfig: Config): StreamJob = {
     info("Creating a ThreadJob, which is only meant for debugging.")
+    val originalConfig = ConfigUtil.loadConfig(submissionConfig)
+
+    // Execute planning
+    val planner = new RemoteJobPlanner(ApplicationDescriptorUtil.getAppDescriptor(ApplicationUtil.fromConfig(originalConfig), originalConfig))
+    val jobConfigs = planner.prepareJobs
+
+    if (jobConfigs.size != 1) {
+      throw new SamzaException("Only single process job is supported.")
+    }
+
+    // This is the full job config
+    val config = jobConfigs.get(0)
+    // This needs to be consistent with RemoteApplicationRunner#run where JobRunner#submit to be called instead of JobRunner#run
+    CoordinatorStreamUtil.writeConfigToCoordinatorStream(config)
+    DiagnosticsUtil.createDiagnosticsStream(config)
 
     val metricsRegistry = new MetricsRegistryMap()
     val coordinatorStreamStore: CoordinatorStreamStore = new CoordinatorStreamStore(config, new MetricsRegistryMap())
     coordinatorStreamStore.init()
 
-    val configFromCoordinatorStream: Config = CoordinatorStreamUtil.readConfigFromCoordinatorStream(coordinatorStreamStore)
-
     val changelogStreamManager = new ChangelogStreamManager(new NamespaceAwareCoordinatorStreamStore(coordinatorStreamStore, SetChangelogMapping.TYPE))
 
-    val coordinator = JobModelManager(configFromCoordinatorStream, changelogStreamManager.readPartitionMapping(),
+    val coordinator = JobModelManager(config, changelogStreamManager.readPartitionMapping(),
       coordinatorStreamStore, metricsRegistry)
     val jobModel = coordinator.jobModel
 

--- a/samza-core/src/main/scala/org/apache/samza/job/local/ThreadJobFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/job/local/ThreadJobFactory.scala
@@ -56,7 +56,7 @@ class ThreadJobFactory extends StreamJobFactory with Logging {
     val jobConfigs = planner.prepareJobs
 
     if (jobConfigs.size != 1) {
-      throw new SamzaException("Only single process job is supported.")
+      throw new SamzaException("Only single thread job is supported.")
     }
 
     // This is the full job config


### PR DESCRIPTION
Design:
https://cwiki.apache.org/confluence/display/SAMZA/SEP-23%3A+Simplify+Job+Runner

Changes:
1. Update ProcessJobFactory to load full job config, execute planning and write full job config back to coordiantor stream, which was done by RemoteApplicationRunner
2. Update ThreadJobFactory to load full job config, execute planning and write full job config back to coordiantor stream, which was done by RemoteApplicationRunner

These are needed as RemoteApplicationRunner no longer get full job config, no longer execute planning and no longer persist full job config in coordinator stream anymore.

API Changes:
None.

Upgrade Instructions:
See https://github.com/apache/samza/pull/1256 for more detailed instructions.

Usage Instructions:
See https://github.com/apache/samza/pull/1256 for more detailed instructions.

Tests
1. Local deploy a yarn job and verified it is working properly.