### PR TITLE
[Test fix]: Increasing heap allocation for test executor for samza-core tests after Gradle 5 upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,6 +206,13 @@ project(":samza-core_$scalaSuffix") {
     configFile = new File(rootDir, "checkstyle/checkstyle.xml")
     toolVersion = "$checkstyleVersion"
   }
+
+  test {
+    // TODO SAMZA-2481: why do some tests need so much memory?
+    minHeapSize = "3g"
+    maxHeapSize = "3g"
+    jvmArgs = ["-XX:+UseConcMarkSweepGC", "-server"]
+  }
 }
 
 project(":samza-azure_$scalaSuffix") {


### PR DESCRIPTION
Symptom: `./gradlew build` does not consistently succeed. Observed failures include tests reported as failing and/or running out of memory.
Cause: Recently, we upgraded to Gradle 5. Gradle 5 lowered some memory allocation defaults (https://docs.gradle.org/5.0/userguide/upgrading_version_4.html#rel5.0:default_memory_settings), and it looks like the lower memory isn't sufficient for some tests.
Changes: Increase the memory for running tests for samza-core, which seems to be the impacted module.
Tests: Ran `./gradlew build`