### PR TITLE
[Test fix] removing minHeapSize and increasing maxHeapSize to 4g

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -209,7 +209,6 @@ project(":samza-core_$scalaSuffix") {
 
   test {
     // TODO SAMZA-2481: why do some tests need so much memory?
-    minHeapSize = "3g"
     maxHeapSize = "3g"
     jvmArgs = ["-XX:+UseConcMarkSweepGC", "-server"]
   }

--- a/build.gradle
+++ b/build.gradle
@@ -209,7 +209,7 @@ project(":samza-core_$scalaSuffix") {
 
   test {
     // TODO SAMZA-2481: why do some tests need so much memory?
-    maxHeapSize = "3g"
+    maxHeapSize = "4g"
     jvmArgs = ["-XX:+UseConcMarkSweepGC", "-server"]
   }
 }


### PR DESCRIPTION
Symptom: CI build fails transiently with an error that looks like:
```
Execution failed for task ':samza-core_2.11:test'.
> Process 'Gradle Test Executor 6' finished with non-zero exit value 1
  This problem might be caused by incorrect test process configuration.
  Please refer to the test execution section in the User Manual at https://docs.gradle.org/5.2.1/userguide/java_testing.html#sec:test_execution
```
Cause: Recently, we upgraded to Gradle 5. Gradle 5 lowered some memory allocation defaults (https://docs.gradle.org/5.0/userguide/upgrading_version_4.html#rel5.0:default_memory_settings), and it looks like the lower memory isn't sufficient for some tests. We tried using 3g of memory in https://github.com/apache/samza/pull/1307, but it still looks like that is not enough.
Changes: Increase the memory for running tests for samza-core, which seems to be the impacted module. The `minHeapSize` configuration was also removed in the hope that it allows memory usage to be automatically managed better.
Tests: CI build passed (https://travis-ci.org/apache/samza/builds/660834705?utm_source=github_status&utm_medium=notification)