### PR TITLE
Setting transactional state restore to default enabled

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
@@ -109,7 +109,7 @@ public class TaskConfig extends MapConfig {
   public static final String TRANSACTIONAL_STATE_CHECKPOINT_ENABLED = "task.transactional.state.checkpoint.enabled";
   private static final boolean DEFAULT_TRANSACTIONAL_STATE_CHECKPOINT_ENABLED = true;
   public static final String TRANSACTIONAL_STATE_RESTORE_ENABLED = "task.transactional.state.restore.enabled";
-  private static final boolean DEFAULT_TRANSACTIONAL_STATE_RESTORE_ENABLED = false;
+  private static final boolean DEFAULT_TRANSACTIONAL_STATE_RESTORE_ENABLED = true;
   public static final String TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE =
       "task.transactional.state.retain.existing.state";
   private static final boolean DEFAULT_TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE = true;

--- a/samza-core/src/test/java/org/apache/samza/system/MockSystemFactory.java
+++ b/samza-core/src/test/java/org/apache/samza/system/MockSystemFactory.java
@@ -154,14 +154,14 @@ public class MockSystemFactory implements SystemFactory {
 
       @Override
       public Integer offsetComparator(String offset1, String offset2) {
-        return null;
+        return offset1.compareTo(offset2);
       }
 
       @Override
       public Map<String, SystemStreamMetadata> getSystemStreamPartitionCounts(Set<String> streamNames, long cacheTTL) {
         return getSystemStreamMetadata(streamNames);
       }
-      
+
       @Override
       public boolean createStream(StreamSpec streamSpec) {
         return true;

--- a/samza-kafka/src/test/scala/org/apache/samza/config/TestKafkaConfig.scala
+++ b/samza-kafka/src/test/scala/org/apache/samza/config/TestKafkaConfig.scala
@@ -169,7 +169,7 @@ class TestKafkaConfig {
     assertEquals("otherstream", storeToChangelog.getOrDefault("test3", ""))
     assertNull(kafkaConfig.getChangelogKafkaProperties("test1").getProperty("retention.ms"))
     assertNull(kafkaConfig.getChangelogKafkaProperties("test2").getProperty("retention.ms"))
-    assertNull(kafkaConfig.getChangelogKafkaProperties("test1").getProperty("min.compaction.lag.ms"))
+    assertNotNull(kafkaConfig.getChangelogKafkaProperties("test1").getProperty("min.compaction.lag.ms"))
 
     props.setProperty("systems." + SYSTEM_NAME + ".samza.factory", "org.apache.samza.system.kafka.SomeOtherFactory")
     val storeToChangelog1 = kafkaConfig.getKafkaChangelogEnabledStores()


### PR DESCRIPTION
**Feature:** Turning transactional state restore on by default in order to roll out at-least-once fixes.
 
**Changes:** Changes the default value of `task.transactional.state.restore.enabled` from `false` to `true`.
 
 **Tests:** Wrote a test job that writes two sets of data, with a commit in between. Verified that on restart, only the first set of data (which is committed) gets restored.

**API Changes:** None
 
**Upgrade Instructions:** Please reference the [samza configuration page](https://samza.apache.org/learn/documentation/latest/jobs/samza-configurations.html#advanced-storage-configurations) for notes on configuring compaction lag for store changelogs that are backed by Kafka. For existing stores, the store specific configuration (`stores.store-name.changelog.min.compaction.lag.ms`) must be set to match the existing properties of the store's changelog topic. For newly created stores, samza will reference this value when creating the changelog topic.

With transactional state restore enabled, this value represents the maximum time duration a job can be down, or otherwise not have performed a checkpoint, while retaining its ability to revert to a store checkpoint transactionally. Once the latest checkpoint (C1) is older than this value, messages (if any) written _after_ C1 will become eligible for compaction and messages written before C1 with the same keys may be erased from the changelog. This prevents the application from accurately reverting to the state of C1 when it resumes.

Please refer to the configuration documentation for tradeoffs to consider on application startup time and changelog topic size.

Once these configurations have been set, upgrade to the version containing this commit, and re-deploy. Subsequent deploys will now revert to state checkpoints transactionally.
 
**Usage Instructions:** None

