### PR TITLE
Revert "Upgrade Gradle to 5.2.1 (#1203)"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ group=org.apache.samza
 version=1.4.0
 scalaSuffix=2.11
 
-gradleVersion=5.2.1
+gradleVersion=4.8
 
 org.gradle.jvmargs="-XX:MaxPermSize=512m"
 


### PR DESCRIPTION
**Symptom**: `gradle -b bootstrap.gradle` will download the wrapper for Gradle 5.2.1, but there are some other parts of Samza which are not compatible with Gradle 5.2.1. Trying to use the `gradlew` wrapper will fail.
**Cause**: https://github.com/apache/samza/pull/1203 did not fully migrate Samza to Gradle 5.2.1 (see https://github.com/apache/samza/pull/1295 for a more complete migration)
**Changes**: Reverted https://github.com/apache/samza/pull/1203, so that Samza is on Gradle 4.8.
**Tests**: Ran `./gradlew clean sourceRelease`, unpacked it, ran `gradle -b bootstrap.gradle` from within the unpacked source, and then verified that `gradle/wrapper/gradle-wrapper.properties` referred to Gradle 4.8.
**API changes**: None
**Usage changes**: None

This will only be applied to the 1.4.0 branch. We should apply https://github.com/apache/samza/pull/1295 for future releases, so Samza should work with Gradle 5+.