### PR TITLE
SAMZA-2534: AzureBlobSystemProducer: Enable adding of number of records in blob as metadata of the blob

### DIFF
--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriter.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriter.java
@@ -178,6 +178,7 @@ public class AzureBlobAvroWriter implements AzureBlobWriter {
       }
       currentBlobWriterComponents.dataFileWriter.appendEncoded(ByteBuffer.wrap(encodedRecord));
       recordsInCurrentBlob++;
+      currentBlobWriterComponents.azureBlobOutputStream.incrementNumberOfRecordsInBlob();
     }
   }
   /**

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriter.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriter.java
@@ -178,6 +178,8 @@ public class AzureBlobAvroWriter implements AzureBlobWriter {
       }
       currentBlobWriterComponents.dataFileWriter.appendEncoded(ByteBuffer.wrap(encodedRecord));
       recordsInCurrentBlob++;
+      // incrementNumberOfRecordsInBlob should always be invoked every time appendEncoded above is invoked.
+      // this is to count the number records in a blob and then use that count as a metadata of the blob.
       currentBlobWriterComponents.azureBlobOutputStream.incrementNumberOfRecordsInBlob();
     }
   }

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobOutputStream.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobOutputStream.java
@@ -85,6 +85,7 @@ public class AzureBlobOutputStream extends OutputStream {
 
   private volatile boolean isClosed = false;
   private long totalUploadedBlockSize = 0;
+  private long totalNumberOfRecordsInBlob = 0;
   private int blockNum;
   private final BlobMetadataGeneratorFactory blobMetadataGeneratorFactory;
   private final Config blobMetadataGeneratorConfig;
@@ -194,7 +195,7 @@ public class AzureBlobOutputStream extends OutputStream {
       LOG.info("For blob: {} committing blockList size:{}", blobAsyncClient.getBlobUrl().toString(), blockList.size());
       metrics.updateAzureCommitMetrics();
       BlobMetadataGenerator blobMetadataGenerator = getBlobMetadataGenerator();
-      commitBlob(blockList, blobMetadataGenerator.getBlobMetadata(new BlobMetadataContext(streamName, totalUploadedBlockSize)));
+      commitBlob(blockList, blobMetadataGenerator.getBlobMetadata(new BlobMetadataContext(streamName, totalUploadedBlockSize, totalNumberOfRecordsInBlob)));
     } catch (Exception e) {
       String msg = String.format("Close blob %s failed with exception. Total pending sends %d",
           blobAsyncClient.getBlobUrl().toString(), pendingUpload.size());
@@ -228,6 +229,10 @@ public class AzureBlobOutputStream extends OutputStream {
       LOG.info("Internal buffer has been released for blob " + blobAsyncClient.getBlobUrl().toString()
           + ". Writes are no longer entertained.");
     }
+  }
+
+  public synchronized void incrementNumberOfRecordsInBlob() {
+    totalNumberOfRecordsInBlob++;
   }
 
   @VisibleForTesting

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobOutputStream.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobOutputStream.java
@@ -162,6 +162,7 @@ public class AzureBlobOutputStream extends OutputStream {
   /**
    * This api waits for all pending upload (stageBlock task) futures to finish.
    * It then synchronously commits the list of blocks to persist the actual blob on storage.
+   * Note: this method does not invoke flush and flush has to be explicitly called before close.
    * @throws IllegalStateException when
    *       - when closing an already closed stream
    * @throws RuntimeException when
@@ -231,6 +232,16 @@ public class AzureBlobOutputStream extends OutputStream {
     }
   }
 
+  /**
+   * This method is to be used for tracking the number of records written to the outputstream.
+   * However, since records are written in chunks through write(byte[],int,int) method,
+   * it is possible that all records are not completely written until flush is invoked.
+   *
+   * Additionally, the count of number of records is intended to be used only as part of
+   * blob's metadata at blob commit time which happens at close.
+   * Thus, the totalNumberOfRecordsInBlob is not fetched until close method.
+   * Since flush is called before close, this totalNumberOfRecordsInBlob is accurate.
+   */
   public synchronized void incrementNumberOfRecordsInBlob() {
     totalNumberOfRecordsInBlob++;
   }

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/utils/BlobMetadataContext.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/utils/BlobMetadataContext.java
@@ -25,10 +25,12 @@ package org.apache.samza.system.azureblob.utils;
 public class BlobMetadataContext {
   private final String streamName;
   private final long blobSize;
+  private final long numberOfMessagesInBlob;
 
-  public BlobMetadataContext(String streamName, long blobSize) {
+  public BlobMetadataContext(String streamName, long blobSize, long numberOfMessagesInBlob) {
     this.streamName = streamName;
     this.blobSize = blobSize;
+    this.numberOfMessagesInBlob = numberOfMessagesInBlob;
   }
 
   public String getStreamName() {
@@ -37,5 +39,9 @@ public class BlobMetadataContext {
 
   public long getBlobSize() {
     return blobSize;
+  }
+
+  public long getNumberOfMessagesInBlob() {
+    return numberOfMessagesInBlob;
   }
 }

--- a/samza-azure/src/test/java/org/apache/samza/system/azureblob/avro/TestAzureBlobAvroWriter.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/azureblob/avro/TestAzureBlobAvroWriter.java
@@ -163,6 +163,7 @@ public class TestAzureBlobAvroWriter {
       azureBlobAvroWriter.write(ome);
     }
     verify(mockDataFileWriter, times(numberOfMessages)).appendEncoded(ByteBuffer.wrap(encodedRecord));
+    verify(mockAzureBlobOutputStream, times(numberOfMessages)).incrementNumberOfRecordsInBlob();
   }
 
   @Test
@@ -174,6 +175,7 @@ public class TestAzureBlobAvroWriter {
       azureBlobAvroWriter.write(omeGenericRecord);
     }
     verify(mockDataFileWriter, times(numberOfMessages)).appendEncoded(ByteBuffer.wrap(encodedRecord));
+    verify(mockAzureBlobOutputStream, times(numberOfMessages)).incrementNumberOfRecordsInBlob();
   }
 
   @Test
@@ -186,6 +188,7 @@ public class TestAzureBlobAvroWriter {
     }
     verify(mockDataFileWriter).appendEncoded(ByteBuffer.wrap(encodedRecord));
     verify(mockDataFileWriter, times(numberOfMessages)).appendEncoded(ByteBuffer.wrap((byte[]) omeEncoded.getMessage()));
+    verify(mockAzureBlobOutputStream, times(numberOfMessages + 1)).incrementNumberOfRecordsInBlob(); // +1 to account for first ome which is not encoded
   }
 
   @Test(expected = IllegalStateException.class)
@@ -421,6 +424,7 @@ public class TestAzureBlobAvroWriter {
 
     verify(mockDataFileWriter, times(10)).appendEncoded(ByteBuffer.wrap(encodedRecord));
     verify(mockDataFileWriter, times(10)).appendEncoded(ByteBuffer.wrap(encodeRecord((IndexedRecord) ome2.getMessage())));
+    verify(mockAzureBlobOutputStream, times(20)).incrementNumberOfRecordsInBlob();
   }
 
   @Test
@@ -434,6 +438,7 @@ public class TestAzureBlobAvroWriter {
     t2.join(60000);
 
     verify(mockDataFileWriter, times(10)).appendEncoded(ByteBuffer.wrap(encodedRecord));
+    verify(mockAzureBlobOutputStream, times(10)).incrementNumberOfRecordsInBlob();
     verify(mockDataFileWriter).flush();
   }
 
@@ -451,6 +456,7 @@ public class TestAzureBlobAvroWriter {
     verify(mockDataFileWriter, times(10)).appendEncoded(ByteBuffer.wrap(encodedRecord));
     verify(mockDataFileWriter, times(10)).appendEncoded(ByteBuffer.wrap(encodeRecord((IndexedRecord) ome2.getMessage())));
     verify(mockDataFileWriter, times(2)).flush();
+    verify(mockAzureBlobOutputStream, times(20)).incrementNumberOfRecordsInBlob();
   }
 
   @Test
@@ -469,6 +475,7 @@ public class TestAzureBlobAvroWriter {
     verify(mockDataFileWriter, times(10)).appendEncoded(ByteBuffer.wrap(encodeRecord((IndexedRecord) ome2.getMessage())));
     verify(mockDataFileWriter, times(2)).flush();
     verify(mockDataFileWriter).close();
+    verify(mockAzureBlobOutputStream, times(20)).incrementNumberOfRecordsInBlob();
   }
 
   private byte[] encodeRecord(IndexedRecord record) throws Exception {

--- a/samza-azure/src/test/java/org/apache/samza/system/azureblob/utils/TestNullBlobMetadataGenerator.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/azureblob/utils/TestNullBlobMetadataGenerator.java
@@ -34,16 +34,16 @@ public class TestNullBlobMetadataGenerator {
 
   @Test
   public void testGetBlobMetadata() {
-    Assert.assertNull(nullBlobMetadataGenerator.getBlobMetadata(new BlobMetadataContext("fake_stream", 100)));
+    Assert.assertNull(nullBlobMetadataGenerator.getBlobMetadata(new BlobMetadataContext("fake_stream", 100, 10)));
   }
 
   @Test
   public void testGetBlobMetadataEmptyInput() {
-    Assert.assertNull(nullBlobMetadataGenerator.getBlobMetadata(new BlobMetadataContext("", 0)));
+    Assert.assertNull(nullBlobMetadataGenerator.getBlobMetadata(new BlobMetadataContext("", 0, 0)));
   }
 
   @Test
   public void testGetBlobMetadataNullInput() {
-    Assert.assertNull(nullBlobMetadataGenerator.getBlobMetadata(new BlobMetadataContext(null, 0)));
+    Assert.assertNull(nullBlobMetadataGenerator.getBlobMetadata(new BlobMetadataContext(null, 0, 0)));
   }
 }


### PR DESCRIPTION
Feature: Enable addition of number of records in a blob to the blob's metadata. 

Changes: BlobMetadataContext passed as input to BlobMetadataGenerator interface now have an additional field giving the number of records in the blob. This can be used as needed by the generator.

API changes: BlobMetadataContext passed as input to BlobMetadataGenerator interface now have an additional field giving the number of records in the blob. This can be used as needed by the generator.

Upgrade Instructions: None

Usage Instructions: None

Tests: unit test updated.