### PR TITLE
SAMZA-2468: Make Standby containers respond to shutdown request

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -868,12 +868,10 @@ class SamzaContainer(
       return
     }
 
-    /**
-      * Countdown the standbyContainerShutdownLatch so standby container can invoke a shutdown sequence
-      */
-    standbyContainerShutdownLatch.countDown();
-
-    shutdownRunLoop()
+    if (taskInstances.size > 0 )
+      shutdownRunLoop()
+    else
+      standbyContainerShutdownLatch.countDown // Countdown the latch so standby container can invoke a shutdown sequence
   }
 
   // Shutdown Runloop

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -868,7 +868,7 @@ class SamzaContainer(
       return
     }
 
-    if (taskInstances.size > 0 )
+    if (taskInstances.size > 0)
       shutdownRunLoop()
     else
       standbyContainerShutdownLatch.countDown // Countdown the latch so standby container can invoke a shutdown sequence

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -26,7 +26,7 @@ import java.nio.file.Path
 import java.time.Duration
 import java.util
 import java.util.{Base64, Optional}
-import java.util.concurrent.{ExecutorService, Executors, ScheduledExecutorService, TimeUnit}
+import java.util.concurrent.{CountDownLatch, ExecutorService, Executors, ScheduledExecutorService, TimeUnit}
 
 import com.google.common.annotations.VisibleForTesting
 import com.google.common.util.concurrent.ThreadFactoryBuilder
@@ -714,6 +714,9 @@ class SamzaContainer(
   var jmxServer: JmxServer = null
 
   @volatile private var status = SamzaContainerStatus.NOT_STARTED
+
+  @volatile private var stopSignalLatch = new CountDownLatch(1);
+
   private var exceptionSeen: Throwable = null
   private var containerListener: SamzaContainerListener = null
 
@@ -767,7 +770,7 @@ class SamzaContainer(
       if (taskInstances.size > 0)
         runLoop.run
       else
-        Thread.sleep(Long.MaxValue)
+        stopSignalLatch.await() // Standby containers do not spin runLoop, instead they wait on signal to invoke shutdown
     } catch {
       case e: InterruptedException =>
         /*
@@ -864,6 +867,11 @@ class SamzaContainer(
       warn("Shutdown is no-op since the container is already in state: " + status)
       return
     }
+
+    /**
+      * Countdown the stopSignalLatch so standby container can invoke a shutdown sequence
+      */
+    stopSignalLatch.countDown();
 
     shutdownRunLoop()
   }

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -715,7 +715,7 @@ class SamzaContainer(
 
   @volatile private var status = SamzaContainerStatus.NOT_STARTED
 
-  @volatile private var stopSignalLatch = new CountDownLatch(1);
+  @volatile private var standbyContainerShutdownLatch = new CountDownLatch(1);
 
   private var exceptionSeen: Throwable = null
   private var containerListener: SamzaContainerListener = null
@@ -770,7 +770,7 @@ class SamzaContainer(
       if (taskInstances.size > 0)
         runLoop.run
       else
-        stopSignalLatch.await() // Standby containers do not spin runLoop, instead they wait on signal to invoke shutdown
+        standbyContainerShutdownLatch.await() // Standby containers do not spin runLoop, instead they wait on signal to invoke shutdown
     } catch {
       case e: InterruptedException =>
         /*
@@ -869,9 +869,9 @@ class SamzaContainer(
     }
 
     /**
-      * Countdown the stopSignalLatch so standby container can invoke a shutdown sequence
+      * Countdown the standbyContainerShutdownLatch so standby container can invoke a shutdown sequence
       */
-    stopSignalLatch.countDown();
+    standbyContainerShutdownLatch.countDown();
 
     shutdownRunLoop()
   }

--- a/samza-core/src/test/scala/org/apache/samza/container/TestSamzaContainer.scala
+++ b/samza-core/src/test/scala/org/apache/samza/container/TestSamzaContainer.scala
@@ -50,7 +50,7 @@ class TestSamzaContainer extends AssertionsForJUnit with MockitoSugar {
   @Mock
   private var config: Config = null
   @Mock
-  private var taskInstance: TaskInstance = null;
+  private var taskInstance: TaskInstance = null
   @Mock
   private var runLoop: Runnable = null
   @Mock
@@ -129,7 +129,6 @@ class TestSamzaContainer extends AssertionsForJUnit with MockitoSugar {
 
   @Test
   def testShutDownSequenceForStandbyContainers() {
-
     class ShutDownSignal(container: SamzaContainer) extends Runnable {
       def run(): Unit = {
         Thread.sleep(2000)


### PR DESCRIPTION
**Issues:** Currently, standby containers don't spin up run loop and do an infinite wait after starting the container storage manager. In the event of a shutdown request from LocalApplicationRunner, these containers don't respond since the shutdown request is coordinator through runloop and it leaves us with the only option of forcefully killing it.

**Changes:** Add a countdown latch to signal the main thread to make standby containers to respond to shutdown instead of infinite sleeping

**Improvement:** StandbyContainer invoke a clean shutdown within a few seconds rather than waiting to be killed for 30 secs

**Tests:** Manually tested the shutdown sequence

**API Changes:** None
**Upgrade instructions:** None
**Usage instructions:** None



