### PR TITLE
SAMZA-2511 : Adding logic to handle container stop fail 

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterResourceManager.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ClusterResourceManager.java
@@ -180,6 +180,13 @@ public abstract class ClusterResourceManager {
      */
     void onStreamProcessorLaunchFailure(SamzaResource resource, Throwable t);
 
+    /**
+     * Callback invoked when there is a failure in stopping a processor on the provided {@link SamzaResource}.
+     * @param resource the resource on which the processor was running
+     * @param t the error in stopping the processor
+     */
+    void onStreamProcessorStopFailure(SamzaResource resource, Throwable t);
+
     /***
      * This callback is invoked when there is an error in the ClusterResourceManager. This is
      * guaranteed to be invoked when there is an uncaught exception in any other

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerAllocator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerAllocator.java
@@ -433,6 +433,10 @@ public class ContainerAllocator implements Runnable {
     resourceRequestState.releaseResource(containerId);
   }
 
+  public void cancelResourceRequest(SamzaResourceRequest samzaResourceRequest) {
+    resourceRequestState.cancelResourceRequest(samzaResourceRequest);
+  }
+
   /**
    * Stops the Allocator. Setting this flag to false exits the allocator loop.
    */

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerAllocator.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerAllocator.java
@@ -433,10 +433,6 @@ public class ContainerAllocator implements Runnable {
     resourceRequestState.releaseResource(containerId);
   }
 
-  public void cancelResourceRequest(SamzaResourceRequest samzaResourceRequest) {
-    resourceRequestState.cancelResourceRequest(samzaResourceRequest);
-  }
-
   /**
    * Stops the Allocator. Setting this flag to false exits the allocator loop.
    */

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerManager.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerManager.java
@@ -249,6 +249,8 @@ public class ContainerManager {
       ContainerPlacementMetadata metaData = getPlacementActionMetadata(processorId).get();
       markContainerPlacementActionFailed(metaData,
           String.format("failed to stop container on current host %s", metaData.getSourceHost()));
+
+      metaData.getResourceRequests().forEach(request -> containerAllocator.cancelResourceRequest(request));
     } else if (processorId != null && standbyContainerManager.isPresent()) {
       standbyContainerManager.get().handleContainerStopFail(processorId, containerId, containerAllocator);
     } else {

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerManager.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerManager.java
@@ -245,6 +245,7 @@ public class ContainerManager {
    * @param containerId last known id of the container deployed
    * @param containerHost host on which container is requested to be deployed
    * @param containerAllocator allocator for requesting resources
+   * TODO: SAMZA-2512 Add integ test for handleContainerStopFail
    */
   void handleContainerStopFail(String processorId, String containerId, String containerHost,
       ContainerAllocator containerAllocator) {

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/StandbyContainerManager.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/StandbyContainerManager.java
@@ -129,8 +129,9 @@ public class StandbyContainerManager {
   /**
    *  Handle the failed stop for a container, based on
    *  Case 1. If it is standby container, continue the failover
-   *  Case 2. If it is an active container, then log a warning and return.
-   * @param containerID the ID of the container that has failed
+   *  Case 2. If it is an active container, then this is in invalid state and throw an exception to alarm/restart.
+   * @param containerID the ID (e.g., 0, 1, 2) of the container that has failed
+   * @param resourceID id of the resource used for the failed container
    */
   public void handleContainerStopFail(String containerID, String resourceID,
       ContainerAllocator containerAllocator) {

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/container/placement/ContainerPlacementMetadata.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/container/placement/ContainerPlacementMetadata.java
@@ -40,7 +40,7 @@ public class ContainerPlacementMetadata {
   /**
    * State to track container failover
    */
-  public enum ContainerStatus { RUNNING, STOP_IN_PROGRESS, STOPPED }
+  public enum ContainerStatus { RUNNING, STOP_IN_PROGRESS, STOP_FAILED, STOPPED }
   // Container Placement request message
   private final ContainerPlacementRequestMessage requestMessage;
   // Host where the container is actively running
@@ -69,10 +69,6 @@ public class ContainerPlacementMetadata {
 
   public synchronized boolean containsResourceRequest(SamzaResourceRequest samzaResourceRequest) {
     return resourceRequests.contains(samzaResourceRequest);
-  }
-
-  public synchronized Set<SamzaResourceRequest> getResourceRequests() {
-    return new HashSet<>(this.resourceRequests);
   }
 
   public synchronized void setActionStatus(ContainerPlacementMessage.StatusCode statusCode, String responseMessage) {

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/container/placement/ContainerPlacementMetadata.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/container/placement/ContainerPlacementMetadata.java
@@ -71,6 +71,10 @@ public class ContainerPlacementMetadata {
     return resourceRequests.contains(samzaResourceRequest);
   }
 
+  public synchronized Set<SamzaResourceRequest> getResourceRequests() {
+    return new HashSet<>(this.resourceRequests);
+  }
+
   public synchronized void setActionStatus(ContainerPlacementMessage.StatusCode statusCode, String responseMessage) {
     this.actionStatus = statusCode;
     this.responseMessage = responseMessage;

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/MockClusterResourceManagerCallback.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/MockClusterResourceManagerCallback.java
@@ -48,6 +48,11 @@ public class MockClusterResourceManagerCallback implements ClusterResourceManage
   }
 
   @Override
+  public void onStreamProcessorStopFailure(SamzaResource resource, Throwable t) {
+    // no op
+  }
+
+  @Override
   public void onError(Throwable e) {
     error = e;
   }

--- a/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnClusterResourceManager.java
+++ b/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnClusterResourceManager.java
@@ -570,6 +570,9 @@ public class YarnClusterResourceManager extends ClusterResourceManager implement
     if (processorId != null) {
       log.info("Got stop error notification for Container ID: {} for Processor ID: {}", containerId, processorId, t);
       YarnContainer container = state.runningProcessors.get(processorId);
+      SamzaResource resource = new SamzaResource(container.resource().getVirtualCores(),
+          container.resource().getMemory(), container.nodeId().getHost(), containerId.toString());
+      clusterManagerCallback.onStreamProcessorStopFailure(resource, t);
     } else {
       log.warn("Did not find the running Processor ID for the stop error notification for Container ID: {}. " +
           "Ignoring notification", containerId);


### PR DESCRIPTION
Problem: The standby container manager does not handle container-stop-failures.
These events can happen as a result of certificate/authentication issue during the execution of the container-stop. The problem is the standby-container-failover flow relies on a stop-container succeeding and in this case does not complete the failover. This means the active container, for which a failover was initiated, is never started again.
In case of a container-placement action, that runs into container-stop-fail, the action is declared as failed. 
Cause: Above.
Fix: The fix is for standby-container-manager to intercept and handle these events by continuing the failover by either selecting another standby container (if one is present i.e., rf > 2) or using a standby host or using any-host.
API changes: None
Upgrade Instructions: None