### PR TITLE
Samza-2540: Legacy Task application are missing app.run.id for both batch & stream jobs

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/execution/JobPlanner.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/JobPlanner.java
@@ -67,6 +67,10 @@ public abstract class JobPlanner {
     return streamManager;
   }
 
+  ExecutionPlan getExecutionPlan() {
+    return getExecutionPlan(null);
+  }
+
   /* package private */
   ExecutionPlan getExecutionPlan(String runId) {
     Map<String, String> allowedUserConfig = new HashMap<>(userConfig);

--- a/samza-core/src/main/java/org/apache/samza/execution/JobPlanner.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/JobPlanner.java
@@ -90,6 +90,13 @@ public abstract class JobPlanner {
       allowedUserConfig.remove(ClusterManagerConfig.JOB_HOST_AFFINITY_ENABLED);
     }
 
+    // APP_RUN_ID should be generated for both LegacyTaskApplications & descriptor based applications
+    // This config is used in BATCH mode to create new intermediate streams on runs and in stream mode use by
+    // Container Placements to identify a deployment of Samza
+    if (StringUtils.isNoneEmpty(runId)) {
+      generatedConfig.put(ApplicationConfig.APP_RUN_ID, runId);
+    }
+
     // merge user-provided configuration with generated configuration. generated configuration has lower priority.
     Config mergedConfig = JobNodeConfigurationGenerator.mergeConfig(allowedUserConfig, generatedConfig);
 
@@ -127,9 +134,6 @@ public abstract class JobPlanner {
 
   private Map<String, String> getGeneratedConfig(String runId) {
     Map<String, String> generatedConfig = new HashMap<>();
-    if (StringUtils.isNoneEmpty(runId)) {
-      generatedConfig.put(ApplicationConfig.APP_RUN_ID, runId);
-    }
 
     Map<String, String> systemStreamConfigs = generateSystemStreamConfigs(appDesc);
     generatedConfig.putAll(systemStreamConfigs);

--- a/samza-core/src/main/java/org/apache/samza/execution/JobPlanner.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/JobPlanner.java
@@ -67,10 +67,6 @@ public abstract class JobPlanner {
     return streamManager;
   }
 
-  ExecutionPlan getExecutionPlan() {
-    return getExecutionPlan(null);
-  }
-
   /* package private */
   ExecutionPlan getExecutionPlan(String runId) {
     Map<String, String> allowedUserConfig = new HashMap<>(userConfig);
@@ -83,7 +79,7 @@ public abstract class JobPlanner {
       if (StringUtils.isBlank(userConfig.get(TaskConfig.INPUT_STREAMS))) {
         allowedUserConfig.remove(TaskConfig.INPUT_STREAMS);
       }
-      generatedConfig.putAll(getGeneratedConfig(runId));
+      generatedConfig.putAll(getGeneratedConfig());
     }
 
     if (ApplicationConfig.ApplicationMode.BATCH.name().equals(generatedConfig.get(ApplicationConfig.APP_MODE))) {
@@ -132,7 +128,7 @@ public abstract class JobPlanner {
     }
   }
 
-  private Map<String, String> getGeneratedConfig(String runId) {
+  private Map<String, String> getGeneratedConfig() {
     Map<String, String> generatedConfig = new HashMap<>();
 
     Map<String, String> systemStreamConfigs = generateSystemStreamConfigs(appDesc);

--- a/samza-core/src/test/java/org/apache/samza/execution/TestJobPlanner.java
+++ b/samza-core/src/test/java/org/apache/samza/execution/TestJobPlanner.java
@@ -20,10 +20,15 @@
 package org.apache.samza.execution;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.apache.samza.application.LegacyTaskApplication;
+import org.apache.samza.application.descriptors.ApplicationDescriptorImpl;
+import org.apache.samza.config.JobConfig;
 import org.apache.samza.config.MapConfig;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class TestJobPlanner {
 
@@ -57,6 +62,28 @@ public class TestJobPlanner {
     MapConfig generatedConfig = JobPlanner.generateSingleJobConfig(testConfig);
     Assert.assertEquals(generatedConfig.get("job.name"), "should-exist-name");
     Assert.assertEquals(generatedConfig.get("job.id"), "should-exist-id");
+  }
+
+  @Test
+  public void testRunIdisConfiguredForAllTypesOfApps() {
+    Map<String, String> testConfig = new HashMap<>();
+    testConfig.put("app.id", "should-exist-id");
+    testConfig.put("app.name", "should-exist-name");
+
+    ApplicationDescriptorImpl applicationDescriptor = Mockito.mock(ApplicationDescriptorImpl.class);
+
+    Mockito.when(applicationDescriptor.getConfig()).thenReturn(new MapConfig(testConfig));
+    Mockito.when(applicationDescriptor.getAppClass()).thenReturn(LegacyTaskApplication.class);
+
+    JobPlanner jobPlanner = new JobPlanner(applicationDescriptor) {
+      @Override
+      public List<JobConfig> prepareJobs() {
+        return null;
+      }
+    };
+
+    ExecutionPlan plan = jobPlanner.getExecutionPlan("custom-run-id");
+    Assert.assertNotNull(plan.getApplicationConfig().getRunId(), "custom-run-id");
   }
 
 }


### PR DESCRIPTION
**Symptom [Bug fix]:** 
- LegacyTaskApplication (ones that do not use descriptors) are missing app.run.id config which makes container placements nonusable with them
- Ideally app.run.id should be injected for all types of apps

**Changes:** Make all kinds of app generate app.run.id

**API changes:** None

**Upgrade Instructions:** None

**Usage Instructions:** None