### PR TITLE
[minor] fix version property in releases pages

### DIFF
--- a/docs/_releases/1.0.0.md
+++ b/docs/_releases/1.0.0.md
@@ -1,5 +1,5 @@
 ---
-version: '1.0'
+version: '1.0.0'
 order: 100
 layout: page
 menu_title: '1.0'

--- a/docs/_releases/1.1.0.md
+++ b/docs/_releases/1.1.0.md
@@ -1,5 +1,5 @@
 ---
-version: '1.1'
+version: '1.1.0'
 order: 110
 layout: page
 menu_title: '1.1'

--- a/docs/_releases/1.2.0.md
+++ b/docs/_releases/1.2.0.md
@@ -1,5 +1,5 @@
 ---
-version: '1.2'
+version: '1.2.0'
 order: 120
 layout: page
 menu_title: '1.2'

--- a/docs/_releases/1.3.0.md
+++ b/docs/_releases/1.3.0.md
@@ -1,5 +1,5 @@
 ---
-version: '1.3'
+version: '1.3.0'
 order: 130
 layout: page
 menu_title: '1.3'

--- a/docs/_releases/1.4.0.md
+++ b/docs/_releases/1.4.0.md
@@ -1,5 +1,5 @@
 ---
-version: '1.4'
+version: '1.4.0'
 order: 140
 layout: page
 menu_title: '1.4'


### PR DESCRIPTION
Symptom: The horizontal RELEASES menu on the website pages do not show any options other than LATEST.
Cause: If the versioned page link can't be found, then the page will not show that version in the menu. The version property which is used to generate the versioned page links only has two parts (e.g. "1.0", "1.1"), but the pages are organized with 3-part versions (e.g. "1.0.0"), so the page links aren't found.
Changes: Use the 3-part version for the version property.
Tests: Deployed the website locally and saw the "1.0.0" entry in the horizontal menu. Note that the entries for "1.1.0"/"1.2.0"/"1.3.0" don't show up because no one published those versioned pages.
API/Usage changes: N/A