### PR TITLE
SAMZA-2551: Upgrade all modules to automatically use checkstyle 6.11.2 (part 2: includes all modules with checkstyle currently enabled, excluding samza-core)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -209,8 +209,7 @@ project(":samza-core_$scalaSuffix") {
 
   checkstyle {
     configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    // temporarily hardcode 6.11.2 until all other modules are upgraded
-    toolVersion = "6.11.2"
+    toolVersion = "$checkstyleVersion"
   }
 
   test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ gradleVersion=5.2.1
 org.gradle.jvmargs="-XX:MaxPermSize=512m"
 
 systemProp.file.encoding=utf-8
-checkstyleVersion=6.11
+checkstyleVersion=6.11.2

--- a/samza-api/src/main/java/org/apache/samza/metrics/SamzaHistogram.java
+++ b/samza-api/src/main/java/org/apache/samza/metrics/SamzaHistogram.java
@@ -48,7 +48,7 @@ public class SamzaHistogram {
     this.gauges = this.percentiles.stream()
         .filter(x -> x > 0 && x <= 100)
         .collect(Collectors.toMap(Function.identity(),
-            x -> registry.newGauge(group, new HistogramGauge(x, name + "_" + String.valueOf(x), 0D))));
+          x -> registry.newGauge(group, new HistogramGauge(x, name + "_" + String.valueOf(x), 0D))));
   }
 
   public void update(long value) {

--- a/samza-api/src/test/java/org/apache/samza/serializers/TestJsonSerdeV2.java
+++ b/samza-api/src/test/java/org/apache/samza/serializers/TestJsonSerdeV2.java
@@ -37,11 +37,11 @@ public class TestJsonSerdeV2 {
     assertEquals(obj, serde.fromBytes(bytes));
     JsonSerdeV2<Map.Entry<String, Object>> serdeHashMapEntry = new JsonSerdeV2<>();
     obj.entrySet().forEach(entry -> {
-        try {
-          serdeHashMapEntry.toBytes(entry);
-        } catch (Exception e) {
-          fail("HashMap Entry serialization failed!");
-        }
-      });
+      try {
+        serdeHashMapEntry.toBytes(entry);
+      } catch (Exception e) {
+        fail("HashMap Entry serialization failed!");
+      }
+    });
   }
 }

--- a/samza-api/src/test/java/org/apache/samza/system/descriptors/examples/expanding/ExampleExpandingSystemDescriptor.java
+++ b/samza-api/src/test/java/org/apache/samza/system/descriptors/examples/expanding/ExampleExpandingSystemDescriptor.java
@@ -31,10 +31,8 @@ public class ExampleExpandingSystemDescriptor extends SystemDescriptor<ExampleEx
   private static final String FACTORY_CLASS_NAME = "org.apache.samza.GraphExpandingSystemFactory";
 
   public ExampleExpandingSystemDescriptor(String systemName) {
-    super(systemName, FACTORY_CLASS_NAME,
-        (InputTransformer<String>) IncomingMessageEnvelope::toString,
-        (streamGraph, inputDescriptor) -> (MessageStream<Long>) streamGraph.getInputStream(inputDescriptor)
-    );
+    super(systemName, FACTORY_CLASS_NAME, (InputTransformer<String>) IncomingMessageEnvelope::toString,
+      (streamGraph, inputDescriptor) -> (MessageStream<Long>) streamGraph.getInputStream(inputDescriptor));
   }
 
   @Override

--- a/samza-api/src/test/java/org/apache/samza/table/remote/TestTableRateLimiter.java
+++ b/samza-api/src/test/java/org/apache/samza/table/remote/TestTableRateLimiter.java
@@ -45,10 +45,10 @@ public class TestTableRateLimiter {
   public TableRateLimiter<String, String> getThrottler(String tag) {
     TableRateLimiter.CreditFunction<String, String> credFn =
         (TableRateLimiter.CreditFunction<String, String>) (key, value, args) -> {
-      int credits = key == null ? 0 : 3;
-      credits += value == null ? 0 : 3;
-      return credits;
-    };
+          int credits = key == null ? 0 : 3;
+          credits += value == null ? 0 : 3;
+          return credits;
+        };
     RateLimiter rateLimiter = mock(RateLimiter.class);
     doReturn(Collections.singleton(tag)).when(rateLimiter).getSupportedTags();
     TableRateLimiter<String, String> rateLimitHelper = new TableRateLimiter<>("foo", rateLimiter, credFn, tag);

--- a/samza-aws/src/main/java/org/apache/samza/system/kinesis/KinesisConfig.java
+++ b/samza-aws/src/main/java/org/apache/samza/system/kinesis/KinesisConfig.java
@@ -84,12 +84,12 @@ public class KinesisConfig extends MapConfig {
     // all properties should now start with stream name
     Set<String> streams = new HashSet<>();
     streamsConfig.keySet().forEach(key -> {
-        String[] parts = key.split("\\.", 2);
-        if (parts.length != 2) {
-          throw new IllegalArgumentException("Ill-formatted stream config: " + key);
-        }
-        streams.add(parts[0]);
-      });
+      String[] parts = key.split("\\.", 2);
+      if (parts.length != 2) {
+        throw new IllegalArgumentException("Ill-formatted stream config: " + key);
+      }
+      streams.add(parts[0]);
+    });
     return streams;
   }
 

--- a/samza-aws/src/main/java/org/apache/samza/system/kinesis/KinesisSystemFactory.java
+++ b/samza-aws/src/main/java/org/apache/samza/system/kinesis/KinesisSystemFactory.java
@@ -76,11 +76,11 @@ public class KinesisSystemFactory implements SystemFactory {
     // Kinesis streams cannot be configured as bootstrap streams
     KinesisConfig kConfig = new KinesisConfig(config);
     kConfig.getKinesisStreams(system).forEach(stream -> {
-        StreamConfig streamConfig = new StreamConfig(kConfig);
-        SystemStream ss = new SystemStream(system, stream);
-        if (streamConfig.getBootstrapEnabled(ss)) {
-          throw new ConfigException("Kinesis streams cannot be configured as bootstrap streams.");
-        }
-      });
+      StreamConfig streamConfig = new StreamConfig(kConfig);
+      SystemStream ss = new SystemStream(system, stream);
+      if (streamConfig.getBootstrapEnabled(ss)) {
+        throw new ConfigException("Kinesis streams cannot be configured as bootstrap streams.");
+      }
+    });
   }
 }

--- a/samza-aws/src/main/java/org/apache/samza/system/kinesis/consumer/KinesisSystemConsumer.java
+++ b/samza-aws/src/main/java/org/apache/samza/system/kinesis/consumer/KinesisSystemConsumer.java
@@ -215,19 +215,19 @@ public class KinesisSystemConsumer extends BlockingEnvelopeMap implements Checkp
   public void afterCheckpoint(Map<SystemStreamPartition, String> sspOffsets) {
     LOG.info("afterCheckpoint called with sspOffsets {}", sspOffsets);
     sspOffsets.forEach((ssp, offset) -> {
-        KinesisRecordProcessor processor = processors.get(ssp);
-        KinesisSystemConsumerOffset kinesisOffset = KinesisSystemConsumerOffset.parse(offset);
-        if (processor == null) {
-          LOG.info("Kinesis Processor is not alive for ssp {}. This could be the result of rebalance. Hence dropping the"
-              + " checkpoint {}.", ssp, offset);
-        } else if (!kinesisOffset.getShardId().equals(processor.getShardId())) {
-          LOG.info("KinesisProcessor for ssp {} currently owns shard {} while the checkpoint is for shard {}. This could"
-              + " be the result of rebalance. Hence dropping the checkpoint {}.", ssp, processor.getShardId(),
-              kinesisOffset.getShardId(), offset);
-        } else {
-          processor.checkpoint(kinesisOffset.getSeqNumber());
-        }
-      });
+      KinesisRecordProcessor processor = processors.get(ssp);
+      KinesisSystemConsumerOffset kinesisOffset = KinesisSystemConsumerOffset.parse(offset);
+      if (processor == null) {
+        LOG.info("Kinesis Processor is not alive for ssp {}. This could be the result of rebalance. Hence dropping the"
+            + " checkpoint {}.", ssp, offset);
+      } else if (!kinesisOffset.getShardId().equals(processor.getShardId())) {
+        LOG.info("KinesisProcessor for ssp {} currently owns shard {} while the checkpoint is for shard {}. This could"
+            + " be the result of rebalance. Hence dropping the checkpoint {}.", ssp, processor.getShardId(),
+            kinesisOffset.getShardId(), offset);
+      } else {
+        processor.checkpoint(kinesisOffset.getSeqNumber());
+      }
+    });
   }
 
   @Override

--- a/samza-aws/src/main/java/org/apache/samza/system/kinesis/descriptors/KinesisInputDescriptor.java
+++ b/samza-aws/src/main/java/org/apache/samza/system/kinesis/descriptors/KinesisInputDescriptor.java
@@ -110,12 +110,11 @@ public class KinesisInputDescriptor<StreamMessageType>
     String clientConfigPrefix =
         String.format(KinesisConfig.CONFIG_STREAM_KINESIS_CLIENT_LIB_CONFIG, systemName, streamId);
 
-    region.ifPresent(
-        val -> config.put(String.format(KinesisConfig.CONFIG_STREAM_REGION, systemName, streamId), val));
+    region.ifPresent(val -> config.put(String.format(KinesisConfig.CONFIG_STREAM_REGION, systemName, streamId), val));
     accessKey.ifPresent(
-        val -> config.put(String.format(KinesisConfig.CONFIG_STREAM_ACCESS_KEY, systemName, streamId), val));
+      val -> config.put(String.format(KinesisConfig.CONFIG_STREAM_ACCESS_KEY, systemName, streamId), val));
     secretKey.ifPresent(
-        val -> config.put(String.format(KinesisConfig.CONFIG_STREAM_SECRET_KEY, systemName, streamId), val));
+      val -> config.put(String.format(KinesisConfig.CONFIG_STREAM_SECRET_KEY, systemName, streamId), val));
     kclConfig.forEach((k, v) -> config.put(clientConfigPrefix + k, v));
 
     return config;

--- a/samza-aws/src/main/java/org/apache/samza/system/kinesis/descriptors/KinesisSystemDescriptor.java
+++ b/samza-aws/src/main/java/org/apache/samza/system/kinesis/descriptors/KinesisSystemDescriptor.java
@@ -121,12 +121,10 @@ public class KinesisSystemDescriptor extends SystemDescriptor<KinesisSystemDescr
     Map<String, String> config = new HashMap<>(super.toConfig());
     String systemName = getSystemName();
 
-    region.ifPresent(
-        val -> config.put(String.format(KinesisConfig.CONFIG_SYSTEM_REGION, systemName), val));
-    proxyHost.ifPresent(
-        val -> config.put(String.format(KinesisConfig.CONFIG_PROXY_HOST, systemName), val));
+    region.ifPresent(val -> config.put(String.format(KinesisConfig.CONFIG_SYSTEM_REGION, systemName), val));
+    proxyHost.ifPresent(val -> config.put(String.format(KinesisConfig.CONFIG_PROXY_HOST, systemName), val));
     proxyPort.ifPresent(
-        val -> config.put(String.format(KinesisConfig.CONFIG_PROXY_PORT, systemName), String.valueOf(val)));
+      val -> config.put(String.format(KinesisConfig.CONFIG_PROXY_PORT, systemName), String.valueOf(val)));
 
     String kclConfigPrefix = String.format(KinesisConfig.CONFIG_SYSTEM_KINESIS_CLIENT_LIB_CONFIG, systemName);
     kclConfig.forEach((k, v) -> config.put(kclConfigPrefix + k, v));

--- a/samza-aws/src/main/java/org/apache/samza/system/kinesis/metrics/KinesisSystemConsumerMetrics.java
+++ b/samza-aws/src/main/java/org/apache/samza/system/kinesis/metrics/KinesisSystemConsumerMetrics.java
@@ -73,7 +73,7 @@ public class KinesisSystemConsumerMetrics {
         .collect(Collectors.toConcurrentMap(Function.identity(), x -> new SamzaHistogram(registry, x, READ_LATENCY)));
     millisBehindLatest = streamNames.stream()
         .collect(Collectors.toConcurrentMap(Function.identity(),
-            x -> new SamzaHistogram(registry, x, MILLIS_BEHIND_LATEST)));
+          x -> new SamzaHistogram(registry, x, MILLIS_BEHIND_LATEST)));
 
     // Locking to ensure that these aggregated metrics will be created only once across multiple system consumers.
     synchronized (LOCK) {

--- a/samza-aws/src/test/java/org/apache/samza/system/kinesis/consumer/TestKinesisRecordProcessor.java
+++ b/samza-aws/src/test/java/org/apache/samza/system/kinesis/consumer/TestKinesisRecordProcessor.java
@@ -233,22 +233,22 @@ public class TestKinesisRecordProcessor {
       List<KinesisRecordProcessor> processors) {
     Map<KinesisRecordProcessor, List<Record>> processorRecordMap = new HashMap<>();
     processors.forEach(processor -> {
-        try {
-          // Create records and call process records
-          IRecordProcessorCheckpointer checkpointer = Mockito.mock(IRecordProcessorCheckpointer.class);
-          doNothing().when(checkpointer).checkpoint(anyString());
-          doNothing().when(checkpointer).checkpoint();
-          ProcessRecordsInput processRecordsInput = Mockito.mock(ProcessRecordsInput.class);
-          when(processRecordsInput.getCheckpointer()).thenReturn(checkpointer);
-          when(processRecordsInput.getMillisBehindLatest()).thenReturn(1000L);
-          List<Record> inputRecords = createRecords(numRecordsPerShard);
-          processorRecordMap.put(processor, inputRecords);
-          when(processRecordsInput.getRecords()).thenReturn(inputRecords);
-          processor.processRecords(processRecordsInput);
-        } catch (ShutdownException | InvalidStateException ex) {
-          throw new RuntimeException(ex);
-        }
-      });
+      try {
+        // Create records and call process records
+        IRecordProcessorCheckpointer checkpointer = Mockito.mock(IRecordProcessorCheckpointer.class);
+        doNothing().when(checkpointer).checkpoint(anyString());
+        doNothing().when(checkpointer).checkpoint();
+        ProcessRecordsInput processRecordsInput = Mockito.mock(ProcessRecordsInput.class);
+        when(processRecordsInput.getCheckpointer()).thenReturn(checkpointer);
+        when(processRecordsInput.getMillisBehindLatest()).thenReturn(1000L);
+        List<Record> inputRecords = createRecords(numRecordsPerShard);
+        processorRecordMap.put(processor, inputRecords);
+        when(processRecordsInput.getRecords()).thenReturn(inputRecords);
+        processor.processRecords(processRecordsInput);
+      } catch (ShutdownException | InvalidStateException ex) {
+        throw new RuntimeException(ex);
+      }
+    });
     return processorRecordMap;
   }
 

--- a/samza-azure/src/main/java/org/apache/samza/coordinator/AzureJobCoordinator.java
+++ b/samza-azure/src/main/java/org/apache/samza/coordinator/AzureJobCoordinator.java
@@ -485,12 +485,12 @@ public class AzureJobCoordinator implements JobCoordinator {
       // Schedule a task to renew the lease after a fixed time interval
       LOG.info("Starting scheduler to keep renewing lease held by the leader.");
       renewLease = new RenewLeaseScheduler((errorMsg) -> {
-          LOG.error(errorMsg);
-          table.updateIsLeader(currentJMVersion.get(), processorId, false);
-          azureLeaderElector.resignLeadership();
-          renewLease.shutdown();
-          liveness.shutdown();
-        }, azureLeaderElector.getLeaseBlobManager(), azureLeaderElector.getLeaseId());
+        LOG.error(errorMsg);
+        table.updateIsLeader(currentJMVersion.get(), processorId, false);
+        azureLeaderElector.resignLeadership();
+        renewLease.shutdown();
+        liveness.shutdown();
+      }, azureLeaderElector.getLeaseBlobManager(), azureLeaderElector.getLeaseId());
       renewLease.scheduleTask();
 
       doOnProcessorChange(new ArrayList<>());

--- a/samza-azure/src/main/java/org/apache/samza/coordinator/scheduler/HeartbeatScheduler.java
+++ b/samza-azure/src/main/java/org/apache/samza/coordinator/scheduler/HeartbeatScheduler.java
@@ -60,14 +60,14 @@ public class HeartbeatScheduler implements TaskScheduler {
   @Override
   public ScheduledFuture scheduleTask() {
     return scheduler.scheduleWithFixedDelay(() -> {
-        try {
-          String currJVM = currentJMVersion.get();
-          LOG.info("Updating heartbeat for processor ID: " + processorId + " and job model version: " + currJVM);
-          table.updateHeartbeat(currJVM, processorId);
-        } catch (Exception e) {
-          errorHandler.accept("Exception in Heartbeat Scheduler. Stopping the processor...");
-        }
-      }, HEARTBEAT_DELAY_SEC, HEARTBEAT_DELAY_SEC, TimeUnit.SECONDS);
+      try {
+        String currJVM = currentJMVersion.get();
+        LOG.info("Updating heartbeat for processor ID: " + processorId + " and job model version: " + currJVM);
+        table.updateHeartbeat(currJVM, processorId);
+      } catch (Exception e) {
+        errorHandler.accept("Exception in Heartbeat Scheduler. Stopping the processor...");
+      }
+    }, HEARTBEAT_DELAY_SEC, HEARTBEAT_DELAY_SEC, TimeUnit.SECONDS);
   }
 
   @Override

--- a/samza-azure/src/main/java/org/apache/samza/coordinator/scheduler/JMVersionUpgradeScheduler.java
+++ b/samza-azure/src/main/java/org/apache/samza/coordinator/scheduler/JMVersionUpgradeScheduler.java
@@ -67,24 +67,24 @@ public class JMVersionUpgradeScheduler implements TaskScheduler {
   @Override
   public ScheduledFuture scheduleTask() {
     return scheduler.scheduleWithFixedDelay(() -> {
-        try {
-          LOG.info("Checking for job model version upgrade");
-          // Read job model version from the blob.
-          String blobJMV = blob.getJobModelVersion();
-          LOG.info("Job Model Version seen on the blob: {}", blobJMV);
-          String blobBarrierState = blob.getBarrierState();
-          String currentJMV = currentJMVersion.get();
-          LOG.info("Current Job Model Version that the job coordinator is working on: {}", currentJMV);
-          String expectedBarrierState = BarrierState.START.toString() + " " + blobJMV;
-          List<String> processorList = blob.getLiveProcessorList();
-          // Check if the job model version on the blob is consistent with the job model version that the processor is operating on.
-          if (processorList != null && processorList.contains(processorId) && !currentJMV.equals(blobJMV) && blobBarrierState.equals(expectedBarrierState) && !versionUpgradeDetected.get()) {
-            listener.onStateChange();
-          }
-        } catch (Exception e) {
-          errorHandler.accept("Exception in Job Model Version Upgrade Scheduler. Stopping the processor...");
+      try {
+        LOG.info("Checking for job model version upgrade");
+        // Read job model version from the blob.
+        String blobJMV = blob.getJobModelVersion();
+        LOG.info("Job Model Version seen on the blob: {}", blobJMV);
+        String blobBarrierState = blob.getBarrierState();
+        String currentJMV = currentJMVersion.get();
+        LOG.info("Current Job Model Version that the job coordinator is working on: {}", currentJMV);
+        String expectedBarrierState = BarrierState.START.toString() + " " + blobJMV;
+        List<String> processorList = blob.getLiveProcessorList();
+        // Check if the job model version on the blob is consistent with the job model version that the processor is operating on.
+        if (processorList != null && processorList.contains(processorId) && !currentJMV.equals(blobJMV) && blobBarrierState.equals(expectedBarrierState) && !versionUpgradeDetected.get()) {
+          listener.onStateChange();
         }
-      }, JMV_UPGRADE_DELAY_SEC, JMV_UPGRADE_DELAY_SEC, TimeUnit.SECONDS);
+      } catch (Exception e) {
+        errorHandler.accept("Exception in Job Model Version Upgrade Scheduler. Stopping the processor...");
+      }
+    }, JMV_UPGRADE_DELAY_SEC, JMV_UPGRADE_DELAY_SEC, TimeUnit.SECONDS);
   }
 
   @Override

--- a/samza-azure/src/main/java/org/apache/samza/coordinator/scheduler/LeaderBarrierCompleteScheduler.java
+++ b/samza-azure/src/main/java/org/apache/samza/coordinator/scheduler/LeaderBarrierCompleteScheduler.java
@@ -77,32 +77,32 @@ public class LeaderBarrierCompleteScheduler implements TaskScheduler {
   @Override
   public ScheduledFuture scheduleTask() {
     return scheduler.scheduleWithFixedDelay(() -> {
-        try {
-          if (!table.getEntity(currentJMVersion.get(), processorId).getIsLeader()) {
-            LOG.info("Not the leader anymore. Shutting down LeaderBarrierCompleteScheduler.");
+      try {
+        if (!table.getEntity(currentJMVersion.get(), processorId).getIsLeader()) {
+          LOG.info("Not the leader anymore. Shutting down LeaderBarrierCompleteScheduler.");
+          barrierTimeout.getAndSet(true);
+          listener.onStateChange();
+        } else {
+          LOG.info("Leader checking for barrier state");
+          // Get processor IDs listed in the table that have the new job model verion.
+          Iterable<ProcessorEntity> tableList = table.getEntitiesWithPartition(nextJMVersion);
+          Set<String> tableProcessors = new HashSet<>();
+          for (ProcessorEntity entity : tableList) {
+            tableProcessors.add(entity.getRowKey());
+          }
+          LOG.info("List of live processors as seen on the blob = {}", blobProcessorSet);
+          LOG.info("List of live processors as seen in the table = {}", tableProcessors);
+          if ((System.currentTimeMillis() - startTime) > (BARRIER_TIMEOUT_SEC * 1000)) {
             barrierTimeout.getAndSet(true);
             listener.onStateChange();
-          } else {
-            LOG.info("Leader checking for barrier state");
-            // Get processor IDs listed in the table that have the new job model verion.
-            Iterable<ProcessorEntity> tableList = table.getEntitiesWithPartition(nextJMVersion);
-            Set<String> tableProcessors = new HashSet<>();
-            for (ProcessorEntity entity : tableList) {
-              tableProcessors.add(entity.getRowKey());
-            }
-            LOG.info("List of live processors as seen on the blob = {}", blobProcessorSet);
-            LOG.info("List of live processors as seen in the table = {}", tableProcessors);
-            if ((System.currentTimeMillis() - startTime) > (BARRIER_TIMEOUT_SEC * 1000)) {
-              barrierTimeout.getAndSet(true);
-              listener.onStateChange();
-            } else if (blobProcessorSet.equals(tableProcessors)) {
-              listener.onStateChange();
-            }
+          } else if (blobProcessorSet.equals(tableProcessors)) {
+            listener.onStateChange();
           }
-        } catch (Exception e) {
-          errorHandler.accept("Exception in LeaderBarrierCompleteScheduler. Stopping the processor...");
         }
-      }, BARRIER_REACHED_DELAY_SEC, BARRIER_REACHED_DELAY_SEC, TimeUnit.SECONDS);
+      } catch (Exception e) {
+        errorHandler.accept("Exception in LeaderBarrierCompleteScheduler. Stopping the processor...");
+      }
+    }, BARRIER_REACHED_DELAY_SEC, BARRIER_REACHED_DELAY_SEC, TimeUnit.SECONDS);
   }
 
   @Override

--- a/samza-azure/src/main/java/org/apache/samza/coordinator/scheduler/LeaderLivenessCheckScheduler.java
+++ b/samza-azure/src/main/java/org/apache/samza/coordinator/scheduler/LeaderLivenessCheckScheduler.java
@@ -64,15 +64,15 @@ public class LeaderLivenessCheckScheduler implements TaskScheduler {
   @Override
   public ScheduledFuture scheduleTask() {
     return scheduler.scheduleWithFixedDelay(() -> {
-        try {
-          LOG.info("Checking for leader liveness");
-          if (!checkIfLeaderAlive()) {
-            listener.onStateChange();
-          }
-        } catch (Exception e) {
-          errorHandler.accept("Exception in Leader Liveness Check Scheduler. Stopping the processor...");
+      try {
+        LOG.info("Checking for leader liveness");
+        if (!checkIfLeaderAlive()) {
+          listener.onStateChange();
         }
-      }, LIVENESS_CHECK_DELAY_SEC, LIVENESS_CHECK_DELAY_SEC, TimeUnit.SECONDS);
+      } catch (Exception e) {
+        errorHandler.accept("Exception in Leader Liveness Check Scheduler. Stopping the processor...");
+      }
+    }, LIVENESS_CHECK_DELAY_SEC, LIVENESS_CHECK_DELAY_SEC, TimeUnit.SECONDS);
   }
 
   @Override

--- a/samza-azure/src/main/java/org/apache/samza/coordinator/scheduler/RenewLeaseScheduler.java
+++ b/samza-azure/src/main/java/org/apache/samza/coordinator/scheduler/RenewLeaseScheduler.java
@@ -56,16 +56,16 @@ public class RenewLeaseScheduler implements TaskScheduler {
   @Override
   public ScheduledFuture scheduleTask() {
     return scheduler.scheduleWithFixedDelay(() -> {
-        try {
-          LOG.info("Renewing lease");
-          boolean status = leaseBlobManager.renewLease(leaseId.get());
-          if (!status) {
-            errorHandler.accept("Unable to renew lease. Continuing as non-leader.");
-          }
-        } catch (Exception e) {
-          errorHandler.accept("Exception in Renew Lease Scheduler. Continuing as non-leader.");
+      try {
+        LOG.info("Renewing lease");
+        boolean status = leaseBlobManager.renewLease(leaseId.get());
+        if (!status) {
+          errorHandler.accept("Unable to renew lease. Continuing as non-leader.");
         }
-      }, RENEW_LEASE_DELAY_SEC, RENEW_LEASE_DELAY_SEC, TimeUnit.SECONDS);
+      } catch (Exception e) {
+        errorHandler.accept("Exception in Renew Lease Scheduler. Continuing as non-leader.");
+      }
+    }, RENEW_LEASE_DELAY_SEC, RENEW_LEASE_DELAY_SEC, TimeUnit.SECONDS);
   }
 
   @Override

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriter.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriter.java
@@ -213,13 +213,13 @@ public class AzureBlobAvroWriter implements AzureBlobWriter {
         throw new IllegalStateException("Attempting to close an already closed AzureBlobAvroWriter");
       }
       allBlobWriterComponents.forEach(blobWriterComponents -> {
-          try {
-            closeDataFileWriter(blobWriterComponents.dataFileWriter, blobWriterComponents.azureBlobOutputStream,
-                blobWriterComponents.blockBlobAsyncClient);
-          } catch (IOException e) {
-            throw new SamzaException(e);
-          }
-        });
+        try {
+          closeDataFileWriter(blobWriterComponents.dataFileWriter, blobWriterComponents.azureBlobOutputStream,
+              blobWriterComponents.blockBlobAsyncClient);
+        } catch (IOException e) {
+          throw new SamzaException(e);
+        }
+      });
       isClosed = true;
     }
   }

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobOutputStream.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobOutputStream.java
@@ -351,15 +351,15 @@ public class AzureBlobOutputStream extends OutputStream {
     pendingUpload.add(future);
 
     future.handle((aVoid, throwable) -> {
-        if (throwable == null) {
-          LOG.info("Upload block for blob: {} with blockid: {} finished.", blobAsyncClient.getBlobUrl().toString(), blockId);
-          pendingUpload.remove(future);
-          return aVoid;
-        } else {
-          throw new AzureException("Blob upload failed for blob " + blobAsyncClient.getBlobUrl().toString()
-              + " and block with id: " + blockId, throwable);
-        }
-      });
+      if (throwable == null) {
+        LOG.info("Upload block for blob: {} with blockid: {} finished.", blobAsyncClient.getBlobUrl().toString(), blockId);
+        pendingUpload.remove(future);
+        return aVoid;
+      } else {
+        throw new AzureException("Blob upload failed for blob " + blobAsyncClient.getBlobUrl().toString()
+            + " and block with id: " + blockId, throwable);
+      }
+    });
 
     blockNum += 1;
     if (blockNum >= MAX_BLOCKS_IN_AZURE_BLOB) {

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/EventHubConfig.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/EventHubConfig.java
@@ -110,10 +110,10 @@ public class EventHubConfig extends MapConfig {
     LOG.info("Building mappings from physicalName to streamId");
     streamConfig.getStreamIds()
         .forEach((streamId) -> {
-            String physicalName = streamConfig.getPhysicalName(streamId);
-            LOG.info("Obtained physicalName: {} for streamId: {} ", physicalName, streamId);
-            physcialToId.put(physicalName, streamId);
-          });
+          String physicalName = streamConfig.getPhysicalName(streamId);
+          LOG.info("Obtained physicalName: {} for streamId: {} ", physicalName, streamId);
+          physcialToId.put(physicalName, streamId);
+        });
   }
 
   private String getFromStreamIdOrName(String configName, String streamName, String defaultString) {

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/admin/EventHubSystemAdmin.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/admin/EventHubSystemAdmin.java
@@ -187,15 +187,15 @@ public class EventHubSystemAdmin implements SystemAdmin {
               .getPartitionRuntimeInformation(partition);
       futureList.add(partitionRuntimeInfo);
       partitionRuntimeInfo.thenAccept(ehPartitionInfo -> {
-          LOG.info(printPartitionRuntimeInfo(ehPartitionInfo));
-          // Set offsets
-          String startingOffset = EventHubSystemConsumer.START_OF_STREAM;
-          String newestOffset = ehPartitionInfo.getLastEnqueuedOffset();
-          String upcomingOffset = EventHubSystemConsumer.END_OF_STREAM;
-          SystemStreamPartitionMetadata sspMetadata = new SystemStreamPartitionMetadata(startingOffset, newestOffset,
-            upcomingOffset);
-          sspMetadataMap.put(new Partition(Integer.parseInt(partition)), sspMetadata);
-        });
+        LOG.info(printPartitionRuntimeInfo(ehPartitionInfo));
+        // Set offsets
+        String startingOffset = EventHubSystemConsumer.START_OF_STREAM;
+        String newestOffset = ehPartitionInfo.getLastEnqueuedOffset();
+        String upcomingOffset = EventHubSystemConsumer.END_OF_STREAM;
+        SystemStreamPartitionMetadata sspMetadata = new SystemStreamPartitionMetadata(startingOffset, newestOffset,
+          upcomingOffset);
+        sspMetadataMap.put(new Partition(Integer.parseInt(partition)), sspMetadata);
+      });
     }
 
     CompletableFuture<Void> futureGroup =

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
@@ -467,29 +467,29 @@ public class EventHubSystemConsumer extends BlockingEnvelopeMap {
     public void onReceive(Iterable<EventData> events) {
       if (events != null) {
         events.forEach(event -> {
-            byte[] eventDataBody = event.getBytes();
-            if (interceptor != null) {
-              eventDataBody = interceptor.intercept(eventDataBody);
-            }
-            String offset = event.getSystemProperties().getOffset();
-            Object partitionKey = event.getSystemProperties().getPartitionKey();
-            if (partitionKey == null) {
-              partitionKey = event.getProperties().get(EventHubSystemProducer.KEY);
-            }
-            try {
-              updateMetrics(event);
+          byte[] eventDataBody = event.getBytes();
+          if (interceptor != null) {
+            eventDataBody = interceptor.intercept(eventDataBody);
+          }
+          String offset = event.getSystemProperties().getOffset();
+          Object partitionKey = event.getSystemProperties().getPartitionKey();
+          if (partitionKey == null) {
+            partitionKey = event.getProperties().get(EventHubSystemProducer.KEY);
+          }
+          try {
+            updateMetrics(event);
 
-              // note that the partition key can be null
-              put(ssp, new EventHubIncomingMessageEnvelope(ssp, offset, partitionKey, eventDataBody, event));
-            } catch (InterruptedException e) {
-              String msg = String.format("Interrupted while adding the event from ssp %s to dispatch queue.", ssp);
-              LOG.error(msg, e);
-              throw new SamzaException(msg, e);
-            }
+            // note that the partition key can be null
+            put(ssp, new EventHubIncomingMessageEnvelope(ssp, offset, partitionKey, eventDataBody, event));
+          } catch (InterruptedException e) {
+            String msg = String.format("Interrupted while adding the event from ssp %s to dispatch queue.", ssp);
+            LOG.error(msg, e);
+            throw new SamzaException(msg, e);
+          }
 
-            // Cache latest checkpoint
-            streamPartitionOffsets.put(ssp, offset);
-          });
+          // Cache latest checkpoint
+          streamPartitionOffsets.put(ssp, offset);
+        });
       }
     }
 

--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/producer/AsyncSystemProducer.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/producer/AsyncSystemProducer.java
@@ -140,25 +140,25 @@ public abstract class AsyncSystemProducer implements SystemProducer {
 
     // Auto update the metrics and possible throwable when futures are complete.
     sendResult.handle((aVoid, throwable) -> {
-        long callbackLatencyMs = System.currentTimeMillis() - afterSendTimeMs;
-        sendCallbackLatency.get(streamId).update(callbackLatencyMs);
-        aggSendCallbackLatency.update(callbackLatencyMs);
-        if (throwable != null) {
-          sendErrors.get(streamId).inc();
-          aggSendErrors.inc();
-          LOG.error("Send message to event hub: {} failed with exception: ", streamId, throwable);
-          sendExceptionOnCallback.compareAndSet(null, throwable);
-        }
-        return aVoid;
-      });
+      long callbackLatencyMs = System.currentTimeMillis() - afterSendTimeMs;
+      sendCallbackLatency.get(streamId).update(callbackLatencyMs);
+      aggSendCallbackLatency.update(callbackLatencyMs);
+      if (throwable != null) {
+        sendErrors.get(streamId).inc();
+        aggSendErrors.inc();
+        LOG.error("Send message to event hub: {} failed with exception: ", streamId, throwable);
+        sendExceptionOnCallback.compareAndSet(null, throwable);
+      }
+      return aVoid;
+    });
   }
 
   public void start() {
     streamIds.forEach(streamId -> {
-        sendCallbackLatency.put(streamId, new SamzaHistogram(metricsRegistry, streamId, SEND_CALLBACK_LATENCY));
-        sendLatency.put(streamId, new SamzaHistogram(metricsRegistry, streamId, SEND_LATENCY));
-        sendErrors.put(streamId, metricsRegistry.newCounter(streamId, SEND_ERRORS));
-      });
+      sendCallbackLatency.put(streamId, new SamzaHistogram(metricsRegistry, streamId, SEND_CALLBACK_LATENCY));
+      sendLatency.put(streamId, new SamzaHistogram(metricsRegistry, streamId, SEND_LATENCY));
+      sendErrors.put(streamId, metricsRegistry.newCounter(streamId, SEND_ERRORS));
+    });
 
     if (aggSendLatency == null) {
       aggSendLatency = new SamzaHistogram(metricsRegistry, AGGREGATE, SEND_LATENCY);

--- a/samza-azure/src/test/java/org/apache/samza/system/azureblob/avro/TestAzureBlobAvroWriter.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/azureblob/avro/TestAzureBlobAvroWriter.java
@@ -294,8 +294,8 @@ public class TestAzureBlobAvroWriter {
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(mockContainerClient, times(2)).getBlobAsyncClient(argument.capture());
     argument.getAllValues().forEach(blobName -> {
-        Assert.assertTrue(blobName.contains(blobUrlPrefix));
-      });
+      Assert.assertTrue(blobName.contains(blobUrlPrefix));
+    });
     List<String> allBlobNames = argument.getAllValues();
     Assert.assertNotEquals(allBlobNames.get(0), allBlobNames.get(1));
 
@@ -359,8 +359,8 @@ public class TestAzureBlobAvroWriter {
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(mockContainerClient, times(2)).getBlobAsyncClient(argument.capture());
     argument.getAllValues().forEach(blobName -> {
-        Assert.assertTrue(blobName.contains(blobUrlPrefix));
-      });
+      Assert.assertTrue(blobName.contains(blobUrlPrefix));
+    });
     List<String> allBlobNames = argument.getAllValues();
     Assert.assertNotEquals(allBlobNames.get(0), allBlobNames.get(1));
 

--- a/samza-azure/src/test/java/org/apache/samza/system/azureblob/avro/TestAzureBlobOutputStream.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/azureblob/avro/TestAzureBlobOutputStream.java
@@ -105,16 +105,16 @@ public class TestAzureBlobOutputStream {
 
     BlobMetadataGenerator mockBlobMetadataGenerator = mock(BlobMetadataGenerator.class);
     doAnswer(invocation -> {
-        BlobMetadataContext blobMetadataContext = invocation.getArgumentAt(0, BlobMetadataContext.class);
-        String streamName = blobMetadataContext.getStreamName();
-        Long blobSize = blobMetadataContext.getBlobSize();
-        Long numberOfRecords = blobMetadataContext.getNumberOfMessagesInBlob();
-        Map<String, String> metadataProperties = new HashMap<>();
-        metadataProperties.put(BLOB_STREAM_NAME_METADATA, streamName);
-        metadataProperties.put(BLOB_RAW_SIZE_BYTES_METADATA, Long.toString(blobSize));
-        metadataProperties.put(BLOB_RECORD_NUMBER_METADATA, Long.toString(numberOfRecords));
-        return metadataProperties;
-      }).when(mockBlobMetadataGenerator).getBlobMetadata(anyObject());
+      BlobMetadataContext blobMetadataContext = invocation.getArgumentAt(0, BlobMetadataContext.class);
+      String streamName = blobMetadataContext.getStreamName();
+      Long blobSize = blobMetadataContext.getBlobSize();
+      Long numberOfRecords = blobMetadataContext.getNumberOfMessagesInBlob();
+      Map<String, String> metadataProperties = new HashMap<>();
+      metadataProperties.put(BLOB_STREAM_NAME_METADATA, streamName);
+      metadataProperties.put(BLOB_RAW_SIZE_BYTES_METADATA, Long.toString(blobSize));
+      metadataProperties.put(BLOB_RECORD_NUMBER_METADATA, Long.toString(numberOfRecords));
+      return metadataProperties;
+    }).when(mockBlobMetadataGenerator).getBlobMetadata(anyObject());
 
     azureBlobOutputStream = spy(new AzureBlobOutputStream(mockBlobAsyncClient, threadPool, mockMetrics,
         blobMetadataGeneratorFactory, blobMetadataGeneratorConfig, FAKE_STREAM,
@@ -196,8 +196,8 @@ public class TestAzureBlobOutputStream {
     verify(azureBlobOutputStream).stageBlock(eq(blockIdEncoded(1)), argument.capture(), eq((int) fullBlockCompressedByte.length));
     verify(azureBlobOutputStream).stageBlock(eq(blockIdEncoded(2)), argument2.capture(), eq((int) halfBlockCompressedByte.length));
     argument.getAllValues().forEach(byteBuffer -> {
-        Assert.assertEquals(ByteBuffer.wrap(fullBlockCompressedByte), byteBuffer);
-      });
+      Assert.assertEquals(ByteBuffer.wrap(fullBlockCompressedByte), byteBuffer);
+    });
     Assert.assertEquals(ByteBuffer.wrap(halfBlockCompressedByte), argument2.getAllValues().get(0));
     verify(mockMetrics, times(3)).updateAzureUploadMetrics();
   }

--- a/samza-azure/src/test/java/org/apache/samza/system/azureblob/producer/TestAzureBlobSystemProducer.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/azureblob/producer/TestAzureBlobSystemProducer.java
@@ -596,11 +596,11 @@ public class TestAzureBlobSystemProducer {
   private void setupWriterForProducer(AzureBlobSystemProducer azureBlobSystemProducer,
       AzureBlobWriter mockAzureBlobWriter, String stream) {
     doAnswer(invocation -> {
-        String blobUrl = invocation.getArgumentAt(0, String.class);
-        String streamName = invocation.getArgumentAt(2, String.class);
-        Assert.assertEquals(stream, streamName);
-        Assert.assertEquals(stream, blobUrl);
-        return mockAzureBlobWriter;
-      }).when(azureBlobSystemProducer).createNewWriter(anyString(), any(), anyString());
+      String blobUrl = invocation.getArgumentAt(0, String.class);
+      String streamName = invocation.getArgumentAt(2, String.class);
+      Assert.assertEquals(stream, streamName);
+      Assert.assertEquals(stream, blobUrl);
+      return mockAzureBlobWriter;
+    }).when(azureBlobSystemProducer).createNewWriter(anyString(), any(), anyString());
   }
 }

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/MockEventHubClientManagerFactory.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/MockEventHubClientManagerFactory.java
@@ -98,12 +98,12 @@ public class MockEventHubClientManagerFactory extends EventHubClientManagerFacto
       // Consumer mocks
       PartitionReceiver mockPartitionReceiver = PowerMockito.mock(PartitionReceiver.class);
       PowerMockito.when(mockPartitionReceiver.setReceiveHandler(any())).then((Answer<Void>) invocationOnMock -> {
-          PartitionReceiveHandler handler = invocationOnMock.getArgumentAt(0, PartitionReceiveHandler.class);
-          if (handler == null) {
-            Assert.fail("Handler for setReceiverHandler was null");
-          }
-          return null;
-        });
+        PartitionReceiveHandler handler = invocationOnMock.getArgumentAt(0, PartitionReceiveHandler.class);
+        if (handler == null) {
+          Assert.fail("Handler for setReceiverHandler was null");
+        }
+        return null;
+      });
       PartitionRuntimeInformation mockPartitionRuntimeInfo = PowerMockito.mock(PartitionRuntimeInformation.class);
       PowerMockito.when(mockPartitionRuntimeInfo.getLastEnqueuedOffset())
               .thenReturn(EventHubSystemConsumer.START_OF_STREAM);
@@ -114,16 +114,16 @@ public class MockEventHubClientManagerFactory extends EventHubClientManagerFacto
       PartitionSender mockPartitionSender1 = PowerMockito.mock(PartitionSender.class);
       PowerMockito.when(mockPartitionSender0.send(any(EventData.class)))
               .then((Answer<CompletableFuture<Void>>) invocationOnMock -> {
-                  EventData data = invocationOnMock.getArgumentAt(0, EventData.class);
-                  receivedData.get(systemName).get(streamName).get(0).add(data);
-                  return new CompletableFuture<>();
-                });
+                EventData data = invocationOnMock.getArgumentAt(0, EventData.class);
+                receivedData.get(systemName).get(streamName).get(0).add(data);
+                return new CompletableFuture<>();
+              });
       PowerMockito.when(mockPartitionSender1.send(any(EventData.class)))
               .then((Answer<CompletableFuture<Void>>) invocationOnMock -> {
-                  EventData data = invocationOnMock.getArgumentAt(0, EventData.class);
-                  receivedData.get(systemName).get(streamName).get(1).add(data);
-                  return new CompletableFuture<>();
-                });
+                EventData data = invocationOnMock.getArgumentAt(0, EventData.class);
+                receivedData.get(systemName).get(streamName).get(1).add(data);
+                return new CompletableFuture<>();
+              });
 
       EventHubRuntimeInformation mockRuntimeInfo = PowerMockito.mock(EventHubRuntimeInformation.class);
       CompletableFuture<EventHubRuntimeInformation> future =  new MockFuture(mockRuntimeInfo);
@@ -133,18 +133,18 @@ public class MockEventHubClientManagerFactory extends EventHubClientManagerFacto
         // Consumer calls
         PowerMockito.when(mockEventHubClient.createReceiver(anyString(), anyString(), anyObject()))
               .then((Answer<CompletableFuture<PartitionReceiver>>) invocationOnMock -> {
-                  String partitionId = invocationOnMock.getArgumentAt(1, String.class);
-                  startingOffsets.put(partitionId, EventPosition.fromEndOfStream());
-                  return CompletableFuture.completedFuture(mockPartitionReceiver);
-                });
+                String partitionId = invocationOnMock.getArgumentAt(1, String.class);
+                startingOffsets.put(partitionId, EventPosition.fromEndOfStream());
+                return CompletableFuture.completedFuture(mockPartitionReceiver);
+              });
 
         PowerMockito.when(mockEventHubClient.createReceiver(anyString(), anyString(), anyObject()))
               .then((Answer<CompletableFuture<PartitionReceiver>>) invocationOnMock -> {
-                  String partitionId = invocationOnMock.getArgumentAt(1, String.class);
-                  EventPosition offset = invocationOnMock.getArgumentAt(2, EventPosition.class);
-                  startingOffsets.put(partitionId, offset);
-                  return CompletableFuture.completedFuture(mockPartitionReceiver);
-                });
+                String partitionId = invocationOnMock.getArgumentAt(1, String.class);
+                EventPosition offset = invocationOnMock.getArgumentAt(2, EventPosition.class);
+                startingOffsets.put(partitionId, offset);
+                return CompletableFuture.completedFuture(mockPartitionReceiver);
+              });
 
         PowerMockito.when(mockEventHubClient.getPartitionRuntimeInformation(anyString())).thenReturn(partitionFuture);
 
@@ -156,12 +156,12 @@ public class MockEventHubClientManagerFactory extends EventHubClientManagerFacto
 
         PowerMockito.when(mockEventHubClient.send(any(EventData.class), anyString()))
                 .then((Answer<CompletableFuture<Void>>) invocationOnMock -> {
-                    EventData data = invocationOnMock.getArgumentAt(0, EventData.class);
-                    String key = invocationOnMock.getArgumentAt(1, String.class);
-                    Integer intKey = Integer.valueOf(key);
-                    receivedData.get(systemName).get(streamName).get(intKey % 2).add(data);
-                    return new CompletableFuture<>();
-                  });
+                  EventData data = invocationOnMock.getArgumentAt(0, EventData.class);
+                  String key = invocationOnMock.getArgumentAt(1, String.class);
+                  Integer intKey = Integer.valueOf(key);
+                  receivedData.get(systemName).get(streamName).get(intKey % 2).add(data);
+                  return new CompletableFuture<>();
+                });
       } catch (Exception e) {
         Assert.fail("Failed to create create mock methods for EventHubClient");
       }

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/admin/TestEventHubSystemAdmin.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/admin/TestEventHubSystemAdmin.java
@@ -86,11 +86,11 @@ public class TestEventHubSystemAdmin {
       Assert.assertTrue(partitionMetadataMap.size() >= MIN_EVENTHUB_ENTITY_PARTITION);
       Assert.assertTrue(partitionMetadataMap.size() <= MAX_EVENTHUB_ENTITY_PARTITION);
       partitionMetadataMap.forEach((partition, metadata) -> {
-          Assert.assertEquals(EventHubSystemConsumer.START_OF_STREAM, metadata.getOldestOffset());
-          Assert.assertNotSame(EventHubSystemConsumer.END_OF_STREAM, metadata.getNewestOffset());
-          String expectedUpcomingOffset = String.valueOf(Long.parseLong(metadata.getNewestOffset()) + 1);
-          Assert.assertEquals(expectedUpcomingOffset, metadata.getUpcomingOffset());
-        });
+        Assert.assertEquals(EventHubSystemConsumer.START_OF_STREAM, metadata.getOldestOffset());
+        Assert.assertNotSame(EventHubSystemConsumer.END_OF_STREAM, metadata.getNewestOffset());
+        String expectedUpcomingOffset = String.valueOf(Long.parseLong(metadata.getNewestOffset()) + 1);
+        Assert.assertEquals(expectedUpcomingOffset, metadata.getUpcomingOffset());
+      });
     }
   }
 

--- a/samza-kv/src/main/java/org/apache/samza/storage/kv/LargeMessageSafeStore.java
+++ b/samza-kv/src/main/java/org/apache/samza/storage/kv/LargeMessageSafeStore.java
@@ -86,8 +86,8 @@ public class LargeMessageSafeStore implements KeyValueStore<byte[], byte[]> {
   @Override
   public void putAll(List<Entry<byte[], byte[]>> entries) {
     entries.forEach(entry -> {
-        validateMessageSize(entry.getValue());
-      });
+      validateMessageSize(entry.getValue());
+    });
     List<Entry<byte[], byte[]>> largeMessageSafeEntries = removeLargeMessages(entries);
     store.putAll(largeMessageSafeEntries);
   }
@@ -146,14 +146,14 @@ public class LargeMessageSafeStore implements KeyValueStore<byte[], byte[]> {
   private List<Entry<byte[], byte[]>> removeLargeMessages(List<Entry<byte[], byte[]>> entries) {
     List<Entry<byte[], byte[]>> largeMessageSafeEntries = new ArrayList<>();
     entries.forEach(entry -> {
-        if (!isLargeMessage(entry.getValue())) {
-          largeMessageSafeEntries.add(entry);
-        } else {
-          LOG.info("Ignoring a large message with size " + entry.getValue().length + " since it is greater than "
-              + "the maximum allowed value of " + maxMessageSize);
-          largeMessageSafeStoreMetrics.ignoredLargeMessages().inc();
-        }
-      });
+      if (!isLargeMessage(entry.getValue())) {
+        largeMessageSafeEntries.add(entry);
+      } else {
+        LOG.info("Ignoring a large message with size " + entry.getValue().length + " since it is greater than "
+            + "the maximum allowed value of " + maxMessageSize);
+        largeMessageSafeStoreMetrics.ignoredLargeMessages().inc();
+      }
+    });
     return largeMessageSafeEntries;
   }
 

--- a/samza-kv/src/main/java/org/apache/samza/storage/kv/LocalTable.java
+++ b/samza-kv/src/main/java/org/apache/samza/storage/kv/LocalTable.java
@@ -118,12 +118,12 @@ public final class LocalTable<K, V> extends BaseReadWriteTable<K, V> {
     List<Entry<K, V>> toPut = new LinkedList<>();
     List<K> toDelete = new LinkedList<>();
     entries.forEach(e -> {
-        if (e.getValue() != null) {
-          toPut.add(e);
-        } else {
-          toDelete.add(e.getKey());
-        }
-      });
+      if (e.getValue() != null) {
+        toPut.add(e);
+      } else {
+        toDelete.add(e.getKey());
+      }
+    });
 
     if (!toPut.isEmpty()) {
       instrument(metrics.numPutAlls, metrics.putAllNs, () -> kvStore.putAll(toPut));

--- a/samza-log4j/src/test/java/org/apache/samza/logging/log4j/TestStreamAppender.java
+++ b/samza-log4j/src/test/java/org/apache/samza/logging/log4j/TestStreamAppender.java
@@ -190,11 +190,11 @@ public class TestStreamAppender {
     // Set up latch
     final CountDownLatch allMessagesSent = new CountDownLatch(messages.size());
     MockSystemProducer.listeners.add((source, envelope) -> {
-        allMessagesSent.countDown();
-        if (allMessagesSent.getCount() == messages.size() - 1) {
-          throw new RuntimeException(); // Throw on the first message
-        }
-      });
+      allMessagesSent.countDown();
+      if (allMessagesSent.getCount() == messages.size() - 1) {
+        throw new RuntimeException(); // Throw on the first message
+      }
+    });
 
     // Log the messages
     messages.forEach((message) -> log.info(message));
@@ -227,13 +227,13 @@ public class TestStreamAppender {
     final CountDownLatch allMessagesSent = new CountDownLatch(expectedMessagesSent); // We expect to drop all but the extra messages
     final CountDownLatch waitForTimeout = new CountDownLatch(1);
     MockSystemProducer.listeners.add((source, envelope) -> {
-        allMessagesSent.countDown();
-        try {
-          waitForTimeout.await();
-        } catch (InterruptedException e) {
-          fail("Test could not run properly because of a thread interrupt.");
-        }
-      });
+      allMessagesSent.countDown();
+      try {
+        waitForTimeout.await();
+      } catch (InterruptedException e) {
+        fail("Test could not run properly because of a thread interrupt.");
+      }
+    });
 
     // Log the messages. This is where the timeout will happen!
     messages.forEach((message) -> log.info(message));

--- a/samza-log4j2/src/test/java/org/apache/samza/logging/log4j2/TestStreamAppender.java
+++ b/samza-log4j2/src/test/java/org/apache/samza/logging/log4j2/TestStreamAppender.java
@@ -204,11 +204,11 @@ public class TestStreamAppender {
     // Set up latch
     final CountDownLatch allMessagesSent = new CountDownLatch(messages.size());
     MockSystemProducer.listeners.add((source, envelope) -> {
-        allMessagesSent.countDown();
-        if (allMessagesSent.getCount() == messages.size() - 1) {
-          throw new RuntimeException(); // Throw on the first message
-        }
-      });
+      allMessagesSent.countDown();
+      if (allMessagesSent.getCount() == messages.size() - 1) {
+        throw new RuntimeException(); // Throw on the first message
+      }
+    });
 
     // Log the messages
     messages.forEach((message) -> log.info(message));
@@ -241,13 +241,13 @@ public class TestStreamAppender {
     final CountDownLatch allMessagesSent = new CountDownLatch(expectedMessagesSent); // We expect to drop all but the extra messages
     final CountDownLatch waitForTimeout = new CountDownLatch(1);
     MockSystemProducer.listeners.add((source, envelope) -> {
-        allMessagesSent.countDown();
-        try {
-          waitForTimeout.await();
-        } catch (InterruptedException e) {
-          fail("Test could not run properly because of a thread interrupt.");
-        }
-      });
+      allMessagesSent.countDown();
+      try {
+        waitForTimeout.await();
+      } catch (InterruptedException e) {
+        fail("Test could not run properly because of a thread interrupt.");
+      }
+    });
 
     // Log the messages. This is where the timeout will happen!
     messages.forEach((message) -> log.info(message));

--- a/samza-test/src/main/java/org/apache/samza/example/AsyncApplicationExample.java
+++ b/samza-test/src/main/java/org/apache/samza/example/AsyncApplicationExample.java
@@ -108,18 +108,18 @@ public class AsyncApplicationExample implements StreamApplication {
 
     static CompletionStage<Member> decorateMember(int memberId) {
       return CompletableFuture.supplyAsync(() -> {
-          /*
-           * Introduce some lag to mimic remote call. In real use cases, this typically translates to over the wire
-           * network call to some rest service.
-           */
-          try {
-            Thread.sleep((long) (Math.random() * 10000));
-          } catch (InterruptedException ec) {
-            System.out.println("Interrupted during sleep");
-          }
+        /*
+         * Introduce some lag to mimic remote call. In real use cases, this typically translates to over the wire
+         * network call to some rest service.
+         */
+        try {
+          Thread.sleep((long) (Math.random() * 10000));
+        } catch (InterruptedException ec) {
+          System.out.println("Interrupted during sleep");
+        }
 
-          return new Member(memberId, getRandomGender(), getRandomCountry());
-        });
+        return new Member(memberId, getRandomGender(), getRandomCountry());
+      });
     }
 
     static String getRandomGender() {

--- a/samza-test/src/main/java/org/apache/samza/test/framework/TestRunner.java
+++ b/samza-test/src/main/java/org/apache/samza/test/framework/TestRunner.java
@@ -320,10 +320,10 @@ public class TestRunner {
     SystemConsumer consumer = factory.getConsumer(systemName, config, null);
     String name = (String) outputDescriptor.getPhysicalName().orElse(streamId);
     metadata.get(name).getSystemStreamPartitionMetadata().keySet().forEach(partition -> {
-        SystemStreamPartition temp = new SystemStreamPartition(systemName, streamId, partition);
-        ssps.add(temp);
-        consumer.register(temp, "0");
-      });
+      SystemStreamPartition temp = new SystemStreamPartition(systemName, streamId, partition);
+      ssps.add(temp);
+      consumer.register(temp, "0");
+    });
 
     long t = System.currentTimeMillis();
     Map<SystemStreamPartition, List<IncomingMessageEnvelope>> output = new HashMap<>();
@@ -361,7 +361,7 @@ public class TestRunner {
     return output.entrySet()
         .stream()
         .collect(Collectors.toMap(entry -> entry.getKey().getPartition().getPartitionId(),
-            entry -> entry.getValue().stream().map(e -> (StreamMessageType) e.getMessage()).collect(Collectors.toList())));
+          entry -> entry.getValue().stream().map(e -> (StreamMessageType) e.getMessage()).collect(Collectors.toList())));
   }
 
   /**
@@ -395,18 +395,18 @@ public class TestRunner {
     InMemorySystemProducer producer = (InMemorySystemProducer) factory.getProducer(systemName, config, null);
     SystemStream sysStream = new SystemStream(systemName, streamName);
     partitionData.forEach((partitionId, partition) -> {
-        partition.forEach(e -> {
-            Object key = e instanceof KV ? ((KV) e).getKey() : null;
-            Object value = e instanceof KV ? ((KV) e).getValue() : e;
-            if (value instanceof IncomingMessageEnvelope) {
-              producer.send((IncomingMessageEnvelope) value);
-            } else {
-              producer.send(systemName, new OutgoingMessageEnvelope(sysStream, Integer.valueOf(partitionId), key, value));
-            }
-          });
-        producer.send(systemName, new OutgoingMessageEnvelope(sysStream, Integer.valueOf(partitionId), null,
-            new EndOfStreamMessage(null)));
+      partition.forEach(e -> {
+        Object key = e instanceof KV ? ((KV) e).getKey() : null;
+        Object value = e instanceof KV ? ((KV) e).getValue() : e;
+        if (value instanceof IncomingMessageEnvelope) {
+          producer.send((IncomingMessageEnvelope) value);
+        } else {
+          producer.send(systemName, new OutgoingMessageEnvelope(sysStream, Integer.valueOf(partitionId), key, value));
+        }
       });
+      producer.send(systemName, new OutgoingMessageEnvelope(sysStream, Integer.valueOf(partitionId), null,
+          new EndOfStreamMessage(null)));
+    });
   }
 
   private void deleteStoreDirectories() {

--- a/samza-test/src/test/java/org/apache/samza/storage/kv/TestKeyValueSizeHistogramMetric.java
+++ b/samza-test/src/test/java/org/apache/samza/storage/kv/TestKeyValueSizeHistogramMetric.java
@@ -105,26 +105,26 @@ public class TestKeyValueSizeHistogramMetric {
     }
 
     metricsRegistry.getGroups().forEach(group -> metricsRegistry.getGroup(group.toString()).forEach((name, metric) -> {
-        if (names.contains(name)) {
-          metric.visit(new MetricsVisitor() {
-            @Override
-            public void counter(Counter counter) {
+      if (names.contains(name)) {
+        metric.visit(new MetricsVisitor() {
+          @Override
+          public void counter(Counter counter) {
 
-            }
+          }
 
-            @Override
-            public <T> void gauge(Gauge<T> gauge) {
-              Double num = (Double) gauge.getValue();
-              Assert.assertNotEquals(0D, (Double) gauge.getValue(), 0.0001);
-            }
+          @Override
+          public <T> void gauge(Gauge<T> gauge) {
+            Double num = (Double) gauge.getValue();
+            Assert.assertNotEquals(0D, (Double) gauge.getValue(), 0.0001);
+          }
 
-            @Override
-            public void timer(Timer timer) {
+          @Override
+          public void timer(Timer timer) {
 
-            }
-          });
-        }
-      }));
+          }
+        });
+      }
+    }));
   }
 
   private String getRandomString() {

--- a/samza-test/src/test/java/org/apache/samza/test/controlmessages/EndOfStreamIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/controlmessages/EndOfStreamIntegrationTest.java
@@ -105,8 +105,8 @@ public class EndOfStreamIntegrationTest extends IntegrationTestHarness {
             .map(KV::getValue)
             .partitionBy(pv -> pv.getMemberId(), pv -> pv, KVSerde.of(new NoOpSerde<>(), new NoOpSerde<>()), "p1")
             .sink((m, collector, coordinator) -> {
-                received.add(m.getValue());
-              });
+              received.add(m.getValue());
+            });
       }
     }
 

--- a/samza-test/src/test/java/org/apache/samza/test/controlmessages/WatermarkIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/controlmessages/WatermarkIntegrationTest.java
@@ -157,8 +157,8 @@ public class WatermarkIntegrationTest extends IntegrationTestHarness {
             .map(KV::getValue)
             .partitionBy(pv -> pv.getMemberId(), pv -> pv, KVSerde.of(new NoOpSerde<>(), new NoOpSerde<>()), "p1")
             .sink((m, collector, coordinator) -> {
-                received.add(m.getValue());
-              });
+              received.add(m.getValue());
+            });
       }
     }
 

--- a/samza-test/src/test/java/org/apache/samza/test/framework/StreamApplicationIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/framework/StreamApplicationIntegrationTest.java
@@ -167,8 +167,8 @@ public class StreamApplicationIntegrationTest {
           .map(m -> new KV(m.getValue().getMemberId(), m.getValue()))
           .sendTo(table)
           .sink((kv, collector, coordinator) -> {
-              LOG.info("Inserted Profile with Key: {} in profile-view-store", kv.getKey());
-            });
+            LOG.info("Inserted Profile with Key: {} in profile-view-store", kv.getKey());
+          });
 
       OutputStream<TestTableData.EnrichedPageView> outputStream = appDescriptor.getOutputStream(enrichedPageViewOSD);
       appDescriptor.getInputStream(pageViewISD)
@@ -177,8 +177,8 @@ public class StreamApplicationIntegrationTest {
           .sendTo(outputStream)
           .map(TestTableData.EnrichedPageView::getPageKey)
           .sink((joinPageKey, collector, coordinator) -> {
-              collector.send(new OutgoingMessageEnvelope(new SystemStream("test", "JoinPageKeys"), null, null, joinPageKey));
-            });
+            collector.send(new OutgoingMessageEnvelope(new SystemStream("test", "JoinPageKeys"), null, null, joinPageKey));
+          });
 
     }
   }

--- a/samza-test/src/test/java/org/apache/samza/test/operator/RepartitionJoinWindowApp.java
+++ b/samza-test/src/test/java/org/apache/samza/test/operator/RepartitionJoinWindowApp.java
@@ -94,11 +94,11 @@ public class RepartitionJoinWindowApp implements StreamApplication {
             new StringSerde(), new JsonSerdeV2<>(UserPageAdClick.class)), "userAdClickWindow")
         .map(windowPane -> KV.of(windowPane.getKey().getKey(), String.valueOf(windowPane.getMessage().size())))
         .sink((message, messageCollector, taskCoordinator) -> {
-            taskCoordinator.commit(TaskCoordinator.RequestScope.ALL_TASKS_IN_CONTAINER);
-            messageCollector.send(
-                new OutgoingMessageEnvelope(
-                    new SystemStream("kafka", outputTopic), null, message.getKey(), message.getValue()));
-          });
+          taskCoordinator.commit(TaskCoordinator.RequestScope.ALL_TASKS_IN_CONTAINER);
+          messageCollector.send(
+              new OutgoingMessageEnvelope(
+                  new SystemStream("kafka", outputTopic), null, message.getKey(), message.getValue()));
+        });
 
 
     intermediateStreamIds.add(((IntermediateMessageStreamImpl) pageViewsRepartitionedByViewId).getStreamId());

--- a/samza-test/src/test/java/org/apache/samza/test/operator/TestAsyncFlatMap.java
+++ b/samza-test/src/test/java/org/apache/samza/test/operator/TestAsyncFlatMap.java
@@ -152,14 +152,14 @@ public class TestAsyncFlatMap extends IntegrationTestHarness {
     private static CompletionStage<Collection<PageView>> filterGuestPageViews(PageView pageView,
         Predicate<PageView> shouldFailProcess, Supplier<Long> processJitter) {
       CompletableFuture<Collection<PageView>> filteredPageViews = CompletableFuture.supplyAsync(() -> {
-          try {
-            Thread.sleep(processJitter.get());
-          } catch (InterruptedException ex) {
-            System.out.println("Interrupted during sleep.");
-          }
+        try {
+          Thread.sleep(processJitter.get());
+        } catch (InterruptedException ex) {
+          System.out.println("Interrupted during sleep.");
+        }
 
-          return Long.valueOf(pageView.getUserId()) < 1 ? Collections.emptyList() : Collections.singleton(pageView);
-        });
+        return Long.valueOf(pageView.getUserId()) < 1 ? Collections.emptyList() : Collections.singleton(pageView);
+      });
 
       if (shouldFailProcess.test(pageView)) {
         filteredPageViews.completeExceptionally(new RuntimeException("Remote service threw an exception"));

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestStreamProcessor.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestStreamProcessor.java
@@ -278,10 +278,10 @@ public class TestStreamProcessor extends IntegrationTestHarness {
       doNothing().when(listener).afterStart();
       doNothing().when(listener).afterFailure(any());
       doAnswer(invocation -> {
-          // stopped successfully
-          shutdownLatch.countDown();
-          return null;
-        }).when(listener).afterStop();
+        // stopped successfully
+        shutdownLatch.countDown();
+        return null;
+      }).when(listener).afterStop();
     }
 
     private void initProducer(String bootstrapServer) {

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
@@ -236,10 +236,10 @@ public class TestZkLocalApplicationRunner extends IntegrationTestHarness {
       config.put(ClusterManagerConfig.HOST_AFFINITY_ENABLED, "false");
     }
     storeName.ifPresent(s -> {
-        config.put(String.format(StorageConfig.FACTORY, s), MockStoreFactory.class.getName());
-        config.put(String.format(StorageConfig.KEY_SERDE, s), "string");
-        config.put(String.format(StorageConfig.MSG_SERDE, s), "string");
-      });
+      config.put(String.format(StorageConfig.FACTORY, s), MockStoreFactory.class.getName());
+      config.put(String.format(StorageConfig.KEY_SERDE, s), "string");
+      config.put(String.format(StorageConfig.MSG_SERDE, s), "string");
+    });
     Map<String, String> samzaContainerConfig = ImmutableMap.<String, String>builder().putAll(config).build();
     Map<String, String> applicationConfig = Maps.newHashMap(samzaContainerConfig);
     applicationConfig.putAll(StandaloneTestUtils.getKafkaSystemConfigs(coordinatorSystemName, bootstrapServers(), zkConnect(), null, StandaloneTestUtils.SerdeAlias.STRING, true));
@@ -274,11 +274,11 @@ public class TestZkLocalApplicationRunner extends IntegrationTestHarness {
     final CountDownLatch secondProcessorRegistered = new CountDownLatch(1);
 
     zkUtils.subscribeToProcessorChange((parentPath, currentChilds) -> {
-        // When appRunner2 with id: PROCESSOR_IDS[1] is registered, run processing message in appRunner1.
-        if (currentChilds.contains(PROCESSOR_IDS[1])) {
-          secondProcessorRegistered.countDown();
-        }
-      });
+      // When appRunner2 with id: PROCESSOR_IDS[1] is registered, run processing message in appRunner1.
+      if (currentChilds.contains(PROCESSOR_IDS[1])) {
+        secondProcessorRegistered.countDown();
+      }
+    });
 
     // Set up stream app appRunner2.
     CountDownLatch processedMessagesLatch = new CountDownLatch(NUM_KAFKA_EVENTS);
@@ -356,11 +356,11 @@ public class TestZkLocalApplicationRunner extends IntegrationTestHarness {
     final CountDownLatch secondProcessorRegistered = new CountDownLatch(1);
 
     zkUtils.subscribeToProcessorChange((parentPath, currentChilds) -> {
-        // When appRunner2 with id: PROCESSOR_IDS[1] is registered, start processing message in appRunner1.
-        if (currentChilds.contains(PROCESSOR_IDS[1])) {
-          secondProcessorRegistered.countDown();
-        }
-      });
+      // When appRunner2 with id: PROCESSOR_IDS[1] is registered, start processing message in appRunner1.
+      if (currentChilds.contains(PROCESSOR_IDS[1])) {
+        secondProcessorRegistered.countDown();
+      }
+    });
 
     // Set up appRunner2.
     CountDownLatch processedMessagesLatch = new CountDownLatch(NUM_KAFKA_EVENTS * 2);
@@ -755,10 +755,10 @@ public class TestZkLocalApplicationRunner extends IntegrationTestHarness {
     Map<String, String> configMap = new HashMap<>();
     CoordinatorStreamValueSerde jsonSerde = new CoordinatorStreamValueSerde("set-config");
     metadataStore.all().forEach((key, value) -> {
-        CoordinatorStreamStore.CoordinatorMessageKey coordinatorMessageKey = CoordinatorStreamStore.deserializeCoordinatorMessageKeyFromJson(key);
-        String deserializedValue = jsonSerde.fromBytes(value);
-        configMap.put(coordinatorMessageKey.getKey(), deserializedValue);
-      });
+      CoordinatorStreamStore.CoordinatorMessageKey coordinatorMessageKey = CoordinatorStreamStore.deserializeCoordinatorMessageKeyFromJson(key);
+      String deserializedValue = jsonSerde.fromBytes(value);
+      configMap.put(coordinatorMessageKey.getKey(), deserializedValue);
+    });
     return new MapConfig(configMap);
   }
 
@@ -1279,8 +1279,8 @@ public class TestZkLocalApplicationRunner extends IntegrationTestHarness {
   private static List<SystemStreamPartition> getSystemStreamPartitions(JobModel jobModel) {
     List<SystemStreamPartition> ssps = new ArrayList<>();
     jobModel.getContainers().forEach((containerName, containerModel) -> {
-        containerModel.getTasks().forEach((taskName, taskModel) -> ssps.addAll(taskModel.getSystemStreamPartitions()));
-      });
+      containerModel.getTasks().forEach((taskName, taskModel) -> ssps.addAll(taskModel.getSystemStreamPartitions()));
+    });
     return ssps;
   }
 

--- a/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
@@ -864,13 +864,13 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     List<String> outMessages = TestAvroSystemFactory.messages.stream()
         .map(x -> {
-            GenericRecord profileAddr = (GenericRecord) ((GenericRecord) x.getMessage()).get("profileAddress");
-            GenericRecord streetNum = (GenericRecord) (profileAddr.get("streetnum"));
-            return ((GenericRecord) x.getMessage()).get("pageKey").toString() + ","
-                + (((GenericRecord) x.getMessage()).get("profileName") == null ? "null" :
-                ((GenericRecord) x.getMessage()).get("profileName").toString()) + ","
-                + profileAddr.get("zip") + "," + streetNum.get("number");
-          })
+          GenericRecord profileAddr = (GenericRecord) ((GenericRecord) x.getMessage()).get("profileAddress");
+          GenericRecord streetNum = (GenericRecord) (profileAddr.get("streetnum"));
+          return ((GenericRecord) x.getMessage()).get("pageKey").toString() + ","
+              + (((GenericRecord) x.getMessage()).get("profileName") == null ? "null" :
+              ((GenericRecord) x.getMessage()).get("profileName").toString()) + ","
+              + profileAddr.get("zip") + "," + streetNum.get("number");
+        })
         .collect(Collectors.toList());
     Assert.assertEquals(numMessages, outMessages.size());
     List<String> expectedOutMessages = TestAvroSystemFactory.getPageKeyProfileNameAddressJoin(numMessages);
@@ -1185,19 +1185,19 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
     HashMap<String, List<String>> pageKeyCountListMap = new HashMap<>();
     TestAvroSystemFactory.messages.stream()
         .map(x -> {
-            String pageKey = ((GenericRecord) x.getMessage()).get("pageKey").toString();
-            String count = ((GenericRecord) x.getMessage()).get("count").toString();
-            pageKeyCountListMap.computeIfAbsent(pageKey, k -> new ArrayList<>()).add(count);
-            return pageKeyCountListMap;
-          });
+          String pageKey = ((GenericRecord) x.getMessage()).get("pageKey").toString();
+          String count = ((GenericRecord) x.getMessage()).get("count").toString();
+          pageKeyCountListMap.computeIfAbsent(pageKey, k -> new ArrayList<>()).add(count);
+          return pageKeyCountListMap;
+        });
 
     HashMap<String, Integer> pageKeyCountMap = new HashMap<>();
     pageKeyCountListMap.forEach((key, list) -> {
-        // Check that the number of windows per key is non-zero but less than the number of input messages per key.
-        Assert.assertTrue(list.size() > 1 && list.size() < numMessages / TestAvroSystemFactory.pageKeys.length);
-        // Collapse the count of messages per key
-        pageKeyCountMap.put(key, list.stream().mapToInt(Integer::parseInt).sum());
-      });
+      // Check that the number of windows per key is non-zero but less than the number of input messages per key.
+      Assert.assertTrue(list.size() > 1 && list.size() < numMessages / TestAvroSystemFactory.pageKeys.length);
+      // Collapse the count of messages per key
+      pageKeyCountMap.put(key, list.stream().mapToInt(Integer::parseInt).sum());
+    });
 
     Set<String> pageKeys = new HashSet<>(Arrays.asList("job", "inbox"));
     HashMap<String, Integer> expectedPageKeyCountMap =

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTableEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTableEndToEnd.java
@@ -126,9 +126,9 @@ public class TestLocalTableEndToEnd extends IntegrationTestHarness {
       GenericInputDescriptor<PageView> pageViewISD = ksd.getInputDescriptor("PageView", new NoOpSerde<>());
       appDesc.getInputStream(pageViewISD)
           .map(pv -> {
-              received.add(pv);
-              return pv;
-            })
+            received.add(pv);
+            return pv;
+          })
           .partitionBy(PageView::getMemberId, v -> v, KVSerde.of(new NoOpSerde<>(), new NoOpSerde<>()), "p1")
           .join(table, new PageViewToProfileJoinFunction())
           .sink((m, collector, coordinator) -> joined.add(m));
@@ -188,15 +188,15 @@ public class TestLocalTableEndToEnd extends IntegrationTestHarness {
 
       profileStream1
           .map(m -> {
-              sentToProfileTable1.add(m);
-              return new KV(m.getMemberId(), m);
-            })
+            sentToProfileTable1.add(m);
+            return new KV(m.getMemberId(), m);
+          })
           .sendTo(profileTable);
       profileStream2
           .map(m -> {
-              sentToProfileTable2.add(m);
-              return new KV(m.getMemberId(), m);
-            })
+            sentToProfileTable2.add(m);
+            return new KV(m.getMemberId(), m);
+          })
           .sendTo(profileTable);
 
       GenericInputDescriptor<PageView> pageViewISD1 = ksd.getInputDescriptor("PageView1", new NoOpSerde<PageView>());

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTableWithSideInputsEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTableWithSideInputsEndToEnd.java
@@ -143,10 +143,10 @@ public class TestLocalTableWithSideInputsEndToEnd extends IntegrationTestHarness
       return new InMemoryTableDescriptor(PROFILE_TABLE, KVSerde.of(new IntegerSerde(), new ProfileJsonSerde()))
           .withSideInputs(ImmutableList.of(PROFILE_STREAM))
           .withSideInputsProcessor((msg, store) -> {
-              Profile profile = (Profile) msg.getMessage();
-              int key = profile.getMemberId();
-              return ImmutableList.of(new Entry<>(key, profile));
-            });
+            Profile profile = (Profile) msg.getMessage();
+            int key = profile.getMemberId();
+            return ImmutableList.of(new Entry<>(key, profile));
+          });
     }
   }
 
@@ -156,10 +156,10 @@ public class TestLocalTableWithSideInputsEndToEnd extends IntegrationTestHarness
       return new RocksDbTableDescriptor(PROFILE_TABLE, KVSerde.of(new IntegerSerde(), new ProfileJsonSerde()))
           .withSideInputs(ImmutableList.of(PROFILE_STREAM))
           .withSideInputsProcessor((msg, store) -> {
-              TestTableData.Profile profile = (TestTableData.Profile) msg.getMessage();
-              int key = profile.getMemberId();
-              return ImmutableList.of(new Entry<>(key, profile));
-            });
+            TestTableData.Profile profile = (TestTableData.Profile) msg.getMessage();
+            int key = profile.getMemberId();
+            return ImmutableList.of(new Entry<>(key, profile));
+          });
     }
   }
 }

--- a/samza-test/src/test/java/org/apache/samza/test/util/ArraySystemConsumer.java
+++ b/samza-test/src/test/java/org/apache/samza/test/util/ArraySystemConsumer.java
@@ -61,11 +61,11 @@ public class ArraySystemConsumer implements SystemConsumer {
       Map<SystemStreamPartition, List<IncomingMessageEnvelope>> envelopeMap = new HashMap<>();
       final AtomicInteger offset = new AtomicInteger(0);
       set.forEach(ssp -> {
-          List<IncomingMessageEnvelope> envelopes = Arrays.stream(getArrayObjects(ssp.getSystemStream().getStream(), config))
-              .map(object -> new IncomingMessageEnvelope(ssp, String.valueOf(offset.incrementAndGet()), null, object)).collect(Collectors.toList());
-          envelopes.add(IncomingMessageEnvelope.buildEndOfStreamEnvelope(ssp));
-          envelopeMap.put(ssp, envelopes);
-        });
+        List<IncomingMessageEnvelope> envelopes = Arrays.stream(getArrayObjects(ssp.getSystemStream().getStream(), config))
+            .map(object -> new IncomingMessageEnvelope(ssp, String.valueOf(offset.incrementAndGet()), null, object)).collect(Collectors.toList());
+        envelopes.add(IncomingMessageEnvelope.buildEndOfStreamEnvelope(ssp));
+        envelopeMap.put(ssp, envelopes);
+      });
       done = true;
       return envelopeMap;
     } else {

--- a/samza-test/src/test/java/org/apache/samza/test/util/SimpleSystemAdmin.java
+++ b/samza-test/src/test/java/org/apache/samza/test/util/SimpleSystemAdmin.java
@@ -53,19 +53,19 @@ public class SimpleSystemAdmin implements SystemAdmin {
   public Map<String, SystemStreamMetadata> getSystemStreamMetadata(Set<String> streamNames) {
     return streamNames.stream()
         .collect(Collectors.toMap(Function.identity(), streamName -> {
-            int messageCount = isBootstrapStream(streamName) ? getMessageCount(streamName) : -1;
-            String oldestOffset = messageCount < 0 ? null : "0";
-            String newestOffset = messageCount < 0 ? null : String.valueOf(messageCount - 1);
-            String upcomingOffset = messageCount < 0 ? null : String.valueOf(messageCount);
-            Map<Partition, SystemStreamMetadata.SystemStreamPartitionMetadata> metadataMap = new HashMap<>();
-            int partitionCount = config.getInt("streams." + streamName + ".partitionCount", 1);
-            for (int i = 0; i < partitionCount; i++) {
-              metadataMap.put(new Partition(i), new SystemStreamMetadata.SystemStreamPartitionMetadata(
-                  oldestOffset, newestOffset, upcomingOffset
-              ));
-            }
-            return new SystemStreamMetadata(streamName, metadataMap);
-          }));
+          int messageCount = isBootstrapStream(streamName) ? getMessageCount(streamName) : -1;
+          String oldestOffset = messageCount < 0 ? null : "0";
+          String newestOffset = messageCount < 0 ? null : String.valueOf(messageCount - 1);
+          String upcomingOffset = messageCount < 0 ? null : String.valueOf(messageCount);
+          Map<Partition, SystemStreamMetadata.SystemStreamPartitionMetadata> metadataMap = new HashMap<>();
+          int partitionCount = config.getInt("streams." + streamName + ".partitionCount", 1);
+          for (int i = 0; i < partitionCount; i++) {
+            metadataMap.put(new Partition(i), new SystemStreamMetadata.SystemStreamPartitionMetadata(
+                oldestOffset, newestOffset, upcomingOffset
+            ));
+          }
+          return new SystemStreamMetadata(streamName, metadataMap);
+        }));
   }
 
   @Override


### PR DESCRIPTION
Issues: Samza is currently using checkstyle 6.11 which doesn't check indentation inside lambdas properly. Auto-formatting from IDEs does handle lambdas better, but then checkstyle will throw an error for the auto-formatting, so the formatting has to be updated manually.
Changes: Upgrade all modules that currently have checkstyle enabled (except samza-core, which was handled in https://github.com/apache/samza/pull/1389) to use checkstyle 6.11.2 which has improved indentation checks, and updated all of the code to match the indentation checks.
Tests: Ran compilation and unit tests.
API/Upgrade/Usage changes: N/A

Note for reviewers: There is no expected change in functionality. There should only be whitespace changes in this PR.