### PR TITLE
SAMZA-2520: Log statement for trimmed messages is incorrect

### DIFF
--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/KeyValueStorageEngine.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/KeyValueStorageEngine.scala
@@ -196,7 +196,7 @@ class KeyValueStorageEngine[K, V](
       }
       lastBatchFlushed = true
     }
-    info(restoredMessages + " entries trimmed for store: " + storeName + " in directory: " + storeDir.toString + ".")
+    info(trimmedMessages + " entries trimmed for store: " + storeName + " in directory: " + storeDir.toString + ".")
 
     // flush the store and the changelog producer
     flush() // TODO HIGH pmaheshw SAMZA-2338: Need a way to flush changelog producers. This only flushes the stores.


### PR DESCRIPTION
**Symptom:** State restore logs trimmed incorrectly
 
**Cause:** Log statement references variable for restored rather than trimmed messages
 
**Tests:** none
**API Changes:** None
**Upgrade instructions:** None
**Usage instructions:** None