### PR TITLE
SAMZA-2517 : Adding handling and relevant exception message for null in oldest offset from system-admin

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/storage/StorageManagerUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/StorageManagerUtil.java
@@ -94,7 +94,8 @@ public class StorageManagerUtil {
             + " The values between these offsets cannot be restored.", resumeOffset, oldestOffset);
       }
     }
-
+    LOG.info("Starting offset for SystemStreamPartition {} is {}, fileOffset: {}, oldestOffset from source: {}", ssp,
+        startingOffset, fileOffset, oldestOffset);
     return startingOffset;
   }
 

--- a/samza-core/src/main/java/org/apache/samza/storage/TaskSideInputStorageManager.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/TaskSideInputStorageManager.java
@@ -118,10 +118,10 @@ public class TaskSideInputStorageManager {
     LOG.info("Initializing side input stores.");
 
     Map<SystemStreamPartition, String> fileOffsets = getFileOffsets();
-    LOG.info("File offsets for the task {}: ", taskName, fileOffsets);
+    LOG.info("File offsets for the task {}: {}", taskName, fileOffsets);
 
     Map<SystemStreamPartition, String> oldestOffsets = getOldestOffsets();
-    LOG.info("Oldest offsets for the task {}: ", taskName, fileOffsets);
+    LOG.info("Oldest offsets for the task {}: {}", taskName, oldestOffsets);
 
     startingOffsets = getStartingOffsets(fileOffsets, oldestOffsets);
     LOG.info("Starting offsets for the task {}: {}", taskName, startingOffsets);
@@ -372,15 +372,9 @@ public class TaskSideInputStorageManager {
         // For SSPs belonging to the system stream, use the partition metadata to get the oldest offset
         // if partitionMetadata was not obtained for any SSP, populate oldest-offset as null
         // Because of https://bugs.openjdk.java.net/browse/JDK-8148463 using lambda will NPE when getOldestOffset() is null
-        Map<SystemStreamPartition, String> offsets = new HashMap<>();
         for (SystemStreamPartition ssp : systemStreamToSsp.get(systemStream)) {
-          if (partitionMetadata == null || partitionMetadata.get(ssp.getPartition()) == null) {
-            offsets.put(ssp, null);
-          } else {
-            offsets.put(ssp, partitionMetadata.get(ssp.getPartition()).getOldestOffset());
-          }
+          oldestOffsets.put(ssp, partitionMetadata.get(ssp.getPartition()).getOldestOffset());
         }
-        oldestOffsets.putAll(offsets);
       });
 
     return oldestOffsets;

--- a/samza-core/src/main/java/org/apache/samza/storage/TaskSideInputStorageManager.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/TaskSideInputStorageManager.java
@@ -346,7 +346,8 @@ public class TaskSideInputStorageManager {
    *   3. Fetches the partition metadata for each system stream and fetch the corresponding partition metadata
    *      and populates the oldest offset for SSPs belonging to the system stream.
    *
-   * @return a {@link Map} of {@link SystemStreamPartition} to their oldest offset.
+   * @return a {@link Map} of {@link SystemStreamPartition} to their oldest offset. If partitionMetadata could not be
+   * obtained for any {@link SystemStreamPartition} the offset for it is populated as null.
    */
   @VisibleForTesting
   Map<SystemStreamPartition, String> getOldestOffsets() {
@@ -363,15 +364,22 @@ public class TaskSideInputStorageManager {
 
     // Step 3
     metadata.forEach((systemStream, systemStreamMetadata) -> {
+
         // get the partition metadata for each system stream
         Map<Partition, SystemStreamMetadata.SystemStreamPartitionMetadata> partitionMetadata =
           systemStreamMetadata.getSystemStreamPartitionMetadata();
 
         // For SSPs belonging to the system stream, use the partition metadata to get the oldest offset
-        Map<SystemStreamPartition, String> offsets = systemStreamToSsp.get(systemStream).stream()
-          .collect(
-              Collectors.toMap(Function.identity(), ssp -> partitionMetadata.get(ssp.getPartition()).getOldestOffset()));
-
+        // if partitionMetadata was not obtained for any SSP, populate oldest-offset as null
+        // Because of https://bugs.openjdk.java.net/browse/JDK-8148463 using lambda will NPE when getOldestOffset() is null
+        Map<SystemStreamPartition, String> offsets = new HashMap<>();
+        for (SystemStreamPartition ssp : systemStreamToSsp.get(systemStream)) {
+          if (partitionMetadata == null || partitionMetadata.get(ssp.getPartition()) == null) {
+            offsets.put(ssp, null);
+          } else {
+            offsets.put(ssp, partitionMetadata.get(ssp.getPartition()).getOldestOffset());
+          }
+        }
         oldestOffsets.putAll(offsets);
       });
 

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -738,7 +738,8 @@ public class ContainerStorageManager {
       String startingOffset = sideInputStorageManagers.get(ssp).getStartingOffset(ssp);
 
       if (startingOffset == null) {
-        throw new SamzaException("No offset defined for SideInput SystemStreamPartition : " + ssp);
+        throw new SamzaException(
+            "No starting offset could be obtained for SideInput SystemStreamPartition : " + ssp + ". Consumer cannot start.");
       }
 
       // register startingOffset with the sysConsumer and register a metric for it

--- a/samza-core/src/test/java/org/apache/samza/storage/TestTaskSideInputStorageManager.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/TestTaskSideInputStorageManager.java
@@ -194,7 +194,7 @@ public class TestTaskSideInputStorageManager {
     final String storeName = "test-get-starting-offset-store";
     final String taskName = "test-get-starting-offset-task";
 
-    Set<SystemStreamPartition> ssps = IntStream.range(1, 6)
+    Set<SystemStreamPartition> ssps = IntStream.range(1, 2)
         .mapToObj(idx -> new SystemStreamPartition("test-system", "test-stream", new Partition(idx)))
         .collect(Collectors.toSet());
     Map<Partition, SystemStreamMetadata.SystemStreamPartitionMetadata> partitionMetadata = ssps.stream()


### PR DESCRIPTION
Problem: When a Kafka broker returns null for oldest-offset, because of a OpenJDK bug (https://bugs.openjdk.java.net/browse/JDK-8148463), the collect() operation in TaskSideInputStorageManager can fail with a misleading null-pointer-exception message.
Note however that, Kafka broker cannot return null for oldest-offset. 

Cause: Above.
Fix: The fix is to use the suggested workaround for the bug https://bugs.openjdk.java.net/browse/JDK-8148463
And update the exception and log messages in case the oldest-offset are returned as null from Kafka.
API changes: None
Upgrade Instructions: None