### PR TITLE
SAMZA-2469: Fix out of order events throwing Duplicate key registration with same timer exception

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/scheduler/EpochTimeScheduler.java
+++ b/samza-core/src/main/java/org/apache/samza/scheduler/EpochTimeScheduler.java
@@ -86,10 +86,10 @@ public class EpochTimeScheduler {
   }
 
   public <K> void deleteTimer(K key) {
-    final List<ScheduledFuture> scheduledFuture = scheduledFutures.remove(key);
-    for (ScheduledFuture s: scheduledFuture) {
-      if (s != null) {
-        s.cancel(false);
+    final List<ScheduledFuture> scheduledFutureList = scheduledFutures.remove(key);
+    for (ScheduledFuture scheduledFuture: scheduledFutureList) {
+      if (scheduledFuture != null) {
+        scheduledFuture.cancel(false);
       }
     }
   }

--- a/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
@@ -225,7 +225,7 @@ class TaskInstance(
 
     exceptionHandler.maybeHandle {
       epochTimeScheduler.removeReadyTimers().entrySet().foreach { entry =>
-        entry.getValue.asInstanceOf[ScheduledCallback[Any]].onCallback(entry.getKey.getKey, collector, coordinator)
+        entry.getValue.asScala.toList.foreach(_.asInstanceOf[ScheduledCallback[Any]].onCallback(entry.getKey.getKey, collector, coordinator))
       }
     }
   }

--- a/samza-core/src/test/java/org/apache/samza/scheduler/TestEpochTimeScheduler.java
+++ b/samza-core/src/test/java/org/apache/samza/scheduler/TestEpochTimeScheduler.java
@@ -52,7 +52,9 @@ public class TestEpochTimeScheduler {
 
   private void fireTimers(EpochTimeScheduler factory) {
     factory.removeReadyTimers().entrySet().forEach(entry -> {
-        entry.getValue().onCallback(entry.getKey().getKey(), mock(MessageCollector.class), mock(TaskCoordinator.class));
+        entry.getValue().forEach(scheduledCallback -> {
+            scheduledCallback.onCallback(entry.getKey().getKey(), mock(MessageCollector.class), mock(TaskCoordinator.class));
+          });
       });
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SAMZA-2469

When using sessions with certain gap and with triggers in beam code with samza runner, for out of order events we are seeing duplicate key registration for the same timer exception.

The exception is thrown in two cases that happen within context of one trigger:
  1.  Two events for same key have same timestamp 
  2.  Events come out of order



