### PR TITLE
SAMZA-2521: Dependency Version Alignment between Samza Sql and Calcite of the janino compiler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -308,7 +308,7 @@ project(":samza-sql_$scalaSuffix") {
     compile project(":samza-kv-rocksdb_$scalaSuffix")
     compile "org.apache.avro:avro:$avroVersion"
     compile "org.apache.calcite:calcite-core:$calciteVersion"
-    compile "org.codehaus.janino:commons-compiler:2.7.6"
+    compile "org.codehaus.janino:commons-compiler:3.0.11"
     compile "org.slf4j:slf4j-api:$slf4jVersion"
     compile "org.reflections:reflections:0.9.10"
 


### PR DESCRIPTION
Dependency Version Alignment between Samza Sql and Calcite of the[ janino compiler](https://github.com/apache/calcite/blob/e3fe745a4e8e5e15ae5e04345975c98ab737b31b/gradle.properties#L96), moving to commons-compiler 3.0.11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/samza/1357)
<!-- Reviewable:end -->
