### PR TITLE
SAMZA-2492: Add new deserialize function for JobGraphJson and change the scope of related classes as public

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/execution/JobGraphJsonGenerator.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/JobGraphJsonGenerator.java
@@ -39,7 +39,6 @@ import org.apache.samza.operators.spec.OutputStreamImpl;
 import org.apache.samza.operators.spec.PartitionByOperatorSpec;
 import org.apache.samza.operators.spec.SendToTableOperatorSpec;
 import org.apache.samza.operators.spec.StreamTableJoinOperatorSpec;
-import org.apache.samza.system.StreamSpec;
 import org.apache.samza.table.descriptors.BaseTableDescriptor;
 import org.apache.samza.table.descriptors.TableDescriptor;
 import org.codehaus.jackson.annotate.JsonProperty;
@@ -51,7 +50,7 @@ import org.codehaus.jackson.map.ObjectMapper;
 public class JobGraphJsonGenerator {
 
   /**
-   * The json representation for stream specification {@link StreamSpec}
+   * The json representation for stream specification {@link org.apache.samza.system.StreamSpec}
    */
   public static final class StreamSpecJson {
     @JsonProperty("id")

--- a/samza-core/src/main/java/org/apache/samza/execution/JobGraphJsonGenerator.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/JobGraphJsonGenerator.java
@@ -39,6 +39,7 @@ import org.apache.samza.operators.spec.OutputStreamImpl;
 import org.apache.samza.operators.spec.PartitionByOperatorSpec;
 import org.apache.samza.operators.spec.SendToTableOperatorSpec;
 import org.apache.samza.operators.spec.StreamTableJoinOperatorSpec;
+import org.apache.samza.system.StreamSpec;
 import org.apache.samza.table.descriptors.BaseTableDescriptor;
 import org.apache.samza.table.descriptors.TableDescriptor;
 import org.codehaus.jackson.annotate.JsonProperty;
@@ -49,6 +50,9 @@ import org.codehaus.jackson.map.ObjectMapper;
  */
 public class JobGraphJsonGenerator {
 
+  /**
+   * The json representation for stream specification {@link StreamSpec}
+   */
   public static final class StreamSpecJson {
     @JsonProperty("id")
     String id;
@@ -76,6 +80,9 @@ public class JobGraphJsonGenerator {
     }
   }
 
+  /**
+   * The json representation for table specification.
+   */
   public static final class TableSpecJson {
     @JsonProperty("id")
     String id;
@@ -91,6 +98,9 @@ public class JobGraphJsonGenerator {
     }
   }
 
+  /**
+   * The json representation for the edge {@link StreamEdge} connecting with source jobs and target jobs
+   */
   public static final class StreamEdgeJson {
     @JsonProperty("streamSpec")
     StreamSpecJson streamSpec;
@@ -112,6 +122,9 @@ public class JobGraphJsonGenerator {
     }
   }
 
+  /**
+   * The json representation for the operator graph between input streams and output streams.
+   */
   public static final class OperatorGraphJson {
     @JsonProperty("inputStreams")
     List<StreamJson> inputStreams;
@@ -133,6 +146,9 @@ public class JobGraphJsonGenerator {
     }
   }
 
+  /**
+   * The json representation for stream.
+   */
   public static final class StreamJson {
     @JsonProperty("streamId")
     String streamId;
@@ -148,6 +164,9 @@ public class JobGraphJsonGenerator {
     }
   }
 
+  /**
+   * The json representation for the job node {@link JobNode}
+   */
   public static final class JobNodeJson {
     @JsonProperty("jobName")
     String jobName;
@@ -169,6 +188,9 @@ public class JobGraphJsonGenerator {
     }
   }
 
+  /**
+   * The json representation for the job graph {@link JobGraph}
+   */
   public static final class JobGraphJson {
     @JsonProperty("jobs")
     List<JobNodeJson> jobs;

--- a/samza-core/src/main/java/org/apache/samza/execution/JobGraphJsonGenerator.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/JobGraphJsonGenerator.java
@@ -21,6 +21,7 @@ package org.apache.samza.execution;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -46,9 +47,9 @@ import org.codehaus.jackson.map.ObjectMapper;
 /**
  * This class generates the JSON representation of the {@link JobGraph}.
  */
-/* package private */ class JobGraphJsonGenerator {
+public class JobGraphJsonGenerator {
 
-  static final class StreamSpecJson {
+  public static final class StreamSpecJson {
     @JsonProperty("id")
     String id;
     @JsonProperty("systemName")
@@ -57,50 +58,118 @@ import org.codehaus.jackson.map.ObjectMapper;
     String physicalName;
     @JsonProperty("partitionCount")
     int partitionCount;
+
+    public String getId() {
+      return id;
+    }
+
+    public String getSystemName() {
+      return systemName;
+    }
+
+    public String getPhysicalName() {
+      return physicalName;
+    }
+
+    public int getPartitionCount() {
+      return partitionCount;
+    }
   }
 
-  static final class TableSpecJson {
+  public static final class TableSpecJson {
     @JsonProperty("id")
     String id;
     @JsonProperty("providerFactory")
     String providerFactory;
+
+    public String getId() {
+      return id;
+    }
+
+    public String getProviderFactory() {
+      return providerFactory;
+    }
   }
 
-  static final class StreamEdgeJson {
+  public static final class StreamEdgeJson {
     @JsonProperty("streamSpec")
     StreamSpecJson streamSpec;
     @JsonProperty("sourceJobs")
     List<String> sourceJobs;
     @JsonProperty("targetJobs")
     List<String> targetJobs;
+
+    public StreamSpecJson getStreamSpec() {
+      return streamSpec;
+    }
+
+    public List<String> getSourceJobs() {
+      return sourceJobs;
+    }
+
+    public List<String> getTargetJobs() {
+      return targetJobs;
+    }
   }
 
-  static final class OperatorGraphJson {
+  public static final class OperatorGraphJson {
     @JsonProperty("inputStreams")
     List<StreamJson> inputStreams;
     @JsonProperty("outputStreams")
     List<StreamJson> outputStreams;
     @JsonProperty("operators")
     Map<String, Map<String, Object>> operators = new HashMap<>();
+
+    public List<StreamJson> getInputStreams() {
+      return inputStreams;
+    }
+
+    public List<StreamJson> getOutputStreams() {
+      return outputStreams;
+    }
+
+    public Map<String, Map<String, Object>> getOperators() {
+      return operators;
+    }
   }
 
-  static final class StreamJson {
+  public static final class StreamJson {
     @JsonProperty("streamId")
     String streamId;
     @JsonProperty("nextOperatorIds")
     Set<String>  nextOperatorIds = new HashSet<>();
+
+    public String getStreamId() {
+      return streamId;
+    }
+
+    public Set<String> getNextOperatorIds() {
+      return nextOperatorIds;
+    }
   }
 
-  static final class JobNodeJson {
+  public static final class JobNodeJson {
     @JsonProperty("jobName")
     String jobName;
     @JsonProperty("jobId")
     String jobId;
     @JsonProperty("operatorGraph")
     OperatorGraphJson operatorGraph;
+
+    public String getJobName() {
+      return jobName;
+    }
+
+    public String getJobId() {
+      return jobId;
+    }
+
+    public OperatorGraphJson getOperatorGraph() {
+      return operatorGraph;
+    }
   }
 
-  static final class JobGraphJson {
+  public static final class JobGraphJson {
     @JsonProperty("jobs")
     List<JobNodeJson> jobs;
     @JsonProperty("sourceStreams")
@@ -115,6 +184,45 @@ import org.codehaus.jackson.map.ObjectMapper;
     String applicationName;
     @JsonProperty("applicationId")
     String applicationId;
+
+    public List<JobNodeJson> getJobs() {
+      return jobs;
+    }
+
+    public Map<String, StreamEdgeJson> getSourceStreams() {
+      return sourceStreams;
+    }
+
+    public Map<String, StreamEdgeJson> getSinkStreams() {
+      return sinkStreams;
+    }
+
+    public Map<String, StreamEdgeJson> getIntermediateStreams() {
+      return intermediateStreams;
+    }
+
+    public Map<String, TableSpecJson> getTables() {
+      return tables;
+    }
+
+    public String getApplicationName() {
+      return applicationName;
+    }
+
+    public String getApplicationId() {
+      return applicationId;
+    }
+  }
+
+  /**
+   * Deserialize the given plain json string to JobGraphJson object
+   * @param plainJson plain json string
+   * @return JobGraphJson object
+   * @throws IOException
+   */
+  public JobGraphJson toJobGraphJson(String plainJson) throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    return mapper.readValue(plainJson.getBytes(), JobGraphJson.class);
   }
 
   /**

--- a/samza-core/src/test/java/org/apache/samza/execution/TestJobGraphJsonGenerator.java
+++ b/samza-core/src/test/java/org/apache/samza/execution/TestJobGraphJsonGenerator.java
@@ -368,6 +368,31 @@ public class TestJobGraphJsonGenerator {
     assertEquals(0, jsonObject.jobs.size());
   }
 
+  @Test
+  public void testToJobGraphJson() throws Exception {
+    JobGraphJsonGenerator jsonGenerator = new JobGraphJsonGenerator();
+
+    JobGraph mockJobGraph = mock(JobGraph.class);
+    ApplicationConfig mockAppConfig = mock(ApplicationConfig.class);
+    when(mockAppConfig.getAppName()).thenReturn("jobName");
+    when(mockAppConfig.getAppId()).thenReturn("jobId");
+    when(mockJobGraph.getApplicationConfig()).thenReturn(mockAppConfig);
+
+    Set<StreamEdge> inEdges = new HashSet<>(mockJobNode.getInEdges().values());
+    Set<StreamEdge> outEdges = new HashSet<>(mockJobNode.getOutEdges().values());
+    when(mockJobGraph.getInputStreams()).thenReturn(new HashSet<>(inEdges));
+    when(mockJobGraph.getOutputStreams()).thenReturn(new HashSet<>(outEdges));
+
+    String plainJson = jsonGenerator.toJson(mockJobGraph);
+
+    JobGraphJsonGenerator.JobGraphJson jobGraphJson = jsonGenerator.toJobGraphJson(plainJson);
+    assertNotNull(jobGraphJson);
+    assertEquals(jobGraphJson.getApplicationName(), "jobName");
+    assertEquals(jobGraphJson.getApplicationId(), "jobId");
+    assertEquals(jobGraphJson.getSourceStreams().size(), inEdges.size());
+    assertEquals(jobGraphJson.getSinkStreams().size(), outEdges.size());
+  }
+
   public class PageViewEvent {
     String getCountry() {
       return "";


### PR DESCRIPTION
#### Issues
In Samza core, `JobGraphJsonGenerator` provides the function to serialize `JobGraphJson` as plan JSON and later the config `samza.internal.execution.plan` will use this string as value.

However, it doesn't provide the deserialize function to help generate `JobGraphJson` from plan JSON string. This function is useful when you need to parse information from the config `samza.internal.execution.plan`.

#### Changes
In this PR, there are two changes made for supporting `JobGraphJson` deserialization:

1. Add new deserialize function `toJobGraphJson()`
1. Change the package scope of related classes as `public`

#### Tests
- [x] All unit tests and integration tests are passed

#### API Changes
* Change package scope as `public` for the following classes:
   * `JobGraphJsonGenerator` class
   * All inner classes inside `JobGraphJsonGenerator`.
* Provide new deserialize function `toJobGraphJson `.

#### Upgrade Instructions
None

#### Usage Instructions
None