### PR TITLE
SAMZA-2532: Refactor MetricsSnapshotReporter and MetricsSnapshotReporterFactory

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporter.scala
+++ b/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporter.scala
@@ -174,10 +174,6 @@ class MetricsSnapshotReporter(
     debug("Finished flushing metrics.")
   }
 
-  def getProducer: SystemProducer = {
-    producer
-  }
-
   def shouldIgnore(group: String, metricName: String) = {
     var isBlacklisted = blacklist.isDefined
     val fullMetricName = group + "." + metricName

--- a/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporter.scala
+++ b/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporter.scala
@@ -181,7 +181,7 @@ class MetricsSnapshotReporter(
     if (isBlacklisted && !blacklistedMetrics.contains(fullMetricName)) {
       if (fullMetricName.matches(blacklist.get)) {
         blacklistedMetrics += fullMetricName
-        info("Blacklisted metric %s because it matched blacklist regex: %s" format(fullMetricName, blacklist.get))
+        debug("Blacklisted metric %s because it matched blacklist regex: %s" format(fullMetricName, blacklist.get))
       } else {
         isBlacklisted = false
       }

--- a/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporter.scala
+++ b/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporter.scala
@@ -174,6 +174,10 @@ class MetricsSnapshotReporter(
     debug("Finished flushing metrics.")
   }
 
+  def getProducer: SystemProducer = {
+    producer
+  }
+
   def shouldIgnore(group: String, metricName: String) = {
     var isBlacklisted = blacklist.isDefined
     val fullMetricName = group + "." + metricName

--- a/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporter.scala
+++ b/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporter.scala
@@ -19,19 +19,15 @@
 
 package org.apache.samza.metrics.reporter
 
+import java.util.concurrent.{Executors, TimeUnit}
+import java.util.{HashMap, Map}
+
 import com.google.common.util.concurrent.ThreadFactoryBuilder
+import org.apache.samza.config.ShellCommandConfig
 import org.apache.samza.metrics._
 import org.apache.samza.serializers.Serializer
-import org.apache.samza.system.OutgoingMessageEnvelope
-import org.apache.samza.system.SystemProducer
-import org.apache.samza.system.SystemStream
+import org.apache.samza.system.{OutgoingMessageEnvelope, SystemProducer, SystemStream}
 import org.apache.samza.util.Logging
-import java.util.HashMap
-import java.util.Map
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
-
-import org.apache.samza.config.ShellCommandConfig
 
 import scala.collection.JavaConverters._
 
@@ -43,7 +39,7 @@ import scala.collection.JavaConverters._
  * taskName // container_567890
  * host // eat1-app128.gird
  * version // 0.0.1
-  * blacklist // Regex of metrics to ignore when flushing
+ * blacklist // Regex of metrics to ignore when flushing
  */
 class MetricsSnapshotReporter(
   producer: SystemProducer,
@@ -68,7 +64,7 @@ class MetricsSnapshotReporter(
   var blacklistedMetrics = Set[String]()
 
   info("got metrics snapshot reporter properties [job name: %s, job id: %s, containerName: %s, version: %s, samzaVersion: %s, host: %s, pollingInterval %s]"
-    format (jobName, jobId, containerName, version, samzaVersion, host, pollingInterval))
+    format(jobName, jobId, containerName, version, samzaVersion, host, pollingInterval))
 
   def start {
     info("Starting producer.")
@@ -91,7 +87,7 @@ class MetricsSnapshotReporter(
   def stop = {
 
     // Scheduling an event with 0 delay to ensure flushing of metrics one last time before shutdown
-    executor.schedule(this,0, TimeUnit.SECONDS)
+    executor.schedule(this, 0, TimeUnit.SECONDS)
 
     info("Stopping reporter timer.")
     // Allow the scheduled task above to finish, and block for termination (for max 60 seconds)
@@ -106,67 +102,81 @@ class MetricsSnapshotReporter(
     }
   }
 
-  def run {
-    debug("Begin flushing metrics.")
-
-    for ((source, registry) <- registries) {
-      debug("Flushing metrics for %s." format source)
-
-      val metricsMsg = new HashMap[String, Map[String, Object]]
-
-      // metrics
-      registry.getGroups.asScala.foreach(group => {
-        val groupMsg = new HashMap[String, Object]
-
-        registry.getGroup(group).asScala.foreach {
-          case (name, metric) =>
-            if (!shouldIgnore(group, name)) {
-              metric.visit(new MetricsVisitor {
-                def counter(counter: Counter) = groupMsg.put(name, counter.getCount: java.lang.Long)
-                def gauge[T](gauge: Gauge[T]) = groupMsg.put(name, gauge.getValue.asInstanceOf[Object])
-                def timer(timer: Timer) = groupMsg.put(name, timer.getSnapshot().getAverage(): java.lang.Double)
-              })
-            }
-        }
-
-        // dont emit empty groups
-        if (!groupMsg.isEmpty) {
-          metricsMsg.put(group, groupMsg)
-        }
-      })
-
-      // publish to Kafka only if the metricsMsg carries any metrics
-      if (!metricsMsg.isEmpty) {
-        val header = new MetricsHeader(jobName, jobId, containerName, execEnvironmentContainerId, source, version, samzaVersion, host, clock(), resetTime)
-        val metrics = new Metrics(metricsMsg)
-
-        debug("Flushing metrics for %s to %s with header and map: header=%s, map=%s." format(source, out, header.getAsMap, metrics.getAsMap))
-
-        val metricsSnapshot = new MetricsSnapshot(header, metrics)
-        val maybeSerialized = if (serializer != null) {
-          serializer.toBytes(metricsSnapshot)
-        } else {
-          metricsSnapshot
-        }
-
-        try {
-
-          producer.send(source, new OutgoingMessageEnvelope(out, host, null, maybeSerialized))
-
-          // Always flush, since we don't want metrics to get batched up.
-          producer.flush(source)
-        } catch {
-          case e: Exception => error("Exception when flushing metrics for source %s " format (source), e)
-        }
-      }
+  def run() {
+    try {
+      innerRun()
+    } catch {
+      case e: Exception =>
+        // Ignore all exceptions - because subsequent executions of this scheduled task will be suppressed
+        // by the executor if the current task throws an unhandled exception.
+        warn("Error while reporting metrics. Will retry in " + pollingInterval + " seconds.", e)
     }
 
+  }
 
+  def innerRun(): Unit = {
+    debug("Begin flushing metrics.")
+    for ((source, registry) <- registries) {
+      publishMetricsForRegistry(source, registry)
+    }
     debug("Finished flushing metrics.")
   }
 
+  def publishMetricsForRegistry(source: String, registry: ReadableMetricsRegistry): Unit = {
+    debug("Flushing metrics for %s." format source)
 
-  def shouldIgnore(group: String, metricName: String) = {
+    val metricsMsg = new HashMap[String, Map[String, Object]]
+
+    // metrics
+    registry.getGroups.asScala.foreach(group => {
+      val groupMsg = new HashMap[String, Object]
+
+      registry.getGroup(group).asScala.foreach {
+        case (name, metric) =>
+          if (!shouldIgnore(group, name)) {
+            metric.visit(new MetricsVisitor {
+              def counter(counter: Counter): Unit = groupMsg.put(name, counter.getCount: java.lang.Long)
+
+              def gauge[T](gauge: Gauge[T]): Unit = groupMsg.put(name, gauge.getValue.asInstanceOf[Object])
+
+              def timer(timer: Timer): Unit = groupMsg.put(name, timer.getSnapshot.getAverage(): java.lang.Double)
+            })
+          }
+      }
+
+      // dont emit empty groups
+      if (!groupMsg.isEmpty) {
+        metricsMsg.put(group, groupMsg)
+      }
+    })
+
+    // publish to Kafka only if the metricsMsg carries any metrics
+    if (!metricsMsg.isEmpty) {
+      val header = new MetricsHeader(jobName, jobId, containerName, execEnvironmentContainerId, source, version, samzaVersion, host, clock(), resetTime)
+      val metrics = new Metrics(metricsMsg)
+
+      debug("Flushing metrics for %s to %s with header and map: header=%s, map=%s." format(source, out, header.getAsMap, metrics.getAsMap()))
+
+      val metricsSnapshot = new MetricsSnapshot(header, metrics)
+      val maybeSerialized = if (serializer != null) {
+        serializer.toBytes(metricsSnapshot)
+      } else {
+        metricsSnapshot
+      }
+
+      try {
+
+        producer.send(source, new OutgoingMessageEnvelope(out, host, null, maybeSerialized))
+
+        // Always flush, since we don't want metrics to get batched up.
+        producer.flush(source)
+      } catch {
+        case e: Exception => error("Exception when flushing metrics for source %s " format (source), e)
+      }
+    }
+  }
+
+  def shouldIgnore(group: String, metricName: String): Boolean = {
     var isBlacklisted = blacklist.isDefined
     val fullMetricName = group + "." + metricName
 

--- a/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporter.scala
+++ b/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporter.scala
@@ -48,7 +48,7 @@ import scala.collection.JavaConverters._
 class MetricsSnapshotReporter(
   producer: SystemProducer,
   out: SystemStream,
-  pollingInterval: Int,
+  reportingInterval: Int,
   jobName: String,
   jobId: String,
   containerName: String,
@@ -67,8 +67,8 @@ class MetricsSnapshotReporter(
   var registries = List[(String, ReadableMetricsRegistry)]()
   var blacklistedMetrics = Set[String]()
 
-  info("got metrics snapshot reporter properties [job name: %s, job id: %s, containerName: %s, version: %s, samzaVersion: %s, host: %s, pollingInterval %s]"
-    format(jobName, jobId, containerName, version, samzaVersion, host, pollingInterval))
+  info("got metrics snapshot reporter properties [job name: %s, job id: %s, containerName: %s, version: %s, samzaVersion: %s, host: %s, reportingInterval %s]"
+    format(jobName, jobId, containerName, version, samzaVersion, host, reportingInterval))
 
   def start {
     info("Starting producer.")
@@ -77,7 +77,7 @@ class MetricsSnapshotReporter(
 
     info("Starting reporter timer.")
 
-    executor.scheduleWithFixedDelay(this, 0, pollingInterval, TimeUnit.SECONDS)
+    executor.scheduleWithFixedDelay(this, 0, reportingInterval, TimeUnit.SECONDS)
   }
 
   def register(source: String, registry: ReadableMetricsRegistry) {
@@ -113,7 +113,7 @@ class MetricsSnapshotReporter(
       case e: Exception =>
         // Ignore all exceptions - because subsequent executions of this scheduled task will be suppressed
         // by the executor if the current task throws an unhandled exception.
-        warn("Error while reporting metrics. Will retry in " + pollingInterval + " seconds.", e)
+        warn("Error while reporting metrics. Will retry in " + reportingInterval + " seconds.", e)
     }
 
   }

--- a/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporterFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporterFactory.scala
@@ -19,53 +19,47 @@
 
 package org.apache.samza.metrics.reporter
 
-import org.apache.samza.util.{Logging, ReflectionUtil, StreamUtil, Util}
 import org.apache.samza.SamzaException
-import org.apache.samza.config.{Config, JobConfig, MetricsConfig, SerializerConfig, StreamConfig, SystemConfig}
-import org.apache.samza.metrics.MetricsReporter
-import org.apache.samza.metrics.MetricsReporterFactory
-import org.apache.samza.metrics.MetricsRegistryMap
-import org.apache.samza.serializers.{MetricsSnapshotSerdeV2, SerdeFactory}
-import org.apache.samza.system.SystemFactory
+import org.apache.samza.config._
+import org.apache.samza.metrics.{MetricsRegistryMap, MetricsReporter, MetricsReporterFactory}
+import org.apache.samza.serializers.{MetricsSnapshotSerdeV2, Serde, SerdeFactory}
+import org.apache.samza.system.{SystemFactory, SystemProducer, SystemStream}
 import org.apache.samza.util.ScalaJavaUtil.JavaOptionals
+import org.apache.samza.util.{Logging, ReflectionUtil, StreamUtil, Util}
 
 class MetricsSnapshotReporterFactory extends MetricsReporterFactory with Logging {
-  def getMetricsReporter(name: String, containerName: String, config: Config): MetricsReporter = {
-    info("Creating new metrics snapshot reporter.")
 
-    val jobConfig = new JobConfig(config)
-    val jobName = JavaOptionals.toRichOptional(jobConfig.getName).toOption
-      .getOrElse(throw new SamzaException("Job name must be defined in config."))
-    val jobId = jobConfig.getJobId
-
-    val metricsConfig = new MetricsConfig(config)
-    val metricsSystemStreamName = JavaOptionals.toRichOptional(metricsConfig.getMetricsSnapshotReporterStream(name))
-      .toOption
-      .getOrElse(throw new SamzaException("No metrics stream defined in config."))
-
-    val systemStream = StreamUtil.getSystemStreamFromNames(metricsSystemStreamName)
-
-    info("Got system stream %s." format systemStream)
-
-    val systemName = systemStream.getSystem
-
+  def getProducer(reporterName: String, config: Config, registry: MetricsRegistryMap): SystemProducer = {
     val systemConfig = new SystemConfig(config)
+    val systemName = getSystemStream(reporterName, config).getSystem
     val systemFactoryClassName = JavaOptionals.toRichOptional(systemConfig.getSystemFactory(systemName)).toOption
       .getOrElse(throw new SamzaException("Trying to fetch system factory for system %s, which isn't defined in config." format systemName))
-
     val systemFactory = ReflectionUtil.getObj(systemFactoryClassName, classOf[SystemFactory])
 
     info("Got system factory %s." format systemFactory)
-
-    val registry = new MetricsRegistryMap
-
     val producer = systemFactory.getProducer(systemName, config, registry)
-
     info("Got producer %s." format producer)
+
+    producer
+  }
+
+  def getSystemStream(reporterName: String, config: Config): SystemStream = {
+    val metricsConfig = new MetricsConfig(config)
+    val metricsSystemStreamName = JavaOptionals.toRichOptional(metricsConfig.getMetricsSnapshotReporterStream(reporterName))
+      .toOption
+      .getOrElse(throw new SamzaException("No metrics stream defined in config."))
+    val systemStream = StreamUtil.getSystemStreamFromNames(metricsSystemStreamName)
+    info("Got system stream %s." format systemStream)
+    systemStream
+  }
+
+  def getSerde(reporterName: String, config: Config): Serde[MetricsSnapshot] = {
     val streamConfig = new StreamConfig(config)
+    val systemConfig = new SystemConfig(config)
+    val systemStream = getSystemStream(reporterName, config)
 
     val streamSerdeName = streamConfig.getStreamMsgSerde(systemStream)
-    val systemSerdeName = systemConfig.getSystemMsgSerde(systemName)
+    val systemSerdeName = systemConfig.getSystemMsgSerde(systemStream.getSystem)
     val serdeName = streamSerdeName.orElse(systemSerdeName.orElse(null))
     val serializerConfig = new SerializerConfig(config)
     val serde = if (serdeName != null) {
@@ -77,15 +71,48 @@ class MetricsSnapshotReporterFactory extends MetricsReporterFactory with Logging
     } else {
       new MetricsSnapshotSerdeV2
     }
-
     info("Got serde %s." format serde)
+    serde
+  }
 
-    val pollingInterval: Int = metricsConfig.getMetricsSnapshotReporterInterval(name)
 
-    info("Setting polling interval to %d" format pollingInterval)
+  def getBlacklist(reporterName: String, config: Config): Option[String] = {
+    val metricsConfig = new MetricsConfig(config)
+    val blacklist = JavaOptionals.toRichOptional(metricsConfig.getMetricsSnapshotReporterBlacklist(reporterName)).toOption
+    info("Got blacklist as: %s" format blacklist)
+    blacklist
+  }
 
-    val blacklist = JavaOptionals.toRichOptional(metricsConfig.getMetricsSnapshotReporterBlacklist(name)).toOption
-    info("Setting blacklist to %s" format blacklist)
+  def getPollingInterval(reporterName: String, config: Config): Int = {
+    val metricsConfig = new MetricsConfig(config)
+    val pollingInterval = metricsConfig.getMetricsSnapshotReporterInterval(reporterName)
+    info("Got polling interval: %d" format pollingInterval)
+    pollingInterval
+  }
+
+  def getJobId(config: Config): String = {
+    val jobConfig = new JobConfig(config)
+    jobConfig.getJobId
+  }
+
+  def getJobName(config: Config): String = {
+    val jobConfig = new JobConfig(config)
+    JavaOptionals.toRichOptional(jobConfig.getName).toOption
+      .getOrElse(throw new SamzaException("Job name must be defined in config."))
+  }
+
+
+  def getMetricsReporter(reporterName: String, containerName: String, config: Config): MetricsReporter = {
+    info("Creating new metrics snapshot reporter.")
+    val registry = new MetricsRegistryMap
+
+    val systemStream = getSystemStream(reporterName, config)
+    val producer = getProducer(reporterName, config, registry)
+    val pollingInterval = getPollingInterval(reporterName, config);
+    val jobName = getJobName(config)
+    val jobId = getJobId(config)
+    val serde = getSerde(reporterName, config)
+    val blacklist = getBlacklist(reporterName, config)
 
     val reporter = new MetricsSnapshotReporter(
       producer,
@@ -95,11 +122,11 @@ class MetricsSnapshotReporterFactory extends MetricsReporterFactory with Logging
       jobId,
       containerName,
       Util.getTaskClassVersion(config),
-      Util.getSamzaVersion(),
+      Util.getSamzaVersion,
       Util.getLocalHost.getHostName,
       serde, blacklist)
 
-    reporter.register(this.getClass.getSimpleName.toString, registry)
+    reporter.register(this.getClass.getSimpleName, registry)
 
     reporter
   }

--- a/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporterFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporterFactory.scala
@@ -29,7 +29,7 @@ import org.apache.samza.util.{Logging, ReflectionUtil, StreamUtil, Util}
 
 class MetricsSnapshotReporterFactory extends MetricsReporterFactory with Logging {
 
-  def getProducer(reporterName: String, config: Config, registry: MetricsRegistryMap): SystemProducer = {
+  protected def getProducer(reporterName: String, config: Config, registry: MetricsRegistryMap): SystemProducer = {
     val systemConfig = new SystemConfig(config)
     val systemName = getSystemStream(reporterName, config).getSystem
     val systemFactoryClassName = JavaOptionals.toRichOptional(systemConfig.getSystemFactory(systemName)).toOption

--- a/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporterFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporterFactory.scala
@@ -43,7 +43,7 @@ class MetricsSnapshotReporterFactory extends MetricsReporterFactory with Logging
     producer
   }
 
-  def getSystemStream(reporterName: String, config: Config): SystemStream = {
+  protected def getSystemStream(reporterName: String, config: Config): SystemStream = {
     val metricsConfig = new MetricsConfig(config)
     val metricsSystemStreamName = JavaOptionals.toRichOptional(metricsConfig.getMetricsSnapshotReporterStream(reporterName))
       .toOption
@@ -53,7 +53,7 @@ class MetricsSnapshotReporterFactory extends MetricsReporterFactory with Logging
     systemStream
   }
 
-  def getSerde(reporterName: String, config: Config): Serde[MetricsSnapshot] = {
+  protected def getSerde(reporterName: String, config: Config): Serde[MetricsSnapshot] = {
     val streamConfig = new StreamConfig(config)
     val systemConfig = new SystemConfig(config)
     val systemStream = getSystemStream(reporterName, config)
@@ -76,26 +76,26 @@ class MetricsSnapshotReporterFactory extends MetricsReporterFactory with Logging
   }
 
 
-  def getBlacklist(reporterName: String, config: Config): Option[String] = {
+  protected def getBlacklist(reporterName: String, config: Config): Option[String] = {
     val metricsConfig = new MetricsConfig(config)
     val blacklist = JavaOptionals.toRichOptional(metricsConfig.getMetricsSnapshotReporterBlacklist(reporterName)).toOption
     info("Got blacklist as: %s" format blacklist)
     blacklist
   }
 
-  def getReportingInterval(reporterName: String, config: Config): Int = {
+  protected def getReportingInterval(reporterName: String, config: Config): Int = {
     val metricsConfig = new MetricsConfig(config)
     val reportingInterval = metricsConfig.getMetricsSnapshotReporterInterval(reporterName)
     info("Got reporting interval: %d" format reportingInterval)
     reportingInterval
   }
 
-  def getJobId(config: Config): String = {
+  protected def getJobId(config: Config): String = {
     val jobConfig = new JobConfig(config)
     jobConfig.getJobId
   }
 
-  def getJobName(config: Config): String = {
+  protected def getJobName(config: Config): String = {
     val jobConfig = new JobConfig(config)
     JavaOptionals.toRichOptional(jobConfig.getName).toOption
       .getOrElse(throw new SamzaException("Job name must be defined in config."))

--- a/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporterFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporterFactory.scala
@@ -83,11 +83,11 @@ class MetricsSnapshotReporterFactory extends MetricsReporterFactory with Logging
     blacklist
   }
 
-  def getPollingInterval(reporterName: String, config: Config): Int = {
+  def getReportingInterval(reporterName: String, config: Config): Int = {
     val metricsConfig = new MetricsConfig(config)
-    val pollingInterval = metricsConfig.getMetricsSnapshotReporterInterval(reporterName)
-    info("Got polling interval: %d" format pollingInterval)
-    pollingInterval
+    val reportingInterval = metricsConfig.getMetricsSnapshotReporterInterval(reporterName)
+    info("Got reporting interval: %d" format reportingInterval)
+    reportingInterval
   }
 
   def getJobId(config: Config): String = {
@@ -108,7 +108,7 @@ class MetricsSnapshotReporterFactory extends MetricsReporterFactory with Logging
 
     val systemStream = getSystemStream(reporterName, config)
     val producer = getProducer(reporterName, config, registry)
-    val pollingInterval = getPollingInterval(reporterName, config);
+    val reportingInterval = getReportingInterval(reporterName, config);
     val jobName = getJobName(config)
     val jobId = getJobId(config)
     val serde = getSerde(reporterName, config)
@@ -117,7 +117,7 @@ class MetricsSnapshotReporterFactory extends MetricsReporterFactory with Logging
     val reporter = new MetricsSnapshotReporter(
       producer,
       systemStream,
-      pollingInterval,
+      reportingInterval,
       jobName,
       jobId,
       containerName,

--- a/samza-core/src/test/java/org/apache/samza/metrics/TestMetricsSnapshotReporter.java
+++ b/samza-core/src/test/java/org/apache/samza/metrics/TestMetricsSnapshotReporter.java
@@ -35,7 +35,10 @@ import org.mockito.ArgumentCaptor;
 import scala.Some;
 import scala.runtime.AbstractFunction0;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.eq;
 
 
 public class TestMetricsSnapshotReporter {

--- a/samza-core/src/test/java/org/apache/samza/metrics/TestMetricsSnapshotReporter.java
+++ b/samza-core/src/test/java/org/apache/samza/metrics/TestMetricsSnapshotReporter.java
@@ -19,22 +19,50 @@
 
 package org.apache.samza.metrics;
 
+import java.util.List;
+import java.util.Map;
+import org.apache.samza.metrics.reporter.MetricsSnapshot;
 import org.apache.samza.metrics.reporter.MetricsSnapshotReporter;
 import org.apache.samza.serializers.MetricsSnapshotSerdeV2;
+import org.apache.samza.serializers.Serializer;
+import org.apache.samza.system.OutgoingMessageEnvelope;
+import org.apache.samza.system.SystemProducer;
 import org.apache.samza.system.SystemStream;
-import org.apache.samza.system.inmemory.InMemorySystemProducer;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import scala.Some;
 import scala.runtime.AbstractFunction0;
 
+import static org.mockito.Mockito.*;
+
 
 public class TestMetricsSnapshotReporter {
+
   private MetricsSnapshotReporter metricsSnapshotReporter;
   private static final String BLACKLIST_ALL = ".*";
   private static final String BLACKLIST_NONE = "";
   private static final String BLACKLIST_GROUPS = ".*(SystemConsumersMetrics|CachedStoreMetrics).*";
   private static final String BLACKLIST_ALL_BUT_TWO_GROUPS = "^(?!.*?(?:SystemConsumersMetrics|CachedStoreMetrics)).*$";
+
+  private static final SystemStream SYSTEM_STREAM = new SystemStream("test system", "test stream");
+  private static final String JOB_NAME = "test job";
+  private static final String JOB_ID = "test jobID";
+  private static final String CONTAINER_NAME = "samza-container-0";
+  private static final String TASK_VERSION = "test version";
+  private static final String SAMZA_VERSION = "test samza version";
+  private static final String HOSTNAME = "test host";
+  private static final int REPORTING_INTERVAL = 60000;
+
+  private Serializer<MetricsSnapshot> SERIALIZER;
+  private SystemProducer PRODUCER;
+
+  @Before
+  public void setup() {
+    PRODUCER = mock(SystemProducer.class);
+    SERIALIZER = new MetricsSnapshotSerdeV2();
+  }
 
   @Test
   public void testBlacklistAll() {
@@ -101,15 +129,61 @@ public class TestMetricsSnapshotReporter {
             "poll-count"));
   }
 
+  @Test
+  public void testMetricsEmission() {
+    // setup
+    SERIALIZER = null;
+    String SOURCE = "testSource";
+    String GROUP = "someGroup";
+    String METRIC_NAME = "someName";
+    MetricsRegistryMap registry = new MetricsRegistryMap();
+
+    metricsSnapshotReporter = getMetricsSnapshotReporter(TestMetricsSnapshotReporter.BLACKLIST_NONE);
+    registry.newGauge(GROUP, METRIC_NAME, 42);
+    metricsSnapshotReporter.register(SOURCE, registry);
+
+    ArgumentCaptor<OutgoingMessageEnvelope> outgoingMessageEnvelopeArgumentCaptor =
+        ArgumentCaptor.forClass(OutgoingMessageEnvelope.class);
+
+    // run
+    metricsSnapshotReporter.run();
+
+    // assert
+    verify(PRODUCER, times(1)).send(eq(SOURCE), outgoingMessageEnvelopeArgumentCaptor.capture());
+    verify(PRODUCER, times(1)).flush(eq(SOURCE));
+
+    List<OutgoingMessageEnvelope> envelopes = outgoingMessageEnvelopeArgumentCaptor.getAllValues();
+
+    Assert.assertEquals(1, envelopes.size());
+
+    MetricsSnapshot metricsSnapshot = ((MetricsSnapshot) envelopes.get(0).getMessage());
+
+    Assert.assertEquals(JOB_NAME, metricsSnapshot.getHeader().getJobName());
+    Assert.assertEquals(JOB_ID, metricsSnapshot.getHeader().getJobId());
+    Assert.assertEquals(CONTAINER_NAME, metricsSnapshot.getHeader().getContainerName());
+    Assert.assertEquals(SOURCE, metricsSnapshot.getHeader().getSource());
+    Assert.assertEquals(SAMZA_VERSION, metricsSnapshot.getHeader().getSamzaVersion());
+    Assert.assertEquals(TASK_VERSION, metricsSnapshot.getHeader().getVersion());
+    Assert.assertEquals(HOSTNAME, metricsSnapshot.getHeader().getHost());
+
+    Map<String, Map<String, Object>> metricMap = metricsSnapshot.getMetrics().getAsMap();
+    Assert.assertEquals(1, metricMap.size());
+    Assert.assertTrue(metricMap.containsKey(GROUP));
+    Assert.assertTrue(metricMap.get(GROUP).containsKey(METRIC_NAME));
+    Assert.assertEquals(42, metricMap.get(GROUP).get(METRIC_NAME));
+  }
+
   private MetricsSnapshotReporter getMetricsSnapshotReporter(String blacklist) {
-    return new MetricsSnapshotReporter(new InMemorySystemProducer("test system", null),
-        new SystemStream("test system", "test stream"), 60000, "test job", "test jobID", "samza-container-0",
-        "test version", "test samza version", "test host", new MetricsSnapshotSerdeV2(), new Some<>(blacklist),
-        new AbstractFunction0<Object>() {
-          @Override
-          public Object apply() {
-            return System.currentTimeMillis();
-          }
-        });
+    return new MetricsSnapshotReporter(PRODUCER, SYSTEM_STREAM, REPORTING_INTERVAL, JOB_NAME, JOB_ID, CONTAINER_NAME,
+        TASK_VERSION, SAMZA_VERSION, HOSTNAME, SERIALIZER, new Some<>(blacklist), getClock());
+  }
+
+  private AbstractFunction0<Object> getClock() {
+    return new AbstractFunction0<Object>() {
+      @Override
+      public Object apply() {
+        return System.currentTimeMillis();
+      }
+    };
   }
 }


### PR DESCRIPTION
Changes:
The refactoring is done to make the reporter stable when
exceptions are encountered. The patch also breaks down
MetricsSnapshotReporterFactory#getMetricsReporter into
smaller overridable pieces to make it more extendable/re-usable.

Tests: Unit test
API Changes: None
Upgrade Instructions: None
Usage Instructions: None