### PR TITLE
SAMZA-2519: Support duplicate timer registration

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/scheduler/EpochTimeScheduler.java
+++ b/samza-core/src/main/java/org/apache/samza/scheduler/EpochTimeScheduler.java
@@ -19,14 +19,15 @@
 
 package org.apache.samza.scheduler;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-
-import static com.google.common.base.Preconditions.checkState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Per-task scheduler for keyed timers.
@@ -36,7 +37,7 @@ import static com.google.common.base.Preconditions.checkState;
  * 3) triggers listener whenever a timer fires.
  */
 public class EpochTimeScheduler {
-
+  private static final Logger LOG = LoggerFactory.getLogger(EpochTimeScheduler.class);
   /**
    * For run loop to listen to timer firing so it can schedule the callbacks.
    */
@@ -57,9 +58,33 @@ public class EpochTimeScheduler {
     this.executor = executor;
   }
 
+  @VisibleForTesting
+  Map<Object, ScheduledFuture> getScheduledFutures() {
+    return scheduledFutures;
+  }
+
   public <K> void setTimer(K key, long timestamp, ScheduledCallback<K> callback) {
-    checkState(!scheduledFutures.containsKey(key),
-        String.format("Duplicate key %s registration for the same timer", key));
+    if (scheduledFutures.containsKey(key)) {
+      LOG.warn("Registering duplicate callback for key: {}. Attempting to cancel the previous callback", key);
+      ScheduledFuture<?> scheduledFuture = scheduledFutures.get(key);
+
+      /*
+       * We can have a race between the time we check for the presence of the key and the time we attempt to cancel;
+       * Hence we check for non-null criteria to ensure the executor hasn't kicked off the callback for the key which
+       * removes the future from the map before invoking onTimer.
+       *  1. In the event that callback is running then we will not attempt to interrupt the action and
+       *     cancel will return as unsuccessful.
+       *  2. In case of the callback successfully executed, we want to allow duplicate registration to keep the
+       *     behavior consistent with the scenario where the callback is already executed or in progress even before
+       *     we entered this condition.
+       */
+      if (scheduledFuture != null
+          && !scheduledFuture.cancel(false)
+          && !scheduledFuture.isDone()) {
+        LOG.debug("Failed to cancel the previous callback successfully. Ignoring the current request to register new callback");
+        return;
+      }
+    }
 
     final long delay = timestamp - System.currentTimeMillis();
     final ScheduledFuture<?> scheduledFuture = executor.schedule(() -> {

--- a/samza-core/src/main/java/org/apache/samza/scheduler/EpochTimeScheduler.java
+++ b/samza-core/src/main/java/org/apache/samza/scheduler/EpochTimeScheduler.java
@@ -81,7 +81,7 @@ public class EpochTimeScheduler {
       if (scheduledFuture != null
           && !scheduledFuture.cancel(false)
           && !scheduledFuture.isDone()) {
-        LOG.debug("Failed to cancel the previous callback successfully. Ignoring the current request to register new callback");
+        LOG.warn("Failed to cancel the previous callback successfully. Ignoring the current request to register new callback");
         return;
       }
     }


### PR DESCRIPTION
**Issue**: In EpochTimeScheduler, when the caller tries to register a duplicate timer with new callback, Samza throws an exception. This behavior prevents callers from updating the callbacks for a given timer key. 
**Changes**: Allow registration for duplicate timer key where the newer callback will overwrite the previous callback provided it can be canceled. Refer to API changes section for semantics change to the existing API.
**Tests**: Added unit tests to validate scenarios where duplicate registration succeeds vs no-ops.
**API Changes**: `setTimer` API now allows duplicate timer registration. The semantics of the duplicate registration is as follows
1. Duplicate registrations will attempt the cancel the previously registered callbacks. If its unsuccessful, the new request to register the timer will be ignored.
2. If the previously registered callback has been fired successfully at the time of the new request, the new request will be fulfilled. This is to ensure we remain consistent and stay inline with the current semantics.

**Upgrade Instructions**: None
**Usage Instructions**: None