### PR TITLE
SAMZA-2556:AzureBlob SystemProducer: Fix NPE thrown during flush. NPE caused by unhandled previous exceptions

### DIFF
--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriter.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriter.java
@@ -195,7 +195,7 @@ public class AzureBlobAvroWriter implements AzureBlobWriter {
   @Override
   public void flush() throws IOException {
     synchronized (currentDataFileWriterLock) {
-      if (currentBlobWriterComponents != null) {
+      if ( !isClosed && currentBlobWriterComponents != null) {
         currentBlobWriterComponents.dataFileWriter.flush();
       }
     }

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriter.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriter.java
@@ -195,7 +195,7 @@ public class AzureBlobAvroWriter implements AzureBlobWriter {
   @Override
   public void flush() throws IOException {
     synchronized (currentDataFileWriterLock) {
-      if ( !isClosed && currentBlobWriterComponents != null) {
+      if (!isClosed && currentBlobWriterComponents != null) {
         currentBlobWriterComponents.dataFileWriter.flush();
       }
     }

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriter.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriter.java
@@ -195,7 +195,9 @@ public class AzureBlobAvroWriter implements AzureBlobWriter {
   @Override
   public void flush() throws IOException {
     synchronized (currentDataFileWriterLock) {
-      currentBlobWriterComponents.dataFileWriter.flush();
+      if (currentBlobWriterComponents != null) {
+        currentBlobWriterComponents.dataFileWriter.flush();
+      }
     }
   }
 


### PR DESCRIPTION
**Bug fix**
**Symptom:**  NPE thrown during SystemProducer.flush if AzureBlobAvroWriter earlier threw an IllegalStateException.

**Cause:** First message passed into AzureBlobAvroWriter is a bad record without schema then the avro objects are not created due to IllegalStateException. However, if the user of the system producer still invokes a flush (either directly or through stop), NPE is thrown as flush of producer invokes flush of the writer which inturn accesses the non-existent avro objects.

**Changes:** check if the avro components are not null before accessing.

API changes: None

Upgrade Instructions: None

Usage Instructions: None

Tests: existing tests pass