### PR TITLE
SAMZA-2524:Fix Util#envVarEscape not to escape apostrophe

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/util/Util.java
+++ b/samza-core/src/main/java/org/apache/samza/util/Util.java
@@ -48,7 +48,6 @@ public class Util {
     return str
         .replace("\\", "\\\\")
         .replace("\"", "\\\"")
-        .replace("'", "\\'")
         .replace("`", "\\`");
   }
 

--- a/samza-core/src/test/java/org/apache/samza/util/TestUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/util/TestUtil.java
@@ -47,11 +47,11 @@ public class TestUtil {
   @Test
   public void testEnvVarEscape() {
     // no special characters in original
-    String noSpecialCharacters = "hello world 123 .?!";
+    String noSpecialCharacters = "hello world 123 .?! '";
     assertEquals(noSpecialCharacters, Util.envVarEscape(noSpecialCharacters));
 
-    String withSpecialCharacters = "quotation \" apostrophe ' backslash \\ grave accent `";
-    String escaped = "quotation \\\" apostrophe \\' backslash \\\\ grave accent \\`";
+    String withSpecialCharacters = "quotation \" backslash \\ grave accent `";
+    String escaped = "quotation \\\" backslash \\\\ grave accent \\`";
     assertEquals(escaped, Util.envVarEscape(withSpecialCharacters));
   }
 


### PR DESCRIPTION
Symptom: Job to fail to launch.
Cause: apostrophe in config is escaped causing SamzaObjectMapper.getObjectMapper().readValue to fail on AM when reading env var.
 Changes: Update Util#envVarEscape not to escape apostrophe.
Tests: Unit tests updated to test such cases.
API Changes: None
Upgrade Instructions: None
Usage Instructions: None