### PR TITLE
SAMZA-2490: AsyncFlatmapOperatorImpl#handleClose should call transformFn.close()

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/operators/impl/AsyncFlatmapOperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/AsyncFlatmapOperatorImpl.java
@@ -49,6 +49,7 @@ public class AsyncFlatmapOperatorImpl<M, RM> extends OperatorImpl<M, RM> {
 
   @Override
   protected void handleClose() {
+    this.transformFn.close();
   }
 
   @Override

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestAsyncFlatmapOperatorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestAsyncFlatmapOperatorImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.operators.impl;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.samza.operators.data.TestMessageEnvelope;
+import org.apache.samza.operators.data.TestOutputMessageEnvelope;
+import org.apache.samza.operators.functions.AsyncFlatMapFunction;
+import org.apache.samza.operators.spec.AsyncFlatMapOperatorSpec;
+import org.apache.samza.task.MessageCollector;
+import org.apache.samza.task.TaskCoordinator;
+import org.junit.Test;
+
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+public class TestAsyncFlatmapOperatorImpl {
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testAsyncFlatMapOperator() {
+    AsyncFlatMapOperatorSpec<TestMessageEnvelope, TestOutputMessageEnvelope> mockOp = mock(AsyncFlatMapOperatorSpec.class);
+    AsyncFlatMapFunction<TestMessageEnvelope, TestOutputMessageEnvelope> txfmFn = mock(AsyncFlatMapFunction.class);
+    when(mockOp.getTransformFn()).thenReturn(txfmFn);
+    AsyncFlatmapOperatorImpl<TestMessageEnvelope, TestOutputMessageEnvelope> opImpl =
+        new AsyncFlatmapOperatorImpl<>(mockOp);
+    TestMessageEnvelope inMsg = mock(TestMessageEnvelope.class);
+    Collection<TestOutputMessageEnvelope> mockOutputs = mock(Collection.class);
+    when(txfmFn.apply(inMsg)).thenReturn(CompletableFuture.supplyAsync(() -> mockOutputs));
+    MessageCollector mockCollector = mock(MessageCollector.class);
+    TaskCoordinator mockCoordinator = mock(TaskCoordinator.class);
+    Collection<TestOutputMessageEnvelope> results = opImpl
+        .handleMessage(inMsg, mockCollector, mockCoordinator);
+    verify(txfmFn, times(1)).apply(inMsg);
+    assertEquals(results, mockOutputs);
+  }
+
+  @Test
+  public void testAsyncFlatMapOperatorClose() {
+    AsyncFlatMapOperatorSpec<TestMessageEnvelope, TestOutputMessageEnvelope> mockOp = mock(AsyncFlatMapOperatorSpec.class);
+    AsyncFlatMapFunction<TestMessageEnvelope, TestOutputMessageEnvelope> txfmFn = mock(AsyncFlatMapFunction.class);
+    when(mockOp.getTransformFn()).thenReturn(txfmFn);
+
+    AsyncFlatmapOperatorImpl<TestMessageEnvelope, TestOutputMessageEnvelope> opImpl =
+        new AsyncFlatmapOperatorImpl<>(mockOp);
+
+    // ensure that close is not called yet
+    verify(txfmFn, times(0)).close();
+    opImpl.handleClose();
+    // ensure that close is called once inside handleClose()
+    verify(txfmFn, times(1)).close();
+  }
+}


### PR DESCRIPTION
Symptom: In beam samza runner, Op#close is not invoked during shutdown, which is not expected.

Cause: AsyncFlatmapOperatorImpl#handleClose() doesn't call transformFn.close(). Therefore the underlying transform function will never be closed.

Changes: Just invoke transformFn.close inside handleClose method should be enough.

Tests: Tested with a samza beam job. After the change, Op#close is able to function properly.