### PR TITLE
SAMZA-2552: Avoid logging false positive error message on each record.

### DIFF
--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/FilterTranslator.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/FilterTranslator.java
@@ -104,6 +104,11 @@ class FilterTranslator {
         LOG.error(errMsg, e);
         throw new SamzaException(errMsg, e);
       }
+      if (result[0] == null) {
+        // Case filter is applied on a null value -> result is neither true or false.
+        // Samza Filter operator supports primitive return types only, return false as per current convention.
+        return false;
+      }
       if (result[0] instanceof Boolean) {
         boolean retVal = (Boolean) result[0];
         LOG.debug(


### PR DESCRIPTION

This happens when the filter expression is evaluated over a null column.

**Symptom:** Logging an error message on each record when the actual state is correct leads to a false positive alerts and will flood the log files for no reason.
 
**Cause:** handling of null case when the class is not correct.
 
**Changes:** Removed the logging when the value is null.
 
**Tests:** Run the Samza SQL tests end to end.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/samza/1387)
<!-- Reviewable:end -->
