### PR TITLE
SAMZA-2493: Keep checkpoint manager consumer open for repeated polling

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
@@ -105,7 +105,7 @@ public class TaskConfig extends MapConfig {
   private static final String BROADCAST_STREAM_PATTERN = "^[\\d]+$";
   private static final String BROADCAST_STREAM_RANGE_PATTERN = "^\\[[\\d]+\\-[\\d]+\\]$";
   public static final String CHECKPOINT_MANAGER_FACTORY = "task.checkpoint.factory";
-  public static final String CHECKPOINT_MANAGER_CONSUMER_STOP_AFTER_FIRST_READ = "task.checkpoint.consumer.stop.after.first.read";
+  public static final String INTERNAL_CHECKPOINT_MANAGER_CONSUMER_STOP_AFTER_FIRST_READ = "samza.internal.task.checkpoint.consumer.stop.after.first.read";
 
   public static final String TRANSACTIONAL_STATE_CHECKPOINT_ENABLED = "task.transactional.state.checkpoint.enabled";
   private static final boolean DEFAULT_TRANSACTIONAL_STATE_CHECKPOINT_ENABLED = true;
@@ -215,11 +215,11 @@ public class TaskConfig extends MapConfig {
   }
 
   /**
-   * Internal config to indicate whether the SystemConsumer underlying a CheckpointManager should be left open after
+   * Internal config to indicate whether the SystemConsumer underlying a CheckpointManager should be stopped after
    * initial read of checkpoints.
    */
   public boolean getCheckpointManagerConsumerStopAfterFirstRead() {
-    return getBoolean(CHECKPOINT_MANAGER_CONSUMER_STOP_AFTER_FIRST_READ, true);
+    return getBoolean(INTERNAL_CHECKPOINT_MANAGER_CONSUMER_STOP_AFTER_FIRST_READ, true);
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
@@ -105,6 +105,7 @@ public class TaskConfig extends MapConfig {
   private static final String BROADCAST_STREAM_PATTERN = "^[\\d]+$";
   private static final String BROADCAST_STREAM_RANGE_PATTERN = "^\\[[\\d]+\\-[\\d]+\\]$";
   public static final String CHECKPOINT_MANAGER_FACTORY = "task.checkpoint.factory";
+  public static final String CHECKPOINT_MANAGER_CONSUMER_STOP_AFTER_FIRST_READ = "task.checkpoint.consumer.stop.after.first.read";
 
   public static final String TRANSACTIONAL_STATE_CHECKPOINT_ENABLED = "task.transactional.state.checkpoint.enabled";
   private static final boolean DEFAULT_TRANSACTIONAL_STATE_CHECKPOINT_ENABLED = true;
@@ -211,6 +212,14 @@ public class TaskConfig extends MapConfig {
         .filter(StringUtils::isNotBlank)
         .map(checkpointManagerFactoryName -> ReflectionUtil.getObj(checkpointManagerFactoryName,
             CheckpointManagerFactory.class).getCheckpointManager(this, metricsRegistry));
+  }
+
+  /**
+   * Internal config to indicate whether the SystemConsumer underlying a CheckpointManager should be left open after
+   * initial read of checkpoints.
+   */
+  public boolean getCheckpointManagerConsumerStopAfterFirstRead() {
+    return getBoolean(CHECKPOINT_MANAGER_CONSUMER_STOP_AFTER_FIRST_READ, true);
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
@@ -105,6 +105,7 @@ public class TaskConfig extends MapConfig {
   private static final String BROADCAST_STREAM_PATTERN = "^[\\d]+$";
   private static final String BROADCAST_STREAM_RANGE_PATTERN = "^\\[[\\d]+\\-[\\d]+\\]$";
   public static final String CHECKPOINT_MANAGER_FACTORY = "task.checkpoint.factory";
+  // standby containers use this flag to indicate that checkpoints will be polled continually, rather than only once at startup like in an active container
   public static final String INTERNAL_CHECKPOINT_MANAGER_CONSUMER_STOP_AFTER_FIRST_READ = "samza.internal.task.checkpoint.consumer.stop.after.first.read";
 
   public static final String TRANSACTIONAL_STATE_CHECKPOINT_ENABLED = "task.transactional.state.checkpoint.enabled";

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -133,12 +133,13 @@ object SamzaContainer extends Logging {
     localityManager: LocalityManager = null,
     startpointManager: StartpointManager = null,
     diagnosticsManager: Option[DiagnosticsManager] = Option.empty) = {
-    val config = jobContext.getConfig
-    if (StandbyTaskUtil.isStandbyContainer(containerId)) {
+    val config = if (StandbyTaskUtil.isStandbyContainer(containerId)) {
       // standby containers will need to continually poll checkpoint messages
-      val newConfig = new util.HashMap[String, String]()
-      newConfig.putAll(config)
+      val newConfig = new util.HashMap[String, String](jobContext.getConfig)
       newConfig.put(TaskConfig.INTERNAL_CHECKPOINT_MANAGER_CONSUMER_STOP_AFTER_FIRST_READ, java.lang.Boolean.FALSE.toString)
+      new MapConfig(newConfig)
+    } else {
+      jobContext.getConfig
     }
     val jobConfig = new JobConfig(config)
     val systemConfig = new SystemConfig(config)

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -138,7 +138,7 @@ object SamzaContainer extends Logging {
       // standby containers will need to continually poll checkpoint messages
       val newConfig = new util.HashMap[String, String]()
       newConfig.putAll(config)
-      newConfig.put(TaskConfig.CHECKPOINT_MANAGER_CONSUMER_STOP_AFTER_FIRST_READ, java.lang.Boolean.FALSE.toString)
+      newConfig.put(TaskConfig.INTERNAL_CHECKPOINT_MANAGER_CONSUMER_STOP_AFTER_FIRST_READ, java.lang.Boolean.FALSE.toString)
     }
     val jobConfig = new JobConfig(config)
     val systemConfig = new SystemConfig(config)

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -50,6 +50,7 @@ import org.apache.samza.task._
 import org.apache.samza.util.ScalaJavaUtil.JavaOptionals
 import org.apache.samza.util.{Util, _}
 import org.apache.samza.SamzaException
+import org.apache.samza.clustermanager.StandbyTaskUtil
 
 import scala.collection.JavaConverters._
 
@@ -133,6 +134,12 @@ object SamzaContainer extends Logging {
     startpointManager: StartpointManager = null,
     diagnosticsManager: Option[DiagnosticsManager] = Option.empty) = {
     val config = jobContext.getConfig
+    if (StandbyTaskUtil.isStandbyContainer(containerId)) {
+      // standby containers will need to continually poll checkpoint messages
+      val newConfig = new util.HashMap[String, String]()
+      newConfig.putAll(config)
+      newConfig.put(TaskConfig.CHECKPOINT_MANAGER_CONSUMER_STOP_AFTER_FIRST_READ, java.lang.Boolean.FALSE.toString)
+    }
     val jobConfig = new JobConfig(config)
     val systemConfig = new SystemConfig(config)
     val containerModel = jobModel.getContainers.get(containerId)

--- a/samza-kafka/src/main/scala/org/apache/samza/checkpoint/kafka/KafkaCheckpointManager.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/checkpoint/kafka/KafkaCheckpointManager.scala
@@ -76,6 +76,9 @@ class KafkaCheckpointManager(checkpointSpec: KafkaStreamSpec,
   val producerRef: AtomicReference[SystemProducer] = new AtomicReference[SystemProducer](getSystemProducer())
   val producerCreationLock: Object = new Object
 
+  // if true, systemConsumer can be safely closed after the first call to readLastCheckpoint.
+  // if false, it must be left open until KafkaCheckpointManager::stop is called.
+  // for active containers, this will be set to true, while false for standby containers.
   val stopConsumerAfterFirstRead: Boolean = new TaskConfig(config).getCheckpointManagerConsumerStopAfterFirstRead
 
   /**

--- a/samza-kafka/src/test/scala/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.scala
+++ b/samza-kafka/src/test/scala/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.scala
@@ -38,6 +38,7 @@ import org.apache.samza.{Partition, SamzaException}
 import org.junit.Assert._
 import org.junit._
 import org.mockito.Mockito
+import org.mockito.Matchers
 
 class TestKafkaCheckpointManager extends KafkaServerTestHarness {
 
@@ -197,9 +198,14 @@ class TestKafkaCheckpointManager extends KafkaServerTestHarness {
     kafkaCheckpointManager.start()
     kafkaCheckpointManager.readLastCheckpoint(taskName)
 
+    Mockito.verify(mockKafkaSystemConsumer, Mockito.times(1)).register(Matchers.any(), Matchers.any())
+    Mockito.verify(mockKafkaSystemConsumer, Mockito.times(1)).start()
+    Mockito.verify(mockKafkaSystemConsumer, Mockito.times(1)).poll(Matchers.any(), Matchers.any())
     Mockito.verify(mockKafkaSystemConsumer, Mockito.times(1)).stop()
 
     kafkaCheckpointManager.stop()
+
+    Mockito.verifyNoMoreInteractions(mockKafkaSystemConsumer)
   }
 
   @Test


### PR DESCRIPTION
**Feature:** Allow control of whether the underlying consumer backing a checkpoint manager will be left open (until stopped), or closed after the initial read of checkpoints
 
**Changes:** Introduces an internal config, injected by SamzaContainer, that is injected dependent on whether the container is standby or not, to control whether the container's checkpoint manager should have it's underlying consumer stopped after initial read or not.
 
 **Tests:** Added a unit test each for the config set to true / false

**API Changes:** None
**Upgrade Instructions:** None 
**Usage Instructions:** None