### PR TITLE
SAMZA-2555: Prevent downloading checkstyle DTD over the internet

### DIFF
--- a/checkstyle/checkstyle-suppressions.xml
+++ b/checkstyle/checkstyle-suppressions.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 
 <!DOCTYPE suppressions PUBLIC
-        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
-        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
 <!--
      // Licensed to the Apache Software Foundation (ASF) under one or more

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-     "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <!--
 // Licensed to the Apache Software Foundation (ASF) under one or more
 // contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
 - By using exact DTD definitions, checkstyle tool will locate resources from within its own jar, avoiding download.
 - Using exact values from checkstyle 6.11.2 release, see:
 - configuration: https://github.com/checkstyle/checkstyle/blob/checkstyle-6.11.2/src/main/resources/com/puppycrawl/tools/checkstyle/configuration_1_3.dtd#L6
 - suppressions: https://github.com/checkstyle/checkstyle/blob/checkstyle-6.11.2/src/main/resources/com/puppycrawl/tools/checkstyle/suppressions_1_1.dtd#L6