### PR TITLE
SAMZA-2498: [Job coordinator isolation] Classloader isolation for SamzaApplication.describe execution in job coordinator

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterBasedJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterBasedJobCoordinator.java
@@ -472,7 +472,7 @@ public class ClusterBasedJobCoordinator {
       // no isolation enabled, so can just execute runClusterBasedJobCoordinator directly
       runClusterBasedJobCoordinator(args);
     } else {
-      runWithClassLoader(new IsolatingClassLoaderFactory().buildClassLoader(), args);
+      runWithClassLoader(new IsolatingClassLoaderFactory().buildMainClassLoader(), args);
     }
     System.exit(0);
   }
@@ -581,7 +581,7 @@ public class ClusterBasedJobCoordinator {
         // load full job config with ConfigLoader
         Config originalConfig = ConfigUtil.loadConfig(submissionConfig);
 
-        JobCoordinatorLaunchUtil.run(ApplicationUtil.fromConfig(originalConfig), originalConfig);
+        JobCoordinatorLaunchUtil.run(ApplicationUtil.fromConfig(originalConfig, true), originalConfig);
       }
 
       LOG.info("Finished running ClusterBasedJobCoordinator");


### PR DESCRIPTION
Feature: https://cwiki.apache.org/confluence/display/SAMZA/SEP-24%3A+Cluster-based+Job+Coordinator+Dependency+Isolation#SEP-24:Cluster-basedJobCoordinatorDependencyIsolation-HandlingSamzaApplication.describe

Changes:
1. Add a method `IsolatingClassLoaderFactory.buildSamzaApplicationClassLoader` to construct a classloader for loading the `SamzaApplication` implementation for an app.
2. If isolation is enabled, then call `buildSamzaApplicationClassLoader` to load the `SamzaApplication` implementation in the job coordinator.

Tests:
Deployed `wikipedia-feed` application (uses low-level API, has custom input descriptor, uses Kafka output descriptor) and `wikipedia-parser` application (uses low-level API, Kafka descriptors) in split deployment mode with some debug logs, and verified the following:
1. `TaskApplicationDescriptorImpl` and `KafkaSystemDescriptor` came from the framework infrastructure classloader.
2. `WikipediaSystemDescriptor` (custom descriptor) came from the application classloader.
3. `WikipediaFeedTaskApplication` (impl of `SamzaApplication`) came from the newly built application describe classloader.
4. Lambda which was used for the `TaskFactory` in `WikipediaFeedTaskApplication` came from the newly built application describe classloader, and it implemented the `StreamTaskFactory` interface which was loaded by the framework API classloader.
5. Verified expected system-stream metadata from custom system (`WikipediaSystemFactory`)
Deployed `wikipedia-parser` application (uses low-level API, Kafka descriptors) and verified the classloaders using debug logs.

API/usage changes: None