### PR TITLE
SAMZA-2525:Fix race condition in ClientHelper#isActiveApplication

### DIFF
--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/ClientHelper.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/ClientHelper.scala
@@ -301,8 +301,8 @@ class ClientHelper(conf: Configuration) extends Logging {
   }
 
   private def isActiveApplication(applicationReport: ApplicationReport): Boolean = {
-    (Running.equals(toAppStatus(applicationReport).get)
-    || New.equals(toAppStatus(applicationReport).get))
+    val status = toAppStatus(applicationReport).get
+    Running.equals(status) || New.equals(status)
   }
 
   def toAppStatus(applicationReport: ApplicationReport): Option[ApplicationStatus] = {


### PR DESCRIPTION
Symptom:Incorrect job status reported, which is previous deployed job status instead of current job.
Cause:ClientHelper#isActiveApplication is invoking toAppStatus twice when comparing status to Running or New. It could happen that 1st time, the status is New which failed Running check, and 2nd invocation returns Running, which failed New check, this will result in the current app to be classified as non active causing ClientHelper to return job status of a previous deployed app.
Changes: Update ClientHelper#isActiveApplication to invoke toAppStatus once and compare both status against this single result.
Tests: None
API Changes: None
Upgrade Instructions: None
Usage Instructions: None