### PR TITLE
SAMZA-2506: Inconsistent end of stream semantics in SystemStreamPartitionMetadata

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/system/inmemory/InMemoryManager.java
+++ b/samza-core/src/main/java/org/apache/samza/system/inmemory/InMemoryManager.java
@@ -182,8 +182,17 @@ class InMemoryManager {
             .collect(Collectors.toMap(entry -> entry.getKey().getPartition(), entry -> {
                 List<IncomingMessageEnvelope> messages = entry.getValue();
                 String oldestOffset = messages.isEmpty() ? null : "0";
-                String newestOffset = messages.isEmpty() ? null : String.valueOf(messages.size() - 1);
                 String upcomingOffset = String.valueOf(messages.size());
+                String newestOffset;
+                if (messages.isEmpty()) {
+                  newestOffset = null;
+                } else if (messages.get(messages.size() - 1).isEndOfStream()) {
+                  newestOffset = messages.size() > 1 ? String.valueOf(messages.size() - 2) : null;
+                  upcomingOffset = String.valueOf(messages.size() - 1);
+                } else {
+                  newestOffset = String.valueOf(messages.size() - 1);
+                  upcomingOffset = String.valueOf(messages.size());
+                }
 
                 return new SystemStreamMetadata.SystemStreamPartitionMetadata(oldestOffset, newestOffset, upcomingOffset);
 

--- a/samza-core/src/test/java/org/apache/samza/system/inmemory/TestInMemoryManager.java
+++ b/samza-core/src/test/java/org/apache/samza/system/inmemory/TestInMemoryManager.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.samza.Partition;
+import org.apache.samza.system.EndOfStreamMessage;
 import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.system.StreamSpec;
 import org.apache.samza.system.SystemStreamMetadata;
@@ -77,9 +78,17 @@ public class TestInMemoryManager {
         ImmutableMap.of(new Partition(0), new SystemStreamMetadata.SystemStreamPartitionMetadata("0", "1", "2")));
     SystemStreamMetadata systemStreamMetadata1 = new SystemStreamMetadata(STREAM1,
         ImmutableMap.of(new Partition(0), new SystemStreamMetadata.SystemStreamPartitionMetadata("0", "0", "1")));
+
     // also test a batch call for multiple streams here
     assertEquals(ImmutableMap.of(STREAM0, systemStreamMetadata0, STREAM1, systemStreamMetadata1),
         this.inMemoryManager.getSystemStreamMetadata(SYSTEM, ImmutableSet.of(STREAM0, STREAM1)));
+
+    // test END_OF_STREAM doesn't alter new or upcoming offset
+    this.inMemoryManager.put(ssp0, "key02", new EndOfStreamMessage());
+    systemStreamMetadata0 = new SystemStreamMetadata(STREAM0,
+        ImmutableMap.of(new Partition(0), new SystemStreamMetadata.SystemStreamPartitionMetadata("0", "1", "2")));
+    assertEquals(ImmutableMap.of(STREAM0, systemStreamMetadata0),
+        this.inMemoryManager.getSystemStreamMetadata(SYSTEM, ImmutableSet.of(STREAM0)));
   }
 
   @Test


### PR DESCRIPTION
I found this when refactoring side input restore to use RunLoop (https://github.com/apache/samza/pull/1343); this patch is necessary to prevent integration tests from failing after that refactor as marking side inputs as caught up relies on newest offset.

**Symptom:** When an end of stream message is present in an in memory SSP, the new and upcoming offset are reported as 1 higher than they should be.

Example:
| E0, offset: 0 | E1, offset: 1 | ... | E3, offset: 3 | EndOfStream |

In the above case, InMemoryManager will report a newestOffset of 4 and an upcomingOffset of 5; they should be 3 and 4 respectively.

See the jira ticket for a more in depth analysis of semantics of end of stream as it relates to offset metadata.
 
**Cause:** InMemoryManager treats end of stream as any other envelope with a numeric offset even though it is not.
 
**Changes:** Check in `InMemoryManager.constructSystemStreamMetadata` whether the last message in the stream is an EndOfStream, and adjust offsets accordingly.
 
**Tests:** Added a unit test to verify that offsets are adjusted by 1 in the case of EndOfStream.