### PR TITLE
SAMZA-2462 : Adding metric for container thread pool size

### DIFF
--- a/docs/learn/documentation/versioned/container/metrics-table.html
+++ b/docs/learn/documentation/versioned/container/metrics-table.html
@@ -218,6 +218,10 @@
         <td>The physical memory used by the Samza container process (native + on heap) (in megabytes)</td>
     </tr>
     <tr>
+        <td>container-thread-pool-size</td>
+        <td>The size of the thread pool used by the Samza container for input processing, configured using job.container.thread.pool.size.</td>
+    </tr>
+    <tr>
         <td>container-startup-time</td>
         <td><a href="#average-time">Average time</a> spent for the container to startup</td>
     </tr>

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -467,6 +467,7 @@ object SamzaContainer extends Logging {
 
     val threadPoolSize = jobConfig.getThreadPoolSize
     info("Got thread pool size: " + threadPoolSize)
+    samzaContainerMetrics.containerThreadPoolSize.set(threadPoolSize)
 
     val taskThreadPool = if (threadPoolSize > 0) {
       Executors.newFixedThreadPool(threadPoolSize,

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
@@ -46,6 +46,7 @@ class SamzaContainerMetrics(
   val diskQuotaBytes = newGauge("disk-quota-bytes", Long.MaxValue)
   val executorWorkFactor = newGauge("executor-work-factor", 1.0)
   val physicalMemoryMb = newGauge[Double]("physical-memory-mb", 0.0F)
+  val containerThreadPoolSize = newGauge("container-thread-pool-size", 0L)
 
   val taskStoreRestorationMetrics: util.Map[TaskName, Gauge[Long]] = new util.HashMap[TaskName, Gauge[Long]]()
 


### PR DESCRIPTION
Adding metric for container thread pool size.

Symptom: Currently it is not possible to track the container-thread-pool size using metrics, even though its possible to configure it similar to container-memory-mb, vcore, etc.
Cause: No metric for this configurable
Fix: Added metric for container thread pool size, updated metrics reference sheet.
API changes: Added new metric for container-thread-pool-size.
Upgrade Instructions: None
Usage Instructions: See the metrics reference sheet for details on the metric.