### PR TITLE
SAMZA-2317: ProcessJob does not call CoordinatorStreamStore.close()

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/coordinator/metadatastore/CoordinatorStreamStore.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/metadatastore/CoordinatorStreamStore.java
@@ -94,7 +94,7 @@ public class CoordinatorStreamStore implements MetadataStore {
   }
 
   @VisibleForTesting
-  CoordinatorStreamStore(Config config, SystemProducer systemProducer, SystemConsumer systemConsumer, SystemAdmin systemAdmin) {
+  protected CoordinatorStreamStore(Config config, SystemProducer systemProducer, SystemConsumer systemConsumer, SystemAdmin systemAdmin) {
     this.config = config;
     this.systemConsumer = systemConsumer;
     this.systemProducer = systemProducer;

--- a/samza-core/src/main/scala/org/apache/samza/job/local/ProcessJob.scala
+++ b/samza-core/src/main/scala/org/apache/samza/job/local/ProcessJob.scala
@@ -22,6 +22,7 @@ package org.apache.samza.job.local
 import java.util.concurrent.CountDownLatch
 
 import org.apache.samza.coordinator.JobModelManager
+import org.apache.samza.coordinator.metadatastore.CoordinatorStreamStore
 import org.apache.samza.job.ApplicationStatus.{New, Running, SuccessfulFinish, UnsuccessfulFinish}
 import org.apache.samza.job.{ApplicationStatus, CommandBuilder, StreamJob}
 import org.apache.samza.util.Logging
@@ -41,7 +42,10 @@ object ProcessJob {
   }
 }
 
-class ProcessJob(commandBuilder: CommandBuilder, val jobModelManager: JobModelManager) extends StreamJob with Logging {
+class ProcessJob(
+  commandBuilder: CommandBuilder,
+  val jobModelManager: JobModelManager,
+  val coordinatorStreamStore: CoordinatorStreamStore) extends StreamJob with Logging {
 
   import ProcessJob._
 
@@ -72,6 +76,7 @@ class ProcessJob(commandBuilder: CommandBuilder, val jobModelManager: JobModelMa
           case e: Exception => error("Encountered an error during job start: %s".format(e.getMessage))
         } finally {
           jobModelManager.stop
+          coordinatorStreamStore.close
           setStatus(if (processExitCode == 0) SuccessfulFinish else UnsuccessfulFinish)
         }
       }

--- a/samza-core/src/main/scala/org/apache/samza/job/local/ProcessJobFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/job/local/ProcessJobFactory.scala
@@ -113,6 +113,6 @@ class ProcessJobFactory extends StreamJobFactory with Logging {
       .setId("0")
       .setUrl(jobModelManager.server.getUrl)
 
-    new ProcessJob(commandBuilder, jobModelManager)
+    new ProcessJob(commandBuilder, jobModelManager, coordinatorStreamStore)
   }
 }


### PR DESCRIPTION
Symptom: Users when deploying a job in dev will see an error message from the kafka consumer finalizer complaining about "kafka consumer allocated and not closed"

This error message will appear multiple times in their job and doesn't actually affect the job's performance or correctness. This leads to users falsely believing that any job failures is because of this message.

Cause:
All Kafka consumers have a finalize method in them. This means when the garbage collector determines that there's no more references to the consumer, it will try to close the consumer and find that the consumer wasn't closed properly yet. This happens because in the ProcessJobFactory, a CoordinatorStreamStore is initialized. It is then wrapped around a NamespaceAwareCoordinatorStreamStore. Later on when the ProcessJob is done, a close() is called on the NamespaceAwareCoordinatorStreamStore, however this doesn't close the original CoordinatorStreamStore (As there could be multiple NamespaceAware stores pointing to one CoordinatorStreamStore). So, from the garbage collector's perspective, it will see that there are no more references to the CoordinatorStreamStore, leading to the finalize method reporting the above error.

Changes: ProcessJob will now have an additional parameter which will be the CoordinatorStreamStore. Then a close is called on the store when the job is done running. That way there is still a reference to the store after the ProcessJob starts. Also updated the TestProcessJob file to test that the store is closed properly. 
This way of fixing this error was chosen as any other solution would involved changing how the coordinatorStreamStore operates which could lead to many unintended side-effects

Tests: To reproduce this error, deploy any job running the latest version of Samza and look in the .out log file. Then run the same job with this fix included and that error message shouldn't appear anymore. Tested this with a test a build in LinkedIn internal to verify the error message isn't there anymore. Also ran "./gradlew clean build" and "./gradlew clean test"