### PR TITLE
SAMZA-2523: Update Util#envVarEscape to escape more characters

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/util/Util.java
+++ b/samza-core/src/main/java/org/apache/samza/util/Util.java
@@ -45,7 +45,11 @@ public class Util {
    * Make an environment variable string safe to pass.
    */
   public static String envVarEscape(String str) {
-    return str.replace("\"", "\\\"").replace("'", "\\'");
+    return str
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+        .replace("'", "\\'")
+        .replace("`", "\\`");
   }
 
   public static String getSamzaVersion() {

--- a/samza-core/src/test/java/org/apache/samza/util/TestUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/util/TestUtil.java
@@ -50,8 +50,8 @@ public class TestUtil {
     String noSpecialCharacters = "hello world 123 .?!";
     assertEquals(noSpecialCharacters, Util.envVarEscape(noSpecialCharacters));
 
-    String withSpecialCharacters = "quotation \" apostrophe '";
-    String escaped = "quotation \\\" apostrophe \\'";
+    String withSpecialCharacters = "quotation \" apostrophe ' backslash \\ grave accent `";
+    String escaped = "quotation \\\" apostrophe \\' backslash \\\\ grave accent \\`";
     assertEquals(escaped, Util.envVarEscape(withSpecialCharacters));
   }
 


### PR DESCRIPTION
Symptom: Job to fail to launch.
Cause: Backslash and grave accent in submission config is not properly escaped, causing launch.sh to break.
Changes: Update Util#envVarEscape to escape backslash as well as grave accent.
Tests: Unit tests updated to test such cases.
API Changes: None
Upgrade Instructions: None
Usage Instructions: None