### PR TITLE
SAMZA-2509: New config name to represent if split deployment feature is enabled

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterBasedJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterBasedJobCoordinator.java
@@ -465,7 +465,7 @@ public class ClusterBasedJobCoordinator {
    */
   public static void main(String[] args) {
     boolean dependencyIsolationEnabled = Boolean.parseBoolean(
-        System.getenv(ShellCommandConfig.ENV_CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED));
+        System.getenv(ShellCommandConfig.ENV_SPLIT_DEPLOYMENT_ENABLED));
     Thread.setDefaultUncaughtExceptionHandler((thread, exception) -> {
         LOG.error("Uncaught exception in ClusterBasedJobCoordinator::main. Exiting job coordinator", exception);
         System.exit(1);

--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -143,8 +143,7 @@ public class JobConfig extends MapConfig {
   public static final String COORDINATOR_STREAM_FACTORY = "job.coordinatorstream.config.factory";
   public static final String DEFAULT_COORDINATOR_STREAM_CONFIG_FACTORY = "org.apache.samza.util.DefaultCoordinatorStreamConfigFactory";
 
-  public static final String CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED =
-      "samza.cluster.based.job.coordinator.dependency.isolation.enabled";
+  public static final String JOB_SPLIT_DEPLOYMENT_ENABLED = "job.split.deployment.enabled";
 
   private static final String JOB_STARTPOINT_ENABLED = "job.startpoint.enabled";
 
@@ -372,8 +371,8 @@ public class JobConfig extends MapConfig {
     return getStandbyTaskReplicationFactor() > 1;
   }
 
-  public boolean getClusterBasedJobCoordinatorDependencyIsolationEnabled() {
-    return getBoolean(CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED, false);
+  public boolean isSplitDeploymentEnabled() {
+    return getBoolean(JOB_SPLIT_DEPLOYMENT_ENABLED, false);
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/config/ShellCommandConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ShellCommandConfig.java
@@ -61,21 +61,22 @@ public class ShellCommandConfig extends MapConfig {
    * Set to "true" if split deployment feature is enabled. Otherwise, will be considered false.
    *
    * The launch process for the cluster-based job coordinator and job container depends on the value of this, since it
-   * needs to be known if the cluster-based job coordinator and job container should be launched in an isolated mode.
+   * needs to be known if the cluster-based job coordinator and job container should be launched in a split deployment
+   * mode.
    * This needs to be an environment variable, because the value needs to be known before the full configs can be read
    * from the metadata store (full configs are only read after launch is complete).
    */
   public static final String ENV_SPLIT_DEPLOYMENT_ENABLED = "ENV_SPLIT_DEPLOYMENT_ENABLED";
 
   /**
-   * When running the cluster-based job coordinator in an isolated mode, it uses JARs and resources from a lib directory
-   * which is provided by the framework. In some cases, it is necessary to use some resources specified by the
-   * application as well. This environment variable can be set to a directory which is different from the framework lib
-   * directory in order to tell Samza where application resources live.
-   * This is an environment variable because it is needed in order to launch the cluster-based job coordinator Java
-   * process, which means access to full configs is not available yet.
+   * When running the cluster-based job coordinator and job container in a split deployment mode, it uses JARs and
+   * resources from a lib directory which is provided by the framework. In some cases, it is necessary to use some
+   * resources specified by the application as well. This environment variable can be set to a directory which is
+   * different from the framework lib directory in order to tell Samza where application resources live.
+   * This is an environment variable because it is needed in order to launch the cluster-based job coordinator and job
+   * container Java processes, which means access to full configs is not available yet.
    * For example, this is used to set a system property for the location of an application-specified log4j configuration
-   * file when launching the cluster-based job coordinator Java process.
+   * file when launching the cluster-based job coordinator and job container Java processes.
    */
   public static final String ENV_APPLICATION_LIB_DIR = "APPLICATION_LIB_DIR";
 

--- a/samza-core/src/main/java/org/apache/samza/config/ShellCommandConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ShellCommandConfig.java
@@ -58,16 +58,14 @@ public class ShellCommandConfig extends MapConfig {
   public static final String ENV_EXECUTION_ENV_CONTAINER_ID = "EXECUTION_ENV_CONTAINER_ID";
 
   /**
-   * Set to "true" if cluster-based job coordinator dependency isolation is enabled. Otherwise, will be considered
-   * false.
+   * Set to "true" if split deployment feature is enabled. Otherwise, will be considered false.
    *
-   * The launch process for the cluster-based job coordinator depends on the value of this, since it needs to be known
-   * if the cluster-based job coordinator should be launched in an isolated mode. This needs to be an environment
-   * variable, because the value needs to be known before the full configs can be read from the metadata store (full
-   * configs are only read after launch is complete).
+   * The launch process for the cluster-based job coordinator and job container depends on the value of this, since it
+   * needs to be known if the cluster-based job coordinator and job container should be launched in an isolated mode.
+   * This needs to be an environment variable, because the value needs to be known before the full configs can be read
+   * from the metadata store (full configs are only read after launch is complete).
    */
-  public static final String ENV_CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED =
-      "CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED";
+  public static final String ENV_SPLIT_DEPLOYMENT_ENABLED = "ENV_SPLIT_DEPLOYMENT_ENABLED";
 
   /**
    * When running the cluster-based job coordinator in an isolated mode, it uses JARs and resources from a lib directory

--- a/samza-core/src/test/java/org/apache/samza/config/TestJobConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestJobConfig.java
@@ -547,15 +547,13 @@ public class TestJobConfig {
 
   @Test
   public void testGetClusterBasedJobCoordinatorDependencyIsolationEnabled() {
-    Config config =
-        new MapConfig(ImmutableMap.of(JobConfig.CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED, "true"));
-    assertTrue(new JobConfig(config).getClusterBasedJobCoordinatorDependencyIsolationEnabled());
+    Config config = new MapConfig(ImmutableMap.of(JobConfig.JOB_SPLIT_DEPLOYMENT_ENABLED, "true"));
+    assertTrue(new JobConfig(config).isSplitDeploymentEnabled());
 
-    config =
-        new MapConfig(ImmutableMap.of(JobConfig.CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED, "false"));
-    assertFalse(new JobConfig(config).getClusterBasedJobCoordinatorDependencyIsolationEnabled());
+    config = new MapConfig(ImmutableMap.of(JobConfig.JOB_SPLIT_DEPLOYMENT_ENABLED, "false"));
+    assertFalse(new JobConfig(config).isSplitDeploymentEnabled());
 
-    assertFalse(new JobConfig(new MapConfig()).getClusterBasedJobCoordinatorDependencyIsolationEnabled());
+    assertFalse(new JobConfig(new MapConfig()).isSplitDeploymentEnabled());
   }
 
   @Test

--- a/samza-yarn/src/test/java/org/apache/samza/job/yarn/TestYarnJob.java
+++ b/samza-yarn/src/test/java/org/apache/samza/job/yarn/TestYarnJob.java
@@ -43,12 +43,11 @@ public class TestYarnJob {
     Config config = new MapConfig();
     assertEquals("./__package/bin/run-jc.sh", YarnJob$.MODULE$.buildJobCoordinatorCmd(config, new JobConfig(config)));
 
-    // cluster-based job coordinator dependency isolation is enabled; use script from framework infrastructure directory
-    Config configJobCoordinatorDependencyIsolationEnabled =
-        new MapConfig(ImmutableMap.of(JobConfig.CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED, "true"));
+    // split deployment is enabled; use script from framework infrastructure directory
+    Config splitDeploymentEnabled =
+        new MapConfig(ImmutableMap.of(JobConfig.JOB_SPLIT_DEPLOYMENT_ENABLED, "true"));
     assertEquals(String.format("./%s/bin/run-jc.sh", DependencyIsolationUtils.FRAMEWORK_INFRASTRUCTURE_DIRECTORY),
-        YarnJob$.MODULE$.buildJobCoordinatorCmd(configJobCoordinatorDependencyIsolationEnabled,
-            new JobConfig(configJobCoordinatorDependencyIsolationEnabled)));
+        YarnJob$.MODULE$.buildJobCoordinatorCmd(splitDeploymentEnabled, new JobConfig(splitDeploymentEnabled)));
   }
 
   @Test
@@ -59,14 +58,14 @@ public class TestYarnJob {
         .put(JobConfig.JOB_ID, "jobId")
         .put(JobConfig.JOB_COORDINATOR_SYSTEM, "jobCoordinatorSystem")
         .put(YarnConfig.AM_JVM_OPTIONS, amJvmOptions) // needs escaping
-        .put(JobConfig.CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED, "false")
+        .put(JobConfig.JOB_SPLIT_DEPLOYMENT_ENABLED, "false")
         .build());
     String expectedCoordinatorStreamConfigStringValue = Util.envVarEscape(SamzaObjectMapper.getObjectMapper()
         .writeValueAsString(CoordinatorStreamUtil.buildCoordinatorStreamConfig(config)));
     Map<String, String> expected = ImmutableMap.of(
         ShellCommandConfig.ENV_COORDINATOR_SYSTEM_CONFIG, expectedCoordinatorStreamConfigStringValue,
         ShellCommandConfig.ENV_JAVA_OPTS, Util.envVarEscape(amJvmOptions),
-        ShellCommandConfig.ENV_CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED, "false");
+        ShellCommandConfig.ENV_SPLIT_DEPLOYMENT_ENABLED, "false");
     assertEquals(expected, JavaConverters.mapAsJavaMapConverter(
         YarnJob$.MODULE$.buildEnvironment(config, new YarnConfig(config), new JobConfig(config))).asJava());
   }
@@ -78,14 +77,14 @@ public class TestYarnJob {
         .put(JobConfig.JOB_ID, "jobId")
         .put(JobConfig.JOB_COORDINATOR_SYSTEM, "jobCoordinatorSystem")
         .put(YarnConfig.AM_JVM_OPTIONS, "")
-        .put(JobConfig.CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED, "true")
+        .put(JobConfig.JOB_SPLIT_DEPLOYMENT_ENABLED, "true")
         .build());
     String expectedCoordinatorStreamConfigStringValue = Util.envVarEscape(SamzaObjectMapper.getObjectMapper()
         .writeValueAsString(CoordinatorStreamUtil.buildCoordinatorStreamConfig(config)));
     Map<String, String> expected = ImmutableMap.of(
         ShellCommandConfig.ENV_COORDINATOR_SYSTEM_CONFIG, expectedCoordinatorStreamConfigStringValue,
         ShellCommandConfig.ENV_JAVA_OPTS, "",
-        ShellCommandConfig.ENV_CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED, "true",
+        ShellCommandConfig.ENV_SPLIT_DEPLOYMENT_ENABLED, "true",
         ShellCommandConfig.ENV_APPLICATION_LIB_DIR, "./__package/lib");
     assertEquals(expected, JavaConverters.mapAsJavaMapConverter(
         YarnJob$.MODULE$.buildEnvironment(config, new YarnConfig(config), new JobConfig(config))).asJava());
@@ -98,7 +97,7 @@ public class TestYarnJob {
         .put(JobConfig.JOB_ID, "jobId")
         .put(JobConfig.JOB_COORDINATOR_SYSTEM, "jobCoordinatorSystem")
         .put(YarnConfig.AM_JVM_OPTIONS, "")
-        .put(JobConfig.CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED, "false")
+        .put(JobConfig.JOB_SPLIT_DEPLOYMENT_ENABLED, "false")
         .put(YarnConfig.AM_JAVA_HOME, "/some/path/to/java/home")
         .build());
     String expectedCoordinatorStreamConfigStringValue = Util.envVarEscape(SamzaObjectMapper.getObjectMapper()
@@ -106,7 +105,7 @@ public class TestYarnJob {
     Map<String, String> expected = ImmutableMap.of(
         ShellCommandConfig.ENV_COORDINATOR_SYSTEM_CONFIG, expectedCoordinatorStreamConfigStringValue,
         ShellCommandConfig.ENV_JAVA_OPTS, "",
-        ShellCommandConfig.ENV_CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED, "false",
+        ShellCommandConfig.ENV_SPLIT_DEPLOYMENT_ENABLED, "false",
         ShellCommandConfig.ENV_JAVA_HOME, "/some/path/to/java/home");
     assertEquals(expected, JavaConverters.mapAsJavaMapConverter(
         YarnJob$.MODULE$.buildEnvironment(config, new YarnConfig(config), new JobConfig(config))).asJava());
@@ -119,14 +118,14 @@ public class TestYarnJob {
         .put(JobConfig.JOB_ID, "jobId")
         .put(JobConfig.CONFIG_LOADER_FACTORY, "org.apache.samza.config.loaders.PropertiesConfigLoaderFactory")
         .put(YarnConfig.AM_JVM_OPTIONS, "")
-        .put(JobConfig.CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED, "true")
+        .put(JobConfig.JOB_SPLIT_DEPLOYMENT_ENABLED, "true")
         .build());
     String expectedSubmissionConfig = Util.envVarEscape(SamzaObjectMapper.getObjectMapper()
         .writeValueAsString(config));
     Map<String, String> expected = ImmutableMap.of(
         ShellCommandConfig.ENV_SUBMISSION_CONFIG, expectedSubmissionConfig,
         ShellCommandConfig.ENV_JAVA_OPTS, "",
-        ShellCommandConfig.ENV_CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED, "true",
+        ShellCommandConfig.ENV_SPLIT_DEPLOYMENT_ENABLED, "true",
         ShellCommandConfig.ENV_APPLICATION_LIB_DIR, "./__package/lib");
     assertEquals(expected, JavaConverters.mapAsJavaMapConverter(
         YarnJob$.MODULE$.buildEnvironment(config, new YarnConfig(config), new JobConfig(config))).asJava());


### PR DESCRIPTION
#### Issues

Currently, we are using `samza.cluster.based.job.coordinator.dependency.isolation.enabled` to show if Samza application enables split deployment on job coordinator.
However, we also need one similar config for the job container with the same purpose. 
So we'd better consolidate them to one generic config `job.split.deployment.enabled`.

#### Changes
1. Renamed `ShellCommandConfig.ENV_CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED` to `ShellCommandConfig. ENV_SPLIT_DEPLOYMENT_ENABLED `
2. Renamed `JobConfig. CLUSTER_BASED_JOB_COORDINATOR_DEPENDENCY_ISOLATION_ENABLED ` to `JobConfig. JOB_SPLIT_DEPLOYMENT_ENABLED `

#### Tests
- [x] All unit tests and integration tests are passed

#### API Changes
None

#### Upgrade Instructions
None

#### Usage Instructions
None