### PR TITLE
SAMZA-2481: Improve memory usage in samza-core unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,6 +181,8 @@ project(":samza-core_$scalaSuffix") {
     compile project(':samza-api')
     compile("com.101tec:zkclient:$zkClientVersion") {
       exclude module: 'junit:junit'
+      // exclude the slf4j implementation since it should be up to the application to choose the logging implementation
+      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     }
     compile "com.google.guava:guava:$guavaVersion"
     compile "net.sf.jopt-simple:jopt-simple:$joptSimpleVersion"
@@ -201,6 +203,8 @@ project(":samza-core_$scalaSuffix") {
     testCompile "org.powermock:powermock-module-junit4:$powerMockVersion"
     testCompile "org.scalatest:scalatest_$scalaSuffix:$scalaTestVersion"
     testCompile "org.hamcrest:hamcrest-all:$hamcrestVersion"
+    // zookeeper debug logging causes some memory issues in tests; avoid those issues by using log4j2, which defaults to error log level
+    testRuntime "org.apache.logging.log4j:log4j-slf4j-impl:$log4j2Version"
   }
 
   checkstyle {
@@ -209,8 +213,8 @@ project(":samza-core_$scalaSuffix") {
   }
 
   test {
-    // TODO SAMZA-2481: why do some tests need so much memory?
-    maxHeapSize = "4g"
+    // some unit tests use embedded zookeeper, so adding some extra memory for those
+    maxHeapSize = "1560m"
     jvmArgs = ["-XX:+UseConcMarkSweepGC", "-server"]
   }
 }

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -40,7 +40,7 @@
   junitVersion = "4.12"
   kafkaVersion = "2.0.1"
   log4jVersion = "1.2.17"
-  log4j2Version = "2.11.0"
+  log4j2Version = "2.12.0"
   metricsVersion = "2.2.0"
   mockitoVersion = "1.10.19"
   powerMockVersion = "1.6.6"


### PR DESCRIPTION
Symptom: `samza-core` requires `maxHeapSize` set to 4g when running unit tests. Otherwise, the test suite may hang or fail (especially in the CI pipeline).
Cause: `TestZkMetadataStore` has some tests around large values being written to zookeeper. That test uses an embedded zookeeper which does a lot of debug logging. The current logging impl for samza-core unit tests is the log4j v1 impl, which somehow defaults to DEBUG logging.
Changes: Use log4j2 logging impl for unit tests, since it seems to default to ERROR logging. We don't need the unit tests of the committed code to report DEBUG logging.
Tests: `./gradlew :samza-core:test` no longer hangs with a lower memory allocation. Before this change, it would hang.
API changes: log4j2 version increased from `2.11.0` to `2.12.0`, so any apps depending on `samza-log4j2` will transitively pull in the new version.
Upgrade/usage instructions: N/A

This also seems to reduce the time to execute `./gradlew :samza-core:test` by about 30-40 seconds (also seemingly due to the reduced debug logging).