### PR TITLE
SAMZA-2551: Upgrade all modules to automatically use checkstyle 6.11.2 (part 6: enable for all modules)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,12 @@ subprojects {
   apply plugin: 'eclipse'
   apply plugin: 'project-report'
   apply plugin: 'jacoco'
+  apply plugin: 'checkstyle'
+
+  checkstyle {
+    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
+    toolVersion = "$checkstyleVersion"
+  }
 
   tasks.withType(ScalaCompile) {
     // show compile errors in console output
@@ -139,7 +145,6 @@ subprojects {
 }
 
 project(':samza-api') {
-  apply plugin: 'checkstyle'
   apply plugin: 'java'
 
   dependencies {
@@ -152,15 +157,10 @@ project(':samza-api') {
     testCompile "junit:junit:$junitVersion"
     testCompile "org.mockito:mockito-core:$mockitoVersion"
   }
-  checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    toolVersion = "$checkstyleVersion"
-  }
 }
 
 project(":samza-core_$scalaSuffix") {
   apply plugin: 'scala'
-  apply plugin: 'checkstyle'
 
   // Force scala joint compilation
   sourceSets.main.scala.srcDir "src/main/java"
@@ -207,11 +207,6 @@ project(":samza-core_$scalaSuffix") {
     testRuntime "org.apache.logging.log4j:log4j-slf4j-impl:$log4j2Version"
   }
 
-  checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    toolVersion = "$checkstyleVersion"
-  }
-
   test {
     // some unit tests use embedded zookeeper, so adding some extra memory for those
     maxHeapSize = "1560m"
@@ -221,7 +216,6 @@ project(":samza-core_$scalaSuffix") {
 
 project(":samza-azure_$scalaSuffix") {
   apply plugin: 'java'
-  apply plugin: 'checkstyle'
 
   dependencies {
     compile "com.azure:azure-storage-blob:12.0.1"
@@ -239,15 +233,10 @@ project(":samza-azure_$scalaSuffix") {
     testCompile "org.powermock:powermock-core:$powerMockVersion"
     testCompile "org.powermock:powermock-module-junit4:$powerMockVersion"
   }
-  checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    toolVersion = "$checkstyleVersion"
-  }
 }
 
 project(":samza-aws_$scalaSuffix") {
   apply plugin: 'java'
-  apply plugin: 'checkstyle'
 
   dependencies {
     compile "com.amazonaws:aws-java-sdk-kinesis:1.11.152"
@@ -269,11 +258,6 @@ project(":samza-aws_$scalaSuffix") {
       url "https://repo1.maven.org/maven2/"
     }
   }
-
-  checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    toolVersion = "$checkstyleVersion"
-  }
 }
 
 project(":samza-elasticsearch_$scalaSuffix") {
@@ -293,7 +277,6 @@ project(":samza-elasticsearch_$scalaSuffix") {
 
 project(":samza-sql_$scalaSuffix") {
   apply plugin: 'java'
-  apply plugin: 'checkstyle'
 
   // Disabling assertions while running test because of a calcite bug in {@link RelOptUtil#eq} method
   // it checks for the type1 != type2 rather than !type1.equals(type2)
@@ -321,16 +304,10 @@ project(":samza-sql_$scalaSuffix") {
 
     testRuntime "org.slf4j:slf4j-simple:$slf4jVersion"
   }
-
-  checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    toolVersion = "$checkstyleVersion"
-  }
 }
 
 project(":samza-sql-shell_$scalaSuffix") {
   apply plugin: 'java'
-  apply plugin: 'checkstyle'
 
   jar {
     manifest {
@@ -349,11 +326,6 @@ project(":samza-sql-shell_$scalaSuffix") {
     compile "org.jline:jline:$jlineVersion"
 
     testCompile "junit:junit:$junitVersion"
-  }
-
-  checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    toolVersion = "$checkstyleVersion"
   }
 
   tasks.create(name: "releaseSqlShellTarGz", dependsOn: configurations.archives.artifacts, type: Tar) {
@@ -397,7 +369,6 @@ project(":samza-tools_$scalaSuffix") {
 
 project(":samza-kafka_$scalaSuffix") {
   apply plugin: 'scala'
-  apply plugin: 'checkstyle'
 
   // Force scala joint compilation
   sourceSets.main.scala.srcDir "src/main/java"
@@ -435,11 +406,6 @@ project(":samza-kafka_$scalaSuffix") {
     testRuntime "org.slf4j:slf4j-simple:$slf4jVersion"
   }
 
-  checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    toolVersion = "$checkstyleVersion"
-  }
-
   test {
     // Bump up the heap so we can start ZooKeeper and Kafka brokers.
     minHeapSize = "1560m"
@@ -455,7 +421,6 @@ project(":samza-kafka_$scalaSuffix") {
 
 project(":samza-log4j_$scalaSuffix") {
   apply plugin: 'java'
-  apply plugin: 'checkstyle'
 
   dependencies {
     compile "log4j:log4j:$log4jVersion"
@@ -465,16 +430,10 @@ project(":samza-log4j_$scalaSuffix") {
     compile "org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion"
     testCompile "junit:junit:$junitVersion"
   }
-
-  checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    toolVersion = "$checkstyleVersion"
-  }
 }
 
 project(":samza-log4j2_$scalaSuffix") {
   apply plugin: 'java'
-  apply plugin: 'checkstyle'
 
   dependencies {
     compile "org.apache.logging.log4j:log4j-1.2-api:$log4j2Version"
@@ -486,17 +445,11 @@ project(":samza-log4j2_$scalaSuffix") {
     compile "org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion"
     testCompile "junit:junit:$junitVersion"
   }
-
-  checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    toolVersion = "$checkstyleVersion"
-  }
 }
 
 project(":samza-yarn_$scalaSuffix") {
   apply plugin: 'scala'
   apply plugin: 'lesscss'
-  apply plugin: 'checkstyle'
 
   // Force scala joint compilation
   sourceSets.main.scala.srcDir "src/main/java"
@@ -546,11 +499,6 @@ project(":samza-yarn_$scalaSuffix") {
     testCompile "org.mockito:mockito-core:$mockitoVersion"
     testCompile project(":samza-core_$scalaSuffix").sourceSets.test.output
     testCompile "org.scalatest:scalatest_$scalaSuffix:$scalaTestVersion"
-  }
-
-  checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    toolVersion = "$checkstyleVersion"
   }
 
   repositories {
@@ -638,7 +586,6 @@ project(":samza-shell") {
 
 project(":samza-kv_$scalaSuffix") {
   apply plugin: 'scala'
-  apply plugin: 'checkstyle'
 
   // Force scala joint compilation
   sourceSets.main.scala.srcDir "src/main/java"
@@ -657,11 +604,6 @@ project(":samza-kv_$scalaSuffix") {
     testCompile "com.google.guava:guava:$guavaVersion"
     testCompile "junit:junit:$junitVersion"
     testCompile "org.mockito:mockito-core:$mockitoVersion"
-  }
-
-  checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    toolVersion = "$checkstyleVersion"
   }
 }
 
@@ -770,7 +712,6 @@ project(":samza-hdfs_$scalaSuffix") {
 
 project(":samza-rest_$scalaSuffix") {
   apply plugin: 'java'
-  apply plugin: 'checkstyle'
 
   dependencies {
     compile project(":samza-shell")
@@ -796,11 +737,6 @@ project(":samza-rest_$scalaSuffix") {
     testCompile "junit:junit:$junitVersion"
     testCompile "org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:$jerseyVersion"
     testCompile "org.mockito:mockito-core:$mockitoVersion"
-  }
-
-  checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    toolVersion = "$checkstyleVersion"
   }
 
   tasks.create(name: "releaseRestServiceTar", type: Tar) {
@@ -834,7 +770,6 @@ project(":samza-rest_$scalaSuffix") {
 
 project(":samza-test_$scalaSuffix") {
   apply plugin: 'scala'
-  apply plugin: 'checkstyle'
 
   // Force scala joint compilation
   sourceSets.main.scala.srcDir "src/main/java"
@@ -893,11 +828,6 @@ project(":samza-test_$scalaSuffix") {
     minHeapSize = "1560m"
     maxHeapSize = "1560m"
     jvmArgs = ["-XX:+UseConcMarkSweepGC", "-server"]
-  }
-
-  checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    toolVersion = "$checkstyleVersion"
   }
 
   tasks.create(name: "releaseTestJobs", dependsOn: configurations.archives.artifacts, type: Tar) {

--- a/checkstyle/checkstyle-suppressions.xml
+++ b/checkstyle/checkstyle-suppressions.xml
@@ -40,5 +40,6 @@
 
   <!-- suppress avro schema classes since they are based on auto-generated code -->
   <suppress files="samza-sql/src/test/java/org/apache/samza/sql/avro/schemas" checks=".*" />
+  <suppress files="samza-tools/src/main/java/org/apache/samza/tools/schemas" checks=".*" />
 </suppressions>
 

--- a/samza-elasticsearch/src/main/java/org/apache/samza/config/ElasticsearchConfig.java
+++ b/samza-elasticsearch/src/main/java/org/apache/samza/config/ElasticsearchConfig.java
@@ -67,12 +67,12 @@ public class ElasticsearchConfig extends MapConfig {
 
   // Index Request
   public Optional<String> getIndexRequestFactoryClassName() {
-      return Optional.ofNullable(get(CONFIG_KEY_INDEX_REQUEST_FACTORY));
+    return Optional.ofNullable(get(CONFIG_KEY_INDEX_REQUEST_FACTORY));
   }
 
   // Transport client settings
   public Optional<String> getTransportHost() {
-      return Optional.ofNullable(get(CONFIG_KEY_CLIENT_TRANSPORT_HOST));
+    return Optional.ofNullable(get(CONFIG_KEY_CLIENT_TRANSPORT_HOST));
   }
 
   public Optional<Integer> getTransportPort() {

--- a/samza-elasticsearch/src/main/java/org/apache/samza/system/elasticsearch/ElasticsearchSystemAdmin.java
+++ b/samza-elasticsearch/src/main/java/org/apache/samza/system/elasticsearch/ElasticsearchSystemAdmin.java
@@ -45,7 +45,6 @@ public class ElasticsearchSystemAdmin implements SystemAdmin {
   @Override
   public Map<SystemStreamPartition, String> getOffsetsAfter(
       Map<SystemStreamPartition, String> map) {
-    int j = 0;
     throw new UnsupportedOperationException();
   }
 

--- a/samza-elasticsearch/src/main/java/org/apache/samza/system/elasticsearch/ElasticsearchSystemAdmin.java
+++ b/samza-elasticsearch/src/main/java/org/apache/samza/system/elasticsearch/ElasticsearchSystemAdmin.java
@@ -32,19 +32,20 @@ import java.util.Set;
  * <p>All the methods on this class return {@link UnsupportedOperationException}.</p>
  */
 public class ElasticsearchSystemAdmin implements SystemAdmin {
-  private static final SystemAdmin singleton = new ElasticsearchSystemAdmin();
+  private static final SystemAdmin SINGLETON = new ElasticsearchSystemAdmin();
 
   private ElasticsearchSystemAdmin() {
     // Ensure this can not be constructed.
   }
 
   public static SystemAdmin getInstance() {
-    return singleton;
+    return SINGLETON;
   }
 
   @Override
   public Map<SystemStreamPartition, String> getOffsetsAfter(
       Map<SystemStreamPartition, String> map) {
+    int j = 0;
     throw new UnsupportedOperationException();
   }
 
@@ -55,6 +56,6 @@ public class ElasticsearchSystemAdmin implements SystemAdmin {
 
   @Override
   public Integer offsetComparator(String offset1, String offset2) {
-	  throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException();
   }
 }

--- a/samza-elasticsearch/src/main/java/org/apache/samza/system/elasticsearch/ElasticsearchSystemProducerMetrics.java
+++ b/samza-elasticsearch/src/main/java/org/apache/samza/system/elasticsearch/ElasticsearchSystemProducerMetrics.java
@@ -23,17 +23,17 @@ import org.apache.samza.metrics.MetricsBase;
 import org.apache.samza.metrics.MetricsRegistry;
 
 public class ElasticsearchSystemProducerMetrics extends MetricsBase {
-    public final Counter bulkSendSuccess;
-    public final Counter inserts;
-    public final Counter updates;
-    public final Counter conflicts;
+  public final Counter bulkSendSuccess;
+  public final Counter inserts;
+  public final Counter updates;
+  public final Counter conflicts;
 
-    public ElasticsearchSystemProducerMetrics(String systemName, MetricsRegistry registry) {
-        super(systemName + "-", registry);
+  public ElasticsearchSystemProducerMetrics(String systemName, MetricsRegistry registry) {
+    super(systemName + "-", registry);
 
-        bulkSendSuccess = newCounter("bulk-send-success");
-        inserts = newCounter("docs-inserted");
-        updates = newCounter("docs-updated");
-        conflicts = newCounter("version-conflicts");
-    }
+    bulkSendSuccess = newCounter("bulk-send-success");
+    inserts = newCounter("docs-inserted");
+    updates = newCounter("docs-updated");
+    conflicts = newCounter("version-conflicts");
+  }
 }

--- a/samza-elasticsearch/src/test/java/org/apache/samza/config/ElasticsearchConfigTest.java
+++ b/samza-elasticsearch/src/test/java/org/apache/samza/config/ElasticsearchConfigTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertTrue;
 
 public class ElasticsearchConfigTest {
 
-  private ElasticsearchConfig EMPTY_CONFIG = new ElasticsearchConfig(
+  private static final ElasticsearchConfig EMPTY_CONFIG = new ElasticsearchConfig(
       "es",
       new MapConfig(Collections.<String, String>emptyMap()));
 

--- a/samza-elasticsearch/src/test/java/org/apache/samza/system/elasticsearch/ElasticsearchSystemProducerMetricsTest.java
+++ b/samza-elasticsearch/src/test/java/org/apache/samza/system/elasticsearch/ElasticsearchSystemProducerMetricsTest.java
@@ -29,27 +29,27 @@ import static org.junit.Assert.*;
 
 public class ElasticsearchSystemProducerMetricsTest {
 
-    public final static String GRP_NAME = "org.apache.samza.system.elasticsearch.ElasticsearchSystemProducerMetrics";
+  public final static String GRP_NAME = "org.apache.samza.system.elasticsearch.ElasticsearchSystemProducerMetrics";
 
-    @Test
-    public void testMetrics() {
-        ReadableMetricsRegistry registry = new MetricsRegistryMap();
-        ElasticsearchSystemProducerMetrics metrics = new ElasticsearchSystemProducerMetrics("es", registry);
-        metrics.bulkSendSuccess.inc(29L);
-        metrics.inserts.inc();
-        metrics.updates.inc(7L);
-        metrics.conflicts.inc(3L);
+  @Test
+  public void testMetrics() {
+    ReadableMetricsRegistry registry = new MetricsRegistryMap();
+    ElasticsearchSystemProducerMetrics metrics = new ElasticsearchSystemProducerMetrics("es", registry);
+    metrics.bulkSendSuccess.inc(29L);
+    metrics.inserts.inc();
+    metrics.updates.inc(7L);
+    metrics.conflicts.inc(3L);
 
-        Set<String> groups = registry.getGroups();
-        assertEquals(1, groups.size());
-        assertEquals(GRP_NAME, groups.toArray()[0]);
+    Set<String> groups = registry.getGroups();
+    assertEquals(1, groups.size());
+    assertEquals(GRP_NAME, groups.toArray()[0]);
 
-        Map<String, Metric> metricMap = registry.getGroup(GRP_NAME);
-        assertEquals(4, metricMap.size());
-        assertEquals(29L, ((Counter) metricMap.get("es-bulk-send-success")).getCount());
-        assertEquals(1L, ((Counter) metricMap.get("es-docs-inserted")).getCount());
-        assertEquals(7L, ((Counter) metricMap.get("es-docs-updated")).getCount());
-        assertEquals(3L, ((Counter) metricMap.get("es-version-conflicts")).getCount());
-    }
+    Map<String, Metric> metricMap = registry.getGroup(GRP_NAME);
+    assertEquals(4, metricMap.size());
+    assertEquals(29L, ((Counter) metricMap.get("es-bulk-send-success")).getCount());
+    assertEquals(1L, ((Counter) metricMap.get("es-docs-inserted")).getCount());
+    assertEquals(7L, ((Counter) metricMap.get("es-docs-updated")).getCount());
+    assertEquals(3L, ((Counter) metricMap.get("es-version-conflicts")).getCount());
+  }
 
 }

--- a/samza-elasticsearch/src/test/java/org/apache/samza/system/elasticsearch/ElasticsearchSystemProducerTest.java
+++ b/samza-elasticsearch/src/test/java/org/apache/samza/system/elasticsearch/ElasticsearchSystemProducerTest.java
@@ -108,7 +108,7 @@ public class ElasticsearchSystemProducerTest {
     verify(processorTwo, never()).flush();
   }
 
-  @Test(expected=SamzaException.class)
+  @Test(expected = SamzaException.class)
   public void testFlushFailedSendFromException() throws Exception {
     ArgumentCaptor<BulkProcessor.Listener> listenerCaptor =
         ArgumentCaptor.forClass(BulkProcessor.Listener.class);
@@ -122,7 +122,7 @@ public class ElasticsearchSystemProducerTest {
     producer.flush(SOURCE_ONE);
   }
 
-  @Test(expected=SamzaException.class)
+  @Test(expected = SamzaException.class)
   public void testFlushFailedSendFromFailedDocument() throws Exception {
     ArgumentCaptor<BulkProcessor.Listener> listenerCaptor =
         ArgumentCaptor.forClass(BulkProcessor.Listener.class);

--- a/samza-elasticsearch/src/test/java/org/apache/samza/system/elasticsearch/indexrequest/DefaultIndexRequestFactoryTest.java
+++ b/samza-elasticsearch/src/test/java/org/apache/samza/system/elasticsearch/indexrequest/DefaultIndexRequestFactoryTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.when;
 
 public class DefaultIndexRequestFactoryTest {
 
-  private static final IndexRequestFactory indexRequestFactory = new DefaultIndexRequestFactory();
+  private static final IndexRequestFactory INDEX_REQUEST_FACTORY = new DefaultIndexRequestFactory();
   private static final String TYPE = "type";
   private static final String INDEX = "index";
   private static final SystemStream SYSTEM = mock(SystemStream.class);
@@ -50,23 +50,23 @@ public class DefaultIndexRequestFactoryTest {
 
   @Test
   public void testGetIndexRequestStreamName()  {
-    IndexRequest indexRequest = indexRequestFactory.
+    IndexRequest indexRequest = INDEX_REQUEST_FACTORY.
         getIndexRequest(new OutgoingMessageEnvelope(SYSTEM, EMPTY_MSG));
 
     assertEquals(INDEX, indexRequest.index());
     assertEquals(TYPE, indexRequest.type());
   }
 
-  @Test(expected=SamzaException.class)
+  @Test(expected = SamzaException.class)
   public void testGetIndexRequestInvalidStreamName()  {
     when(SYSTEM.getStream()).thenReturn(INDEX);
-    indexRequestFactory.getIndexRequest(new OutgoingMessageEnvelope(SYSTEM, EMPTY_MSG));
+    INDEX_REQUEST_FACTORY.getIndexRequest(new OutgoingMessageEnvelope(SYSTEM, EMPTY_MSG));
   }
 
   @Test
   public void testGetIndexRequestNoId() throws Exception {
     IndexRequest indexRequest =
-        indexRequestFactory.getIndexRequest(new OutgoingMessageEnvelope(SYSTEM, EMPTY_MSG));
+        INDEX_REQUEST_FACTORY.getIndexRequest(new OutgoingMessageEnvelope(SYSTEM, EMPTY_MSG));
 
     assertNull(indexRequest.id());
   }
@@ -74,14 +74,14 @@ public class DefaultIndexRequestFactoryTest {
   @Test
   public void testGetIndexRequestWithId() throws Exception {
     IndexRequest indexRequest =
-        indexRequestFactory.getIndexRequest(new OutgoingMessageEnvelope(SYSTEM, "id", EMPTY_MSG));
+        INDEX_REQUEST_FACTORY.getIndexRequest(new OutgoingMessageEnvelope(SYSTEM, "id", EMPTY_MSG));
 
     assertEquals("id", indexRequest.id());
   }
 
   @Test
   public void testGetIndexRequestNoPartitionKey() throws Exception {
-    IndexRequest indexRequest = indexRequestFactory.getIndexRequest(
+    IndexRequest indexRequest = INDEX_REQUEST_FACTORY.getIndexRequest(
         new OutgoingMessageEnvelope(SYSTEM, EMPTY_MSG));
 
     assertNull(indexRequest.routing());
@@ -89,7 +89,7 @@ public class DefaultIndexRequestFactoryTest {
 
   @Test
   public void testGetIndexRequestWithPartitionKey() throws Exception {
-    IndexRequest indexRequest = indexRequestFactory.getIndexRequest(
+    IndexRequest indexRequest = INDEX_REQUEST_FACTORY.getIndexRequest(
         new OutgoingMessageEnvelope(SYSTEM, "shardKey", "id", EMPTY_MSG));
 
     assertEquals("shardKey", indexRequest.routing());
@@ -97,7 +97,7 @@ public class DefaultIndexRequestFactoryTest {
 
   @Test
   public void testGetIndexRequestMessageBytes() throws Exception {
-    IndexRequest indexRequest = indexRequestFactory.getIndexRequest(
+    IndexRequest indexRequest = INDEX_REQUEST_FACTORY.getIndexRequest(
         new OutgoingMessageEnvelope(SYSTEM, "{\"foo\":\"bar\"}".getBytes(Charsets.UTF_8)));
 
     assertEquals(Collections.singletonMap("foo", "bar"), indexRequest.sourceAsMap());
@@ -105,14 +105,14 @@ public class DefaultIndexRequestFactoryTest {
 
   @Test
   public void testGetIndexRequestMessageMap() throws Exception {
-    IndexRequest indexRequest = indexRequestFactory.getIndexRequest(
+    IndexRequest indexRequest = INDEX_REQUEST_FACTORY.getIndexRequest(
         new OutgoingMessageEnvelope(SYSTEM, Collections.singletonMap("foo", "bar")));
 
     assertEquals(Collections.singletonMap("foo", "bar"), indexRequest.sourceAsMap());
   }
 
-  @Test(expected=SamzaException.class)
+  @Test(expected = SamzaException.class)
   public void testGetIndexRequestInvalidMessage() throws Exception {
-    indexRequestFactory.getIndexRequest(new OutgoingMessageEnvelope(SYSTEM, "{'foo':'bar'}"));
+    INDEX_REQUEST_FACTORY.getIndexRequest(new OutgoingMessageEnvelope(SYSTEM, "{'foo':'bar'}"));
   }
 }

--- a/samza-hdfs/src/main/java/org/apache/samza/system/hdfs/descriptors/HdfsSystemDescriptor.java
+++ b/samza-hdfs/src/main/java/org/apache/samza/system/hdfs/descriptors/HdfsSystemDescriptor.java
@@ -225,30 +225,28 @@ public class HdfsSystemDescriptor extends SystemDescriptor<HdfsSystemDescriptor>
     Map<String, String> config = new HashMap<>(super.toConfig());
     String systemName = getSystemName();
 
-    datePathFormat.ifPresent(
-        val -> config.put(String.format(HdfsConfig.DATE_PATH_FORMAT_STRING(), systemName), val));
+    datePathFormat.ifPresent(val -> config.put(String.format(HdfsConfig.DATE_PATH_FORMAT_STRING(), systemName), val));
     outputBaseDir.ifPresent(val -> config.put(String.format(HdfsConfig.BASE_OUTPUT_DIR(), systemName), val));
     writeBatchSizeBytes.ifPresent(
-        val -> config.put(String.format(HdfsConfig.WRITE_BATCH_SIZE_BYTES(), systemName), String.valueOf(val)));
+      val -> config.put(String.format(HdfsConfig.WRITE_BATCH_SIZE_BYTES(), systemName), String.valueOf(val)));
     writeBatchSizeRecords.ifPresent(
-        val -> config.put(String.format(HdfsConfig.WRITE_BATCH_SIZE_RECORDS(), systemName), String.valueOf(val)));
-    writeCompressionType.ifPresent(
-        val -> config.put(String.format(HdfsConfig.COMPRESSION_TYPE(), systemName), val));
+      val -> config.put(String.format(HdfsConfig.WRITE_BATCH_SIZE_RECORDS(), systemName), String.valueOf(val)));
+    writeCompressionType.ifPresent(val -> config.put(String.format(HdfsConfig.COMPRESSION_TYPE(), systemName), val));
     writerClass.ifPresent(val -> config.put(String.format(HdfsConfig.HDFS_WRITER_CLASS_NAME(), systemName), val));
 
     consumerBufferCapacity.ifPresent(
-        val -> config.put(String.format(HdfsConfig.CONSUMER_BUFFER_CAPACITY(), systemName), String.valueOf(val)));
+      val -> config.put(String.format(HdfsConfig.CONSUMER_BUFFER_CAPACITY(), systemName), String.valueOf(val)));
     consumerMaxRetries.ifPresent(
-        val -> config.put(String.format(HdfsConfig.CONSUMER_NUM_MAX_RETRIES(), systemName), String.valueOf(val)));
+      val -> config.put(String.format(HdfsConfig.CONSUMER_NUM_MAX_RETRIES(), systemName), String.valueOf(val)));
     consumerWhiteList.ifPresent(
-        val -> config.put(String.format(HdfsConfig.CONSUMER_PARTITIONER_WHITELIST(), systemName), val));
+      val -> config.put(String.format(HdfsConfig.CONSUMER_PARTITIONER_WHITELIST(), systemName), val));
     consumerBlackList.ifPresent(
-        val -> config.put(String.format(HdfsConfig.CONSUMER_PARTITIONER_BLACKLIST(), systemName), val));
+      val -> config.put(String.format(HdfsConfig.CONSUMER_PARTITIONER_BLACKLIST(), systemName), val));
     consumerGroupPattern.ifPresent(
-        val -> config.put(String.format(HdfsConfig.CONSUMER_PARTITIONER_GROUP_PATTERN(), systemName), val));
+      val -> config.put(String.format(HdfsConfig.CONSUMER_PARTITIONER_GROUP_PATTERN(), systemName), val));
     consumerReader.ifPresent(val -> config.put(String.format(HdfsConfig.FILE_READER_TYPE(), systemName), val));
     consumerStagingDirectory.ifPresent(
-        val -> config.put(String.format(HdfsConfig.STAGING_DIRECTORY(), systemName), val));
+      val -> config.put(String.format(HdfsConfig.STAGING_DIRECTORY(), systemName), val));
 
     return config;
   }

--- a/samza-hdfs/src/test/java/org/apache/samza/system/hdfs/TestHdfsSystemConsumer.java
+++ b/samza-hdfs/src/test/java/org/apache/samza/system/hdfs/TestHdfsSystemConsumer.java
@@ -113,7 +113,7 @@ public class TestHdfsSystemConsumer {
     while (eventsReceived < totalEvents && remainingRetries > 0) {
       remainingRetries--;
       Map<SystemStreamPartition, List<IncomingMessageEnvelope>> result = systemConsumer.poll(systemStreamPartitionSet, 1000);
-      for(SystemStreamPartition ssp : result.keySet()) {
+      for (SystemStreamPartition ssp : result.keySet()) {
         List<IncomingMessageEnvelope> messageEnvelopeList = result.get(ssp);
         overallResults.putIfAbsent(ssp, new ArrayList<>());
         overallResults.get(ssp).addAll(messageEnvelopeList);
@@ -127,7 +127,7 @@ public class TestHdfsSystemConsumer {
     Assert.assertEquals(NUM_FILES, overallResults.size());
     overallResults.values().forEach(messages -> {
       Assert.assertEquals(NUM_EVENTS + 1, messages.size());
-      for (int index = 0;index < NUM_EVENTS; index++) {
+      for (int index = 0; index < NUM_EVENTS; index++) {
         GenericRecord record = (GenericRecord) messages.get(index).getMessage();
         Assert.assertEquals(index % NUM_EVENTS, record.get(FIELD_1));
         Assert.assertEquals("string_" + (index % NUM_EVENTS), record.get(FIELD_2).toString());

--- a/samza-hdfs/src/test/java/org/apache/samza/system/hdfs/partitioner/TestDirectoryPartitioner.java
+++ b/samza-hdfs/src/test/java/org/apache/samza/system/hdfs/partitioner/TestDirectoryPartitioner.java
@@ -70,7 +70,7 @@ public class TestDirectoryPartitioner {
   @Test
   public void testBasicWhiteListFiltering() {
     List<FileMetadata> testList = new ArrayList<>();
-    int NUM_INPUT = 9;
+    int numInput = 9;
     String[] inputFiles = {
       "part-001.avro",
       "part-002.avro",
@@ -82,27 +82,27 @@ public class TestDirectoryPartitioner {
       "delta-02.avro",
       "part-006.avro"};
     long[] fileLength = {150582, 138132, 214005, 205738, 158273, 982345, 313245, 234212, 413232};
-    for (int i = 0; i < NUM_INPUT; i++) {
+    for (int i = 0; i < numInput; i++) {
       testList.add(new FileMetadata(inputFiles[i], fileLength[i]));
     }
     String whiteList = "part-.*\\.avro";
     String blackList = "";
     String groupPattern = "";
-    int EXPECTED_NUM_PARTITION = 6;
-    int[][] EXPECTED_PARTITIONING = {{0}, {1}, {2}, {4}, {6}, {8}};
+    int expectedNumPartition = 6;
+    int[][] expectedPartitioning = {{0}, {1}, {2}, {4}, {6}, {8}};
 
     DirectoryPartitioner directoryPartitioner =
       new DirectoryPartitioner(whiteList, blackList, groupPattern, new TestFileSystemAdapter(testList));
     Map<Partition, SystemStreamPartitionMetadata> metadataMap = directoryPartitioner.getPartitionMetadataMap("hdfs", null);
-    Assert.assertEquals(EXPECTED_NUM_PARTITION, metadataMap.size());
+    Assert.assertEquals(expectedNumPartition, metadataMap.size());
     Map<Partition, List<String>> descriptorMap = directoryPartitioner.getPartitionDescriptor("hdfs");
-    verifyPartitionDescriptor(inputFiles, EXPECTED_PARTITIONING, EXPECTED_NUM_PARTITION, descriptorMap);
+    verifyPartitionDescriptor(inputFiles, expectedPartitioning, expectedNumPartition, descriptorMap);
   }
 
   @Test
   public void testBasicBlackListFiltering() {
     List<FileMetadata> testList = new ArrayList<>();
-    int NUM_INPUT = 9;
+    int numInput = 9;
     String[] inputFiles = {
       "part-001.avro",
       "part-002.avro",
@@ -114,27 +114,27 @@ public class TestDirectoryPartitioner {
       "delta-02.avro",
       "part-006.avro"};
     long[] fileLength = {150582, 138132, 214005, 205738, 158273, 982345, 313245, 234212, 413232};
-    for (int i = 0; i < NUM_INPUT; i++) {
+    for (int i = 0; i < numInput; i++) {
       testList.add(new FileMetadata(inputFiles[i], fileLength[i]));
     }
     String whiteList = ".*";
     String blackList = "delta-.*\\.avro";
     String groupPattern = "";
-    int EXPECTED_NUM_PARTITION = 6;
-    int[][] EXPECTED_PARTITIONING = {{0}, {1}, {2}, {4}, {6}, {8}};
+    int expectedNumPartition = 6;
+    int[][] expectedPartitioning = {{0}, {1}, {2}, {4}, {6}, {8}};
 
     DirectoryPartitioner directoryPartitioner =
       new DirectoryPartitioner(whiteList, blackList, groupPattern, new TestFileSystemAdapter(testList));
     Map<Partition, SystemStreamPartitionMetadata> metadataMap = directoryPartitioner.getPartitionMetadataMap("hdfs", null);
-    Assert.assertEquals(EXPECTED_NUM_PARTITION, metadataMap.size());
+    Assert.assertEquals(expectedNumPartition, metadataMap.size());
     Map<Partition, List<String>> descriporMap = directoryPartitioner.getPartitionDescriptor("hdfs");
-    verifyPartitionDescriptor(inputFiles, EXPECTED_PARTITIONING, EXPECTED_NUM_PARTITION, descriporMap);
+    verifyPartitionDescriptor(inputFiles, expectedPartitioning, expectedNumPartition, descriporMap);
   }
 
   @Test
   public void testWhiteListBlackListFiltering() {
     List<FileMetadata> testList = new ArrayList<>();
-    int NUM_INPUT = 9;
+    int numInput = 9;
     String[] inputFiles = {
       "part-001.avro",
       "part-002.avro",
@@ -146,27 +146,27 @@ public class TestDirectoryPartitioner {
       "delta-02.avro",
       "part-006.avro"};
     long[] fileLength = {150582, 138132, 214005, 205738, 158273, 982345, 313245, 234212, 413232};
-    for (int i = 0; i < NUM_INPUT; i++) {
+    for (int i = 0; i < numInput; i++) {
       testList.add(new FileMetadata(inputFiles[i], fileLength[i]));
     }
     String whiteList = "part-.*\\.avro";
     String blackList = "part-002.avro";
     String groupPattern = "";
-    int EXPECTED_NUM_PARTITION = 5;
-    int[][] EXPECTED_PARTITIONING = {{0}, {2}, {4}, {6}, {8}};
+    int expectedNumPartition = 5;
+    int[][] expectedPartitioning = {{0}, {2}, {4}, {6}, {8}};
 
     DirectoryPartitioner directoryPartitioner =
       new DirectoryPartitioner(whiteList, blackList, groupPattern, new TestFileSystemAdapter(testList));
     Map<Partition, SystemStreamPartitionMetadata> metadataMap = directoryPartitioner.getPartitionMetadataMap("hdfs", null);
-    Assert.assertEquals(EXPECTED_NUM_PARTITION, metadataMap.size());
+    Assert.assertEquals(expectedNumPartition, metadataMap.size());
     Map<Partition, List<String>> descriporMap = directoryPartitioner.getPartitionDescriptor("hdfs");
-    verifyPartitionDescriptor(inputFiles, EXPECTED_PARTITIONING, EXPECTED_NUM_PARTITION, descriporMap);
+    verifyPartitionDescriptor(inputFiles, expectedPartitioning, expectedNumPartition, descriporMap);
   }
 
   @Test
   public void testBasicGrouping() {
     List<FileMetadata> testList = new ArrayList<>();
-    int NUM_INPUT = 9;
+    int numInput = 9;
     String[] inputFiles = {
       "00_10-run_2016-08-15-13-04-part.0.150582.avro",
       "00_10-run_2016-08-15-13-04-part.1.138132.avro",
@@ -178,15 +178,15 @@ public class TestDirectoryPartitioner {
       "00_10-run_2016-08-15-13-06-part.1.234212.avro",
       "00_10-run_2016-08-15-13-06-part.2.413232.avro"};
     long[] fileLength = {150582, 138132, 214005, 205738, 158273, 982345, 313245, 234212, 413232};
-    for (int i = 0; i < NUM_INPUT; i++) {
+    for (int i = 0; i < numInput; i++) {
       testList.add(new FileMetadata(inputFiles[i], fileLength[i]));
     }
 
     String whiteList = ".*\\.avro";
     String blackList = "";
     String groupPattern = ".*part\\.[id]\\..*\\.avro"; // 00_10-run_2016-08-15-13-04-part.[id].138132.avro
-    int EXPECTED_NUM_PARTITION = 3;
-    int[][] EXPECTED_PARTITIONING = {
+    int expectedNumPartition = 3;
+    int[][] expectedPartitioning = {
       {0, 3, 6}, // files from index 0, 3, 6 should be grouped into one partition
       {1, 4, 7}, // similar as above
       {2, 5, 8}};
@@ -194,9 +194,9 @@ public class TestDirectoryPartitioner {
     DirectoryPartitioner directoryPartitioner =
       new DirectoryPartitioner(whiteList, blackList, groupPattern, new TestFileSystemAdapter(testList));
     Map<Partition, SystemStreamPartitionMetadata> metadataMap = directoryPartitioner.getPartitionMetadataMap("hdfs", null);
-    Assert.assertEquals(EXPECTED_NUM_PARTITION, metadataMap.size());
+    Assert.assertEquals(expectedNumPartition, metadataMap.size());
     Map<Partition, List<String>> descriporMap = directoryPartitioner.getPartitionDescriptor("hdfs");
-    verifyPartitionDescriptor(inputFiles, EXPECTED_PARTITIONING, EXPECTED_NUM_PARTITION, descriporMap);
+    verifyPartitionDescriptor(inputFiles, expectedPartitioning, expectedNumPartition, descriporMap);
   }
 
   @Test
@@ -204,7 +204,7 @@ public class TestDirectoryPartitioner {
     // the update is valid when there are only new files being added to the directory
     // no changes on the old files
     List<FileMetadata> testList = new ArrayList<>();
-    int NUM_INPUT = 6;
+    int numInput = 6;
     String[] inputFiles = {
       "part-001.avro",
       "part-002.avro",
@@ -213,23 +213,23 @@ public class TestDirectoryPartitioner {
       "part-004.avro",
       "part-006.avro"};
     long[] fileLength = {150582, 138132, 214005, 205738, 158273, 982345};
-    for (int i = 0; i < NUM_INPUT; i++) {
+    for (int i = 0; i < numInput; i++) {
       testList.add(new FileMetadata(inputFiles[i], fileLength[i]));
     }
     String whiteList = ".*";
     String blackList = "";
     String groupPattern = "";
-    int EXPECTED_NUM_PARTITION = 6;
-    int[][] EXPECTED_PARTITIONING = {{0}, {1}, {2}, {3}, {4}, {5}};
+    int expectedNumPartition = 6;
+    int[][] expectedPartitioning = {{0}, {1}, {2}, {3}, {4}, {5}};
 
     DirectoryPartitioner directoryPartitioner =
       new DirectoryPartitioner(whiteList, blackList, groupPattern, new TestFileSystemAdapter(testList));
     Map<Partition, SystemStreamPartitionMetadata> metadataMap = directoryPartitioner.getPartitionMetadataMap("hdfs", null);
-    Assert.assertEquals(EXPECTED_NUM_PARTITION, metadataMap.size());
+    Assert.assertEquals(expectedNumPartition, metadataMap.size());
     Map<Partition, List<String>> descriporMap = directoryPartitioner.getPartitionDescriptor("hdfs");
-    verifyPartitionDescriptor(inputFiles, EXPECTED_PARTITIONING, EXPECTED_NUM_PARTITION, descriporMap);
+    verifyPartitionDescriptor(inputFiles, expectedPartitioning, expectedNumPartition, descriporMap);
 
-    NUM_INPUT = 7;
+    numInput = 7;
     String[] updatedInputFiles = {
       "part-001.avro",
       "part-002.avro",
@@ -240,22 +240,22 @@ public class TestDirectoryPartitioner {
       "part-006.avro"};
     long[] updatedFileLength = {150582, 138132, 214005, 205738, 158273, 2513454, 982345};
     testList.clear();
-    for (int i = 0; i < NUM_INPUT; i++) {
+    for (int i = 0; i < numInput; i++) {
       testList.add(new FileMetadata(updatedInputFiles[i], updatedFileLength[i]));
     }
     directoryPartitioner =
       new DirectoryPartitioner(whiteList, blackList, groupPattern, new TestFileSystemAdapter(testList));
     metadataMap = directoryPartitioner.getPartitionMetadataMap("hdfs", descriporMap);
-    Assert.assertEquals(EXPECTED_NUM_PARTITION, metadataMap.size()); // still expect only 6 partitions instead of 7
+    Assert.assertEquals(expectedNumPartition, metadataMap.size()); // still expect only 6 partitions instead of 7
     Map<Partition, List<String>> updatedDescriptorMap = directoryPartitioner.getPartitionDescriptor("hdfs");
-    verifyPartitionDescriptor(inputFiles, EXPECTED_PARTITIONING, EXPECTED_NUM_PARTITION, updatedDescriptorMap);
+    verifyPartitionDescriptor(inputFiles, expectedPartitioning, expectedNumPartition, updatedDescriptorMap);
   }
 
   @Test
   public void testInvalidDirectoryUpdating() {
     // the update is invalid when at least one old file is removed
     List<FileMetadata> testList = new ArrayList<>();
-    int NUM_INPUT = 6;
+    int numInput = 6;
     String[] inputFiles = {
       "part-001.avro",
       "part-002.avro",
@@ -264,21 +264,21 @@ public class TestDirectoryPartitioner {
       "part-004.avro",
       "part-006.avro"};
     long[] fileLength = {150582, 138132, 214005, 205738, 158273, 982345};
-    for (int i = 0; i < NUM_INPUT; i++) {
+    for (int i = 0; i < numInput; i++) {
       testList.add(new FileMetadata(inputFiles[i], fileLength[i]));
     }
     String whiteList = ".*";
     String blackList = "";
     String groupPattern = "";
-    int EXPECTED_NUM_PARTITION = 6;
-    int[][] EXPECTED_PARTITIONING = {{0}, {1}, {2}, {3}, {4}, {5}};
+    int expectedNumPartition = 6;
+    int[][] expectedPartitioning = {{0}, {1}, {2}, {3}, {4}, {5}};
 
     DirectoryPartitioner directoryPartitioner =
       new DirectoryPartitioner(whiteList, blackList, groupPattern, new TestFileSystemAdapter(testList));
     Map<Partition, SystemStreamPartitionMetadata> metadataMap = directoryPartitioner.getPartitionMetadataMap("hdfs", null);
-    Assert.assertEquals(EXPECTED_NUM_PARTITION, metadataMap.size());
+    Assert.assertEquals(expectedNumPartition, metadataMap.size());
     Map<Partition, List<String>> descriporMap = directoryPartitioner.getPartitionDescriptor("hdfs");
-    verifyPartitionDescriptor(inputFiles, EXPECTED_PARTITIONING, EXPECTED_NUM_PARTITION, descriporMap);
+    verifyPartitionDescriptor(inputFiles, expectedPartitioning, expectedNumPartition, descriporMap);
 
     String[] updatedInputFiles = {
       "part-001.avro",
@@ -289,7 +289,7 @@ public class TestDirectoryPartitioner {
       "part-006.avro"};
     long[] updatedFileLength = {150582, 138132, 214005, 205738, 158273, 982345};
     testList.clear();
-    for (int i = 0; i < NUM_INPUT; i++) {
+    for (int i = 0; i < numInput; i++) {
       testList.add(new FileMetadata(updatedInputFiles[i], updatedFileLength[i]));
     }
     directoryPartitioner =

--- a/samza-hdfs/src/test/java/org/apache/samza/system/hdfs/reader/TestAvroFileHdfsReader.java
+++ b/samza-hdfs/src/test/java/org/apache/samza/system/hdfs/reader/TestAvroFileHdfsReader.java
@@ -87,7 +87,7 @@ public class TestAvroFileHdfsReader {
     SingleFileHdfsReader reader = new AvroFileHdfsReader(ssp);
     reader.open(AVRO_FILE, "0");
     int index = 0;
-    for (;index < NUM_EVENTS / 2; index++) {
+    for (; index < NUM_EVENTS / 2; index++) {
       GenericRecord record = (GenericRecord) reader.readNext().getMessage();
       Assert.assertEquals(index, record.get(FIELD_1));
       Assert.assertEquals("string_" + index, record.get(FIELD_2).toString());
@@ -96,7 +96,7 @@ public class TestAvroFileHdfsReader {
     reader.close();
     reader = new AvroFileHdfsReader(ssp);
     reader.open(AVRO_FILE, offset);
-    for (;index < NUM_EVENTS; index++) {
+    for (; index < NUM_EVENTS; index++) {
       GenericRecord record = (GenericRecord) reader.readNext().getMessage();
       Assert.assertEquals(index, record.get(FIELD_1));
       Assert.assertEquals("string_" + index, record.get(FIELD_2).toString());
@@ -110,7 +110,7 @@ public class TestAvroFileHdfsReader {
     SystemStreamPartition ssp = new SystemStreamPartition("hdfs", "testStream", new Partition(0));
     SingleFileHdfsReader reader = new AvroFileHdfsReader(ssp);
     reader.open(AVRO_FILE, "0");
-    for (int i = 0;i < NUM_EVENTS / 2; i++) {
+    for (int i = 0; i < NUM_EVENTS / 2; i++) {
       reader.readNext();
     }
     String offset = reader.nextOffset();

--- a/samza-kv-couchbase/src/test/java/org/apache/samza/table/remote/couchbase/TestCouchbaseBucketRegistry.java
+++ b/samza-kv-couchbase/src/test/java/org/apache/samza/table/remote/couchbase/TestCouchbaseBucketRegistry.java
@@ -22,7 +22,6 @@ package org.apache.samza.table.remote.couchbase;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.CouchbaseCluster;
 import com.couchbase.client.java.env.CouchbaseEnvironment;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
@@ -60,9 +59,9 @@ public class TestCouchbaseBucketRegistry {
     when(CouchbaseCluster.create(any(CouchbaseEnvironment.class), anyListOf(String.class))).thenReturn(cluster);
     CouchbaseBucketRegistry registry = new CouchbaseBucketRegistry();
     Bucket bucket1 = registry.getBucket(bucketName1, clusterNodes, configs);
-    Bucket bucket1_copy = registry.getBucket(bucketName1, clusterNodes, configs);
+    Bucket bucket1Copy = registry.getBucket(bucketName1, clusterNodes, configs);
     Bucket bucket2 = registry.getBucket(bucketName2, clusterNodes, configs);
-    assertEquals(bucket1, bucket1_copy);
+    assertEquals(bucket1, bucket1Copy);
     assertNotEquals(bucket1, bucket2);
   }
 

--- a/samza-kv-inmemory/src/test/java/org/apache/samza/storage/kv/inmemory/TestInMemoryKeyValueStore.java
+++ b/samza-kv-inmemory/src/test/java/org/apache/samza/storage/kv/inmemory/TestInMemoryKeyValueStore.java
@@ -46,7 +46,7 @@ public class TestInMemoryKeyValueStore {
         new KeyValueStoreMetrics("testInMemory", new MetricsRegistryMap()));
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     String prefix = "prefix";
-    for(int i = 0; i < 100; i++) {
+    for (int i = 0; i < 100; i++) {
       store.put(genKey(outputStream, prefix, i), genValue());
     }
 

--- a/samza-kv-rocksdb/src/main/java/org/apache/samza/storage/kv/RocksDbOptionsHelper.java
+++ b/samza-kv-rocksdb/src/main/java/org/apache/samza/storage/kv/RocksDbOptionsHelper.java
@@ -110,14 +110,14 @@ public class RocksDbOptionsHelper {
     options.setKeepLogFileNum(storeConfig.getLong(ROCKSDB_KEEP_LOG_FILE_NUM, 2));
     options.setDeleteObsoleteFilesPeriodMicros(storeConfig.getLong(ROCKSDB_DELETE_OBSOLETE_FILES_PERIOD_MICROS, 21600000000L));
     // The default for rocksdb is 18446744073709551615, which is larger than java Long.MAX_VALUE. Hence setting it only if it's passed.
-    if(storeConfig.containsKey(ROCKSDB_MAX_MANIFEST_FILE_SIZE)) {
-        options.setMaxManifestFileSize(storeConfig.getLong(ROCKSDB_MAX_MANIFEST_FILE_SIZE));
+    if (storeConfig.containsKey(ROCKSDB_MAX_MANIFEST_FILE_SIZE)) {
+      options.setMaxManifestFileSize(storeConfig.getLong(ROCKSDB_MAX_MANIFEST_FILE_SIZE));
     }
     // use prepareForBulk load only when i. the store is being requested in BulkLoad mode
     // and ii. the storeDirectory does not exist (fresh restore), because bulk load does not work seamlessly with
     // existing stores : https://github.com/facebook/rocksdb/issues/2734
     StorageManagerUtil storageManagerUtil = new StorageManagerUtil();
-    if(storeMode.equals(StorageEngineFactory.StoreMode.BulkLoad) && !storageManagerUtil.storeExists(storeDir)) {
+    if (storeMode.equals(StorageEngineFactory.StoreMode.BulkLoad) && !storageManagerUtil.storeExists(storeDir)) {
       log.info("Using prepareForBulkLoad for restore to " + storeDir);
       options.prepareForBulkLoad();
     }

--- a/samza-kv-rocksdb/src/main/java/org/apache/samza/storage/kv/RocksDbReadingTool.java
+++ b/samza-kv-rocksdb/src/main/java/org/apache/samza/storage/kv/RocksDbReadingTool.java
@@ -49,21 +49,21 @@ public class RocksDbReadingTool extends CommandLine {
       .withOptionalArg()
       .ofType(Long.class)
       .describedAs("long-key")
-      .withValuesSeparatedBy( ',' );
+      .withValuesSeparatedBy(',');
 
   private ArgumentAcceptingOptionSpec<String> stringKeyArgu = parser()
       .accepts("string-key", "a list of string keys. Sperated by ','.")
       .withOptionalArg()
       .ofType(String.class)
       .describedAs("string-key")
-      .withValuesSeparatedBy( ',' );
+      .withValuesSeparatedBy(',');
 
   private ArgumentAcceptingOptionSpec<Integer> integerKeyArgu = parser()
       .accepts("integer-key", "a list of integer keys. Sperated by ','.")
       .withOptionalArg()
       .ofType(Integer.class)
       .describedAs("integer-key")
-      .withValuesSeparatedBy( ',' );
+      .withValuesSeparatedBy(',');
 
   private String dbPath = "";
   private String dbName = "";

--- a/samza-kv-rocksdb/src/test/java/org/apache/samza/storage/kv/TestRocksDbKeyValueStoreJava.java
+++ b/samza-kv-rocksdb/src/test/java/org/apache/samza/storage/kv/TestRocksDbKeyValueStoreJava.java
@@ -55,7 +55,7 @@ public class TestRocksDbKeyValueStoreJava {
 
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     String prefix = "prefix";
-    for(int i = 0; i < 100; i++) {
+    for (int i = 0; i < 100; i++) {
       store.put(genKey(outputStream, prefix, i), genValue());
     }
 
@@ -95,7 +95,7 @@ public class TestRocksDbKeyValueStoreJava {
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     String prefix = "this is the key prefix";
     Random r = new Random();
-    for(int i = 0; i < 100000; i++) {
+    for (int i = 0; i < 100000; i++) {
       store.put(genKey(outputStream, prefix, r.nextInt()), genValue());
     }
 

--- a/samza-tools/src/main/java/org/apache/samza/tools/GenerateKafkaEvents.java
+++ b/samza-tools/src/main/java/org/apache/samza/tools/GenerateKafkaEvents.java
@@ -135,13 +135,13 @@ public class GenerateKafkaEvents {
         final int finalIndex = 0;
         Pair<String, byte[]> record = eventGenerator.apply(index);
         producer.send(new ProducerRecord<>(topicName, record.getLeft().getBytes("UTF-8"), record.getRight()),
-            (metadata, exception) -> {
-              if (exception == null) {
-                LOG.info("send completed for event {} at offset {}", finalIndex, metadata.offset());
-              } else {
-                throw new RuntimeException("Failed to send message.", exception);
-              }
-            });
+          (metadata, exception) -> {
+            if (exception == null) {
+              LOG.info("send completed for event {} at offset {}", finalIndex, metadata.offset());
+            } else {
+              throw new RuntimeException("Failed to send message.", exception);
+            }
+          });
         System.out.println(String.format("Published event %d to topic %s", index, topicName));
         if (doSleep) {
           Thread.sleep(1000);

--- a/samza-tools/src/main/java/org/apache/samza/tools/RandomValueGenerator.java
+++ b/samza-tools/src/main/java/org/apache/samza/tools/RandomValueGenerator.java
@@ -46,7 +46,7 @@ public class RandomValueGenerator {
     }
     // assert(max > min);
 
-    return (rand.nextInt(max - min + 1) + min);
+    return rand.nextInt(max - min + 1) + min;
   }
 
   public String getNextString(int min, int max) {

--- a/samza-tools/src/main/java/org/apache/samza/tools/SamzaSqlConsole.java
+++ b/samza-tools/src/main/java/org/apache/samza/tools/SamzaSqlConsole.java
@@ -19,7 +19,6 @@
 
 package org.apache.samza.tools;
 
-import com.google.common.base.Joiner;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -36,8 +35,6 @@ import org.apache.samza.config.TaskConfig;
 import org.apache.samza.container.grouper.task.SingleContainerGrouperFactory;
 import org.apache.samza.serializers.StringSerdeFactory;
 import org.apache.samza.sql.avro.ConfigBasedAvroRelSchemaProviderFactory;
-import org.apache.samza.sql.fn.FlattenUdf;
-import org.apache.samza.sql.fn.RegexMatchUdf;
 import org.apache.samza.sql.impl.ConfigBasedIOResolverFactory;
 import org.apache.samza.sql.interfaces.SqlIOConfig;
 import org.apache.samza.sql.runner.SamzaSqlApplicationConfig;

--- a/samza-tools/src/main/java/org/apache/samza/tools/avro/AvroSchemaGenRelConverterFactory.java
+++ b/samza-tools/src/main/java/org/apache/samza/tools/avro/AvroSchemaGenRelConverterFactory.java
@@ -38,6 +38,6 @@ public class AvroSchemaGenRelConverterFactory implements SamzaRelConverterFactor
   @Override
   public SamzaRelConverter create(SystemStream systemStream, RelSchemaProvider relSchemaProvider, Config config) {
     return relConverters.computeIfAbsent(systemStream,
-        ss -> new AvroSchemaGenRelConverter(ss, (AvroRelSchemaProvider) relSchemaProvider, config));
+      ss -> new AvroSchemaGenRelConverter(ss, (AvroRelSchemaProvider) relSchemaProvider, config));
   }
 }

--- a/samza-tools/src/main/java/org/apache/samza/tools/avro/AvroSerDeFactory.java
+++ b/samza-tools/src/main/java/org/apache/samza/tools/avro/AvroSerDeFactory.java
@@ -31,7 +31,6 @@ import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.samza.SamzaException;
 import org.apache.samza.config.Config;
 import org.apache.samza.serializers.Serde;
@@ -43,7 +42,7 @@ import org.apache.samza.serializers.SerdeFactory;
  */
 public class AvroSerDeFactory implements SerdeFactory {
 
-  public static String CFG_AVRO_SCHEMA = "serializers.avro.schema";
+  public static final String CFG_AVRO_SCHEMA = "serializers.avro.schema";
 
   @Override
   public Serde getSerde(String name, Config config) {

--- a/samza-tools/src/main/java/org/apache/samza/tools/benchmark/AbstractSamzaBench.java
+++ b/samza-tools/src/main/java/org/apache/samza/tools/benchmark/AbstractSamzaBench.java
@@ -81,7 +81,7 @@ public abstract class AbstractSamzaBench {
   protected int totalEvents;
   protected String streamId;
 
-  public AbstractSamzaBench(String scriptName, String args[]) throws ParseException {
+  public AbstractSamzaBench(String scriptName, String[] args) throws ParseException {
     options = new Options();
     options.addOption(
         CommandLineHelper.createOption(OPT_SHORT_PROPERTIES_FILE, OPT_LONG_PROPERTIES_FILE, OPT_ARG_PROPERTIES_FILE,
@@ -143,8 +143,8 @@ public abstract class AbstractSamzaBench {
   }
 
   Config convertToSamzaConfig(Properties props) {
-      Map<String, String> propsValue =
-          props.stringPropertyNames().stream().collect(Collectors.toMap(Function.identity(), props::getProperty));
-      return new MapConfig(propsValue);
-    }
+    Map<String, String> propsValue =
+        props.stringPropertyNames().stream().collect(Collectors.toMap(Function.identity(), props::getProperty));
+    return new MapConfig(propsValue);
+  }
 }

--- a/samza-tools/src/main/java/org/apache/samza/tools/benchmark/ConfigBasedSspGrouperFactory.java
+++ b/samza-tools/src/main/java/org/apache/samza/tools/benchmark/ConfigBasedSspGrouperFactory.java
@@ -52,7 +52,7 @@ class ConfigBasedSspGrouperFactory implements SystemStreamPartitionGrouperFactor
 
   private class ConfigBasedSspGrouper implements SystemStreamPartitionGrouper {
     private final Config config;
-    private HashMap<String, Set<Integer>> _streamPartitionsMap = new HashMap<>();
+    private HashMap<String, Set<Integer>> streamPartitionsMap = new HashMap<>();
 
     public ConfigBasedSspGrouper(Config config) {
       this.config = config;
@@ -75,13 +75,13 @@ class ConfigBasedSspGrouperFactory implements SystemStreamPartitionGrouperFactor
     private Set<Integer> getPartitions(SystemStream systemStream) {
       String streamName = systemStream.getStream();
 
-      if (!_streamPartitionsMap.containsKey(streamName)) {
+      if (!streamPartitionsMap.containsKey(streamName)) {
         String partitions = config.get(String.format(CONFIG_STREAM_PARTITIONS, streamName));
-        _streamPartitionsMap.put(streamName, Arrays.stream(partitions.split(CFG_PARTITIONS_DELIMITER))
+        streamPartitionsMap.put(streamName, Arrays.stream(partitions.split(CFG_PARTITIONS_DELIMITER))
             .map(Integer::parseInt)
             .collect(Collectors.toSet()));
       }
-      return _streamPartitionsMap.get(streamName);
+      return streamPartitionsMap.get(streamName);
     }
   }
 }

--- a/samza-tools/src/main/java/org/apache/samza/tools/benchmark/SystemConsumerBench.java
+++ b/samza-tools/src/main/java/org/apache/samza/tools/benchmark/SystemConsumerBench.java
@@ -43,12 +43,12 @@ import org.apache.samza.util.NoOpMetricsRegistry;
  */
 public class SystemConsumerBench extends AbstractSamzaBench {
 
-  public static void main(String args[]) throws Exception {
+  public static void main(String[] args) throws Exception {
     SystemConsumerBench bench = new SystemConsumerBench(args);
     bench.start();
   }
 
-  public SystemConsumerBench(String args[]) throws ParseException {
+  public SystemConsumerBench(String[] args) throws ParseException {
     super("system-consumer-bench", args);
   }
 
@@ -77,7 +77,7 @@ public class SystemConsumerBench extends AbstractSamzaBench {
 
     System.out.println("Ending consumption at " + Instant.now());
     System.out.println(String.format("Event Rate is %s Messages/Sec ",
-        (numEvents * 1000 / Duration.between(startTime, Instant.now()).toMillis())));
+        numEvents * 1000 / Duration.between(startTime, Instant.now()).toMillis()));
     consumer.stop();
     System.exit(0);
   }

--- a/samza-tools/src/main/java/org/apache/samza/tools/benchmark/SystemConsumerWithSamzaBench.java
+++ b/samza-tools/src/main/java/org/apache/samza/tools/benchmark/SystemConsumerWithSamzaBench.java
@@ -56,7 +56,7 @@ public class SystemConsumerWithSamzaBench extends AbstractSamzaBench {
     super("system-consumer-with-samza-bench", args);
   }
 
-  public static void main(String args[]) throws Exception {
+  public static void main(String[] args) throws Exception {
     SystemConsumerBench bench = new SystemConsumerBench(args);
     bench.start();
   }
@@ -98,7 +98,7 @@ public class SystemConsumerWithSamzaBench extends AbstractSamzaBench {
     System.out.println("\n*******************");
     System.out.println(String.format("Started at %s Ending at %s ", consumeFn.startTime, endTime));
     System.out.println(String.format("Event Rate is %s Messages/Sec ",
-        (consumeFn.getEventsConsumed() * 1000 / Duration.between(consumeFn.startTime, Instant.now()).toMillis())));
+        consumeFn.getEventsConsumed() * 1000 / Duration.between(consumeFn.startTime, Instant.now()).toMillis()));
 
     System.out.println(
         "Event Rate is " + consumeFn.getEventsConsumed() * 1000 / Duration.between(consumeFn.startTime, endTime).toMillis());

--- a/samza-tools/src/main/java/org/apache/samza/tools/benchmark/SystemProducerBench.java
+++ b/samza-tools/src/main/java/org/apache/samza/tools/benchmark/SystemProducerBench.java
@@ -23,16 +23,11 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.samza.Partition;
-import org.apache.samza.config.Config;
-import org.apache.samza.config.MapConfig;
 import org.apache.samza.system.OutgoingMessageEnvelope;
 import org.apache.samza.system.SystemProducer;
 import org.apache.samza.system.SystemStreamPartition;
@@ -53,12 +48,12 @@ public class SystemProducerBench extends AbstractSamzaBench {
 
   private byte[] value;
 
-  public static void main(String args[]) throws Exception {
+  public static void main(String[] args) throws Exception {
     SystemProducerBench bench = new SystemProducerBench(args);
     bench.start();
   }
 
-  public SystemProducerBench(String args[]) throws ParseException {
+  public SystemProducerBench(String[] args) throws ParseException {
     super("system-producer", args);
   }
 
@@ -93,13 +88,13 @@ public class SystemProducerBench extends AbstractSamzaBench {
 
     System.out.println("Ending production at " + Instant.now());
     System.out.println(String.format("Event Rate is %s Messages/Sec",
-        (totalEvents * 1000 / Duration.between(startTime, Instant.now()).toMillis())));
+        totalEvents * 1000 / Duration.between(startTime, Instant.now()).toMillis()));
 
     producer.flush(source);
 
     System.out.println("Ending flush at " + Instant.now());
     System.out.println(String.format("Event Rate with flush is %s Messages/Sec",
-        (totalEvents * 1000 / Duration.between(startTime, Instant.now()).toMillis())));
+        totalEvents * 1000 / Duration.between(startTime, Instant.now()).toMillis()));
     producer.stop();
     System.exit(0);
   }


### PR DESCRIPTION
Issues: Several modules never had checkstyle enabled, so they were inconsistent with Samza checkstyle.
Changes: Enable checkstyle for all modules automatically through `subprojects` in `build.gradle` and make the code consistent with checkstyle. This will automatically apply checkstyle to new modules in the future as well.
Tests: Ran compilation and unit tests.
API/Upgrade/Usage changes: None

Note for reviewers: There is no expected change in functionality.