### PR TITLE
SAMZA-2495: InMemorySystemAdmin offsets off by one when END_OF_STREAM present

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/system/inmemory/InMemoryManager.java
+++ b/samza-core/src/main/java/org/apache/samza/system/inmemory/InMemoryManager.java
@@ -182,8 +182,17 @@ class InMemoryManager {
             .collect(Collectors.toMap(entry -> entry.getKey().getPartition(), entry -> {
                 List<IncomingMessageEnvelope> messages = entry.getValue();
                 String oldestOffset = messages.isEmpty() ? null : "0";
-                String newestOffset = messages.isEmpty() ? null : String.valueOf(messages.size() - 1);
                 String upcomingOffset = String.valueOf(messages.size());
+                String newestOffset;
+                if (messages.isEmpty()) {
+                  newestOffset = null;
+                } else if (messages.get(messages.size() - 1).isEndOfStream()) {
+                  newestOffset = messages.size() > 1 ? String.valueOf(messages.size() - 2) : null;
+                  upcomingOffset = String.valueOf(messages.size() - 1);
+                } else {
+                  newestOffset = String.valueOf(messages.size() - 1);
+                  upcomingOffset = String.valueOf(messages.size());
+                }
 
                 return new SystemStreamMetadata.SystemStreamPartitionMetadata(oldestOffset, newestOffset, upcomingOffset);
 


### PR DESCRIPTION
I found this when refactoring side input restore to use RunLoop (https://github.com/apache/samza/pull/1330); this patch is necessary to prevent integration tests from failing after that refactor as marking side inputs as caught relies on newest offset.

**Symptom:** When an end of stream message is present in an in memory SSP, the new and upcoming offset are reported as 1 higher than they should be.

Example:
| E1, offset: 0 | E2, offset: 1 | ... | E4, offset: 3 | EndOfStream |

In the above case, InMemoryManager will report a newestOffset of 4 and an upcomingOffset of 5; they should be 3 and 4 respectively.
 
**Cause:** InMemoryManager treats end of stream as any other envelope with a numeric offset even though it is not.
 
**Changes:** Check in `InMemoryManager.constructSystemStreamMetadata` whether the last message in the stream is an EndOfStream, and adjust offsets accordingly.
 
**Tests:** Added a unit test to verify that offsets are adjusted by 1 in the case of EndOfStream.