### PR TITLE
SAMZA-2547: Add missing "tableId" for SendToTableOperatorSpec in Samza job execution plan

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/execution/JobGraphJsonGenerator.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/JobGraphJsonGenerator.java
@@ -19,6 +19,7 @@
 
 package org.apache.samza.execution;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -35,6 +36,7 @@ import org.apache.samza.operators.spec.OperatorSpec;
 import org.apache.samza.operators.spec.OutputOperatorSpec;
 import org.apache.samza.operators.spec.OutputStreamImpl;
 import org.apache.samza.operators.spec.PartitionByOperatorSpec;
+import org.apache.samza.operators.spec.SendToTableOperatorSpec;
 import org.apache.samza.operators.spec.StreamTableJoinOperatorSpec;
 import org.apache.samza.table.descriptors.BaseTableDescriptor;
 import org.apache.samza.table.descriptors.TableDescriptor;
@@ -164,7 +166,8 @@ import org.codehaus.jackson.map.ObjectMapper;
    * @param spec a {@link OperatorSpec} instance
    * @return map of the operator properties
    */
-  private Map<String, Object> operatorToMap(OperatorSpec spec) {
+  @VisibleForTesting
+  Map<String, Object> operatorToMap(OperatorSpec spec) {
     Map<String, Object> map = new HashMap<>();
     map.put("opCode", spec.getOpCode().name());
     map.put("opId", spec.getOpId());
@@ -186,8 +189,8 @@ import org.codehaus.jackson.map.ObjectMapper;
       map.put("tableId", tableId);
     }
 
-    if (spec instanceof StreamTableJoinOperatorSpec) {
-      String tableId = ((StreamTableJoinOperatorSpec) spec).getTableId();
+    if (spec instanceof SendToTableOperatorSpec) {
+      String tableId = ((SendToTableOperatorSpec) spec).getTableId();
       map.put("tableId", tableId);
     }
 

--- a/samza-core/src/test/java/org/apache/samza/execution/TestJobGraphJsonGenerator.java
+++ b/samza-core/src/test/java/org/apache/samza/execution/TestJobGraphJsonGenerator.java
@@ -31,6 +31,11 @@ import org.apache.samza.config.ApplicationConfig;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.JobConfig;
 import org.apache.samza.config.MapConfig;
+import org.apache.samza.operators.functions.StreamTableJoinFunction;
+import org.apache.samza.operators.spec.OperatorSpec;
+import org.apache.samza.operators.spec.OperatorSpecs;
+import org.apache.samza.operators.spec.SendToTableOperatorSpec;
+import org.apache.samza.operators.spec.StreamTableJoinOperatorSpec;
 import org.apache.samza.system.descriptors.GenericInputDescriptor;
 import org.apache.samza.system.descriptors.GenericOutputDescriptor;
 import org.apache.samza.system.descriptors.GenericSystemDescriptor;
@@ -368,4 +373,41 @@ public class TestJobGraphJsonGenerator {
       return "";
     }
   }
+
+  @Test
+  public void testOperatorToMapForTable() {
+    JobGraphJsonGenerator jsonGenerator = new JobGraphJsonGenerator();
+    Map<String, Object> map;
+    SendToTableOperatorSpec<Object, Object> sendToTableOperatorSpec =
+        OperatorSpecs.createSendToTableOperatorSpec("test-sent-to-table", "test-sent-to");
+    map = jsonGenerator.operatorToMap(sendToTableOperatorSpec);
+    assertTrue(map.containsKey("tableId"));
+    assertEquals(map.get("tableId"), "test-sent-to-table");
+    assertEquals(map.get("opCode"), OperatorSpec.OpCode.SEND_TO.name());
+    assertEquals(map.get("opId"), "test-sent-to");
+    StreamTableJoinOperatorSpec<String, String, String, String> streamTableJoinOperatorSpec =
+        OperatorSpecs.createStreamTableJoinOperatorSpec("test-join-table", new TestStreamTableJoinFunction(),
+            "test-join");
+    map = jsonGenerator.operatorToMap(streamTableJoinOperatorSpec);
+    assertTrue(map.containsKey("tableId"));
+    assertEquals(map.get("tableId"), "test-join-table");
+    assertEquals(map.get("opCode"), OperatorSpec.OpCode.JOIN.name());
+    assertEquals(map.get("opId"), "test-join");
+  }
+
+  private class TestStreamTableJoinFunction implements StreamTableJoinFunction<String, String, String, String> {
+    @Override
+    public String apply(String message, String record) {
+      return null;
+    }
+    @Override
+    public String getMessageKey(String message) {
+      return null;
+    }
+    @Override
+    public String getRecordKey(String record) {
+      return null;
+    }
+  }
+
 }

--- a/samza-core/src/test/java/org/apache/samza/execution/TestJobGraphJsonGenerator.java
+++ b/samza-core/src/test/java/org/apache/samza/execution/TestJobGraphJsonGenerator.java
@@ -386,28 +386,12 @@ public class TestJobGraphJsonGenerator {
     assertEquals(map.get("opCode"), OperatorSpec.OpCode.SEND_TO.name());
     assertEquals(map.get("opId"), "test-sent-to");
     StreamTableJoinOperatorSpec<String, String, String, String> streamTableJoinOperatorSpec =
-        OperatorSpecs.createStreamTableJoinOperatorSpec("test-join-table", new TestStreamTableJoinFunction(),
-            "test-join");
+        OperatorSpecs.createStreamTableJoinOperatorSpec("test-join-table", mock(StreamTableJoinFunction.class), "test-join");
     map = jsonGenerator.operatorToMap(streamTableJoinOperatorSpec);
     assertTrue(map.containsKey("tableId"));
     assertEquals(map.get("tableId"), "test-join-table");
     assertEquals(map.get("opCode"), OperatorSpec.OpCode.JOIN.name());
     assertEquals(map.get("opId"), "test-join");
-  }
-
-  private class TestStreamTableJoinFunction implements StreamTableJoinFunction<String, String, String, String> {
-    @Override
-    public String apply(String message, String record) {
-      return null;
-    }
-    @Override
-    public String getMessageKey(String message) {
-      return null;
-    }
-    @Override
-    public String getRecordKey(String record) {
-      return null;
-    }
   }
 
 }


### PR DESCRIPTION
#### Symptom
There is `tableId` information for `StreamTableJoinOperatorSpec` in Samza job execution plan:
```json
"samza-hello-fluent-api-remote-table-venice-i001-alazhang-join-1": {
    "opId": "samza-hello-fluent-api-remote-table-venice-i001-alazhang-join-1",
    "tableId": "table-id",
    "opCode": "JOIN",
    "sourceLocation": "VeniceRemoteTableJoinApp.java:69",
    "nextOperatorIds": [
        "samza-hello-fluent-api-remote-table-venice-i001-alazhang-send_to-2"
    ]
}
```
However, there is no `tableId ` information for `SendToTableOperatorSpec`.
```json
 "samza-hello-fluent-api-remote-table-venice-i001-alazhang-send_to-2": {
    "opId": "samza-hello-fluent-api-remote-table-venice-i001-alazhang-send_to-2",
    "opCode": "SEND_TO",
    "sourceLocation": "VeniceRemoteTableJoinApp.java:70",
    "outputStreamId": "PageViewUserAgentTypeEvent",
    "nextOperatorIds": []
}           
```

#### Cause
Currently, JobGraphJsonGenerator.operatorToMap() function populates "tableId" field when the given operator spec is table related. 
However, as shown in the below codes, we forgot to handle `SendToTableOperatorSpec`, but handle `StreamTableJoinOperatorSpec` twice somehow. 

```java
private Map<String, Object> operatorToMap(OperatorSpec spec) {
    Map<String, Object> map = new HashMap<>();
    map.put("opCode", spec.getOpCode().name());
    map.put("opId", spec.getOpId());
    map.put("sourceLocation", spec.getSourceLocation());
    ...

    if (spec instanceof StreamTableJoinOperatorSpec) {
      String tableId = ((StreamTableJoinOperatorSpec) spec).getTableId();
      map.put("tableId", tableId);
    }

    if (spec instanceof StreamTableJoinOperatorSpec) {
      String tableId = ((StreamTableJoinOperatorSpec) spec).getTableId();
      map.put("tableId", tableId);
    }

    if (spec instanceof JoinOperatorSpec) {
      map.put("ttlMs", ((JoinOperatorSpec) spec).getTtlMs());
    }

    return map;
  }
```
#### Changes
Replace `StreamTableJoinOperatorSpec` with `SendToTableOperatorSpec` in one of above if statements.

#### Tests
Add test case to test all Table related operators.