### PR TITLE
SAMZA-2496: TestContainerHeartbeatMonitor does not properly stop the ContainerHeartbeatMonitor

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/container/ContainerHeartbeatMonitor.java
+++ b/samza-core/src/main/java/org/apache/samza/container/ContainerHeartbeatMonitor.java
@@ -19,6 +19,7 @@
 
 package org.apache.samza.container;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -33,16 +34,26 @@ import org.slf4j.LoggerFactory;
 public class ContainerHeartbeatMonitor {
   private static final Logger LOG = LoggerFactory.getLogger(ContainerHeartbeatMonitor.class);
   private static final ThreadFactory THREAD_FACTORY = new HeartbeatThreadFactory();
-  private static final int SCHEDULE_MS = 60000;
-  private static final int SHUTDOWN_TIMOUT_MS = 120000;
-  private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(THREAD_FACTORY);
+  @VisibleForTesting
+  static final int SCHEDULE_MS = 60000;
+  @VisibleForTesting
+  static final int SHUTDOWN_TIMOUT_MS = 120000;
+
   private final Runnable onContainerExpired;
   private final ContainerHeartbeatClient containerHeartbeatClient;
+  private final ScheduledExecutorService scheduler;
   private boolean started = false;
 
   public ContainerHeartbeatMonitor(Runnable onContainerExpired, ContainerHeartbeatClient containerHeartbeatClient) {
+    this(onContainerExpired, containerHeartbeatClient, Executors.newSingleThreadScheduledExecutor(THREAD_FACTORY));
+  }
+
+  @VisibleForTesting
+  ContainerHeartbeatMonitor(Runnable onContainerExpired, ContainerHeartbeatClient containerHeartbeatClient,
+      ScheduledExecutorService scheduler) {
     this.onContainerExpired = onContainerExpired;
     this.containerHeartbeatClient = containerHeartbeatClient;
+    this.scheduler = scheduler;
   }
 
   public void start() {

--- a/samza-core/src/test/java/org/apache/samza/container/TestContainerHeartbeatMonitor.java
+++ b/samza-core/src/test/java/org/apache/samza/container/TestContainerHeartbeatMonitor.java
@@ -22,10 +22,11 @@ package org.apache.samza.container;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
@@ -37,57 +38,78 @@ import static org.mockito.Mockito.when;
 
 
 public class TestContainerHeartbeatMonitor {
+  @Mock
+  private Runnable onExpired;
+  @Mock
+  private ContainerHeartbeatClient containerHeartbeatClient;
+
+  private ScheduledExecutorService scheduler;
+  /**
+   * Use this to detect when the scheduler has finished executing the fixed-rate task.
+   */
+  private CountDownLatch schedulerFixedRateExecutionLatch;
+
+  private ContainerHeartbeatMonitor containerHeartbeatMonitor;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    this.schedulerFixedRateExecutionLatch = new CountDownLatch(1);
+    this.scheduler = buildScheduledExecutorService(this.schedulerFixedRateExecutionLatch);
+    this.containerHeartbeatMonitor =
+        new ContainerHeartbeatMonitor(this.onExpired, this.containerHeartbeatClient, this.scheduler);
+  }
+
   @Test
   public void testCallbackWhenHeartbeatDead() throws InterruptedException {
-    ContainerHeartbeatClient mockClient = mock(ContainerHeartbeatClient.class);
-    CountDownLatch countDownLatch = new CountDownLatch(1);
-    Runnable onExpired = countDownLatch::countDown;
     ContainerHeartbeatResponse response = new ContainerHeartbeatResponse(false);
-    when(mockClient.requestHeartbeat()).thenReturn(response);
-    ScheduledExecutorService scheduler = buildScheduledExecutorService();
-    ContainerHeartbeatMonitor monitor = new ContainerHeartbeatMonitor(onExpired, mockClient, scheduler);
-    monitor.start();
-    boolean success = countDownLatch.await(2, TimeUnit.SECONDS);
-    assertTrue(success);
+    when(this.containerHeartbeatClient.requestHeartbeat()).thenReturn(response);
+    this.containerHeartbeatMonitor.start();
+    // wait for the executor to finish the heartbeat check task
+    boolean fixedRateTaskCompleted = this.schedulerFixedRateExecutionLatch.await(2, TimeUnit.SECONDS);
+    assertTrue("Did not complete heartbeat check", fixedRateTaskCompleted);
     // check that the shutdown task got submitted, but don't actually execute it since it will shut down the process
-    verify(scheduler).schedule(any(Runnable.class), eq((long) ContainerHeartbeatMonitor.SHUTDOWN_TIMOUT_MS),
+    verify(this.scheduler).schedule(any(Runnable.class), eq((long) ContainerHeartbeatMonitor.SHUTDOWN_TIMOUT_MS),
         eq(TimeUnit.MILLISECONDS));
+    verify(this.onExpired).run();
 
-    monitor.stop();
-    verify(scheduler).shutdown();
+    this.containerHeartbeatMonitor.stop();
+    verify(this.scheduler).shutdown();
   }
 
   @Test
   public void testDoesNotCallbackWhenHeartbeatAlive() throws InterruptedException {
-    ContainerHeartbeatClient client = mock(ContainerHeartbeatClient.class);
-    CountDownLatch countDownLatch = new CountDownLatch(1);
-    Runnable onExpired = countDownLatch::countDown;
     ContainerHeartbeatResponse response = new ContainerHeartbeatResponse(true);
-    when(client.requestHeartbeat()).thenReturn(response);
-    ScheduledExecutorService scheduler = buildScheduledExecutorService();
-    ContainerHeartbeatMonitor monitor = new ContainerHeartbeatMonitor(onExpired, client, scheduler);
-    monitor.start();
-    boolean success = countDownLatch.await(2, TimeUnit.SECONDS);
-    assertFalse(success);
-    assertEquals(1, countDownLatch.getCount());
+    when(this.containerHeartbeatClient.requestHeartbeat()).thenReturn(response);
+    this.containerHeartbeatMonitor.start();
+    // wait for the executor to finish the heartbeat check task
+    boolean fixedRateTaskCompleted = this.schedulerFixedRateExecutionLatch.await(2, TimeUnit.SECONDS);
+    assertTrue("Did not complete heartbeat check", fixedRateTaskCompleted);
     // shutdown task should not have been submitted
-    verify(scheduler, never()).schedule(any(Runnable.class), anyLong(), any());
+    verify(this.scheduler, never()).schedule(any(Runnable.class), anyLong(), any());
+    verify(this.onExpired, never()).run();
 
-    monitor.stop();
-    verify(scheduler).shutdown();
+    this.containerHeartbeatMonitor.stop();
+    verify(this.scheduler).shutdown();
   }
 
   /**
-   * Build a mock {@link ScheduledExecutorService} which will execute a fixed-rate task once. It will not execute any
-   * one-shot tasks, but it can be used to verify that the one-shot task was submitted.
+   * Build a mock {@link ScheduledExecutorService} which will execute a fixed-rate task once. It will count down on
+   * {@code schedulerFixedRateExecutionLatch} when the task is finished executing.
+   * It will not execute any one-shot tasks, but it can be used to verify that the one-shot task was submitted.
    */
-  private static ScheduledExecutorService buildScheduledExecutorService() {
+  private static ScheduledExecutorService buildScheduledExecutorService(
+      CountDownLatch schedulerFixedRateExecutionLatch) {
     ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
     when(scheduler.scheduleAtFixedRate(any(), eq(0L), eq((long) ContainerHeartbeatMonitor.SCHEDULE_MS),
         eq(TimeUnit.MILLISECONDS))).thenAnswer(invocation -> {
             Runnable command = invocation.getArgumentAt(0, Runnable.class);
-            // just need to invoke the command once for these tests
-            (new Thread(command)).start();
+            (new Thread(() -> {
+                // just need to invoke the command once for these tests
+                command.run();
+                // notify that the execution is done, so verifications can begin
+                schedulerFixedRateExecutionLatch.countDown();
+              })).start();
             // return value is not used by ContainerHeartbeatMonitor
             return null;
           });


### PR DESCRIPTION
Symptom: In some environments, the samza-core unit test suite fails with `Process 'Gradle Test Executor N' finished with non-zero exit value 1 This problem might be caused by incorrect test process configuration.`
Cause: `ContainerHeartbeatMonitor` submits a delayed "force shutdown" task (uses `System.exit(1)`) to shut down the process when the job coordinator dies. In `TestContainerHeartbeatMonitor`, this "force shutdown" task is not cancelled when the test is complete. If the remainder of the samza-core tests last longer than the shutdown timeout (2 minutes), then the shutdown task will kill the test suite process with an exit code of 1. In some environments, `TestContainerHeartbeatMonitor` runs late enough in the test suite (it seems like the ordering of test classes is non-deterministic) that the test suite finishes successfully before the 2 minute timeout, so this error is not always seen.
Fix: In the test, mock the executor service so that the "force shutdown" task never runs.
Tests: Reduced the force shutdown timeout to 3 seconds in order to consistently reproduce the issue before the change. Then, applied the change and kept the 3-second timeout and verified that there no longer was an issue.
API/Usage changes: N/A