### PR TITLE
SAMZA-2498: [Job coordinator isolation] Classloader isolation for SamzaApplication.describe execution in job coordinator

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/classloader/DependencyIsolationUtils.java
+++ b/samza-core/src/main/java/org/apache/samza/classloader/DependencyIsolationUtils.java
@@ -42,9 +42,18 @@ public class DependencyIsolationUtils {
 
   /**
    * Name of the file which contains the class names (or globs) which should be loaded from the framework API
-   * classloader.
+   * classloader by all classloaders.
+   * See {@link IsolatingClassLoaderFactory} for more context about what this is used for.
    */
   public static final String FRAMEWORK_API_CLASS_LIST_FILE_NAME = "samza-framework-api-classes.txt";
+
+  /**
+   * Name of the file which contains the class names (or globs) of pluggable components used during the application
+   * description step (e.g. system descriptors, table functions), which should be loaded from the framework API
+   * classloader for the application classloader.
+   * See {@link IsolatingClassLoaderFactory} for more context about what this is used for.
+   */
+  public static final String FRAMEWORK_DESCRIPTORS_FILE_NAME = "samza-framework-descriptors-classes.txt";
 
   public static final String RUNTIME_FRAMEWORK_RESOURCES_PATHING_JAR_NAME = "runtime-framework-resources-pathing.jar";
 }

--- a/samza-core/src/test/java/org/apache/samza/classloader/TestIsolatingClassLoaderFactory.java
+++ b/samza-core/src/test/java/org/apache/samza/classloader/TestIsolatingClassLoaderFactory.java
@@ -37,8 +37,9 @@ import static org.junit.Assert.assertTrue;
 public class TestIsolatingClassLoaderFactory {
   @Test
   public void testGetApiClasses() throws URISyntaxException {
-    File apiClassListFile = Paths.get(getClass().getResource("/classloader").toURI()).toFile();
-    List<String> apiClassNames = IsolatingClassLoaderFactory.getFrameworkApiClassGlobs(apiClassListFile);
+    File apiClassListFile =
+        new File(Paths.get(getClass().getResource("/classloader").toURI()).toFile(), "samza-framework-api-classes.txt");
+    List<String> apiClassNames = IsolatingClassLoaderFactory.readClassListFile(apiClassListFile);
     List<String> expected = ImmutableList.of(
         "org.apache.samza.JavaClass",
         "org.apache.samza.JavaClass$InnerJavaClass",
@@ -51,9 +52,9 @@ public class TestIsolatingClassLoaderFactory {
 
   @Test(expected = SamzaException.class)
   public void testGetApiClassesFileDoesNotExist() throws URISyntaxException {
-    File nonExistentDirectory =
-        new File(Paths.get(getClass().getResource("/classloader").toURI()).toFile(), "doesNotExist");
-    IsolatingClassLoaderFactory.getFrameworkApiClassGlobs(nonExistentDirectory);
+    File nonExistentFile =
+        new File(Paths.get(getClass().getResource("/classloader").toURI()).toFile(), "doesNotExist.txt");
+    IsolatingClassLoaderFactory.readClassListFile(nonExistentFile);
   }
 
   @Test


### PR DESCRIPTION
Feature: https://cwiki.apache.org/confluence/display/SAMZA/SEP-24%3A+Cluster-based+Job+Coordinator+Dependency+Isolation#SEP-24:Cluster-basedJobCoordinatorDependencyIsolation-HandlingSamzaApplication.describe

Changes: Add a new `samza-framework-descriptors-classes.txt` whitelist which will be the list of descriptors (including table functions) that are considered part of the framework, which apps may use to in their implementation of `SamzaApplication.describe`.

Testing:
1. Deployed `wikipedia-feed` application with isolation enabled and verified (using logs) that the correct classloaders were used to load the descriptors (the app uses a Kafka descriptor and a custom descriptor).
2. Modified `wikipedia-feed` to use a table descriptor and a fake table function which was included as part of the framework descriptors. Verified (using logs) that the correct classloaders loaded the table components in the job coordinator.
Note that further testing is going to be needed when using this new flow on the processing containers. We will need to ensure that the infrastructure classloader can use the descriptors properly when executing processing logic.

API/usage changes:
1. No change for applications.
2. When preparing the tarball for the framework API, an additional `samza-framework-descriptors-classes.txt` needs to be included, and it needs to include the classes (or globs) for the descriptors that are considered part of the framework.