### PR TITLE
SAMZA-2553: Fix NPE when one of the condition value is null

### DIFF
--- a/samza-sql/src/test/java/org/apache/samza/sql/util/SampleRelTableKeyConverter.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/util/SampleRelTableKeyConverter.java
@@ -34,6 +34,10 @@ public class SampleRelTableKeyConverter implements SamzaRelTableKeyConverter {
     if (relRecord.getFieldValues().get(0) instanceof SamzaSqlRelRecord) {
       relRecord = (SamzaSqlRelRecord) relRecord.getFieldValues().get(0);
     }
-    return relRecord.getFieldValues().stream().map(Object::toString).collect(Collectors.toList()).get(0);
+    return relRecord.getFieldValues()
+        .stream()
+        .map(x -> x == null ? null : x.toString())
+        .collect(Collectors.toList())
+        .get(0);
   }
 }

--- a/samza-sql/src/test/java/org/apache/samza/sql/util/SampleRelTableKeyConverterTest.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/util/SampleRelTableKeyConverterTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.sql.util;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.samza.sql.SamzaSqlRelRecord;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class SampleRelTableKeyConverterTest {
+
+  @Test
+  public void testNullValue() {
+    SampleRelTableKeyConverter sampleRelTableKeyConverter = new SampleRelTableKeyConverter();
+    List<Object> values = new ArrayList<>();
+    values.add(null);
+    SamzaSqlRelRecord samzaSqlRelRecord = new SamzaSqlRelRecord(ImmutableList.of("c1"), values);
+    Object key = sampleRelTableKeyConverter.convertToTableKeyFormat(samzaSqlRelRecord);
+    Assert.assertNull(key);
+  }
+}


### PR DESCRIPTION
This PR is a **Bug fix**
**Symptom:** When one of the value for filter condition is null.
**Cause:**  Will lead to an NPE
**Changes:** Added handling for null case 
**Tests:** Added more tests and run current tests end to end.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/samza/1388)
<!-- Reviewable:end -->
