### PR TITLE
Fix new flaky test

### DIFF
--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobOutputStream.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobOutputStream.java
@@ -230,13 +230,13 @@ public class AzureBlobOutputStream extends OutputStream {
     blobAsyncClient.commitBlockListWithResponse(blockList, null, blobMetadata, null, null).block();
   }
 
-  // TODO-NEW JIRA stubbing BlockBlobAsyncClient.stageBlock was causing flaky tests.
+  // SAMZA-2476 stubbing BlockBlobAsyncClient.stageBlock was causing flaky tests.
   @VisibleForTesting
   void stageBlock(String blockIdEncoded, ByteBuffer outputStream, int blockSize) {
     blobAsyncClient.stageBlock(blockIdEncoded, Flux.just(outputStream), blockSize).block();
   }
 
-  // TODO-NEW JIRA blockList cleared makes it hard to test close
+  // blockList cleared makes it hard to test close
   @VisibleForTesting
   void clearAndMarkClosed() {
     blockList.clear();

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobOutputStream.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobOutputStream.java
@@ -179,10 +179,7 @@ public class AzureBlobOutputStream extends OutputStream {
           blobAsyncClient.getBlobUrl().toString(), pendingUpload.size());
       throw new AzureException(msg, e);
     } finally {
-      blockList.clear();
-      pendingUpload.stream().forEach(future -> future.cancel(true));
-      pendingUpload.clear();
-      isClosed = true;
+      clearAndMarkClosed();
     }
   }
 
@@ -233,6 +230,21 @@ public class AzureBlobOutputStream extends OutputStream {
     blobAsyncClient.commitBlockListWithResponse(blockList, null, blobMetadata, null, null).block();
   }
 
+  // TODO-NEW JIRA stubbing BlockBlobAsyncClient.stageBlock was causing flaky tests.
+  @VisibleForTesting
+  void stageBlock(String blockIdEncoded, ByteBuffer outputStream, int blockSize) {
+    blobAsyncClient.stageBlock(blockIdEncoded, Flux.just(outputStream), blockSize).block();
+  }
+
+  // TODO-NEW JIRA blockList cleared makes it hard to test close
+  @VisibleForTesting
+  void clearAndMarkClosed() {
+    blockList.clear();
+    pendingUpload.stream().forEach(future -> future.cancel(true));
+    pendingUpload.clear();
+    isClosed = true;
+  }
+
   /**
    * This api will async upload the outputstream into block using stageBlocks,
    * reint outputstream
@@ -275,7 +287,7 @@ public class AzureBlobOutputStream extends OutputStream {
             LOG.info("{} Upload block start for blob: {} for block size:{}.", blobAsyncClient.getBlobUrl().toString(), blockId, blockSize);
             metrics.updateAzureUploadMetrics();
             // StageBlock generates exception on Failure.
-            blobAsyncClient.stageBlock(blockIdEncoded, Flux.just(outputStream), blockSize).block();
+            stageBlock(blockIdEncoded, outputStream, blockSize);
             break;
           } catch (Exception e) {
             attemptCount += 1;


### PR DESCRIPTION
Symptom:
Travis builds occasionally fail with AssertionError for org.apache.samza.system.azureblob.avro.TestAzureBlobOutputStream.testFlushFailed.
Example: https://travis-ci.org/apache/samza/builds/658407113?utm_source=github_status&utm_medium=notification

Cause:
Seems to be due to using stubbing com.azure.storage.blob.specialized.BlockBlobAsyncClient.stageBlock throw an exception to make flush fail for AzureBlobOutputStream

Changes:
pull call to all of Blob client into package private methods of AzureBlobOutputStream and verify that method.

Tests:
Rerun of TestAzureBlobOutputStream in original code cause 230 failures in 60K runs
Rerun of TestAzureBlobOutputStream with this fix causes 0 failures in 60K runs