### PR TITLE
SAMZA-2464: Container shuts down when task fails to remove old state checkpoint dirs

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
@@ -277,7 +277,7 @@ class TaskInstance(
       try {
         storageManager.removeOldCheckpoints(checkpointId)
       } catch {
-        case e: Exception => error("Failed to remove old checkpoints", e)
+        case e: Exception => error("Failed to remove old checkpoints for task: %s. Current checkpointId: %s" format (taskName, checkpointId), e)
       }
     }
 

--- a/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
@@ -274,7 +274,11 @@ class TaskInstance(
 
     if (storageManager != null) {
       trace("Remove old checkpoint stores for taskName: %s" format taskName)
-      storageManager.removeOldCheckpoints(checkpointId)
+      try {
+        storageManager.removeOldCheckpoints(checkpointId)
+      } catch {
+        case e: Exception => error("Failed to remove old checkpoints", e)
+      }
     }
 
     if (inputCheckpoint != null) {

--- a/samza-core/src/test/scala/org/apache/samza/container/TestTaskInstance.scala
+++ b/samza-core/src/test/scala/org/apache/samza/container/TestTaskInstance.scala
@@ -336,7 +336,7 @@ class TestTaskInstance extends AssertionsForJUnit with MockitoSugar {
   }
 
   @Test
-  def testCommitFailsIfErrorClearingOldCheckpoints() { // required for transactional state
+  def testCommitContinuesIfErrorClearingOldCheckpoints() { // required for transactional state
     val commitsCounter = mock[Counter]
     when(this.metrics.commits).thenReturn(commitsCounter)
 
@@ -352,10 +352,8 @@ class TestTaskInstance extends AssertionsForJUnit with MockitoSugar {
     } catch {
       case e: SamzaException =>
         // exception is expected, container should fail if could not get changelog offsets.
-        return
+        fail("Exception from removeOldCheckpoints should have been caught")
     }
-
-    fail("Should have failed commit if error getting newest changelog offests")
   }
 
   /**


### PR DESCRIPTION
**Symptom:** Container shuts down with exception on invocation of TaskStorageManager.removeOldCheckpoints from TaskInstance.commit
 
**Cause:** Concurrent modification of checkpoint directories by other processes / threads may cause FileNotFoundException to be thrown and shutdown the container. IOException may be thrown for other miscellaneous failures; these should not cause the container to shutdown but be logged and allow processing to continue.
 
**Tests:** Added a unit test which fails when exception from removeOldCheckpoints is not caught.

**API Changes:** None
**Upgrade instructions:** None
**Usage instructions:** None