### PR TITLE
SAMZA-2530: Split out processing logic from TaskSideInputStorageManager

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/storage/TaskSideInputHandler.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/TaskSideInputHandler.java
@@ -22,7 +22,6 @@ package org.apache.samza.storage;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
-import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -80,14 +79,14 @@ public class TaskSideInputHandler {
 
     this.sspToStores = new HashMap<>();
     storeToSSPs.forEach((store, ssps) -> {
-      for (SystemStreamPartition ssp: ssps) {
-        this.sspToStores.computeIfAbsent(ssp, key -> new HashSet<>());
-        this.sspToStores.computeIfPresent(ssp, (key, value) -> {
-          value.add(store);
-          return value;
-        });
-      }
-    });
+        for (SystemStreamPartition ssp: ssps) {
+          this.sspToStores.computeIfAbsent(ssp, key -> new HashSet<>());
+          this.sspToStores.computeIfPresent(ssp, (key, value) -> {
+              value.add(store);
+              return value;
+            });
+        }
+      });
 
     this.taskSideInputStorageManager = new TaskSideInputStorageManager(taskName,
         taskMode,

--- a/samza-core/src/main/java/org/apache/samza/storage/TaskSideInputHandler.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/TaskSideInputHandler.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.storage;
+
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.File;
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.apache.samza.Partition;
+import org.apache.samza.SamzaException;
+import org.apache.samza.container.TaskName;
+import org.apache.samza.job.model.TaskMode;
+import org.apache.samza.storage.kv.Entry;
+import org.apache.samza.storage.kv.KeyValueStore;
+import org.apache.samza.system.IncomingMessageEnvelope;
+import org.apache.samza.system.StreamMetadataCache;
+import org.apache.samza.system.SystemAdmins;
+import org.apache.samza.system.SystemStream;
+import org.apache.samza.system.SystemStreamMetadata;
+import org.apache.samza.system.SystemStreamPartition;
+import org.apache.samza.util.Clock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.collection.JavaConverters;
+
+
+/**
+ * This class encapsulates all processing logic / state for all side input SSPs within a task.
+ */
+public class TaskSideInputHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(TaskSideInputHandler.class);
+
+  private final StorageManagerUtil storageManagerUtil = new StorageManagerUtil();
+
+  private final TaskName taskName;
+  private final TaskSideInputStorageManager taskSideInputStorageManager;
+  private final Map<SystemStreamPartition, Set<String>> sspToStores;
+  private final Map<String, SideInputsProcessor> storeToProcessor;
+  private final SystemAdmins systemAdmins;
+  private final StreamMetadataCache streamMetadataCache;
+  private final Map<SystemStreamPartition, String> lastProcessedOffsets = new ConcurrentHashMap<>();
+
+  private Map<SystemStreamPartition, String> startingOffsets;
+
+  public TaskSideInputHandler(
+      TaskName taskName,
+      TaskMode taskMode,
+      File storeBaseDir,
+      Map<String, StorageEngine> storeToStorageEngines,
+      Map<String, Set<SystemStreamPartition>> storeToSSPs,
+      Map<String, SideInputsProcessor> storeToProcessor,
+      SystemAdmins systemAdmins,
+      StreamMetadataCache streamMetadataCache,
+      Clock clock) {
+    this.taskName = taskName;
+    this.systemAdmins = systemAdmins;
+    this.streamMetadataCache = streamMetadataCache;
+    this.storeToProcessor = storeToProcessor;
+
+    this.sspToStores = storeToSSPs.entrySet().stream()
+        .flatMap(storeAndSSPs -> storeAndSSPs.getValue().stream()
+            .map(ssp -> new AbstractMap.SimpleImmutableEntry<>(ssp, storeAndSSPs.getKey())))
+        .collect(Collectors.groupingBy(
+            Map.Entry::getKey,
+            Collectors.mapping(Map.Entry::getValue, Collectors.toSet())));
+
+    this.taskSideInputStorageManager = new TaskSideInputStorageManager(taskName,
+        taskMode,
+        storeBaseDir,
+        storeToStorageEngines,
+        storeToSSPs,
+        clock);
+
+    validateProcessorConfiguration();
+  }
+
+  public TaskName getTaskName() {
+    return this.taskName;
+  }
+
+  public void init() {
+    this.taskSideInputStorageManager.init();
+
+    Map<SystemStreamPartition, String> fileOffsets = taskSideInputStorageManager.getFileOffsets();
+    this.lastProcessedOffsets.putAll(fileOffsets);
+    this.startingOffsets = getStartingOffsets(fileOffsets, getOldestOffsets());
+  }
+
+  public void process(IncomingMessageEnvelope envelope) {
+    SystemStreamPartition envelopeSSP = envelope.getSystemStreamPartition();
+    String envelopeOffset = envelope.getOffset();
+
+    for (String store: this.sspToStores.get(envelopeSSP)) {
+      SideInputsProcessor storeProcessor = this.storeToProcessor.get(store);
+      KeyValueStore keyValueStore = (KeyValueStore) this.taskSideInputStorageManager.getStore(store);
+      Collection<Entry<?, ?>> entriesToBeWritten = storeProcessor.process(envelope, keyValueStore);
+
+      // TODO: SAMZA-2255: optimize writes to side input stores
+      for (Entry entry : entriesToBeWritten) {
+        // If the key is null we ignore, if the value is null, we issue a delete, else we issue a put
+        if (entry.getKey() != null) {
+          if (entry.getValue() != null) {
+            keyValueStore.put(entry.getKey(), entry.getValue());
+          } else {
+            keyValueStore.delete(entry.getKey());
+          }
+        }
+      }
+    }
+
+    this.lastProcessedOffsets.put(envelopeSSP, envelopeOffset);
+  }
+
+  public void flush() {
+    this.taskSideInputStorageManager.flush(this.lastProcessedOffsets);
+  }
+
+  public String getStartingOffset(SystemStreamPartition ssp) {
+    return this.startingOffsets.get(ssp);
+  }
+
+  public String getLastProcessedOffset(SystemStreamPartition ssp) {
+    return this.lastProcessedOffsets.get(ssp);
+  }
+
+  public void stop() {
+    this.taskSideInputStorageManager.stop(this.lastProcessedOffsets);
+  }
+
+  /**
+   * Gets the starting offsets for the {@link SystemStreamPartition}s belonging to all the side input stores.
+   * If the local file offset is available and is greater than the oldest available offset from source, uses it,
+   * else falls back to oldest offset in the source.
+   *
+   * @param fileOffsets offsets from the local offset file
+   * @param oldestOffsets oldest offsets from the source
+   * @return a {@link Map} of {@link SystemStreamPartition} to offset
+   */
+  @VisibleForTesting
+  Map<SystemStreamPartition, String> getStartingOffsets(
+      Map<SystemStreamPartition, String> fileOffsets, Map<SystemStreamPartition, String> oldestOffsets) {
+    Map<SystemStreamPartition, String> startingOffsets = new HashMap<>();
+
+    this.sspToStores.keySet().forEach(ssp -> {
+        String fileOffset = fileOffsets.get(ssp);
+        String oldestOffset = oldestOffsets.get(ssp);
+
+        startingOffsets.put(ssp,
+            this.storageManagerUtil.getStartingOffset(
+                ssp, this.systemAdmins.getSystemAdmin(ssp.getSystem()), fileOffset, oldestOffset));
+      });
+
+    return startingOffsets;
+  }
+
+  /**
+   * Gets the oldest offset for the {@link SystemStreamPartition}s associated with all the store side inputs.
+   *   1. Groups the list of the SSPs based on system stream
+   *   2. Fetches the {@link SystemStreamMetadata} from {@link StreamMetadataCache}
+   *   3. Fetches the partition metadata for each system stream and fetch the corresponding partition metadata
+   *      and populates the oldest offset for SSPs belonging to the system stream.
+   *
+   * @return a {@link Map} of {@link SystemStreamPartition} to their oldest offset. If partitionMetadata could not be
+   * obtained for any {@link SystemStreamPartition} the offset for it is populated as null.
+   */
+  @VisibleForTesting
+  Map<SystemStreamPartition, String> getOldestOffsets() {
+    Map<SystemStreamPartition, String> oldestOffsets = new HashMap<>();
+
+    // Step 1
+    Map<SystemStream, List<SystemStreamPartition>> systemStreamToSsp = this.sspToStores.keySet().stream()
+        .collect(Collectors.groupingBy(SystemStreamPartition::getSystemStream));
+
+    // Step 2
+    Map<SystemStream, SystemStreamMetadata> metadata = JavaConverters.mapAsJavaMapConverter(
+        streamMetadataCache.getStreamMetadata(
+            JavaConverters.asScalaSetConverter(systemStreamToSsp.keySet()).asScala().toSet(), false)).asJava();
+
+    // Step 3
+    metadata.forEach((systemStream, systemStreamMetadata) -> {
+
+        // get the partition metadata for each system stream
+        Map<Partition, SystemStreamMetadata.SystemStreamPartitionMetadata> partitionMetadata =
+            systemStreamMetadata.getSystemStreamPartitionMetadata();
+
+        // For SSPs belonging to the system stream, use the partition metadata to get the oldest offset
+        // if partitionMetadata was not obtained for any SSP, populate oldest-offset as null
+        // Because of https://bugs.openjdk.java.net/browse/JDK-8148463 using lambda will NPE when getOldestOffset() is null
+        for (SystemStreamPartition ssp : systemStreamToSsp.get(systemStream)) {
+          oldestOffsets.put(ssp, partitionMetadata.get(ssp.getPartition()).getOldestOffset());
+        }
+      });
+
+    return oldestOffsets;
+  }
+
+  private void validateProcessorConfiguration() {
+    Set<String> stores = this.sspToStores.values().stream()
+        .flatMap(Collection::stream)
+        .collect(Collectors.toSet());
+
+    stores.forEach(storeName -> {
+        if (!storeToProcessor.containsKey(storeName)) {
+          throw new SamzaException(
+              String.format("Side inputs processor missing for store: %s.", storeName));
+        }
+      });
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/storage/TaskSideInputStorageManager.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/TaskSideInputStorageManager.java
@@ -20,34 +20,20 @@
 package org.apache.samza.storage;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.samza.Partition;
 import org.apache.samza.SamzaException;
-import org.apache.samza.config.Config;
 import org.apache.samza.container.TaskName;
 import org.apache.samza.job.model.TaskMode;
-import org.apache.samza.storage.kv.Entry;
-import org.apache.samza.storage.kv.KeyValueStore;
-import org.apache.samza.system.IncomingMessageEnvelope;
-import org.apache.samza.system.StreamMetadataCache;
-import org.apache.samza.system.SystemAdmins;
-import org.apache.samza.system.SystemStream;
-import org.apache.samza.system.SystemStreamMetadata;
 import org.apache.samza.system.SystemStreamPartition;
 import org.apache.samza.util.Clock;
 import org.apache.samza.util.FileUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.collection.JavaConverters;
 
 import java.io.File;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -62,53 +48,23 @@ public class TaskSideInputStorageManager {
   private static final long STORE_DELETE_RETENTION_MS = TimeUnit.DAYS.toMillis(1); // same as changelog delete retention
 
   private final Clock clock;
-  private final Map<String, SideInputsProcessor> storeToProcessor;
   private final Map<String, StorageEngine> stores;
   private final File storeBaseDir;
   private final Map<String, Set<SystemStreamPartition>> storeToSSps;
-  private final Map<SystemStreamPartition, Set<String>> sspsToStores;
-  private final StreamMetadataCache streamMetadataCache;
-  private final SystemAdmins systemAdmins;
   private final TaskName taskName;
   private final TaskMode taskMode;
-  private final Map<SystemStreamPartition, String> lastProcessedOffsets = new ConcurrentHashMap<>();
   private final StorageManagerUtil storageManagerUtil = new StorageManagerUtil();
 
-  private Map<SystemStreamPartition, String> startingOffsets;
-
-  public TaskSideInputStorageManager(
-      TaskName taskName,
-      TaskMode taskMode,
-      StreamMetadataCache streamMetadataCache,
-      File storeBaseDir,
-      Map<String, StorageEngine> sideInputStores,
-      Map<String, SideInputsProcessor> storesToProcessor,
-      Map<String, Set<SystemStreamPartition>> storesToSSPs,
-      SystemAdmins systemAdmins,
-      Config config,
-      Clock clock) {
+  public TaskSideInputStorageManager(TaskName taskName, TaskMode taskMode, File storeBaseDir, Map<String, StorageEngine> sideInputStores,
+      Map<String, Set<SystemStreamPartition>> storesToSSPs, Clock clock) {
     this.clock = clock;
     this.stores = sideInputStores;
     this.storeBaseDir = storeBaseDir;
     this.storeToSSps = storesToSSPs;
-    this.streamMetadataCache = streamMetadataCache;
-    this.systemAdmins = systemAdmins;
     this.taskName = taskName;
     this.taskMode = taskMode;
-    this.storeToProcessor = storesToProcessor;
 
     validateStoreConfiguration();
-
-    this.sspsToStores = new HashMap<>();
-    storesToSSPs.forEach((store, ssps) -> {
-        for (SystemStreamPartition ssp: ssps) {
-          sspsToStores.computeIfAbsent(ssp, key -> new HashSet<>());
-          sspsToStores.computeIfPresent(ssp, (key, value) -> {
-              value.add(store);
-              return value;
-            });
-        }
-      });
   }
 
   /**
@@ -120,35 +76,32 @@ public class TaskSideInputStorageManager {
     Map<SystemStreamPartition, String> fileOffsets = getFileOffsets();
     LOG.info("File offsets for the task {}: {}", taskName, fileOffsets);
 
-    Map<SystemStreamPartition, String> oldestOffsets = getOldestOffsets();
-    LOG.info("Oldest offsets for the task {}: {}", taskName, oldestOffsets);
-
-    startingOffsets = getStartingOffsets(fileOffsets, oldestOffsets);
-    LOG.info("Starting offsets for the task {}: {}", taskName, startingOffsets);
-
-    lastProcessedOffsets.putAll(fileOffsets);
-    LOG.info("Last processed offsets for the task {}: {}", taskName, lastProcessedOffsets);
-
     initializeStoreDirectories();
   }
 
   /**
    * Flushes the contents of the underlying store and writes the offset file to disk.
    * Synchronized inorder to be exclusive with process()
+   *
+   * @param lastProcessedOffsets The last processed offsets for each SSP. These will be used when writing offsets files
+   *                             for each store.
    */
-  public synchronized void flush() {
+  public synchronized void flush(Map<SystemStreamPartition, String> lastProcessedOffsets) {
     LOG.info("Flushing the side input stores.");
     stores.values().forEach(StorageEngine::flush);
-    writeOffsetFiles();
+    writeOffsetFiles(lastProcessedOffsets);
   }
 
   /**
    * Stops the storage engines for all the stores and writes the offset file to disk.
+   *
+   * @param lastProcessedOffsets The last processed offsets for each SSP. These will be used when writing offsets files
+   *                             for each store.
    */
-  public void stop() {
+  public void stop(Map<SystemStreamPartition, String> lastProcessedOffsets) {
     LOG.info("Stopping the side input stores.");
     stores.values().forEach(StorageEngine::stop);
-    writeOffsetFiles();
+    writeOffsetFiles(lastProcessedOffsets);
   }
 
   /**
@@ -161,75 +114,9 @@ public class TaskSideInputStorageManager {
     return stores.get(storeName);
   }
 
-  /**
-   * Gets the starting offset for the given side input {@link SystemStreamPartition}.
-   *
-   * Note: The method doesn't respect {@link org.apache.samza.config.StreamConfig#CONSUMER_OFFSET_DEFAULT} and
-   * {@link org.apache.samza.config.StreamConfig#CONSUMER_RESET_OFFSET} configurations. It will use the local offset
-   * file if it is valid, else it will fall back to oldest offset in the stream.
-   *
-   * @param ssp side input system stream partition to get the starting offset for
-   * @return the starting offset
-   */
-  public String getStartingOffset(SystemStreamPartition ssp) {
-    return startingOffsets.get(ssp);
-  }
-
   // Get the taskName associated with this instance.
   public TaskName getTaskName() {
     return this.taskName;
-  }
-
-  /**
-   * Gets the last processed offset for the given side input {@link SystemStreamPartition}.
-   *
-   * @param ssp side input system stream partition to get the last processed offset for
-   * @return the last processed offset
-   */
-  public String getLastProcessedOffset(SystemStreamPartition ssp) {
-    return lastProcessedOffsets.get(ssp);
-  }
-
-  /**
-   * For unit testing only
-   */
-  @VisibleForTesting
-  void updateLastProcessedOffset(SystemStreamPartition ssp, String offset) {
-    lastProcessedOffsets.put(ssp, offset);
-  }
-
-  /**
-   * Processes the incoming side input message envelope and updates the last processed offset for its SSP.
-   * Synchronized inorder to be exclusive with flush().
-   *
-   * @param message incoming message to be processed
-   */
-  public synchronized void process(IncomingMessageEnvelope message) {
-    SystemStreamPartition ssp = message.getSystemStreamPartition();
-    Set<String> storeNames = sspsToStores.get(ssp);
-
-    for (String storeName : storeNames) {
-      SideInputsProcessor sideInputsProcessor = storeToProcessor.get(storeName);
-
-      KeyValueStore keyValueStore = (KeyValueStore) stores.get(storeName);
-      Collection<Entry<?, ?>> entriesToBeWritten = sideInputsProcessor.process(message, keyValueStore);
-
-      // Iterate over the list to be written.
-      // TODO: SAMZA-2255: Optimize value writes in TaskSideInputStorageManager
-      for (Entry entry : entriesToBeWritten) {
-        // If the key is null we ignore, if the value is null, we issue a delete, else we issue a put
-        if (entry.getKey() != null) {
-          if (entry.getValue() != null) {
-            keyValueStore.put(entry.getKey(), entry.getValue());
-          } else {
-            keyValueStore.delete(entry.getKey());
-          }
-        }
-      }
-    }
-
-    // update the last processed offset
-    lastProcessedOffsets.put(ssp, message.getOffset());
   }
 
   /**
@@ -260,7 +147,7 @@ public class TaskSideInputStorageManager {
    * Its contents are a JSON encoded mapping from each side input SSP to its last processed offset, and a checksum.
    */
   @VisibleForTesting
-  void writeOffsetFiles() {
+  void writeOffsetFiles(Map<SystemStreamPartition, String> lastProcessedOffsets) {
     storeToSSps.entrySet().stream()
         .filter(entry -> isPersistedStore(entry.getKey())) // filter out in-memory side input stores
         .forEach((entry) -> {
@@ -283,7 +170,6 @@ public class TaskSideInputStorageManager {
    *
    * @return a {@link Map} of {@link SystemStreamPartition} to offset in the offset files.
    */
-  @SuppressWarnings("unchecked")
   @VisibleForTesting
   Map<SystemStreamPartition, String> getFileOffsets() {
     LOG.info("Loading initial offsets from the file for side input stores.");
@@ -313,73 +199,6 @@ public class TaskSideInputStorageManager {
     return storageManagerUtil.getTaskStoreDir(storeBaseDir, storeName, taskName, taskMode);
   }
 
-  /**
-   * Gets the starting offsets for the {@link SystemStreamPartition}s belonging to all the side input stores.
-   * If the local file offset is available and is greater than the oldest available offset from source, uses it,
-   * else falls back to oldest offset in the source.
-   *
-   * @param fileOffsets offsets from the local offset file
-   * @param oldestOffsets oldest offsets from the source
-   * @return a {@link Map} of {@link SystemStreamPartition} to offset
-   */
-  @VisibleForTesting
-  Map<SystemStreamPartition, String> getStartingOffsets(
-      Map<SystemStreamPartition, String> fileOffsets, Map<SystemStreamPartition, String> oldestOffsets) {
-    Map<SystemStreamPartition, String> startingOffsets = new HashMap<>();
-
-    sspsToStores.keySet().forEach(ssp -> {
-        String fileOffset = fileOffsets.get(ssp);
-        String oldestOffset = oldestOffsets.get(ssp);
-
-        startingOffsets.put(ssp,
-          storageManagerUtil.getStartingOffset(
-            ssp, systemAdmins.getSystemAdmin(ssp.getSystem()), fileOffset, oldestOffset));
-      });
-
-    return startingOffsets;
-  }
-
-  /**
-   * Gets the oldest offset for the {@link SystemStreamPartition}s associated with all the store side inputs.
-   *   1. Groups the list of the SSPs based on system stream
-   *   2. Fetches the {@link SystemStreamMetadata} from {@link StreamMetadataCache}
-   *   3. Fetches the partition metadata for each system stream and fetch the corresponding partition metadata
-   *      and populates the oldest offset for SSPs belonging to the system stream.
-   *
-   * @return a {@link Map} of {@link SystemStreamPartition} to their oldest offset. If partitionMetadata could not be
-   * obtained for any {@link SystemStreamPartition} the offset for it is populated as null.
-   */
-  @VisibleForTesting
-  Map<SystemStreamPartition, String> getOldestOffsets() {
-    Map<SystemStreamPartition, String> oldestOffsets = new HashMap<>();
-
-    // Step 1
-    Map<SystemStream, List<SystemStreamPartition>> systemStreamToSsp = sspsToStores.keySet().stream()
-        .collect(Collectors.groupingBy(SystemStreamPartition::getSystemStream));
-
-    // Step 2
-    Map<SystemStream, SystemStreamMetadata> metadata = JavaConverters.mapAsJavaMapConverter(
-        streamMetadataCache.getStreamMetadata(
-            JavaConverters.asScalaSetConverter(systemStreamToSsp.keySet()).asScala().toSet(), false)).asJava();
-
-    // Step 3
-    metadata.forEach((systemStream, systemStreamMetadata) -> {
-
-        // get the partition metadata for each system stream
-        Map<Partition, SystemStreamMetadata.SystemStreamPartitionMetadata> partitionMetadata =
-          systemStreamMetadata.getSystemStreamPartitionMetadata();
-
-        // For SSPs belonging to the system stream, use the partition metadata to get the oldest offset
-        // if partitionMetadata was not obtained for any SSP, populate oldest-offset as null
-        // Because of https://bugs.openjdk.java.net/browse/JDK-8148463 using lambda will NPE when getOldestOffset() is null
-        for (SystemStreamPartition ssp : systemStreamToSsp.get(systemStream)) {
-          oldestOffsets.put(ssp, partitionMetadata.get(ssp.getPartition()).getOldestOffset());
-        }
-      });
-
-    return oldestOffsets;
-  }
-
   private boolean isValidSideInputStore(String storeName, File storeLocation) {
     return isPersistedStore(storeName)
         && !storageManagerUtil.isStaleStore(storeLocation, STORE_DELETE_RETENTION_MS, clock.currentTimeMillis(), true)
@@ -395,11 +214,6 @@ public class TaskSideInputStorageManager {
 
   private void validateStoreConfiguration() {
     stores.forEach((storeName, storageEngine) -> {
-        if (!storeToProcessor.containsKey(storeName)) {
-          throw new SamzaException(
-              String.format("Side inputs processor missing for store: %s.", storeName));
-        }
-
         if (storageEngine.getStoreProperties().isLoggedStore()) {
           throw new SamzaException(
               String.format("Cannot configure both side inputs and a changelog for store: %s.", storeName));

--- a/samza-core/src/test/java/org/apache/samza/storage/TestTaskSideInputHandler.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/TestTaskSideInputHandler.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.storage;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.samza.Partition;
+import org.apache.samza.container.TaskName;
+import org.apache.samza.job.model.TaskMode;
+import org.apache.samza.system.StreamMetadataCache;
+import org.apache.samza.system.SystemAdmin;
+import org.apache.samza.system.SystemAdmins;
+import org.apache.samza.system.SystemStream;
+import org.apache.samza.system.SystemStreamMetadata;
+import org.apache.samza.system.SystemStreamPartition;
+import org.apache.samza.util.Clock;
+import org.apache.samza.util.ScalaJavaUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+
+public class TestTaskSideInputHandler {
+  private static final String TEST_TASK_NAME = "test-task";
+  private static final String TEST_SYSTEM = "test-system";
+  private static final String TEST_STORE = "test-store";
+  private static final String TEST_STREAM = "test-stream";
+
+    /**
+   * This test is for cases, when calls to systemAdmin (e.g., KafkaSystemAdmin's) get-stream-metadata method return null.
+   */
+  @Test
+  public void testGetStartingOffsetsWhenStreamMetadataIsNull() {
+    final String taskName = "test-get-starting-offset-task";
+
+    Set<SystemStreamPartition> ssps = IntStream.range(1, 2)
+        .mapToObj(idx -> new SystemStreamPartition(TEST_SYSTEM, TEST_STREAM, new Partition(idx)))
+        .collect(Collectors.toSet());
+    Map<Partition, SystemStreamMetadata.SystemStreamPartitionMetadata> partitionMetadata = ssps.stream()
+        .collect(Collectors.toMap(SystemStreamPartition::getPartition,
+            x -> new SystemStreamMetadata.SystemStreamPartitionMetadata(null, "1", "2")));
+
+
+    TaskSideInputHandler handler = new MockTaskSideInputHandlerBuilder(taskName, TaskMode.Active)
+        .addStreamMetadata(Collections.singletonMap(new SystemStream(TEST_SYSTEM, TEST_STREAM),
+            new SystemStreamMetadata(TEST_STREAM, partitionMetadata)))
+        .addStore(TEST_STORE, ssps)
+        .build();
+
+    handler.init();
+
+    ssps.forEach(ssp -> {
+        String startingOffset = handler.getStartingOffset(
+            new SystemStreamPartition(TEST_SYSTEM, TEST_STREAM, ssp.getPartition()));
+        Assert.assertNull("Starting offset should be null", startingOffset);
+      });
+  }
+
+  @Test
+  public void testGetStartingOffsets() {
+    final String storeName = "test-get-starting-offset-store";
+    final String taskName = "test-get-starting-offset-task";
+
+    Set<SystemStreamPartition> ssps = IntStream.range(1, 6)
+        .mapToObj(idx -> new SystemStreamPartition(TEST_SYSTEM, TEST_STREAM, new Partition(idx)))
+        .collect(Collectors.toSet());
+
+
+    TaskSideInputHandler handler = new MockTaskSideInputHandlerBuilder(taskName, TaskMode.Active)
+        .addStore(storeName, ssps)
+        .build();
+
+    // set up file and oldest offsets. for even partitions, fileOffsets will be larger; for odd partitions oldestOffsets will be larger
+    Map<SystemStreamPartition, String> fileOffsets = ssps.stream()
+        .collect(Collectors.toMap(Function.identity(), ssp -> {
+            int partitionId = ssp.getPartition().getPartitionId();
+            int offset = partitionId % 2 == 0 ? partitionId + 10 : partitionId;
+            return String.valueOf(offset);
+          }));
+    Map<SystemStreamPartition, String> oldestOffsets = ssps.stream()
+        .collect(Collectors.toMap(Function.identity(), ssp -> {
+            int partitionId = ssp.getPartition().getPartitionId();
+            int offset = partitionId % 2 == 0 ? partitionId : partitionId + 10;
+
+            return String.valueOf(offset);
+          }));
+
+    doCallRealMethod().when(handler).getStartingOffsets(fileOffsets, oldestOffsets);
+
+    Map<SystemStreamPartition, String> startingOffsets = handler.getStartingOffsets(fileOffsets, oldestOffsets);
+
+    assertTrue("Failed to get starting offsets for all ssps", startingOffsets.size() == 5);
+    startingOffsets.forEach((ssp, offset) -> {
+        int partitionId = ssp.getPartition().getPartitionId();
+        String expectedOffset = partitionId % 2 == 0
+            // 1 + fileOffset
+            ? getOffsetAfter(String.valueOf(ssp.getPartition().getPartitionId() + 10))
+            // oldestOffset
+            : String.valueOf(ssp.getPartition().getPartitionId() + 10);
+        assertEquals("Larger of fileOffsets and oldestOffsets should always be chosen", expectedOffset, offset);
+      });
+  }
+
+  private static final class MockTaskSideInputHandlerBuilder {
+    final TaskName taskName;
+    final TaskMode taskMode;
+    final File storeBaseDir;
+
+    final Map<String, StorageEngine> stores = new HashMap<>();
+    final Map<String, Set<SystemStreamPartition>> storeToSSPs = new HashMap<>();
+    final Clock clock = mock(Clock.class);
+    final Map<String, SideInputsProcessor> storeToProcessor = new HashMap<>();
+    final StreamMetadataCache streamMetadataCache = mock(StreamMetadataCache.class);
+    final SystemAdmins systemAdmins = mock(SystemAdmins.class);
+
+    public MockTaskSideInputHandlerBuilder(String taskName, TaskMode taskMode) {
+      this.taskName = new TaskName(taskName);
+      this.taskMode = taskMode;
+      this.storeBaseDir = mock(File.class);
+
+      initializeMocks();
+    }
+
+    private void initializeMocks() {
+      SystemAdmin admin = mock(SystemAdmin.class);
+      doAnswer(invocation -> {
+          String offset1 = invocation.getArgumentAt(0, String.class);
+          String offset2 = invocation.getArgumentAt(1, String.class);
+
+          return Long.compare(Long.parseLong(offset1), Long.parseLong(offset2));
+        }).when(admin).offsetComparator(any(), any());
+      doAnswer(invocation -> {
+          Map<SystemStreamPartition, String> sspToOffsets = invocation.getArgumentAt(0, Map.class);
+
+          return sspToOffsets.entrySet()
+              .stream()
+              .collect(Collectors.toMap(Map.Entry::getKey,
+                  entry -> getOffsetAfter(entry.getValue())));
+        }).when(admin).getOffsetsAfter(any());
+      doReturn(admin).when(systemAdmins).getSystemAdmin(TEST_SYSTEM);
+      doReturn(ScalaJavaUtil.toScalaMap(new HashMap<>())).when(streamMetadataCache).getStreamMetadata(any(), anyBoolean());
+    }
+
+
+    MockTaskSideInputHandlerBuilder addStreamMetadata(Map<SystemStream, SystemStreamMetadata> streamMetadata) {
+      doReturn(ScalaJavaUtil.toScalaMap(streamMetadata)).when(streamMetadataCache).getStreamMetadata(any(), anyBoolean());
+      return this;
+    }
+
+    MockTaskSideInputHandlerBuilder addStore(String storeName, Set<SystemStreamPartition> storeSSPs) {
+      storeToSSPs.put(storeName, storeSSPs);
+      storeToProcessor.put(storeName, mock(SideInputsProcessor.class));
+      return this;
+    }
+
+    TaskSideInputHandler build() {
+      return spy(new TaskSideInputHandler(taskName,
+          taskMode,
+          storeBaseDir,
+          stores,
+          storeToSSPs,
+          storeToProcessor,
+          systemAdmins,
+          streamMetadataCache,
+          clock));
+    }
+  }
+
+  private static String getOffsetAfter(String offset) {
+    return String.valueOf(Long.parseLong(offset) + 1);
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/storage/TestTaskSideInputHandler.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/TestTaskSideInputHandler.java
@@ -40,13 +40,18 @@ import org.apache.samza.util.ScalaJavaUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 
 public class TestTaskSideInputHandler {
-  private static final String TEST_TASK_NAME = "test-task";
   private static final String TEST_SYSTEM = "test-system";
   private static final String TEST_STORE = "test-store";
   private static final String TEST_STREAM = "test-stream";

--- a/samza-core/src/test/java/org/apache/samza/storage/TestTaskSideInputStorageManager.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/TestTaskSideInputStorageManager.java
@@ -79,7 +79,7 @@ public class TestTaskSideInputStorageManager {
       verify(storageEngine).flush();
     }
 
-    verify(testSideInputStorageManager).writeOffsetFiles(eq(processedOffsets));
+    verify(testSideInputStorageManager).writeFileOffsets(eq(processedOffsets));
 
     File storeDir = testSideInputStorageManager.getStoreLocation(storeName);
     assertTrue("Store directory: " + storeDir.getPath() + " is missing.", storeDir.exists());
@@ -105,7 +105,7 @@ public class TestTaskSideInputStorageManager {
     testSideInputStorageManager.stop(processedOffsets);
 
     verify(testSideInputStorageManager.getStore(storeName)).stop();
-    verify(testSideInputStorageManager).writeOffsetFiles(eq(processedOffsets));
+    verify(testSideInputStorageManager).writeFileOffsets(eq(processedOffsets));
   }
 
   @Test
@@ -118,7 +118,7 @@ public class TestTaskSideInputStorageManager {
         .build();
 
     initializeSideInputStorageManager(testSideInputStorageManager);
-    testSideInputStorageManager.writeOffsetFiles(Collections.emptyMap()); // should be no-op
+    testSideInputStorageManager.writeFileOffsets(Collections.emptyMap()); // should be no-op
     File storeDir = testSideInputStorageManager.getStoreLocation(storeName);
 
     assertFalse("Store directory: " + storeDir.getPath() + " should not be created for non-persisted store", storeDir.exists());
@@ -142,7 +142,7 @@ public class TestTaskSideInputStorageManager {
         .build();
 
     initializeSideInputStorageManager(testSideInputStorageManager);
-    testSideInputStorageManager.writeOffsetFiles(processedOffsets);
+    testSideInputStorageManager.writeFileOffsets(processedOffsets);
     File storeDir = testSideInputStorageManager.getStoreLocation(storeName);
 
     assertTrue("Store directory: " + storeDir.getPath() + " is missing.", storeDir.exists());
@@ -174,7 +174,7 @@ public class TestTaskSideInputStorageManager {
     Map<SystemStreamPartition, String> processedOffsets = ssps.stream()
         .collect(Collectors.toMap(Function.identity(), ssp -> offset));
 
-    testSideInputStorageManager.writeOffsetFiles(processedOffsets);
+    testSideInputStorageManager.writeFileOffsets(processedOffsets);
 
     Map<SystemStreamPartition, String> fileOffsets = testSideInputStorageManager.getFileOffsets();
     ssps.forEach(ssp -> {


### PR DESCRIPTION
**Issues**: `TaskSideInputStorageManager` conflates both processing and storage logic. This is problematic as adding support of transactional state in standby containers requires heavy additions to both. Refactoring is necessary in order to avoid `TaskSideInputStorageManager` from becoming a difficult to maintain behemoth (like `ContainerStorageManager` is now). After this change, introduction of support for transactional state in standby containers can evolve cleanly.
 
**Changes**: Processing logic is moved out of `TaskSideInputStorageManager` and into a new class `TaskSideInputHandler`. This includes: coordination of oldestOffsets, lastProcessedOffsets, startingOffsets, and processing behavior for a given SSP envelope.

Management of stores' StorageEngines remains in `TaskSideInputStorageManager` as it is today.

`ContainerStorageManager` now interfaces only with `TaskSideInputHandler` to handle side input lifecycle, processing, and flush.

There is **NO NEW** functionality added in this patch, only a refactor.
 
**Tests**: Existing unit tests located in `TaskSideInputStorageManager` have been adapted to the class's new responsibilities, or moved and re-implemented for `TaskSideInputHandler`.

**API Changes**: None. The classes touched are internal to Samza.
 
**Upgrade Instructions**: None.
 
**Usage Instructions**: None.

**NOTES**: Since it is difficult to parse where new code is coming from when new classes are written, I've included comments / annotations across the PR to indicate where code that appears as "addition" was sourced from.