### PR TITLE
SAMZA-2336: Disable transactional state restore when not supported

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
@@ -310,7 +310,15 @@ public class TaskConfig extends MapConfig {
   }
 
   public boolean getTransactionalStateRestoreEnabled() {
-    return getBoolean(TRANSACTIONAL_STATE_RESTORE_ENABLED, DEFAULT_TRANSACTIONAL_STATE_RESTORE_ENABLED);
+    JobConfig jobConfig = new JobConfig(this);
+
+    boolean standByEnabled = jobConfig.getStandbyTasksEnabled();
+    boolean asyncCommitEnabled = getAsyncCommit();
+
+    // TODO remove check of standby enabled when SAMZA-2353 is completed
+    // TODO remove check of async commit when SAMZA-2505 is completed
+    // transactional state restore must remain disabled until it is supported in the above use cases
+    return !standByEnabled && !asyncCommitEnabled && getBoolean(TRANSACTIONAL_STATE_RESTORE_ENABLED, DEFAULT_TRANSACTIONAL_STATE_RESTORE_ENABLED);
   }
 
   public boolean getTransactionalStateRetainExistingState() {

--- a/samza-core/src/test/java/org/apache/samza/config/TestTaskConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestTaskConfig.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.*;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -331,6 +332,30 @@ public class TestTaskConfig {
 
     // config not specified
     assertEquals(TaskConfig.DEFAULT_TASK_SHUTDOWN_MS, new TaskConfig(new MapConfig()).getShutdownMs());
+  }
+
+  @Test
+  public void testGetTransactionalStateRestoreEnabled() {
+    Map<String, String> configMap = new HashMap<>();
+    configMap.put(TaskConfig.TRANSACTIONAL_STATE_RESTORE_ENABLED, "true");
+
+    // standby and async commit both off; transactional state restore returned as enabled
+    assertTrue(new TaskConfig(new MapConfig(configMap)).getTransactionalStateRestoreEnabled());
+
+    // standby off and async commit on; transactional state restore returned as disabled
+    configMap.put(TaskConfig.ASYNC_COMMIT, "true");
+    configMap.put(JobConfig.STANDBY_TASKS_REPLICATION_FACTOR, "1");
+    assertFalse(new TaskConfig(new MapConfig(configMap)).getTransactionalStateRestoreEnabled());
+
+    // standby on and async commit off; transactional state restore returned as disabled
+    configMap.put(TaskConfig.ASYNC_COMMIT, "false");
+    configMap.put(JobConfig.STANDBY_TASKS_REPLICATION_FACTOR, "2");
+    assertFalse(new TaskConfig(new MapConfig(configMap)).getTransactionalStateRestoreEnabled());
+
+    // standby on and async commit on; transactional state restore returned as disabled
+    configMap.put(TaskConfig.ASYNC_COMMIT, "true");
+    configMap.put(JobConfig.STANDBY_TASKS_REPLICATION_FACTOR, "2");
+    assertFalse(new TaskConfig(new MapConfig(configMap)).getTransactionalStateRestoreEnabled());
   }
 
   /**


### PR DESCRIPTION
**Feature:** Disable transactional state for use cases that are not yet supported
 
**Changes:** Modifies the logic to accessing the `task.transactional.state.restore.enabled` by returning false if standby or async commit are enabled.

 **Tests:** Added a unit test each for each permutation of configuration.

**API Changes:** None
**Upgrade Instructions:** None 
**Usage Instructions:** None