### PR TITLE
SAMZA-2461: Fix Concurrent Modification Exception in InMemorySystem

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/system/inmemory/InMemoryManager.java
+++ b/samza-core/src/main/java/org/apache/samza/system/inmemory/InMemoryManager.java
@@ -20,6 +20,7 @@
 package org.apache.samza.system.inmemory;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -199,6 +200,6 @@ class InMemoryManager {
       return new ArrayList<>();
     }
 
-    return messageEnvelopesForSSP.subList(startingOffset, messageEnvelopesForSSP.size());
+    return ImmutableList.copyOf(messageEnvelopesForSSP.subList(startingOffset, messageEnvelopesForSSP.size()));
   }
 }


### PR DESCRIPTION
Symptom: There is a chance to run into ConcurrentModificationException using InMemorySystem.

Cause: The returned list of InMemoryManager#poll is a sublist of the original list. While iterating the sublist, if the original list is modified, ConcurrentModificationException will be thrown.

Changes: We need to make the returned list of InMemoryManager#poll to be a new copy.

Tests: Tested with a samza beam job. Didn't see the exception any more.


