### PR TITLE
SAMZA-2470: Add Samza job lineage interfaces

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/lineage/LineageFactory.java
+++ b/samza-api/src/main/java/org/apache/samza/lineage/LineageFactory.java
@@ -1,0 +1,22 @@
+package org.apache.samza.lineage;
+
+import org.apache.samza.config.Config;
+
+
+/**
+ * The LineageFactory class helps parse and generate job lineage information from Samza job config.
+ */
+public interface LineageFactory<T> {
+
+  /**
+   * Parse and generate job lineage data model from Samza job config, the data model includes job's inputs, outputs and
+   * other metadata information.
+   * The config should include full inputs and outputs information, those information are usually populated by job
+   * planner and config rewriters.
+   * It is the user's responsibility to make sure config contains all required information before call this function.
+   *
+   * @param config Samza job config
+   * @return Samza job lineage data model
+   */
+  T getLineage(Config config);
+}

--- a/samza-api/src/main/java/org/apache/samza/lineage/LineageFactory.java
+++ b/samza-api/src/main/java/org/apache/samza/lineage/LineageFactory.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.samza.lineage;
 
 import org.apache.samza.config.Config;

--- a/samza-api/src/main/java/org/apache/samza/lineage/LineageReporter.java
+++ b/samza-api/src/main/java/org/apache/samza/lineage/LineageReporter.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.samza.lineage;
 
 /**

--- a/samza-api/src/main/java/org/apache/samza/lineage/LineageReporter.java
+++ b/samza-api/src/main/java/org/apache/samza/lineage/LineageReporter.java
@@ -1,0 +1,25 @@
+package org.apache.samza.lineage;
+
+/**
+ * The LineageReporter interface defines how Samza writes job lineage information to outside systems, such as messaging
+ * systems like Kafka, or file systems.
+ * Implementations are responsible for accepting lineage data and writing them to their backend systems.
+ */
+public interface LineageReporter<T> {
+
+  /**
+   * Start the reporter.
+   */
+  void start();
+
+  /**
+   * Stop the reporter.
+   */
+  void stop();
+
+  /**
+   * Send the specified Samza job lineage data to outside system.
+   * @param lineage Samza job lineage data model
+   */
+  void report(T lineage);
+}

--- a/samza-api/src/main/java/org/apache/samza/lineage/LineageReporterFactory.java
+++ b/samza-api/src/main/java/org/apache/samza/lineage/LineageReporterFactory.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.samza.lineage;
 
 import org.apache.samza.config.Config;

--- a/samza-api/src/main/java/org/apache/samza/lineage/LineageReporterFactory.java
+++ b/samza-api/src/main/java/org/apache/samza/lineage/LineageReporterFactory.java
@@ -1,0 +1,17 @@
+package org.apache.samza.lineage;
+
+import org.apache.samza.config.Config;
+
+
+/**
+ * The LineageReporterFactory class help to build lineage reporter {@link org.apache.samza.lineage.LineageReporter}
+ */
+public interface LineageReporterFactory<T> {
+
+  /**
+   * Build lineage reporter instance with required information from config, e.g. system stream, serde, etc.
+   * @param config Samza job config
+   * @return lineage reporter instance
+   */
+  LineageReporter<T> getLineageReporter(Config config);
+}

--- a/samza-core/src/main/java/org/apache/samza/config/LineageConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/LineageConfig.java
@@ -1,0 +1,30 @@
+package org.apache.samza.config;
+
+import java.util.Optional;
+
+
+/**
+ * Config helper methods related to Samza job lineage
+ */
+public class LineageConfig extends MapConfig {
+
+  public static final String LINEAGE_FACTORY = "lineage.factory";
+  public static final String LINEAGE_REPORTER_FACTORY = "lineage.reporter.factory";
+  public static final String LINEAGE_REPORTER_STREAM = "lineage.reporter.stream";
+
+  public LineageConfig(Config config) {
+    super(config);
+  }
+
+  public Optional<String> getLineageFactoryClassName() {
+    return Optional.ofNullable(get(LINEAGE_FACTORY));
+  }
+
+  public Optional<String> getLineageReporterFactoryClassName() {
+    return Optional.ofNullable(get(LINEAGE_REPORTER_FACTORY));
+  }
+
+  public Optional<String> getLineageReporterStreamName() {
+    return Optional.ofNullable(get(LINEAGE_REPORTER_STREAM));
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/config/LineageConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/LineageConfig.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.samza.config;
 
 import java.util.Optional;

--- a/samza-core/src/main/java/org/apache/samza/lineage/LineageEmitter.java
+++ b/samza-core/src/main/java/org/apache/samza/lineage/LineageEmitter.java
@@ -1,0 +1,51 @@
+package org.apache.samza.lineage;
+
+import java.util.Optional;
+import org.apache.samza.config.ApplicationConfig;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.LineageConfig;
+import org.apache.samza.util.ReflectionUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * The LineageEmitter class helps generate and emit job lineage data to specified sink stream.
+ */
+public final class LineageEmitter {
+
+  public static final Logger LOGGER = LoggerFactory.getLogger(LineageEmitter.class);
+
+  /**
+   * Emit the job lineage information to specified sink stream.
+   * @param config Samza job config
+   */
+  public static void emit(Config config) {
+    LineageConfig lineageConfig = new LineageConfig(config);
+    Optional<String> lineageFactoryClassName = lineageConfig.getLineageFactoryClassName();
+    Optional<String> lineageReporterFactoryClassName = lineageConfig.getLineageReporterFactoryClassName();
+
+    if (!lineageFactoryClassName.isPresent() && !lineageReporterFactoryClassName.isPresent()) {
+      return;
+    }
+    if (!lineageFactoryClassName.isPresent()) {
+      LOGGER.warn("Missing the config: {}, skip to enable lineage feature", LineageConfig.LINEAGE_FACTORY);
+      return;
+    }
+    if (!lineageReporterFactoryClassName.isPresent()) {
+      LOGGER.warn("Missing the config: {}, skip to enable lineage feature", LineageConfig.LINEAGE_REPORTER_FACTORY);
+      return;
+    }
+
+    LineageFactory lineageFactory = ReflectionUtil.getObj(lineageFactoryClassName.get(), LineageFactory.class);
+    LineageReporterFactory lineageReporterFactory =
+        ReflectionUtil.getObj(lineageReporterFactoryClassName.get(), LineageReporterFactory.class);
+    LineageReporter lineageReporter = lineageReporterFactory.getLineageReporter(config);
+
+    lineageReporter.start();
+    lineageReporter.report(lineageFactory.getLineage(config));
+    lineageReporter.stop();
+
+    LOGGER.info("Emitted lineage data to sink stream for job: {}", new ApplicationConfig(config).getAppName());
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/lineage/LineageEmitter.java
+++ b/samza-core/src/main/java/org/apache/samza/lineage/LineageEmitter.java
@@ -3,6 +3,7 @@ package org.apache.samza.lineage;
 import java.util.Optional;
 import org.apache.samza.config.ApplicationConfig;
 import org.apache.samza.config.Config;
+import org.apache.samza.config.ConfigException;
 import org.apache.samza.config.LineageConfig;
 import org.apache.samza.util.ReflectionUtil;
 import org.slf4j.Logger;
@@ -10,7 +11,7 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * The LineageEmitter class helps generate and emit job lineage data to specified sink stream.
+ * The LineageEmitter class helps generate and emit job lineage data to configured sink stream.
  */
 public final class LineageEmitter {
 
@@ -29,12 +30,10 @@ public final class LineageEmitter {
       return;
     }
     if (!lineageFactoryClassName.isPresent()) {
-      LOGGER.warn("Missing the config: {}, skip to enable lineage feature", LineageConfig.LINEAGE_FACTORY);
-      return;
+      throw new ConfigException(String.format("Missing the lineage config: %s", LineageConfig.LINEAGE_FACTORY));
     }
     if (!lineageReporterFactoryClassName.isPresent()) {
-      LOGGER.warn("Missing the config: {}, skip to enable lineage feature", LineageConfig.LINEAGE_REPORTER_FACTORY);
-      return;
+      throw new ConfigException(String.format("Missing the lineage config: %s", LineageConfig.LINEAGE_REPORTER_FACTORY));
     }
 
     LineageFactory lineageFactory = ReflectionUtil.getObj(lineageFactoryClassName.get(), LineageFactory.class);

--- a/samza-core/src/main/java/org/apache/samza/lineage/LineageEmitter.java
+++ b/samza-core/src/main/java/org/apache/samza/lineage/LineageEmitter.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.samza.lineage;
 
 import java.util.Optional;

--- a/samza-core/src/test/java/org/apache/samza/config/TestLineageConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestLineageConfig.java
@@ -1,0 +1,40 @@
+package org.apache.samza.config;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class TestLineageConfig {
+
+  @Test
+  public void testGetLineageFactoryClassName() {
+    String expectedLineageFactory = "org.apache.samza.MockLineageFactory";
+    MapConfig config =
+        new MapConfig(ImmutableMap.of(LineageConfig.LINEAGE_FACTORY, expectedLineageFactory));
+    LineageConfig lineageConfig = new LineageConfig(config);
+    assertTrue(lineageConfig.getLineageFactoryClassName().isPresent());
+    assertEquals(expectedLineageFactory, lineageConfig.getLineageFactoryClassName().get());
+  }
+
+  @Test
+  public void testGetLineageReporterFactoryClassName() {
+    String expectedLineageReporterFactory = "org.apache.samza.MockLineageReporterFactory";
+    MapConfig config =
+        new MapConfig(ImmutableMap.of(LineageConfig.LINEAGE_REPORTER_FACTORY, expectedLineageReporterFactory));
+    LineageConfig lineageConfig = new LineageConfig(config);
+    assertTrue(lineageConfig.getLineageReporterFactoryClassName().isPresent());
+    assertEquals(expectedLineageReporterFactory, lineageConfig.getLineageReporterFactoryClassName().get());
+  }
+
+  @Test
+  public void testGetLineageReporterStreamName() {
+    String expectedLineageReporterStream = "kafka.foo";
+    MapConfig config =
+        new MapConfig(ImmutableMap.of(LineageConfig.LINEAGE_REPORTER_STREAM, expectedLineageReporterStream));
+    LineageConfig lineageConfig = new LineageConfig(config);
+    assertTrue(lineageConfig.getLineageReporterStreamName().isPresent());
+    assertEquals(expectedLineageReporterStream, lineageConfig.getLineageReporterStreamName().get());
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/config/TestLineageConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestLineageConfig.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.samza.config;
 
 import com.google.common.collect.ImmutableMap;

--- a/samza-core/src/test/java/org/apache/samza/lineage/TestLineageEmitter.java
+++ b/samza-core/src/test/java/org/apache/samza/lineage/TestLineageEmitter.java
@@ -1,0 +1,41 @@
+package org.apache.samza.lineage;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.samza.config.ConfigException;
+import org.apache.samza.config.LineageConfig;
+import org.apache.samza.config.MapConfig;
+import org.junit.Test;
+
+
+public class TestLineageEmitter {
+
+  @Test(expected = ConfigException.class)
+  public void testEmitWhenNotConfigLineageFactory() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(LineageConfig.LINEAGE_REPORTER_FACTORY, "org.apache.samza.lineage.mock.MockLineageReporterFactory");
+    LineageEmitter.emit(new MapConfig(configs));
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testEmitWhenNotConfigLineageReporterFactory() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(LineageConfig.LINEAGE_FACTORY, "org.apache.samza.lineage.mock.MockLineageFactory");
+    LineageEmitter.emit(new MapConfig(configs));
+  }
+
+  @Test
+  public void testEmitWhenConfigNeitherOfLineageFactoryAndLineageRepoterFactory() {
+    Map<String, String> configs = new HashMap<>();
+    LineageEmitter.emit(new MapConfig(configs));
+  }
+
+  @Test
+  public void testEmit() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put(LineageConfig.LINEAGE_FACTORY, "org.apache.samza.lineage.mock.MockLineageFactory");
+    configs.put(LineageConfig.LINEAGE_REPORTER_FACTORY, "org.apache.samza.lineage.mock.MockLineageReporterFactory");
+    LineageEmitter.emit(new MapConfig(configs));
+  }
+
+}

--- a/samza-core/src/test/java/org/apache/samza/lineage/TestLineageEmitter.java
+++ b/samza-core/src/test/java/org/apache/samza/lineage/TestLineageEmitter.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.samza.lineage;
 
 import java.util.HashMap;

--- a/samza-core/src/test/java/org/apache/samza/lineage/mock/MockLineage.java
+++ b/samza-core/src/test/java/org/apache/samza/lineage/mock/MockLineage.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.samza.lineage.mock;
 
 public class MockLineage {

--- a/samza-core/src/test/java/org/apache/samza/lineage/mock/MockLineage.java
+++ b/samza-core/src/test/java/org/apache/samza/lineage/mock/MockLineage.java
@@ -1,0 +1,4 @@
+package org.apache.samza.lineage.mock;
+
+public class MockLineage {
+}

--- a/samza-core/src/test/java/org/apache/samza/lineage/mock/MockLineageFactory.java
+++ b/samza-core/src/test/java/org/apache/samza/lineage/mock/MockLineageFactory.java
@@ -1,0 +1,13 @@
+package org.apache.samza.lineage.mock;
+
+import org.apache.samza.config.Config;
+import org.apache.samza.lineage.LineageFactory;
+import org.apache.samza.lineage.mock.MockLineage;
+
+
+public class MockLineageFactory implements LineageFactory<MockLineage> {
+  @Override
+  public MockLineage getLineage(Config config) {
+    return new MockLineage();
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/lineage/mock/MockLineageFactory.java
+++ b/samza-core/src/test/java/org/apache/samza/lineage/mock/MockLineageFactory.java
@@ -1,8 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.samza.lineage.mock;
 
 import org.apache.samza.config.Config;
 import org.apache.samza.lineage.LineageFactory;
-import org.apache.samza.lineage.mock.MockLineage;
 
 
 public class MockLineageFactory implements LineageFactory<MockLineage> {

--- a/samza-core/src/test/java/org/apache/samza/lineage/mock/MockLineageReporter.java
+++ b/samza-core/src/test/java/org/apache/samza/lineage/mock/MockLineageReporter.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.samza.lineage.mock;
 
 import org.apache.samza.lineage.LineageReporter;

--- a/samza-core/src/test/java/org/apache/samza/lineage/mock/MockLineageReporter.java
+++ b/samza-core/src/test/java/org/apache/samza/lineage/mock/MockLineageReporter.java
@@ -1,0 +1,21 @@
+package org.apache.samza.lineage.mock;
+
+import org.apache.samza.lineage.LineageReporter;
+
+
+public class MockLineageReporter implements LineageReporter<MockLineage> {
+  @Override
+  public void start() {
+
+  }
+
+  @Override
+  public void stop() {
+
+  }
+
+  @Override
+  public void report(MockLineage lineage) {
+
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/lineage/mock/MockLineageReporterFactory.java
+++ b/samza-core/src/test/java/org/apache/samza/lineage/mock/MockLineageReporterFactory.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.samza.lineage.mock;
 
 import org.apache.samza.config.Config;

--- a/samza-core/src/test/java/org/apache/samza/lineage/mock/MockLineageReporterFactory.java
+++ b/samza-core/src/test/java/org/apache/samza/lineage/mock/MockLineageReporterFactory.java
@@ -1,0 +1,13 @@
+package org.apache.samza.lineage.mock;
+
+import org.apache.samza.config.Config;
+import org.apache.samza.lineage.LineageReporter;
+import org.apache.samza.lineage.LineageReporterFactory;
+
+
+public class MockLineageReporterFactory implements LineageReporterFactory<MockLineage> {
+  @Override
+  public LineageReporter<MockLineage> getLineageReporter(Config config) {
+    return new MockLineageReporter();
+  }
+}


### PR DESCRIPTION
### Background

Add interfaces to provide the ability to allow the users to define their own job lineage data model and store in the specified outside systems.

### Changes
- [x] Add LineageFactory class to allow users to build their own job lineage data model
- [x] Add LineageReporter and LineageReporterFactory classes to allow users to have their own way to store lineage information in outside systems.
- [x] Emit job lineage data in `JobModelManager.readJobModel()` function, because this function provides the ability to dynamically load Kafka topics matched specified regex pattern. 

### Test
- [x] All unit tests and integration tests are passed

### Upgrade Instructions
None

### Usage Instructions

The users need to config `lineage.factory` and `lineage.reporter.factory` to enable the lineage function.

