### PR TITLE
SAMZA-2477: JobModel isn't updated with latest "task.inputs" if enabled regex topic rewriter

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/coordinator/JobModelManager.scala
+++ b/samza-core/src/main/scala/org/apache/samza/coordinator/JobModelManager.scala
@@ -268,23 +268,10 @@ object JobModelManager extends Logging {
     */
   private def getInputStreamPartitions(config: Config, streamMetadataCache: StreamMetadataCache): Set[SystemStreamPartition] = {
 
-    def invokeRegexTopicRewriter(config: Config): Config = {
-      val jobConfig = new JobConfig(config)
-      JavaOptionals.toRichOptional(jobConfig.getConfigRewriters).toOption match {
-        case Some(rewriters) => rewriters.split(",").
-          filter(rewriterName => JavaOptionals.toRichOptional(jobConfig.getConfigRewriterClass(rewriterName)).toOption
-            .getOrElse(throw new SamzaException("Unable to find class config for config rewriter %s." format rewriterName))
-            .equalsIgnoreCase(classOf[RegExTopicGenerator].getName)).
-          foldLeft(config)(ConfigUtil.applyRewriter(_, _))
-        case _ => config
-      }
-    }
-
-    val configAfterRegexTopicRewrite = invokeRegexTopicRewriter(config)
-    val taskConfigAfterRegexTopicRewrite = new TaskConfig(configAfterRegexTopicRewrite)
+    val taskConfig = new TaskConfig(config)
     // Expand regex input, if a regex-rewriter is defined in config
     val inputSystemStreams =
-      JavaConverters.asScalaSetConverter(taskConfigAfterRegexTopicRewrite.getInputStreams).asScala.toSet
+      JavaConverters.asScalaSetConverter(taskConfig.getInputStreams).asScala.toSet
 
     // Get the set of partitions for each SystemStream from the stream metadata
     streamMetadataCache
@@ -339,6 +326,23 @@ object JobModelManager extends Logging {
   }
 
   /**
+   * Refresh Kafka topic list used as input streams if enabled {@link org.apache.samza.config.RegExTopicGenerator}
+   * @param config Samza job config
+   * @return refreshed config
+   */
+  private def refreshConfigByRegexTopicRewriter(config: Config): Config = {
+    val jobConfig = new JobConfig(config)
+    JavaOptionals.toRichOptional(jobConfig.getConfigRewriters).toOption match {
+      case Some(rewriters) => rewriters.split(",").
+        filter(rewriterName => JavaOptionals.toRichOptional(jobConfig.getConfigRewriterClass(rewriterName)).toOption
+          .getOrElse(throw new SamzaException("Unable to find class config for config rewriter %s." format rewriterName))
+          .equalsIgnoreCase(classOf[RegExTopicGenerator].getName)).
+        foldLeft(config)(ConfigUtil.applyRewriter(_, _))
+      case _ => config
+    }
+  }
+
+  /**
     * Does the following:
     * 1. Fetches metadata of the input streams defined in configuration through {@param streamMetadataCache}.
     * 2. Applies the {@see SystemStreamPartitionGrouper}, {@see TaskNameGrouper} defined in the configuration
@@ -353,20 +357,23 @@ object JobModelManager extends Logging {
                    changeLogPartitionMapping: util.Map[TaskName, Integer],
                    streamMetadataCache: StreamMetadataCache,
                    grouperMetadata: GrouperMetadata): JobModel = {
-    val taskConfig = new TaskConfig(config)
-    // Do grouping to fetch TaskName to SSP mapping
-    val allSystemStreamPartitions = getMatchedInputStreamPartitions(config, streamMetadataCache)
+    // refresh config if enabled regex topic rewriter
+    val newConfig = refreshConfigByRegexTopicRewriter(config)
 
-    // processor list is required by some of the groupers. So, let's pass them as part of the config.
-    // Copy the config and add the processor list to the config copy.
-    val configMap = new util.HashMap[String, String](config)
+    val taskConfig = new TaskConfig(newConfig)
+    // Do grouping to fetch TaskName to SSP mapping
+    val allSystemStreamPartitions = getMatchedInputStreamPartitions(newConfig, streamMetadataCache)
+
+    // processor list is required by some of the groupers. So, let's pass them as part of the newConfig.
+    // Copy the newConfig and add the processor list to the newConfig copy.
+    val configMap = new util.HashMap[String, String](newConfig)
     configMap.put(JobConfig.PROCESSOR_LIST, String.join(",", grouperMetadata.getProcessorLocality.keySet()))
     val grouper = getSystemStreamPartitionGrouper(new MapConfig(configMap))
 
-    val jobConfig = new JobConfig(config)
+    val jobConfig = new JobConfig(newConfig)
 
     val groups: util.Map[TaskName, util.Set[SystemStreamPartition]] = if (jobConfig.isSSPGrouperProxyEnabled) {
-      val sspGrouperProxy: SSPGrouperProxy =  new SSPGrouperProxy(config, grouper)
+      val sspGrouperProxy: SSPGrouperProxy =  new SSPGrouperProxy(newConfig, grouper)
       sspGrouperProxy.group(allSystemStreamPartitions, grouperMetadata)
     } else {
       warn("SSPGrouperProxy is disabled (%s = false). Stateful jobs may produce erroneous results if this is not enabled." format JobConfig.SSP_INPUT_EXPANSION_ENABLED)
@@ -402,9 +409,9 @@ object JobModelManager extends Logging {
       ReflectionUtil.getObj(taskConfig.getTaskNameGrouperFactory, classOf[TaskNameGrouperFactory])
     val standbyTasksEnabled = jobConfig.getStandbyTasksEnabled
     val standbyTaskReplicationFactor = jobConfig.getStandbyTaskReplicationFactor
-    val taskNameGrouperProxy = new TaskNameGrouperProxy(containerGrouperFactory.build(config), standbyTasksEnabled, standbyTaskReplicationFactor)
+    val taskNameGrouperProxy = new TaskNameGrouperProxy(containerGrouperFactory.build(newConfig), standbyTasksEnabled, standbyTaskReplicationFactor)
     var containerModels: util.Set[ContainerModel] = null
-    val isHostAffinityEnabled = new ClusterManagerConfig(config).getHostAffinityEnabled
+    val isHostAffinityEnabled = new ClusterManagerConfig(newConfig).getHostAffinityEnabled
     if(isHostAffinityEnabled) {
       containerModels = taskNameGrouperProxy.group(taskModels, grouperMetadata)
     } else {
@@ -412,7 +419,7 @@ object JobModelManager extends Logging {
     }
 
     val containerMap = containerModels.asScala.map(containerModel => containerModel.getId -> containerModel).toMap
-    new JobModel(config, containerMap.asJava)
+    new JobModel(newConfig, containerMap.asJava)
   }
 }
 


### PR DESCRIPTION
### Symptom
JobModelManager provides readJobModel() function to let `JobCoordinator`, `ClusterBasedJboCoordinator` and etc know the latest JobModel information.

If the users enable regex topic rewriter in their config, `readJobModel()` function will dynamically load the latest Kafka topic list and generate new TaskModel with new topic partition mappings.

However, it doesn't update the `task.inputs` in JobModel's Config. So other services depend on `task.inputs` information will still see stale data.

### Cause
`JobModelManager.readJobModel()` uses the original config instead of the updated config to build `JobModel`.

### Changes
Use updated config to build final `JobModel`.

### Tests
- [x] All unit tests and integration tests are passed

### API Changes
None

### Upgrade Instructions
None

### Usage Instructions
None
