### PR TITLE
SAMZA-2501 : Optimizing startpoint manager to not make successive bootstrapMessage calls to coordinator-store

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterBasedJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterBasedJobCoordinator.java
@@ -266,7 +266,9 @@ public class ClusterBasedJobCoordinator {
       StartpointManager startpointManager = createStartpointManager();
       startpointManager.start();
       try {
-        startpointManager.fanOut(JobModelUtil.getTaskToSystemStreamPartitions(jobModel));
+        if () {
+          startpointManager.fanOut(JobModelUtil.getTaskToSystemStreamPartitions(jobModel));
+        }
       } finally {
         startpointManager.stop();
       }

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterBasedJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterBasedJobCoordinator.java
@@ -262,15 +262,15 @@ public class ClusterBasedJobCoordinator {
       MetadataResourceUtil metadataResourceUtil = new MetadataResourceUtil(jobModel, this.metrics, config);
       metadataResourceUtil.createResources();
 
-      // fan out the startpoints
-      StartpointManager startpointManager = createStartpointManager();
-      startpointManager.start();
-      try {
-        if (new ClusterManagerConfig(config).getStartpointFanoutEnabled()) {
+      // fan out the startpoints if startpoints is enabled
+      if (new JobConfig(config).getStartpointEnabled()) {
+        StartpointManager startpointManager = createStartpointManager();
+        startpointManager.start();
+        try {
           startpointManager.fanOut(JobModelUtil.getTaskToSystemStreamPartitions(jobModel));
+        } finally {
+          startpointManager.stop();
         }
-      } finally {
-        startpointManager.stop();
       }
 
       // Remap changelog partitions to tasks

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterBasedJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterBasedJobCoordinator.java
@@ -266,7 +266,7 @@ public class ClusterBasedJobCoordinator {
       StartpointManager startpointManager = createStartpointManager();
       startpointManager.start();
       try {
-        if (!new ClusterManagerConfig(config).getStartpointFanoutDisabled()) {
+        if (new ClusterManagerConfig(config).getStartpointFanoutEnabled()) {
           startpointManager.fanOut(JobModelUtil.getTaskToSystemStreamPartitions(jobModel));
         }
       } finally {

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterBasedJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterBasedJobCoordinator.java
@@ -266,7 +266,7 @@ public class ClusterBasedJobCoordinator {
       StartpointManager startpointManager = createStartpointManager();
       startpointManager.start();
       try {
-        if () {
+        if (!new ClusterManagerConfig(config).getStartpointFanoutDisabled()) {
           startpointManager.fanOut(JobModelUtil.getTaskToSystemStreamPartitions(jobModel));
         }
       } finally {

--- a/samza-core/src/main/java/org/apache/samza/config/ClusterManagerConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ClusterManagerConfig.java
@@ -127,7 +127,6 @@ public class ClusterManagerConfig extends MapConfig {
    */
   private static final String AM_JMX_ENABLED = "yarn.am.jmx.enabled";
   private static final String CLUSTER_MANAGER_JMX_ENABLED = "cluster-manager.jobcoordinator.jmx.enabled";
-  private static final String CLUSTER_MANAGER_STARTPOINT_FANOUT_ENABLED = "job.startpoint.fanout.enabled";
 
   public ClusterManagerConfig(Config config) {
       super(config);
@@ -263,9 +262,5 @@ public class ClusterManagerConfig extends MapConfig {
     } else {
       return true;
     }
-  }
-
-  public boolean getStartpointFanoutEnabled() {
-    return getBoolean(CLUSTER_MANAGER_STARTPOINT_FANOUT_ENABLED, true);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/config/ClusterManagerConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ClusterManagerConfig.java
@@ -127,7 +127,7 @@ public class ClusterManagerConfig extends MapConfig {
    */
   private static final String AM_JMX_ENABLED = "yarn.am.jmx.enabled";
   private static final String CLUSTER_MANAGER_JMX_ENABLED = "cluster-manager.jobcoordinator.jmx.enabled";
-  private static final String CLUSTER_MANAGER_STARTPOINT_FANOUT_DISABLED = "job.startpoint.fanout.disabled";
+  private static final String CLUSTER_MANAGER_STARTPOINT_FANOUT_ENABLED = "job.startpoint.fanout.enabled";
 
   public ClusterManagerConfig(Config config) {
       super(config);
@@ -265,7 +265,7 @@ public class ClusterManagerConfig extends MapConfig {
     }
   }
 
-  public boolean getStartpointFanoutDisabled() {
-    return getBoolean(CLUSTER_MANAGER_STARTPOINT_FANOUT_DISABLED, false);
+  public boolean getStartpointFanoutEnabled() {
+    return getBoolean(CLUSTER_MANAGER_STARTPOINT_FANOUT_ENABLED, true);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/config/ClusterManagerConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ClusterManagerConfig.java
@@ -127,6 +127,7 @@ public class ClusterManagerConfig extends MapConfig {
    */
   private static final String AM_JMX_ENABLED = "yarn.am.jmx.enabled";
   private static final String CLUSTER_MANAGER_JMX_ENABLED = "cluster-manager.jobcoordinator.jmx.enabled";
+  private static final String CLUSTER_MANAGER_STARTPOINT_FANOUT_DISABLED = "job.startpoint.fanout.disabled";
 
   public ClusterManagerConfig(Config config) {
       super(config);
@@ -262,5 +263,9 @@ public class ClusterManagerConfig extends MapConfig {
     } else {
       return true;
     }
+  }
+
+  public boolean getStartpointFanoutDisabled() {
+    return getBoolean(CLUSTER_MANAGER_STARTPOINT_FANOUT_DISABLED, false);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -146,6 +146,8 @@ public class JobConfig extends MapConfig {
   public static final String CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED =
       "samza.cluster.based.job.coordinator.dependency.isolation.enabled";
 
+  private static final String JOB_STARTPOINT_ENABLED = "job.startpoint.enabled";
+
   public JobConfig(Config config) {
     super(config);
   }
@@ -403,5 +405,9 @@ public class JobConfig extends MapConfig {
    */
   public Optional<String> getConfigLoaderFactory() {
     return Optional.ofNullable(get(CONFIG_LOADER_FACTORY));
+  }
+
+  public boolean getStartpointEnabled() {
+    return getBoolean(JOB_STARTPOINT_ENABLED, true);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
+++ b/samza-core/src/main/java/org/apache/samza/processor/StreamProcessor.java
@@ -396,8 +396,10 @@ public class StreamProcessor {
     // Metadata store lifecycle managed outside of the SamzaContainer.
     // All manager lifecycles are managed in the SamzaContainer including startpointManager
     StartpointManager startpointManager = null;
-    if (metadataStore != null) {
+    if (metadataStore != null && new JobConfig(config).getStartpointEnabled()) {
       startpointManager = new StartpointManager(metadataStore);
+    } else if (!new JobConfig(config).getStartpointEnabled()) {
+      LOGGER.warn("StartpointManager not instantiated because startpoints is not enabled");
     } else {
       LOGGER.warn("StartpointManager cannot be instantiated because no metadata store defined for this stream processor");
     }

--- a/samza-core/src/main/java/org/apache/samza/runtime/ContainerLaunchUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/ContainerLaunchUtil.java
@@ -102,7 +102,10 @@ public class ContainerLaunchUtil {
       LocalityManager localityManager = new LocalityManager(new NamespaceAwareCoordinatorStreamStore(coordinatorStreamStore, SetContainerHostMapping.TYPE));
 
       // StartpointManager wraps the coordinatorStreamStore in the namespaces internally
-      StartpointManager startpointManager = new StartpointManager(coordinatorStreamStore);
+      StartpointManager startpointManager = null;
+      if (new JobConfig(config).getStartpointEnabled()) {
+        startpointManager = new StartpointManager(coordinatorStreamStore);
+      }
 
       Map<String, MetricsReporter> metricsReporters = loadMetricsReporters(appDesc, containerId, config);
 

--- a/samza-core/src/main/java/org/apache/samza/startpoint/StartpointManager.java
+++ b/samza-core/src/main/java/org/apache/samza/startpoint/StartpointManager.java
@@ -175,7 +175,6 @@ public class StartpointManager {
   @VisibleForTesting
   public Optional<Startpoint> readStartpoint(SystemStreamPartition ssp, TaskName taskName) {
     Map<String, byte[]> startpointBytes = readWriteStore.all();
-    // there is no task-name to use as key for the startpoint in this case (only the ssp), so we use a null task-name
     return readStartpoint(startpointBytes, ssp, taskName);
   }
 

--- a/samza-core/src/main/java/org/apache/samza/startpoint/StartpointManager.java
+++ b/samza-core/src/main/java/org/apache/samza/startpoint/StartpointManager.java
@@ -278,7 +278,11 @@ public class StartpointManager {
       }
 
       Map<SystemStreamPartition, Optional<Startpoint>> startpoint = startpointMap.get(taskName);
+      startpoint.entrySet().stream().filter(x -> x.getValue().isPresent()).forEach(x -> deleteKeys.put(x.getKey(), null));
+
       Map<SystemStreamPartition, Optional<Startpoint>> startpointForTask = startpointForTaskMap.get(taskName);
+      startpointForTask.entrySet().stream().filter(x -> x.getValue().isPresent()).forEach(x -> deleteKeys.put(x.getKey(), taskName));
+
       Map<SystemStreamPartition, Optional<Startpoint>> startpointWithPrecedence = ssps.stream()
           .collect(Collectors.toMap(ssp -> ssp,
               ssp -> resolveStartpointPrecendence(startpoint.get(ssp), startpointForTask.get(ssp))));

--- a/samza-core/src/main/java/org/apache/samza/startpoint/StartpointManager.java
+++ b/samza-core/src/main/java/org/apache/samza/startpoint/StartpointManager.java
@@ -282,7 +282,7 @@ public class StartpointManager {
       Map<SystemStreamPartition, Optional<Startpoint>> startpointWithPrecedence = ssps.stream()
           .collect(Collectors.toMap(ssp -> ssp,
               ssp -> resolveStartpointPrecendence(startpoint.get(ssp), startpointForTask.get(ssp))));
-      startpointWithPrecedence.entrySet().stream().filter(x -> !x.getValue().isPresent()).forEach(x -> {
+      startpointWithPrecedence.entrySet().stream().filter(x -> x.getValue().isPresent()).forEach(x -> {
           fanOuts.putIfAbsent(taskName, new StartpointFanOutPerTask(now));
           fanOuts.get(taskName).getFanOuts().put(x.getKey(), x.getValue().get());
         });

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
@@ -326,13 +326,15 @@ public class ZkJobCoordinator implements JobCoordinator {
         }
         configStore.flush();
 
-        // fan out the startpoints
-        StartpointManager startpointManager = createStartpointManager();
-        startpointManager.start();
-        try {
-          startpointManager.fanOut(JobModelUtil.getTaskToSystemStreamPartitions(jobModel));
-        } finally {
-          startpointManager.stop();
+        if (new JobConfig(config).getStartpointEnabled()) {
+          // fan out the startpoints
+          StartpointManager startpointManager = createStartpointManager();
+          startpointManager.start();
+          try {
+            startpointManager.fanOut(JobModelUtil.getTaskToSystemStreamPartitions(jobModel));
+          } finally {
+            startpointManager.stop();
+          }
         }
       } else {
         LOG.warn("No metadata store registered to this job coordinator. Config not written to the metadata store and no Startpoints fan out.");

--- a/samza-core/src/main/scala/org/apache/samza/job/local/ProcessJobFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/job/local/ProcessJobFactory.scala
@@ -91,13 +91,15 @@ class ProcessJobFactory extends StreamJobFactory with Logging {
     val metadataResourceUtil = new MetadataResourceUtil(jobModel, metricsRegistry, config)
     metadataResourceUtil.createResources()
 
-    // fan out the startpoints
-    val startpointManager = new StartpointManager(coordinatorStreamStore)
-    startpointManager.start()
-    try {
-      startpointManager.fanOut(JobModelUtil.getTaskToSystemStreamPartitions(jobModel))
-    } finally {
-      startpointManager.stop()
+    if (new JobConfig(config).getStartpointEnabled()) {
+      // fan out the startpoints
+      val startpointManager = new StartpointManager(coordinatorStreamStore)
+      startpointManager.start()
+      try {
+        startpointManager.fanOut(JobModelUtil.getTaskToSystemStreamPartitions(jobModel))
+      } finally {
+        startpointManager.stop()
+      }
     }
 
     val taskConfig = new TaskConfig(config)

--- a/samza-core/src/main/scala/org/apache/samza/job/local/ThreadJobFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/job/local/ThreadJobFactory.scala
@@ -91,13 +91,15 @@ class ThreadJobFactory extends StreamJobFactory with Logging {
     val metadataResourceUtil = new MetadataResourceUtil(jobModel, metricsRegistry, config)
     metadataResourceUtil.createResources()
 
-    // fan out the startpoints
-    val startpointManager = new StartpointManager(coordinatorStreamStore)
-    startpointManager.start()
-    try {
-      startpointManager.fanOut(JobModelUtil.getTaskToSystemStreamPartitions(jobModel))
-    } finally {
-      startpointManager.stop()
+    if (new JobConfig(config).getStartpointEnabled()) {
+      // fan out the startpoints
+      val startpointManager = new StartpointManager(coordinatorStreamStore)
+      startpointManager.start()
+      try {
+        startpointManager.fanOut(JobModelUtil.getTaskToSystemStreamPartitions(jobModel))
+      } finally {
+        startpointManager.stop()
+      }
     }
 
     val containerId = "0"


### PR DESCRIPTION
Symptom: Currently the startpoint manager queries metastore for task-ssps and for each ssp queries coordinator-store, issuing a re-read on the coordinator store. This causes increased AM startup time and depending on the number of input SSPs to a job (thousands in case of regex), YARN may timeout the AM.
Cause: Above.
Fix: This change reduces to number of metastore reads to 2; one for startpoints keyed by ssp and the other for startpoints keyed by ssp+taskname.
API changes: None
Upgrade Instructions: None