### PR TITLE
SAMZA-2463: Duplicate firings of processing timers

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/scheduler/EpochTimeScheduler.java
+++ b/samza-core/src/main/java/org/apache/samza/scheduler/EpochTimeScheduler.java
@@ -90,7 +90,11 @@ public class EpochTimeScheduler {
 
   public Map<TimerKey<?>, ScheduledCallback> removeReadyTimers() {
     final Map<TimerKey<?>, ScheduledCallback> timers = new TreeMap<>(readyTimers);
-    readyTimers.keySet().removeAll(timers.keySet());
+    // Remove keys on the map directly instead of using key set iterator and remove all
+    // on the key set as it results in duplicate firings due to weakly consistent SetView
+    for (TimerKey<?> key : timers.keySet()) {
+      readyTimers.remove(key);
+    }
     return timers;
   }
 


### PR DESCRIPTION
**Symptom**: Duplicate firing of processing timers
**Cause**: In EpochTimeScheduler, the `removeReadyTimers`  returns the timers that are ready to be fired and also remove them from local book-keeping. We operate on the SetView returned by entrySet() to remove the timers. Since the iterator of the SetView is weakly consistent, there is possibilities in timers surviving the remove and results in duplicate timers being fired.
**Changes**: Remove the keys from the local book keeping map directly instead of using the `keySet()` and `removeAll()`
**Tests**: Tested using the Nexmark beam benchmark test suite. Will explore a way to unit test this change and follow it up on a separate PR.
**API Changes**: None
**Upgrade Instructions**: None
**Usage Instructions**: None