### PR TITLE
SAMZA-2510: Incorrect shutdown status due to race between runloop and process callback thread

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
+++ b/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
@@ -648,6 +648,8 @@ public class RunLoop implements Runnable, Throttleable {
     @Override
     public void onFailure(TaskCallback callback, Throwable t) {
       try {
+        // set the exception code ahead of marking the message as processed to make sure the exception
+        // is visible to the run loop thread promptly. Refer SAMZA-2510 for more details.
         abort(t);
         state.doneProcess();
         // update pending count, but not offset

--- a/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
+++ b/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
@@ -19,7 +19,6 @@
 
 package org.apache.samza.container;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -212,11 +211,6 @@ public class RunLoop implements Runnable, Throttleable {
   public void shutdown() {
     shutdownNow = true;
     resume();
-  }
-
-  @VisibleForTesting
-  Throwable getThrowable() {
-    return throwable;
   }
 
   /**

--- a/samza-core/src/test/java/org/apache/samza/container/TestRunLoop.java
+++ b/samza-core/src/test/java/org/apache/samza/container/TestRunLoop.java
@@ -60,7 +60,6 @@ import scala.Option;
 import scala.collection.JavaConverters;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyObject;

--- a/samza-core/src/test/java/org/apache/samza/container/TestRunLoop.java
+++ b/samza-core/src/test/java/org/apache/samza/container/TestRunLoop.java
@@ -19,6 +19,7 @@
 
 package org.apache.samza.container;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,6 +30,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.samza.Partition;
+import org.apache.samza.SamzaException;
 import org.apache.samza.checkpoint.Checkpoint;
 import org.apache.samza.checkpoint.OffsetManager;
 import org.apache.samza.context.ContainerContext;
@@ -779,5 +781,28 @@ public class TestRunLoop {
     runLoop.run();
 
     commitLatch.await();
+  }
+
+  @Test(expected = SamzaException.class)
+  public void testExceptionIsPropagatedAfterShutdown() {
+    SystemConsumers consumerMultiplexer = mock(SystemConsumers.class);
+    when(consumerMultiplexer.pollIntervalMs()).thenReturn(10);
+    OffsetManager offsetManager = mock(OffsetManager.class);
+
+    TestTask task0 = new TestTask(false, false, false, null);
+    TaskInstance t0 = createTaskInstance(task0, taskName0, ssp0, offsetManager, consumerMultiplexer);
+
+    Map<TaskName, TaskInstance> tasks = ImmutableMap.of(taskName0, t0);
+
+    int maxMessagesInFlight = 2;
+    RunLoop runLoop = new RunLoop(tasks, executor, consumerMultiplexer, maxMessagesInFlight, windowMs, commitMs,
+        callbackTimeoutMs, maxThrottlingDelayMs, maxIdleMs, containerMetrics,
+        () -> 0L, false);
+    when(consumerMultiplexer.choose(false))
+        .thenReturn(envelope0)
+        .thenReturn(ssp0EndOfStream)
+        .thenReturn(null);
+
+    runLoop.run();
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/container/TestRunLoop.java
+++ b/samza-core/src/test/java/org/apache/samza/container/TestRunLoop.java
@@ -132,7 +132,6 @@ public class TestRunLoop {
     private AtomicInteger completed = new AtomicInteger(0);
     private TestCode callbackHandler = null;
     private TestCode commitHandler = null;
-    private Runnable endOfStreamHandler = null;
     private TaskCoordinator.RequestScope commitRequest = null;
     private TaskCoordinator.RequestScope shutdownRequest = TaskCoordinator.RequestScope.ALL_TASKS_IN_CONTAINER;
 
@@ -210,14 +209,7 @@ public class TestRunLoop {
 
     @Override
     public void onEndOfStream(MessageCollector collector, TaskCoordinator coordinator) {
-      if (endOfStreamHandler != null) {
-        endOfStreamHandler.run();
-      }
       coordinator.commit(TaskCoordinator.RequestScope.CURRENT_TASK);
-    }
-
-    void setEndOfStreamHandler(Runnable endOfStreamHandler) {
-      this.endOfStreamHandler = endOfStreamHandler;
     }
 
     void setShutdownRequest(TaskCoordinator.RequestScope shutdownRequest) {
@@ -808,9 +800,6 @@ public class TestRunLoop {
         callbackTimeoutMs, maxThrottlingDelayMs, maxIdleMs, containerMetrics,
         () -> 0L, false);
 
-    // Verify if the throwable flag is set ahead of issuing a shutdown request due to end of stream.
-    Runnable checkThrowableBeforeShutdown = () -> assertNotNull(runLoop.getThrowable());
-    task0.setEndOfStreamHandler(checkThrowableBeforeShutdown);
     when(consumerMultiplexer.choose(false))
         .thenReturn(envelope0)
         .thenReturn(ssp0EndOfStream)


### PR DESCRIPTION
**Symptom**: A race between the process callback thread and the runloop thread can result in incorrect shutdown status for shutdown triggered by end of stream.
**Issue**: Currently runloop performs message choosing and dispatching in a loop indefinitely until interrupted by a shutdown request or an exception during processing. In async mode, message completion is notified by the process callback thread using `onComplete()` and `onFailure()` to represent corresponding success and failure. The failure callback updates the exception code within the runloop to notify processing failures. Similarly, shutdown can be requested by user code or end of stream messages through various scopes(task level, container level). These requests are notified to the runloop through shutdownNow flag.
Currently as long as shutdownNow flag is not set, the exception code is promptly seen by the runloop and propagated upstream correctly. However, if a shutdown triggered by end of stream is requested, runloop doesn't check the exception code before exiting.
**Changes**: Make sure we check the exception code before we exit. Also, set the exception code on process failure before updating the state to done to promptly signal runloop about failure.
**Tests**: Added unit tests to check if the exception is thrown even if the shutdown is requested ahead of callback failure.
**API Changes**: None
**Usage Instructions**: None
**Upgrade Instructions**: None