### PR TITLE
SAMZA-2472: Use runtime-framework-resources-pathing.jar to specify part of the runtime classpath and leverage it in IsolatingClassLoaderFactory

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/classloader/DependencyIsolationUtils.java
+++ b/samza-core/src/main/java/org/apache/samza/classloader/DependencyIsolationUtils.java
@@ -45,4 +45,6 @@ public class DependencyIsolationUtils {
    * classloader.
    */
   public static final String FRAMEWORK_API_CLASS_LIST_FILE_NAME = "samza-framework-api-classes.txt";
+
+  public static final String RUNTIME_FRAMEWORK_RESOURCES_PATHING_JAR_NAME = "runtime-framework-resources-pathing.jar";
 }

--- a/samza-shell/src/main/bash/run-class.sh
+++ b/samza-shell/src/main/bash/run-class.sh
@@ -53,13 +53,13 @@ export APPLICATION_LIB_DIR=$APPLICATION_LIB_DIR
 echo APPLICATION_LIB_DIR=$APPLICATION_LIB_DIR
 echo BASE_LIB_DIR=$BASE_LIB_DIR
 
-CLASSPATH=""
+BASE_LIB_CLASSPATH=""
 # all the jars need to be appended on newlines to ensure line argument length of 72 bytes is not violated
 for file in $BASE_LIB_DIR/*.[jw]ar;
 do
-  CLASSPATH=$CLASSPATH" $file \n"
+  BASE_LIB_CLASSPATH=$BASE_LIB_CLASSPATH" $file \n"
 done
-echo generated from BASE_LIB_DIR CLASSPATH=$CLASSPATH
+echo generated from BASE_LIB_DIR BASE_LIB_CLASSPATH=$BASE_LIB_CLASSPATH
 
 # In some cases (AWS) $JAVA_HOME/bin doesn't contain jar.
 if [ -z "$JAVA_HOME" ] || [ ! -e "$JAVA_HOME/bin/jar" ]; then
@@ -68,10 +68,23 @@ else
   JAR="$JAVA_HOME/bin/jar"
 fi
 
+# Create a pathing JAR for the JARs in the BASE_LIB_DIR
 # Newlines and spaces are intended to ensure proper parsing of manifest in pathing jar
-printf "Class-Path: \n $CLASSPATH \n" > manifest.txt
-# Creates a new archive and adds custom manifest information to pathing.jar
-eval "$JAR -cvmf manifest.txt pathing.jar"
+printf "Class-Path: \n $BASE_LIB_CLASSPATH \n" > base-lib-manifest.txt
+# Creates a new archive and adds custom manifest information to base-lib-pathing.jar
+eval "$JAR -cvmf base-lib-manifest.txt base-lib-pathing.jar"
+
+# Create a pathing JAR for the runtime framework resources. It is useful to separate this from the base-lib-pathing.jar
+# because the split deployment framework may only need the resources from this runtime pathing JAR.
+if ! [[ $HADOOP_CONF_DIR =~ .*/$ ]]; then
+  # manifest requires a directory to have a trailing slash
+  HADOOP_CONF_DIR="$HADOOP_CONF_DIR/"
+fi
+# HADOOP_CONF_DIR should be supplied to classpath explicitly for Yarn to parse configs
+RUNTIME_FRAMEWORK_RESOURCES_CLASSPATH="$HADOOP_CONF_DIR \n"
+# TODO add JARs from ADDITIONAL_CLASSPATH_DIR to runtime-framework-resources-pathing.jar as well
+printf "Class-Path: \n $RUNTIME_FRAMEWORK_RESOURCES_CLASSPATH \n" > runtime-framework-resources-manifest.txt
+eval "$JAR -cvmf runtime-framework-resources-manifest.txt runtime-framework-resources-pathing.jar"
 
 if [ -z "$JAVA_HOME" ]; then
   JAVA="java"
@@ -150,12 +163,11 @@ fi
 # Check if 64 bit is set. If not - try and set it if it's supported
 [[ $JAVA_OPTS != *-d64* ]] && check_and_enable_64_bit_mode
 
-# HADOOP_CONF_DIR should be supplied to classpath explicitly for Yarn to parse configs
-echo $JAVA $JAVA_OPTS -cp $HADOOP_CONF_DIR:pathing.jar "$@"
+echo $JAVA $JAVA_OPTS -cp base-lib-pathing.jar:runtime-framework-resources-pathing.jar "$@"
 
 ## If localized resource lib directory is defined, then include it in the classpath.
 if [[ -z "${ADDITIONAL_CLASSPATH_DIR}" ]]; then
-   exec $JAVA $JAVA_OPTS -cp $HADOOP_CONF_DIR:pathing.jar "$@"
+  exec $JAVA $JAVA_OPTS -cp base-lib-pathing.jar:runtime-framework-resources-pathing.jar "$@"
 else
-  exec $JAVA $JAVA_OPTS -cp $HADOOP_CONF_DIR:pathing.jar:$ADDITIONAL_CLASSPATH_DIR "$@"
+  exec $JAVA $JAVA_OPTS -cp base-lib-pathing.jar:runtime-framework-resources-pathing.jar:$ADDITIONAL_CLASSPATH_DIR "$@"
 fi


### PR DESCRIPTION
**Symptom**: When running in YARN and job coordinator dependency isolation is enabled, the framework infrastructure is unable to access the correct YARN configurations. This means that when it tries to interact with YARN, it is not using the correct configurations, and that results in issues. The observed issue was that the YARN client from the Samza side did not follow the RM HA config correctly, and so there was an issue in connecting to the RM.
**Cause**: The YARN client reads configurations from certain resource files on the classpath. In `run-class.sh`, the `HADOOP_CONF_DIR` is directly used and added to the classpath. In job coordinator dependency isolation mode, the classpath in `run-class.sh` is not used for the framework infrastructure, since `IsolatingClassLoaderFactory` builds its own classpath. Therefore, the `HADOOP_CONF_DIR` is not on the framework infrastructure classpath.
**Changes**: Refactored `run-class.sh` to create an additional "runtime framework resources" pathing JAR (`runtime-framework-resources-pathing.jar`). The `HADOOP_CONF_DIR` is included in this new pathing JAR. `runtime-framework-resources-pathing.jar` is added to the regular classpath in order to keep backwards compatibility, and it is also detected and used in `IsolatingClassLoaderFactory` when isolation is enabled.
**Tests**: Deployed a job with isolation enabled in `samza-hello-samza` and verified using a log that `yarn.resourcemanager.scheduler.class` is properly set (the default of CapacityScheduler is overridden to FifoScheduler in the `samza-hello-samza` set-up). I also deployed the job without the fix and verified that the `yarn.resourcemanager.scheduler.class` property was not properly overridden.
**API changes**: None
**Upgrade/usage instructions**: None

An additional benefit of this is that we can add other runtime resources in the future to this pathing JAR (e.g. `ADDITIONAL_CLASSPATH_DIR`) and not need to worry about argument limits.