### PR TITLE
SAMZA-2522: Add metadata generator for azure storage blob

### DIFF
--- a/docs/learn/documentation/versioned/jobs/samza-configurations.md
+++ b/docs/learn/documentation/versioned/jobs/samza-configurations.md
@@ -271,6 +271,8 @@ Configs for producing to [Azure Blob Storage](https://azure.microsoft.com/en-us/
 |systems.**_system-name_**.azureblob.flushTimeoutMs|180000 (3 mins)|timeout to finish uploading all blocks before committing a blob.|
 |systems.**_system-name_**.azureblob.closeTimeoutMs|300000 (5 mins)|timeout to finish committing all the blobs currently being written to. This does not include the flush timeout per blob.|
 |systems.**_system-name_**.azureblob.suffixRandomStringToBlobName|true|if true, a random string of 8 chars is suffixed to the blob name to prevent name collision when more than one Samza tasks are writing to the same SSP.|
+|systems.**_system-name_**.azureblob.metadataPropertiesGeneratorFactory|`org.apache.samza.system.`<br>`azureblob.utils.`<br>`NullBlobMetadataGeneratorFactory`|Fully qualified class name of the `org.apache.samza.system.azureblob.utils.BlobMetadataGeneratorFactory` impl for the system producer. <br><br>The default metadata generator does not add any metadata to the blob.| 
+|systems.**_system-name_**.azureblob.metadataGeneratorConfig| |Additional configs for the metadata generator should be prefixed with this string which is passed to the generator.<br>For example, to pass a "key":"value" pair to the metadata generator, add config like systems.<system-name>.azureblob.metadataGeneratorConfig.\<key\> with value \<value\>| 
 
 
 ### <a name="state-storage"></a>[4. State Storage](#state-storage)

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobConfig.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobConfig.java
@@ -39,7 +39,8 @@ public class AzureBlobConfig extends MapConfig {
   public static final String SYSTEM_WRITER_FACTORY_CLASS_NAME_DEFAULT = "org.apache.samza.system.azureblob.avro.AzureBlobAvroWriterFactory";
 
   // Azure Storage Account name under which the Azure container representing this system is.
-  // System name = Azure container name (https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names)
+  // System name = Azure container name
+  // (https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names)
   public static final String SYSTEM_AZURE_ACCOUNT_NAME = Config.SENSITIVE_PREFIX + SYSTEM_AZUREBLOB_PREFIX + "account.name";
 
   // Azure Storage Account key associated with the Azure Storage Account
@@ -93,6 +94,18 @@ public class AzureBlobConfig extends MapConfig {
   // when more than one Samza tasks are writing to the same SSP.
   public static final String SYSTEM_SUFFIX_RANDOM_STRING_TO_BLOB_NAME = SYSTEM_AZUREBLOB_PREFIX + "suffixRandomStringToBlobName";
   private static final boolean SYSTEM_SUFFIX_RANDOM_STRING_TO_BLOB_NAME_DEFAULT = true;
+
+  // full class name of an implementation of org.apache.samza.system.azureblob.utils.BlobMetadataGeneratorFactory
+  // this factory should return an implementation of org.apache.samza.system.azureblob.utils.BlobMetadataGenerator
+  // this generator will be invoked when a blob is committed to add metadata properties to it
+  public static final String SYSTEM_BLOB_METADATA_PROPERTIES_GENERATOR_FACTORY = SYSTEM_AZUREBLOB_PREFIX + "metadataPropertiesGeneratorFactory";
+  private static final String SYSTEM_BLOB_METADATA_PROPERTIES_GENERATOR_FACTORY_DEFAULT =
+      "org.apache.samza.system.azureblob.utils.NullBlobMetadataGeneratorFactory";
+
+  // Additional configs for the metadata generator should be prefixed with this string which is passed to the generator.
+  // for example, to pass a "key":"value" pair to the metadata generator, add config like
+  // systems.<system-name>.azureblob.metadataGeneratorConfig.<key> with value <value>
+  public static final String SYSTEM_BLOB_METADATA_GENERATOR_CONFIG_PREFIX = SYSTEM_AZUREBLOB_PREFIX + "metadataGeneratorConfig";
 
   public AzureBlobConfig(Config config) {
     super(config);
@@ -184,5 +197,14 @@ public class AzureBlobConfig extends MapConfig {
 
   public long getMaxMessagesPerBlob(String systemName) {
     return getLong(String.format(SYSTEM_MAX_MESSAGES_PER_BLOB, systemName), SYSTEM_MAX_MESSAGES_PER_BLOB_DEFAULT);
+  }
+
+  public String getSystemMetadataPropertiesGeneratorFactory(String systemName) {
+    return get(String.format(SYSTEM_BLOB_METADATA_PROPERTIES_GENERATOR_FACTORY, systemName),
+        SYSTEM_BLOB_METADATA_PROPERTIES_GENERATOR_FACTORY_DEFAULT);
+  }
+
+  public Config getSystemMetadataGeneratorConfigs(String systemName) {
+    return subset(String.format(SYSTEM_BLOB_METADATA_GENERATOR_CONFIG_PREFIX, systemName));
   }
 }

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobConfig.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobConfig.java
@@ -105,7 +105,7 @@ public class AzureBlobConfig extends MapConfig {
   // Additional configs for the metadata generator should be prefixed with this string which is passed to the generator.
   // for example, to pass a "key":"value" pair to the metadata generator, add config like
   // systems.<system-name>.azureblob.metadataGeneratorConfig.<key> with value <value>
-  public static final String SYSTEM_BLOB_METADATA_GENERATOR_CONFIG_PREFIX = SYSTEM_AZUREBLOB_PREFIX + "metadataGeneratorConfig";
+  public static final String SYSTEM_BLOB_METADATA_GENERATOR_CONFIG_PREFIX = SYSTEM_AZUREBLOB_PREFIX + "metadataGeneratorConfig.";
 
   public AzureBlobConfig(Config config) {
     super(config);
@@ -199,12 +199,12 @@ public class AzureBlobConfig extends MapConfig {
     return getLong(String.format(SYSTEM_MAX_MESSAGES_PER_BLOB, systemName), SYSTEM_MAX_MESSAGES_PER_BLOB_DEFAULT);
   }
 
-  public String getSystemMetadataPropertiesGeneratorFactory(String systemName) {
+  public String getSystemBlobMetadataPropertiesGeneratorFactory(String systemName) {
     return get(String.format(SYSTEM_BLOB_METADATA_PROPERTIES_GENERATOR_FACTORY, systemName),
         SYSTEM_BLOB_METADATA_PROPERTIES_GENERATOR_FACTORY_DEFAULT);
   }
 
-  public Config getSystemMetadataGeneratorConfigs(String systemName) {
+  public Config getSystemBlobMetadataGeneratorConfigs(String systemName) {
     return subset(String.format(SYSTEM_BLOB_METADATA_GENERATOR_CONFIG_PREFIX, systemName));
   }
 }

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriter.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriter.java
@@ -110,7 +110,6 @@ public class AzureBlobAvroWriter implements AzureBlobWriter {
   private final long maxRecordsPerBlob;
   private final boolean useRandomStringInBlobName;
   private final Object currentDataFileWriterLock = new Object();
-  private volatile long blobNumber = 0;
   private volatile long recordsInCurrentBlob = 0;
   private BlobMetadataGeneratorFactory blobMetadataGeneratorFactory;
   private Config blobMetadataGeneratorConfig;

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriter.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriter.java
@@ -46,7 +46,9 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.samza.SamzaException;
+import org.apache.samza.config.Config;
 import org.apache.samza.system.OutgoingMessageEnvelope;
+import org.apache.samza.system.azureblob.utils.BlobMetadataGeneratorFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,10 +110,15 @@ public class AzureBlobAvroWriter implements AzureBlobWriter {
   private final long maxRecordsPerBlob;
   private final boolean useRandomStringInBlobName;
   private final Object currentDataFileWriterLock = new Object();
+  private volatile long blobNumber = 0;
   private volatile long recordsInCurrentBlob = 0;
+  private BlobMetadataGeneratorFactory blobMetadataGeneratorFactory;
+  private Config blobMetadataGeneratorConfig;
+  private String streamName;
 
   public AzureBlobAvroWriter(BlobContainerAsyncClient containerAsyncClient, String blobURLPrefix,
       Executor blobThreadPool, AzureBlobWriterMetrics metrics,
+      BlobMetadataGeneratorFactory blobMetadataGeneratorFactory, Config blobMetadataGeneratorConfig, String streamName,
       int maxBlockFlushThresholdSize, long flushTimeoutMs, Compression compression, boolean useRandomStringInBlobName,
       long maxBlobSize, long maxRecordsPerBlob) {
 
@@ -125,6 +132,9 @@ public class AzureBlobAvroWriter implements AzureBlobWriter {
     this.useRandomStringInBlobName = useRandomStringInBlobName;
     this.maxBlobSize = maxBlobSize;
     this.maxRecordsPerBlob = maxRecordsPerBlob;
+    this.blobMetadataGeneratorFactory = blobMetadataGeneratorFactory;
+    this.blobMetadataGeneratorConfig = blobMetadataGeneratorConfig;
+    this.streamName = streamName;
   }
 
   /**
@@ -217,6 +227,7 @@ public class AzureBlobAvroWriter implements AzureBlobWriter {
       Executor blobThreadPool, int maxBlockFlushThresholdSize, int flushTimeoutMs, String blobURLPrefix,
       DataFileWriter<IndexedRecord> dataFileWriter,
       AzureBlobOutputStream azureBlobOutputStream, BlockBlobAsyncClient blockBlobAsyncClient,
+      BlobMetadataGeneratorFactory blobMetadataGeneratorFactory, Config blobMetadataGeneratorConfig, String streamName,
       long maxBlobSize, long maxRecordsPerBlob, Compression compression, boolean useRandomStringInBlobName) {
     if (dataFileWriter == null || azureBlobOutputStream == null || blockBlobAsyncClient == null) {
       this.currentBlobWriterComponents = null;
@@ -235,6 +246,9 @@ public class AzureBlobAvroWriter implements AzureBlobWriter {
     this.useRandomStringInBlobName = useRandomStringInBlobName;
     this.maxBlobSize = maxBlobSize;
     this.maxRecordsPerBlob = maxRecordsPerBlob;
+    this.blobMetadataGeneratorFactory = blobMetadataGeneratorFactory;
+    this.blobMetadataGeneratorConfig = blobMetadataGeneratorConfig;
+    this.streamName = streamName;
   }
 
   @VisibleForTesting
@@ -318,8 +332,14 @@ public class AzureBlobAvroWriter implements AzureBlobWriter {
     BlockBlobAsyncClient blockBlobAsyncClient = containerAsyncClient.getBlobAsyncClient(blobURL).getBlockBlobAsyncClient();
 
     DataFileWriter<IndexedRecord> dataFileWriter = new DataFileWriter<>(datumWriter);
-    AzureBlobOutputStream azureBlobOutputStream = new AzureBlobOutputStream(blockBlobAsyncClient, blobThreadPool, metrics,
-            flushTimeoutMs, maxBlockFlushThresholdSize, compression);
+    AzureBlobOutputStream azureBlobOutputStream;
+    try {
+      azureBlobOutputStream = new AzureBlobOutputStream(blockBlobAsyncClient, blobThreadPool, metrics,
+          blobMetadataGeneratorFactory, blobMetadataGeneratorConfig,
+          streamName, flushTimeoutMs, maxBlockFlushThresholdSize, compression);
+    } catch (Exception e) {
+      throw new SamzaException("Unable to create AzureBlobOutputStream", e);
+    }
     dataFileWriter.create(schema, azureBlobOutputStream);
     dataFileWriter.setFlushOnEveryBlock(false);
     this.currentBlobWriterComponents = new BlobWriterComponents(dataFileWriter, azureBlobOutputStream, blockBlobAsyncClient);

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriterFactory.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriterFactory.java
@@ -26,6 +26,8 @@ import org.apache.samza.system.azureblob.producer.AzureBlobWriterMetrics;
 import com.azure.storage.blob.BlobContainerAsyncClient;
 import java.io.IOException;
 import java.util.concurrent.Executor;
+import org.apache.samza.config.Config;
+import org.apache.samza.system.azureblob.utils.BlobMetadataGeneratorFactory;
 
 
 public class AzureBlobAvroWriterFactory implements AzureBlobWriterFactory {
@@ -35,9 +37,11 @@ public class AzureBlobAvroWriterFactory implements AzureBlobWriterFactory {
    */
   public AzureBlobWriter getWriterInstance(BlobContainerAsyncClient containerAsyncClient, String blobURL,
       Executor blobUploadThreadPool, AzureBlobWriterMetrics metrics,
+      BlobMetadataGeneratorFactory blobMetadataGeneratorFactory, Config blobMetadataGeneratorConfig, String streamName,
       int maxBlockFlushThresholdSize, long flushTimeoutMs, Compression compression, boolean useRandomStringInBlobName,
       long maxBlobSize, long maxMessagesPerBlob) throws IOException {
     return new AzureBlobAvroWriter(containerAsyncClient, blobURL, blobUploadThreadPool, metrics,
-        maxBlockFlushThresholdSize, flushTimeoutMs, compression, useRandomStringInBlobName, maxBlobSize, maxMessagesPerBlob);
+          blobMetadataGeneratorFactory, blobMetadataGeneratorConfig, streamName, maxBlockFlushThresholdSize, flushTimeoutMs,
+          compression, useRandomStringInBlobName, maxBlobSize, maxMessagesPerBlob);
   }
 }

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/producer/AzureBlobSystemProducer.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/producer/AzureBlobSystemProducer.java
@@ -177,13 +177,13 @@ public class AzureBlobSystemProducer implements SystemProducer {
 
     this.metrics = new AzureBlobSystemProducerMetrics(systemName, config.getAzureAccountName(systemName), metricsRegistry);
 
-    String blobMetadataGeneratorFactoryClassName = this.config.getSystemMetadataPropertiesGeneratorFactory(this.systemName);
+    String blobMetadataGeneratorFactoryClassName = this.config.getSystemBlobMetadataPropertiesGeneratorFactory(this.systemName);
     try {
       blobMetadataGeneratorFactory = (BlobMetadataGeneratorFactory) Class.forName(blobMetadataGeneratorFactoryClassName).newInstance();
     } catch (Exception e) {
       throw new SystemProducerException("Could not create blob metadata generator factory with name " + blobMetadataGeneratorFactoryClassName, e);
     }
-    blobMetadataGeneratorConfig = this.config.getSystemMetadataGeneratorConfigs(systemName);
+    blobMetadataGeneratorConfig = this.config.getSystemBlobMetadataGeneratorConfigs(systemName);
   }
 
   /**

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/producer/AzureBlobWriterFactory.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/producer/AzureBlobWriterFactory.java
@@ -23,6 +23,8 @@ import org.apache.samza.system.azureblob.compression.Compression;
 import com.azure.storage.blob.BlobContainerAsyncClient;
 import java.io.IOException;
 import java.util.concurrent.Executor;
+import org.apache.samza.config.Config;
+import org.apache.samza.system.azureblob.utils.BlobMetadataGeneratorFactory;
 
 
 public interface AzureBlobWriterFactory {
@@ -32,6 +34,8 @@ public interface AzureBlobWriterFactory {
    * @param blobURL Azure blob url
    * @param blobUploadThreadPool thread pool to be used by writer for uploading
    * @param metrics metrics to measure the number of bytes written by writer
+   * @param blobMetadataGeneratorFactory factory to get generator for metadata properties for a blob
+   * @param streamName name of the stream that this AzureBlobWriter is associated with
    * @param maxBlockFlushThresholdSize threshold at which to upload
    * @param flushTimeoutMs timeout after which the flush is abandoned
    * @return AzureBlobWriter instance
@@ -39,6 +43,7 @@ public interface AzureBlobWriterFactory {
    */
   AzureBlobWriter getWriterInstance(BlobContainerAsyncClient containerAsyncClient, String blobURL,
       Executor blobUploadThreadPool, AzureBlobWriterMetrics metrics,
+      BlobMetadataGeneratorFactory blobMetadataGeneratorFactory, Config blobMetadataGeneratorConfig, String streamName,
       int maxBlockFlushThresholdSize, long flushTimeoutMs, Compression compression, boolean useRandomStringInBlobName,
       long maxBlobSize, long maxMessagesPerBlob) throws IOException;
 }

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/utils/BlobMetadataContext.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/utils/BlobMetadataContext.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.system.azureblob.utils;
+
+/**
+ * Properties about a Blob which can then be used to generate metadata for the blob
+ */
+public class BlobMetadataContext {
+  private final String streamName;
+  private final long blobSize;
+
+  public BlobMetadataContext(String streamName, long blobSize) {
+    this.streamName = streamName;
+    this.blobSize = blobSize;
+  }
+
+  public String getStreamName() {
+    return streamName;
+  }
+
+  public long getBlobSize() {
+    return blobSize;
+  }
+}

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/utils/BlobMetadataGenerator.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/utils/BlobMetadataGenerator.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.system.azureblob.utils;
+
+import java.util.Map;
+
+
+/**
+ * Interface for generating metadata properties of an Azure Blob.
+ * Implementation is not expected to be thread safe.
+ */
+public interface BlobMetadataGenerator {
+
+  /**
+   * create metadata properties for a blob
+   * @param blobMetatadataConext contains details about the blob that can be used for generating metadata
+   * @return map containing metadata properties to be associated with the blob
+   */
+  Map<String, String> getBlobMetadata(BlobMetadataContext blobMetatadataConext);
+}

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/utils/BlobMetadataGeneratorFactory.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/utils/BlobMetadataGeneratorFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.system.azureblob.utils;
+
+import org.apache.samza.config.Config;
+
+
+public interface BlobMetadataGeneratorFactory {
+
+  /**
+   * Creates an instance of {@link BlobMetadataGenerator}
+   */
+  BlobMetadataGenerator getBlobMetadataGeneratorInstance(Config blobMetadataGeneratorConfig);
+}

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/utils/NullBlobMetadataGenerator.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/utils/NullBlobMetadataGenerator.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.system.azureblob.utils;
+
+import java.util.Map;
+
+
+public class NullBlobMetadataGenerator implements BlobMetadataGenerator {
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Map<String, String> getBlobMetadata(BlobMetadataContext blobMetadataContext) {
+    return null;
+  }
+}

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/utils/NullBlobMetadataGeneratorFactory.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/utils/NullBlobMetadataGeneratorFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.system.azureblob.utils;
+
+import org.apache.samza.config.Config;
+
+
+public class NullBlobMetadataGeneratorFactory implements BlobMetadataGeneratorFactory {
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public BlobMetadataGenerator getBlobMetadataGeneratorInstance(Config blobMetadataGeneratorConfig) {
+    return new NullBlobMetadataGenerator();
+  }
+}

--- a/samza-azure/src/test/java/org/apache/samza/system/azureblob/avro/TestAzureBlobOutputStream.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/azureblob/avro/TestAzureBlobOutputStream.java
@@ -20,6 +20,7 @@
 package org.apache.samza.system.azureblob.avro;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import org.apache.samza.AzureException;
 import org.apache.samza.system.azureblob.compression.Compression;
 import org.apache.samza.system.azureblob.producer.AzureBlobWriterMetrics;
@@ -33,6 +34,10 @@ import java.util.Map;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import org.apache.samza.config.Config;
+import org.apache.samza.system.azureblob.utils.BlobMetadataContext;
+import org.apache.samza.system.azureblob.utils.BlobMetadataGenerator;
+import org.apache.samza.system.azureblob.utils.BlobMetadataGeneratorFactory;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,7 +52,9 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.anyObject;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -72,6 +79,11 @@ public class TestAzureBlobOutputStream {
   private static final byte[] COMPRESSED_BYTES = RANDOM_STRING.substring(0, THRESHOLD / 2).getBytes();
   private AzureBlobWriterMetrics mockMetrics;
   private Compression mockCompression;
+  private static final String FAKE_STREAM = "FAKE_STREAM";
+  private static final String BLOB_RAW_SIZE_BYTES_METADATA = "rawSizeBytes";
+  private static final String BLOB_STREAM_NAME_METADATA = "streamName";
+  private final BlobMetadataGeneratorFactory blobMetadataGeneratorFactory = mock(BlobMetadataGeneratorFactory.class);
+  private final Config blobMetadataGeneratorConfig = mock(Config.class);
 
   @Before
   public void setup() throws Exception {
@@ -90,12 +102,25 @@ public class TestAzureBlobOutputStream {
     mockCompression = mock(Compression.class);
     doReturn(COMPRESSED_BYTES).when(mockCompression).compress(BYTES);
 
+    BlobMetadataGenerator mockBlobMetadataGenerator = mock(BlobMetadataGenerator.class);
+    doAnswer(invocation -> {
+        BlobMetadataContext blobMetadataContext = invocation.getArgumentAt(0, BlobMetadataContext.class);
+        String streamName = blobMetadataContext.getStreamName();
+        Long blobSize = blobMetadataContext.getBlobSize();
+        Map<String, String> metadataProperties = new HashMap<>();
+        metadataProperties.put(BLOB_STREAM_NAME_METADATA, streamName);
+        metadataProperties.put(BLOB_RAW_SIZE_BYTES_METADATA, Long.toString(blobSize));
+        return metadataProperties;
+      }).when(mockBlobMetadataGenerator).getBlobMetadata(anyObject());
+
     azureBlobOutputStream = spy(new AzureBlobOutputStream(mockBlobAsyncClient, threadPool, mockMetrics,
+        blobMetadataGeneratorFactory, blobMetadataGeneratorConfig, FAKE_STREAM,
         60000, THRESHOLD, mockByteArrayOutputStream, mockCompression));
 
     doNothing().when(azureBlobOutputStream).commitBlob(any(ArrayList.class), anyMap());
     doNothing().when(azureBlobOutputStream).stageBlock(anyString(), any(ByteBuffer.class), anyInt());
     doNothing().when(azureBlobOutputStream).clearAndMarkClosed();
+    doReturn(mockBlobMetadataGenerator).when(azureBlobOutputStream).getBlobMetadataGenerator();
   }
 
   @Test
@@ -216,7 +241,8 @@ public class TestAzureBlobOutputStream {
     verify(azureBlobOutputStream).commitBlob(blockListArgument.capture(), blobMetadataArg.capture());
     Assert.assertEquals(Arrays.asList(blockIdEncoded), blockListArgument.getAllValues().get(0));
     Map<String, String> blobMetadata = (Map<String, String>) blobMetadataArg.getAllValues().get(0);
-    Assert.assertEquals(blobMetadata.get(AzureBlobOutputStream.BLOB_RAW_SIZE_BYTES_METADATA), Long.toString(THRESHOLD));
+    Assert.assertEquals(blobMetadata.get(BLOB_RAW_SIZE_BYTES_METADATA), Long.toString(THRESHOLD));
+    Assert.assertEquals(blobMetadata.get(BLOB_STREAM_NAME_METADATA), FAKE_STREAM);
   }
 
   @Test
@@ -239,13 +265,15 @@ public class TestAzureBlobOutputStream {
     Assert.assertEquals(blockIdEncoded, blockListArgument.getAllValues().get(0).toArray()[0]);
     Assert.assertEquals(blockIdEncoded1, blockListArgument.getAllValues().get(0).toArray()[1]);
     Map<String, String> blobMetadata = (Map<String, String>) blobMetadataArg.getAllValues().get(0);
-    Assert.assertEquals(blobMetadata.get(AzureBlobOutputStream.BLOB_RAW_SIZE_BYTES_METADATA), Long.toString(2 * THRESHOLD));
+    Assert.assertEquals(blobMetadata.get(BLOB_RAW_SIZE_BYTES_METADATA), Long.toString(2 * THRESHOLD));
+    Assert.assertEquals(blobMetadata.get(BLOB_STREAM_NAME_METADATA), FAKE_STREAM);
   }
 
   @Test(expected = AzureException.class)
   public void testCloseFailed() {
 
     azureBlobOutputStream = spy(new AzureBlobOutputStream(mockBlobAsyncClient, threadPool, mockMetrics,
+        blobMetadataGeneratorFactory, blobMetadataGeneratorConfig, FAKE_STREAM,
         60000, THRESHOLD, mockByteArrayOutputStream, mockCompression));
 
     //doNothing().when(azureBlobOutputStream).commitBlob(any(ArrayList.class), anyMap());
@@ -286,6 +314,7 @@ public class TestAzureBlobOutputStream {
   @Test (expected = AzureException.class)
   public void testFlushFailed() throws IOException {
     azureBlobOutputStream = spy(new AzureBlobOutputStream(mockBlobAsyncClient, threadPool, mockMetrics,
+        blobMetadataGeneratorFactory, blobMetadataGeneratorConfig, FAKE_STREAM,
         60000, THRESHOLD, mockByteArrayOutputStream, mockCompression));
 
     doNothing().when(azureBlobOutputStream).commitBlob(any(ArrayList.class), anyMap());

--- a/samza-azure/src/test/java/org/apache/samza/system/azureblob/producer/TestAzureBlobSystemProducer.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/azureblob/producer/TestAzureBlobSystemProducer.java
@@ -45,6 +45,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -95,7 +96,7 @@ public class TestAzureBlobSystemProducer {
 
     systemProducer = spy(new AzureBlobSystemProducer(SYSTEM_NAME, azureBlobConfig, mockMetricsRegistry));
     // use mock writer impl
-    doReturn(mockAzureWriter).when(systemProducer).createNewWriter(anyString(), any());
+    setupWriterForProducer(systemProducer, mockAzureWriter, STREAM);
     // bypass Azure connection setup
     doNothing().when(systemProducer).setupAzureContainer(anyString(), anyString());
   }
@@ -415,7 +416,7 @@ public class TestAzureBlobSystemProducer {
     systemProducer.register(source1);
     systemProducer.start();
 
-    doReturn(mockAzureWriter1).when(systemProducer).createNewWriter(anyString(), any());
+    setupWriterForProducer(systemProducer, mockAzureWriter1, stream1);
 
     Thread t1 = sendFlushInThread(source1, ome1, systemProducer, sendsInFirstThread);
     Thread t2 = sendFlushInThread(source1, ome1, systemProducer, sendsInSecondThread);
@@ -451,7 +452,7 @@ public class TestAzureBlobSystemProducer {
     // bypass Azure connection setup
     doNothing().when(systemProducer).setupAzureContainer(anyString(), anyString());
 
-    doReturn(mockAzureWriter1).when(systemProducer).createNewWriter(anyString(), any());
+    setupWriterForProducer(systemProducer, mockAzureWriter1, stream1);
 
     systemProducer.register(source1);
     systemProducer.start();
@@ -493,7 +494,7 @@ public class TestAzureBlobSystemProducer {
     // bypass Azure connection setup
     doNothing().when(systemProducer).setupAzureContainer(anyString(), anyString());
 
-    doReturn(mockAzureWriter1).when(systemProducer).createNewWriter(anyString(), any());
+    setupWriterForProducer(systemProducer, mockAzureWriter1, STREAM);
 
     systemProducer.register(source1);
     systemProducer.start();
@@ -590,5 +591,16 @@ public class TestAzureBlobSystemProducer {
     bareConfigs.put(String.format(AzureBlobConfig.SYSTEM_CLOSE_TIMEOUT_MS, SYSTEM_NAME), "1000");
     Config config = new MapConfig(bareConfigs);
     return config;
+  }
+
+  private void setupWriterForProducer(AzureBlobSystemProducer azureBlobSystemProducer,
+      AzureBlobWriter mockAzureBlobWriter, String stream) {
+    doAnswer(invocation -> {
+        String blobUrl = invocation.getArgumentAt(0, String.class);
+        String streamName = invocation.getArgumentAt(2, String.class);
+        Assert.assertEquals(stream, streamName);
+        Assert.assertEquals(stream, blobUrl);
+        return mockAzureBlobWriter;
+      }).when(azureBlobSystemProducer).createNewWriter(anyString(), any(), anyString());
   }
 }

--- a/samza-azure/src/test/java/org/apache/samza/system/azureblob/utils/TestNullBlobMetadataGenerator.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/azureblob/utils/TestNullBlobMetadataGenerator.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.system.azureblob.utils;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class TestNullBlobMetadataGenerator {
+  private NullBlobMetadataGenerator nullBlobMetadataGenerator;
+
+  @Before
+  public void setup() {
+    nullBlobMetadataGenerator = new NullBlobMetadataGenerator();
+  }
+
+  @Test
+  public void testGetBlobMetadata() {
+    Assert.assertNull(nullBlobMetadataGenerator.getBlobMetadata(new BlobMetadataContext("fake_stream", 100)));
+  }
+
+  @Test
+  public void testGetBlobMetadataEmptyInput() {
+    Assert.assertNull(nullBlobMetadataGenerator.getBlobMetadata(new BlobMetadataContext("", 0)));
+  }
+
+  @Test
+  public void testGetBlobMetadataNullInput() {
+    Assert.assertNull(nullBlobMetadataGenerator.getBlobMetadata(new BlobMetadataContext(null, 0)));
+  }
+}


### PR DESCRIPTION
**Feature:** This PR extends the existing AzureBlobSystemProducer by adding the ability to enhance an azure storage blob with metadata - basically key-value pairs to the blob's metadata (sits outside of the blob's actual content). This aids tremendously in ingesting these blobs into Kusto (Azure's data explorer). 

**Changes:** New interfaces BlobMetadataGeneratorFactory, BlobMetadataGenerator and class BlobMetadataContext added where the user needs to implement BlobMetadataGeneratorFactory and BlobMetadataGenerator which takes in a BlobMetadataContext containing the stream name and the size of the current blob being committed. An instance of the generator will be created when the blob is about to be committed. Generator is invoked to get metadata and the returned metadata is attached to the blob.
Any additional configs (key:value pairs) needed for this generator can be passed as with prefix systems.<system-name>.azureblob.metadataGeneratorConfig.\<key\> with value \<value\>. 

A default impl is provided which does not add anything to the blob.

**API changes:** New interfaces BlobMetadataGeneratorFactory, BlobMetadataGenerator and class BlobMetadataContext added. New configs with prefix systems.<system-name>.azureblob.metadataGeneratorConfig. The factory is wired in through systems.<system-name>.azureblob.metadataPropertiesGeneratorFactory. 
Prior to this PR, "rawSizeBytes" metadata was always added  by default to the blobs committed. Now, that will not be the case. A BlobMetadataGenerator implementation has to be provided to add this. 

**Upgrade instructions:** Backwards incompatible. "rawSizeBytes" metadata will no longer be added by default. Instead a generator will have to be provided. 

**Usage instructions:** Wire in the generator factory through systems.<system-name>.azureblob.metadataPropertiesGeneratorFactory and pass in additional configs with prefix systems.<system-name>.azureblob.metadataGeneratorConfig 

**Tests:** Existing tests updated to assert for metadata attached.