### PR TITLE
SAMZA-2518: Update JobCoordinatorLaunchUtil to fetch launch config from metadata store.

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -132,7 +132,7 @@ public class JobConfig extends MapConfig {
 
   // Auto-sizing related configs that take precedence over respective sizing confings job.container.count, etc,
   // *only* when job.autosizing.enabled is true. Otherwise current behavior is maintained.
-  private static final String JOB_AUTOSIZING_CONFIG_PREFIX = "job.autosizing."; // used to determine if a config is related to autosizing
+  public static final String JOB_AUTOSIZING_CONFIG_PREFIX = "job.autosizing."; // used to determine if a config is related to autosizing
   public static final String JOB_AUTOSIZING_ENABLED = JOB_AUTOSIZING_CONFIG_PREFIX + "enabled";
   public static final String JOB_AUTOSIZING_CONTAINER_COUNT = JOB_AUTOSIZING_CONFIG_PREFIX + "container.count";
   public static final String JOB_AUTOSIZING_CONTAINER_THREAD_POOL_SIZE = JOB_AUTOSIZING_CONFIG_PREFIX + "container.thread.pool.size";

--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -132,7 +132,7 @@ public class JobConfig extends MapConfig {
 
   // Auto-sizing related configs that take precedence over respective sizing confings job.container.count, etc,
   // *only* when job.autosizing.enabled is true. Otherwise current behavior is maintained.
-  public static final String JOB_AUTOSIZING_CONFIG_PREFIX = "job.autosizing."; // used to determine if a config is related to autosizing
+  private static final String JOB_AUTOSIZING_CONFIG_PREFIX = "job.autosizing."; // used to determine if a config is related to autosizing
   public static final String JOB_AUTOSIZING_ENABLED = JOB_AUTOSIZING_CONFIG_PREFIX + "enabled";
   public static final String JOB_AUTOSIZING_CONTAINER_COUNT = JOB_AUTOSIZING_CONFIG_PREFIX + "container.count";
   public static final String JOB_AUTOSIZING_CONTAINER_THREAD_POOL_SIZE = JOB_AUTOSIZING_CONFIG_PREFIX + "container.thread.pool.size";
@@ -351,7 +351,7 @@ public class JobConfig extends MapConfig {
    * @param configParam the config param to determine
    * @return true if the config is related to autosizing, false otherwise
    */
-  public boolean isAutosizingConfig(String configParam) {
+  public static boolean isAutosizingConfig(String configParam) {
     return configParam.startsWith(JOB_AUTOSIZING_CONFIG_PREFIX);
   }
 

--- a/samza-core/src/main/scala/org/apache/samza/util/CoordinatorStreamUtil.scala
+++ b/samza-core/src/main/scala/org/apache/samza/util/CoordinatorStreamUtil.scala
@@ -124,7 +124,7 @@ object CoordinatorStreamUtil extends Logging {
       val config = readConfigFromCoordinatorStream(metadataStore)
       val launchConfig: util.Map[String, String] = new util.HashMap[String, String]()
       for ((key:String, value:String) <- config.asScala) {
-        if (key.startsWith(JobConfig.JOB_AUTOSIZING_CONFIG_PREFIX)) {
+        if (JobConfig.isAutosizingConfig(key)) {
           launchConfig.put(key, value)
         }
       }
@@ -190,7 +190,7 @@ object CoordinatorStreamUtil extends Logging {
       val jobConfig = new JobConfig(config)
       if (jobConfig.getAutosizingEnabled) {
         // If autosizing is enabled, we retain auto-sizing related configs
-        keysToRemove = keysToRemove.filter(configKey => !jobConfig.isAutosizingConfig(configKey))
+        keysToRemove = keysToRemove.filter(configKey => !JobConfig.isAutosizingConfig(configKey))
       }
 
       info("Deleting old configs that are no longer defined: %s".format(keysToRemove))

--- a/samza-core/src/main/scala/org/apache/samza/util/CoordinatorStreamUtil.scala
+++ b/samza-core/src/main/scala/org/apache/samza/util/CoordinatorStreamUtil.scala
@@ -122,12 +122,8 @@ object CoordinatorStreamUtil extends Logging {
       new MapConfig()
     } else {
       val config = readConfigFromCoordinatorStream(metadataStore)
-      val launchConfig: util.Map[String, String] = new util.HashMap[String, String]()
-      for ((key:String, value:String) <- config.asScala) {
-        if (JobConfig.isAutosizingConfig(key)) {
-          launchConfig.put(key, value)
-        }
-      }
+      val launchConfig = config.asScala.filterKeys(key => JobConfig.isAutosizingConfig(key)).asJava
+
       new MapConfig(launchConfig)
     }
   }


### PR DESCRIPTION
Design:
https://cwiki.apache.org/confluence/display/SAMZA/SEP-23%3A+Simplify+Job+Runner

Changes:
1. Add readLaunchConfigFromCoordinatorStream() in CoordinatorStreamUtil
2. Add an extra step in JobCoordinatorLaunchUtil to invoke readLaunchConfigFromCoordinatorStream()

API Changes:
None

Upgrade Instructions:
None

Usage Instructions:
None

Tests:
Unit Tests