### PR TITLE
SAMZA-2476:Fix flaky tests in TestAzureBlobOutputStream

### DIFF
--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobOutputStream.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobOutputStream.java
@@ -173,7 +173,7 @@ public class AzureBlobOutputStream extends OutputStream {
       LOG.info("For blob: {} committing blockList size:{}", blobAsyncClient.getBlobUrl().toString(), blockList.size());
       metrics.updateAzureCommitMetrics();
       Map<String, String> blobMetadata = Collections.singletonMap(BLOB_RAW_SIZE_BYTES_METADATA, Long.toString(totalUploadedBlockSize));
-      blobAsyncClient.commitBlockListWithResponse(blockList, null, blobMetadata, null, null).block();
+      commitBlob(blockList, blobMetadata);
     } catch (Exception e) {
       String msg = String.format("Close blob %s failed with exception. Total pending sends %d",
           blobAsyncClient.getBlobUrl().toString(), pendingUpload.size());
@@ -225,6 +225,11 @@ public class AzureBlobOutputStream extends OutputStream {
     this.maxBlockFlushThresholdSize = maxBlockFlushThresholdSize;
     this.metrics = metrics;
     this.compression = compression;
+  }
+
+  @VisibleForTesting
+  void commitBlob(ArrayList<String> blockList, Map<String, String> blobMetadata) {
+    blobAsyncClient.commitBlockListWithResponse(blockList, null, blobMetadata, null, null).block();
   }
 
   /**

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobOutputStream.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobOutputStream.java
@@ -227,6 +227,7 @@ public class AzureBlobOutputStream extends OutputStream {
     this.compression = compression;
   }
 
+  // SAMZA-2476 stubbing BlockBlobAsyncClient.commitBlockListWithResponse was causing flaky tests.
   @VisibleForTesting
   void commitBlob(ArrayList<String> blockList, Map<String, String> blobMetadata) {
     blobAsyncClient.commitBlockListWithResponse(blockList, null, blobMetadata, null, null).block();


### PR DESCRIPTION
Symptom:
    Travis builds occasionally fail with org.mockito.exceptions.misusing.UnfinishedStubbingException for org.apache.samza.system.azureblob.avro.TestAzureBlobOutputStream.testCloseMultipleBlocks. 

Cause: 
Seems to be due to using PowerMockito.doAnswer for mocking com.azure.storage.blob.specialized.BlockBlobAsyncClient.commitBlockListWithResponse

Changes:
pull call to commitBlockListWithResponse into a package private method of AzureBlobOutputStream and verify that method.

Tests: 
Rerun of TestAzureBlobOutputStream in original code cause 240 failures in 10K runs
Rerun of TestAzureBlobOutputStream with this fix causes 0 failures in 10K runs