### PR TITLE
[Minor test fix] Enabled and fixed a TestKafkaCheckpointManager test

### DIFF
--- a/samza-kafka/src/test/scala/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.scala
+++ b/samza-kafka/src/test/scala/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.scala
@@ -66,6 +66,7 @@ class TestKafkaCheckpointManager extends KafkaServerTestHarness {
     props.map(_root_.kafka.server.KafkaConfig.fromProps)
   }
 
+  @Test
   def testWriteCheckpointShouldRecreateSystemProducerOnFailure(): Unit = {
     val checkpointTopic = "checkpoint-topic-2"
     val mockKafkaProducer: SystemProducer = Mockito.mock(classOf[SystemProducer])
@@ -82,7 +83,6 @@ class TestKafkaCheckpointManager extends KafkaServerTestHarness {
     val spec = new KafkaStreamSpec("id", checkpointTopic, checkpointSystemName, 1, 1, props)
     val checkPointManager = Mockito.spy(new KafkaCheckpointManager(spec, new MockSystemFactory, false, config, new NoOpMetricsRegistry))
     val newKafkaProducer: SystemProducer = Mockito.mock(classOf[SystemProducer])
-    checkPointManager.MaxRetryDurationInMillis = 1
 
     Mockito.doReturn(newKafkaProducer).when(checkPointManager).getSystemProducer()
 


### PR DESCRIPTION
Symptom: `TestKafkaCheckpointManager.testWriteCheckpointShouldRecreateSystemProducerOnFailure` was not enabled. It also did not pass when it was enabled. It doesn't seem like this was a disabled flaky test; just seems like the author forgot to enable it.
Cause:
1. Missing the `@Test` annotation.
2. Retry timeout was set too low, so the test never had the chance to recreate the system producer.
Tests: `./gradlew :samza-kafka:test --tests TestKafkaCheckpointManager`
API/Usage changes: N/A