### PR TITLE
Remove TestSuiteAnnotation from TestBatchProcessor

### DIFF
--- a/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchProcessor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchProcessor.java
@@ -28,18 +28,10 @@ import java.util.function.Supplier;
 import org.apache.samza.table.ReadWriteTable;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
 import static java.lang.Thread.*;
 import static org.mockito.Mockito.*;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-    TestBatchProcessor.TestCreate.class,
-    TestBatchProcessor.TestUpdatesAndLookup.class,
-    TestBatchProcessor.TestBatchTriggered.class
-  })
 public class TestBatchProcessor {
   private static final int SLOW_OPERATION_TIME_MS = 500;
   private static final Supplier<Void> SLOW_UPDATE_SUPPLIER = () -> {


### PR DESCRIPTION
Note - This seemed trivial enough to not create a ticket, but let me know if there should be a ticket
Symptoms: Currently in Linkedin internal, when building Samza with the latest open source changes on Mac, TestBatchProcessor tests keep failing.
Causes: Currently this TestSuiteAnnotation used in TestBatchProcessor is causing the tests to be ran twice when building using gradle (documented in gradle/gradle#5484). This seems to be causing issues internally where because we cap the memory used for testing to 1.5gb (in a recent commit) currently, leads to this test failing. The current theory is that Mac seems to be using more memory as building on Linux passes.
Fix: By removing the TestSuiteAnnotation, these tests are only ran once and leads to the build passing. As it seems like running these tests twice are redundant, we can remove the annotation.
Tests: Try to build samza internally with the latest open source changes (git merge master HEAD) and this test will fail on Mac.
I've verified that removing this annotation still leads to these tests being ran but only once and the TestSuite doesn't seem to be used anywhere in Samza.
Ran ./gradlew clean build test to verify building still works.