### PR TITLE
SAMZA-2502: Byte array keys be partitioned based on array contents in…

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/system/inmemory/InMemorySystemProducer.java
+++ b/samza-core/src/main/java/org/apache/samza/system/inmemory/InMemorySystemProducer.java
@@ -20,6 +20,7 @@
 package org.apache.samza.system.inmemory;
 
 import com.google.common.base.Preconditions;
+import java.util.Arrays;
 import org.apache.samza.Partition;
 import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.system.OutgoingMessageEnvelope;
@@ -90,7 +91,7 @@ public class InMemorySystemProducer implements SystemProducer {
     Preconditions.checkNotNull(partitionKey, "Failed to compute partition key for the message: " + envelope);
 
     int partition =
-        Math.abs(partitionKey.hashCode()) % memoryManager.getPartitionCountForSystemStream(envelope.getSystemStream());
+        Math.abs(hashCode(partitionKey)) % memoryManager.getPartitionCountForSystemStream(envelope.getSystemStream());
 
     SystemStreamPartition ssp = new SystemStreamPartition(envelope.getSystemStream(), new Partition(partition));
     memoryManager.put(ssp, key, message);
@@ -120,5 +121,13 @@ public class InMemorySystemProducer implements SystemProducer {
   @Override
   public void flush(String source) {
     // nothing to do
+  }
+
+  /**
+   * Return the hash code of the partitionKey. When partitionKey is a byte array, it returns a hash code based on
+   * the contents of the byte array. This guarantees that byte arrays with same contents get the same hash code.
+   */
+  private int hashCode(Object partitionKey) {
+    return (partitionKey instanceof byte[]) ? Arrays.hashCode((byte[]) partitionKey) : partitionKey.hashCode();
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/system/inmemory/TestInMemorySystemProducer.java
+++ b/samza-core/src/test/java/org/apache/samza/system/inmemory/TestInMemorySystemProducer.java
@@ -1,0 +1,65 @@
+package org.apache.samza.system.inmemory;
+
+import org.apache.samza.system.OutgoingMessageEnvelope;
+import org.apache.samza.system.SystemStream;
+import org.apache.samza.system.SystemStreamPartition;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import static org.mockito.Mockito.*;
+
+
+public class TestInMemorySystemProducer {
+
+  @Mock
+  private InMemoryManager inMemoryManager;
+
+  private InMemorySystemProducer inMemorySystemProducer;
+  private boolean testFinished;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    this.inMemorySystemProducer = new InMemorySystemProducer("systemName", this.inMemoryManager);
+    this.testFinished = false;
+  }
+
+  /**
+   * Test keys of type byte[] goes to the same partition if they have the same contents.
+   */
+  @Test
+  public void testPartition() {
+    doReturn(1000).when(inMemoryManager).getPartitionCountForSystemStream(any());
+    doAnswer(new Answer<Void>() {
+      int partitionOfFirstMessage = -1;
+      int partitionOfSecondMessage = -2;
+
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        SystemStreamPartition ssp = invocation.getArgumentAt(0, SystemStreamPartition.class);
+        if (partitionOfFirstMessage == -1) {
+          partitionOfFirstMessage = ssp.getPartition().getPartitionId();
+        } else {
+          partitionOfSecondMessage = ssp.getPartition().getPartitionId();
+          Assert.assertEquals(partitionOfFirstMessage, partitionOfSecondMessage);
+          testFinished = true;
+        }
+        return null;
+      }
+    }).when(inMemoryManager).put(any(), any(), any());
+
+    byte[] key1 = new byte[]{1, 2, 3};
+    byte[] key2 = new byte[]{1, 2, 3};
+    SystemStream systemStream = new SystemStream("TestSystem", "TestStream");
+    OutgoingMessageEnvelope outgoingMessageEnvelope1 = new OutgoingMessageEnvelope(systemStream, key1, null);
+    OutgoingMessageEnvelope outgoingMessageEnvelope2 = new OutgoingMessageEnvelope(systemStream, key2, null);
+    inMemorySystemProducer.send("TestSource", outgoingMessageEnvelope1);
+    inMemorySystemProducer.send("TestSource", outgoingMessageEnvelope2);
+    Assert.assertTrue(testFinished);
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/system/inmemory/TestInMemorySystemProducer.java
+++ b/samza-core/src/test/java/org/apache/samza/system/inmemory/TestInMemorySystemProducer.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.samza.system.inmemory;
 
 import org.apache.samza.system.OutgoingMessageEnvelope;


### PR DESCRIPTION
Issue:
InMemorySystemProducer uses the hashCode of the partition key to decide to which partition the message goes. This works well when the key is an object whose hashCode method can be override. But in the case when the partition key is serialized as a byte[], the message can go to any partition. It turns out that the hash code of a byte array is based on the address in memory but not the content. Therefore, even though two messages may have same key, they can be sent to different partitions after their keys are serialized into byte[] whose hash code is kind of random.

 
Fix:
We want to be able to partition messages based on the contents of the partition keys. An easy fix would be: in the case of byte array, we calculate the hash code with Arrays.hashCode(byte[] input). This allows us to calculate the hash code of the byte array by its contents.

Test:
Added a unit test in TestInMemorySystemProducer.