### PR TITLE
SAMZA-2491: log uncaught exceptions in JC

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterBasedJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterBasedJobCoordinator.java
@@ -464,12 +464,17 @@ public class ClusterBasedJobCoordinator {
   public static void main(String[] args) {
     boolean dependencyIsolationEnabled = Boolean.parseBoolean(
         System.getenv(ShellCommandConfig.ENV_CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED));
+    Thread.setDefaultUncaughtExceptionHandler((thread, exception) -> {
+        LOG.error("Uncaught exception in ClusterBasedJobCoordinator::main. Exiting job coordinator", exception);
+        System.exit(1);
+      });
     if (!dependencyIsolationEnabled) {
       // no isolation enabled, so can just execute runClusterBasedJobCoordinator directly
       runClusterBasedJobCoordinator(args);
     } else {
       runWithClassLoader(new IsolatingClassLoaderFactory().buildClassLoader(), args);
     }
+    System.exit(0);
   }
 
   /**


### PR DESCRIPTION
**Symptom**: A job deployment timed out waiting for application attempt to transition from New to Running.

**Cause**: ClusterBasedJobCoordinator threw an exception during startup due to a misconfiguration, but did not kill the AM process (likely due to non-daemon threads).

 Tests: manual tests

API Changes: None
Upgrade Instructions: None
Usage Instructions: None