### PR TITLE
SAMZA-2561: Add job features to MetricsHeader

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/metrics/ApiType.java
+++ b/samza-core/src/main/java/org/apache/samza/metrics/ApiType.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.metrics;
+
+public enum ApiType {
+  SAMZA_LOW_LEVEL, SAMZA_HIGH_LEVEL, SAMZA_SQL, SAMZA_BEAM
+}

--- a/samza-core/src/main/java/org/apache/samza/metrics/DeploymentType.java
+++ b/samza-core/src/main/java/org/apache/samza/metrics/DeploymentType.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.metrics;
+
+public enum DeploymentType {
+  YARN, STANDALONE
+}

--- a/samza-core/src/main/java/org/apache/samza/util/DiagnosticsUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/util/DiagnosticsUtil.java
@@ -70,7 +70,10 @@ public class DiagnosticsUtil {
       MetricsHeader metricsHeader =
           new MetricsHeader(jobName, jobId, "samza-container-" + containerId, execEnvContainerId.orElse(""),
               LocalContainerRunner.class.getName(), Util.getTaskClassVersion(config), Util.getSamzaVersion(),
-              Util.getLocalHost().getHostName(), System.currentTimeMillis(), System.currentTimeMillis());
+              Util.getLocalHost().getHostName(), System.currentTimeMillis(), System.currentTimeMillis(), Util.getDeploymentType(config),
+              Util.getApiType(config), Util.getContainerCount(config), Util.getContainerMemoryMb(config), Util.getNumCores(config),
+              Util.getThreadPoolSize(config), Util.getHostAffinityEnabled(config), Util.getSspGrouperFactory(config),
+              Util.getContainerRetryCount(config), Util.getContainerRetryWindowMs(config), Util.getMaxConcurrency(config), Util.getMaxJvmHeapMb());
 
       class MetadataFileContents {
         public final String version;
@@ -127,6 +130,14 @@ public class DiagnosticsUtil {
       String hostName = Util.getLocalHost().getHostName();
       Optional<String> diagnosticsReporterStreamName =
           metricsConfig.getMetricsSnapshotReporterStream(diagnosticsReporterName);
+      String deploymentType = Util.getDeploymentType(config);
+      String apiType = Util.getApiType(config);
+      int numContainers = Util.getContainerCount(config);
+      boolean hostAffinityEnabled = Util.getHostAffinityEnabled(config);
+      String sspGrouperFactory = Util.getSspGrouperFactory(config);
+      int containerRetryCount = Util.getContainerRetryCount(config);
+      long containerRetryWindowMs = Util.getContainerRetryWindowMs(config);
+      int maxConcurrency = Util.getMaxConcurrency(config);
 
       if (!diagnosticsReporterStreamName.isPresent()) {
         throw new ConfigException(
@@ -151,7 +162,9 @@ public class DiagnosticsUtil {
               new StorageConfig(config).getNumPersistentStores(), maxHeapSizeBytes, containerThreadPoolSize,
               containerId, execEnvContainerId.orElse(""), taskClassVersion, samzaVersion, hostName,
               diagnosticsSystemStream, systemProducer,
-              Duration.ofMillis(new TaskConfig(config).getShutdownMs()), jobConfig.getAutosizingEnabled());
+              Duration.ofMillis(new TaskConfig(config).getShutdownMs()), jobConfig.getAutosizingEnabled(),
+              deploymentType, apiType, numContainers, hostAffinityEnabled, sspGrouperFactory, containerRetryCount,
+              containerRetryWindowMs, maxConcurrency);
 
       diagnosticsManagerReporterPair = Optional.of(new ImmutablePair<>(diagnosticsManager, diagnosticsReporter));
     }

--- a/samza-core/src/main/java/org/apache/samza/util/Util.java
+++ b/samza-core/src/main/java/org/apache/samza/util/Util.java
@@ -29,15 +29,23 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import com.google.common.collect.Lists;
 import org.apache.samza.SamzaException;
+import org.apache.samza.application.StreamApplication;
 import org.apache.samza.config.ApplicationConfig;
+import org.apache.samza.config.ClusterManagerConfig;
 import org.apache.samza.config.Config;
+import org.apache.samza.config.JobConfig;
 import org.apache.samza.config.TaskConfig;
+import org.apache.samza.metrics.ApiType;
+import org.apache.samza.metrics.DeploymentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
 public class Util {
   private static final Logger LOG = LoggerFactory.getLogger(Util.class);
+  private static final String YARN_JOB_FACTORY_CLASS = "org.apache.samza.job.yarn.YarnJobFactory";
+  private static final String BEAM_RUNNER_CLASS = "org.apache.beam.runners.samza.SamzaRunner";
+  private static final String SQL_RUNNER_CLASS = "org.apache.samza.sql.runner.SamzaSqlApplication";
 
   static final String FALLBACK_VERSION = "0.0.1";
 
@@ -122,5 +130,86 @@ public class Util {
       }
     }
     return localHost;
+  }
+
+  public static String getDeploymentType(Config config) {
+    JobConfig jobConfig = new JobConfig(config);
+    Optional<String> streamJobFactoryClass = jobConfig.getStreamJobFactoryClass();
+    if (streamJobFactoryClass.isPresent()) {
+      if (streamJobFactoryClass.get().equals(YARN_JOB_FACTORY_CLASS)) {
+        return DeploymentType.YARN.name();
+      } else {
+        return DeploymentType.STANDALONE.name();
+      }
+    }
+    return "NOT_DEFINED";
+  }
+
+  public static String getApiType(Config config) {
+    ApplicationConfig appConfig = new ApplicationConfig(config);
+    String appClass = appConfig.getAppClass();
+    if (appClass == null || appClass.isEmpty()) {
+      return ApiType.SAMZA_LOW_LEVEL.name();
+    }
+    if (appClass.equals(BEAM_RUNNER_CLASS)) {
+      return ApiType.SAMZA_BEAM.name();
+    }
+    if (appClass.equals(SQL_RUNNER_CLASS)) {
+      return ApiType.SAMZA_SQL.name();
+    }
+    if (appClass.getClass().isInstance(StreamApplication.class)) {
+      return ApiType.SAMZA_HIGH_LEVEL.name();
+    }
+    return ApiType.SAMZA_LOW_LEVEL.name();
+  }
+
+  public static int getContainerCount(Config config) {
+    JobConfig jobConfig = new JobConfig(config);
+    return jobConfig.getContainerCount();
+  }
+
+  public static int getContainerMemoryMb(Config config) {
+    ClusterManagerConfig clusterManagerConfig = new ClusterManagerConfig(config);
+    return clusterManagerConfig.getContainerMemoryMb();
+  }
+
+  public static int getNumCores(Config config) {
+    ClusterManagerConfig clusterManagerConfig = new ClusterManagerConfig(config);
+    return clusterManagerConfig.getNumCores();
+  }
+
+  public static int getThreadPoolSize(Config config) {
+    JobConfig jobConfig = new JobConfig(config);
+    return jobConfig.getThreadPoolSize();
+  }
+
+  public static String getSspGrouperFactory(Config config) {
+    JobConfig jobConfig = new JobConfig(config);
+    return jobConfig.getSystemStreamPartitionGrouperFactory();
+  }
+
+  public static boolean getHostAffinityEnabled(Config config) {
+    ClusterManagerConfig clusterManagerConfig = new ClusterManagerConfig(config);
+    return clusterManagerConfig.getHostAffinityEnabled();
+  }
+
+  public static int getContainerRetryCount(Config config) {
+    ClusterManagerConfig clusterManagerConfig = new ClusterManagerConfig(config);
+    return clusterManagerConfig.getContainerRetryCount();
+  }
+
+  public static int getContainerRetryWindowMs(Config config) {
+    ClusterManagerConfig clusterManagerConfig = new ClusterManagerConfig(config);
+    return clusterManagerConfig.getContainerRetryWindowMs();
+  }
+
+  public static int getMaxConcurrency(Config config) {
+    TaskConfig taskConfig = new TaskConfig(config);
+    return taskConfig.getMaxConcurrency();
+  }
+
+  public static int getMaxJvmHeapMb() {
+    Long maxJvmHeapMb = Runtime.getRuntime().maxMemory() / (1024 * 1024);
+    return maxJvmHeapMb.intValue();
   }
 }

--- a/samza-core/src/main/scala/org/apache/samza/diagnostics/DiagnosticsStreamMessage.java
+++ b/samza-core/src/main/scala/org/apache/samza/diagnostics/DiagnosticsStreamMessage.java
@@ -65,12 +65,17 @@ public class DiagnosticsStreamMessage {
   private final Map<String, Map<String, Object>> metricsMessage;
 
   public DiagnosticsStreamMessage(String jobName, String jobId, String containerName, String executionEnvContainerId,
-      String taskClassVersion, String samzaVersion, String hostname, long timestamp, long resetTimestamp) {
+      String taskClassVersion, String samzaVersion, String hostname, long timestamp, long resetTimestamp,
+      String deploymentType, String apiType, int numContainers, int containerMemoryMb, int numCores, int threadPoolSize,
+      boolean hostAffinityEnabled, String sspGrouperFactory, int containerRetryCount,
+      long containerRetryWindowMs, int maxConcurrency, int maxJvmHeapMb) {
 
     // Create the metricHeader
     metricsHeader =
         new MetricsHeader(jobName, jobId, containerName, executionEnvContainerId, DiagnosticsManager.class.getName(),
-            taskClassVersion, samzaVersion, hostname, timestamp, resetTimestamp);
+            taskClassVersion, samzaVersion, hostname, timestamp, resetTimestamp, deploymentType, apiType, numContainers,
+            containerMemoryMb, numCores, threadPoolSize, hostAffinityEnabled, sspGrouperFactory,
+            containerRetryCount, containerRetryWindowMs, maxConcurrency, maxJvmHeapMb);
 
     this.metricsMessage = new HashMap<>();
   }
@@ -237,7 +242,13 @@ public class DiagnosticsStreamMessage {
             metricsSnapshot.getHeader().getContainerName(), metricsSnapshot.getHeader().getExecEnvironmentContainerId(),
             metricsSnapshot.getHeader().getVersion(), metricsSnapshot.getHeader().getSamzaVersion(),
             metricsSnapshot.getHeader().getHost(), metricsSnapshot.getHeader().getTime(),
-            metricsSnapshot.getHeader().getResetTime());
+            metricsSnapshot.getHeader().getResetTime(), metricsSnapshot.getHeader().getDeploymentType(),
+            metricsSnapshot.getHeader().getApiType(), metricsSnapshot.getHeader().getNumContainers(),
+            metricsSnapshot.getHeader().getContainerMemoryMb(), metricsSnapshot.getHeader().getContainerCpuCores(),
+            metricsSnapshot.getHeader().getContainerThreadPoolSize(), metricsSnapshot.getHeader().getHostAffinity(),
+            metricsSnapshot.getHeader().getSspGrouper(), metricsSnapshot.getHeader().getMaxContainerRetryCount(),
+            metricsSnapshot.getHeader().getContainerRetryWindowMs(), metricsSnapshot.getHeader().getTaskMaxConcurrency(),
+            metricsSnapshot.getHeader().getMaxJvmHeapMb());
 
     Map<String, Map<String, Object>> metricsMap = metricsSnapshot.getMetrics().getAsMap();
     Map<String, Object> diagnosticsManagerGroupMap = metricsMap.get(GROUP_NAME_FOR_DIAGNOSTICS_MANAGER);

--- a/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsHeader.scala
+++ b/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsHeader.scala
@@ -35,7 +35,19 @@ object MetricsHeader {
       map.get("samza-version").toString,
       map.get("host").toString,
       map.get("time").asInstanceOf[Number].longValue,
-      map.get("reset-time").asInstanceOf[Number].longValue)
+      map.get("reset-time").asInstanceOf[Number].longValue,
+      map.get("deployment-type").toString,
+      map.get("api-type").toString,
+      map.get("num-containers").asInstanceOf[Number].intValue(),
+      map.get("container-memory-mb").asInstanceOf[Number].intValue(),
+      map.get("container-cpu-cores").asInstanceOf[Number].intValue(),
+      map.get("container-thread-pool-size").asInstanceOf[Number].intValue(),
+      map.get("host-affinity").asInstanceOf[Boolean].booleanValue(),
+      map.get("ssp-grouper").toString,
+      map.get("max-container-retry-count").asInstanceOf[Number].intValue(),
+      map.get("container-retry-window-ms").asInstanceOf[Number].longValue(),
+      map.get("task-max-concurrency").asInstanceOf[Number].intValue(),
+      map.get("max-jvm-heap-mb").asInstanceOf[Number].intValue())
   }
 }
 
@@ -52,7 +64,19 @@ class MetricsHeader(
   @BeanProperty val samzaVersion: String,
   @BeanProperty val host: String,
   @BeanProperty val time: Long,
-  @BeanProperty val resetTime: Long) {
+  @BeanProperty val resetTime: Long,
+  @BeanProperty val deploymentType: String,
+  @BeanProperty val apiType: String,
+  @BeanProperty val numContainers: Int,
+  @BeanProperty val containerMemoryMb: Int,
+  @BeanProperty val containerCpuCores: Int,
+  @BeanProperty val containerThreadPoolSize: Int,
+  @BeanProperty val hostAffinity: Boolean,
+  @BeanProperty val sspGrouper: String,
+  @BeanProperty val maxContainerRetryCount: Int,
+  @BeanProperty val containerRetryWindowMs: Long,
+  @BeanProperty val taskMaxConcurrency: Int,
+  @BeanProperty val maxJvmHeapMb: Int) {
 
   def getAsMap: Map[String, Object] = {
     val map = new HashMap[String, Object]
@@ -66,6 +90,18 @@ class MetricsHeader(
     map.put("host", host)
     map.put("time", time: java.lang.Long)
     map.put("reset-time", resetTime: java.lang.Long)
+    map.put("deployment-type", deploymentType)
+    map.put("api-type", apiType)
+    map.put("num-containers", numContainers: java.lang.Integer)
+    map.put("container-memory-mb", containerMemoryMb: java.lang.Integer)
+    map.put("container-cpu-cores", containerCpuCores: java.lang.Integer)
+    map.put("container-thread-pool-size", containerThreadPoolSize: java.lang.Integer)
+    map.put("host-affinity", hostAffinity: java.lang.Boolean)
+    map.put("ssp-grouper", sspGrouper)
+    map.put("max-container-retry-count", maxContainerRetryCount: java.lang.Integer)
+    map.put("container-retry-window-ms", containerRetryWindowMs: java.lang.Long)
+    map.put("task-max-concurrency", taskMaxConcurrency: java.lang.Integer)
+    map.put("max-jvm-heap-mb", maxJvmHeapMb: java.lang.Integer)
     map
   }
 }

--- a/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporter.scala
+++ b/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporter.scala
@@ -57,6 +57,18 @@ class MetricsSnapshotReporter(
   host: String,
   serializer: Serializer[MetricsSnapshot] = null,
   blacklist: Option[String],
+  deploymentType: String,
+  apiType: String,
+  numContainers: Int,
+  containerMemoryMb: Int,
+  numCores: Int,
+  threadPoolSize: Int,
+  hostAffinityEnabled: Boolean,
+  sspGrouperFactory: String,
+  containerRetryCount: Int,
+  containerRetryWindowMs: Long,
+  maxConcurrency: Int,
+  maxJvmHeapMb: Int,
   clock: () => Long = () => { System.currentTimeMillis }) extends MetricsReporter with Runnable with Logging {
 
   val execEnvironmentContainerId = Option[String](System.getenv(ShellCommandConfig.ENV_EXECUTION_ENV_CONTAINER_ID)).getOrElse("")
@@ -148,7 +160,10 @@ class MetricsSnapshotReporter(
 
       // publish to Kafka only if the metricsMsg carries any metrics
       if (!metricsMsg.isEmpty) {
-        val header = new MetricsHeader(jobName, jobId, containerName, execEnvironmentContainerId, source, version, samzaVersion, host, clock(), resetTime)
+        val header = new MetricsHeader(jobName, jobId, containerName, execEnvironmentContainerId, source, version,
+          samzaVersion, host, clock(), resetTime, deploymentType, apiType, numContainers, containerMemoryMb, numCores,
+          threadPoolSize, hostAffinityEnabled, sspGrouperFactory, containerRetryCount,
+          containerRetryWindowMs, maxConcurrency, maxJvmHeapMb)
         val metrics = new Metrics(metricsMsg)
 
         debug("Flushing metrics for %s to %s with header and map: header=%s, map=%s." format(source, out, header.getAsMap, metrics.getAsMap()))

--- a/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporterFactory.scala
+++ b/samza-core/src/main/scala/org/apache/samza/metrics/reporter/MetricsSnapshotReporterFactory.scala
@@ -124,7 +124,20 @@ class MetricsSnapshotReporterFactory extends MetricsReporterFactory with Logging
       Util.getTaskClassVersion(config),
       Util.getSamzaVersion,
       Util.getLocalHost.getHostName,
-      serde, blacklist)
+      serde,
+      blacklist,
+      Util.getDeploymentType(config),
+      Util.getApiType(config),
+      Util.getContainerCount(config),
+      Util.getContainerMemoryMb(config),
+      Util.getNumCores(config),
+      Util.getThreadPoolSize(config),
+      Util.getHostAffinityEnabled(config),
+      Util.getSspGrouperFactory(config),
+      Util.getContainerRetryCount(config),
+      Util.getContainerRetryWindowMs(config),
+      Util.getMaxConcurrency(config),
+      Util.getMaxJvmHeapMb)
 
     reporter.register(this.getClass.getSimpleName, registry)
 

--- a/samza-core/src/test/java/org/apache/samza/diagnostics/TestDiagnosticsManager.java
+++ b/samza-core/src/test/java/org/apache/samza/diagnostics/TestDiagnosticsManager.java
@@ -59,6 +59,14 @@ public class TestDiagnosticsManager {
   private int numPersistentStores = 2;
   private int containerNumCores = 2;
   private boolean autosizingEnabled = false;
+  private String deploymentType = "test deployment type";
+  private String apiType = "test api type";
+  private int numContainers = 1;
+  private boolean hostAffinityEnabled = false;
+  private String sspGrouperFactory = "org.apache.samza.container.grouper.stream.GroupByPartitionFactory";
+  private int containerRetryCount = 8;
+  private long containerRetryWindowMs = 300000;
+  private int maxConcurrency = 1;
   private Map<String, ContainerModel> containerModels = TestDiagnosticsStreamMessage.getSampleContainerModels();
   private Collection<DiagnosticsExceptionEvent> exceptionEventList = TestDiagnosticsStreamMessage.getExceptionList();
 
@@ -78,9 +86,10 @@ public class TestDiagnosticsManager {
         });
 
     this.diagnosticsManager =
-        new DiagnosticsManager(jobName, jobId, containerModels, containerMb, containerNumCores, numPersistentStores, maxHeapSize, containerThreadPoolSize,
-            "0", executionEnvContainerId, taskClassVersion, samzaVersion, hostname, diagnosticsSystemStream,
-            mockSystemProducer, Duration.ofSeconds(1), mockExecutorService, autosizingEnabled);
+        new DiagnosticsManager(jobName, jobId, containerModels, containerMb, containerNumCores, numPersistentStores, maxHeapSize,
+            containerThreadPoolSize, "0", executionEnvContainerId, taskClassVersion, samzaVersion, hostname, diagnosticsSystemStream,
+            mockSystemProducer, Duration.ofSeconds(1), mockExecutorService, autosizingEnabled, deploymentType, apiType, numContainers,
+            hostAffinityEnabled, sspGrouperFactory, containerRetryCount, containerRetryWindowMs, maxConcurrency);
 
     exceptionEventList.forEach(
       diagnosticsExceptionEvent -> this.diagnosticsManager.addExceptionEvent(diagnosticsExceptionEvent));
@@ -95,7 +104,8 @@ public class TestDiagnosticsManager {
         new DiagnosticsManager(jobName, jobId, containerModels, containerMb, containerNumCores, numPersistentStores,
             maxHeapSize, containerThreadPoolSize, "0", executionEnvContainerId, taskClassVersion, samzaVersion,
             hostname, diagnosticsSystemStream, mockSystemProducer, Duration.ofSeconds(1), mockExecutorService,
-            autosizingEnabled);
+            autosizingEnabled, deploymentType, apiType, numContainers,
+            hostAffinityEnabled, sspGrouperFactory, containerRetryCount, containerRetryWindowMs, maxConcurrency);
 
     diagnosticsManager.start();
 
@@ -114,7 +124,8 @@ public class TestDiagnosticsManager {
         new DiagnosticsManager(jobName, jobId, containerModels, containerMb, containerNumCores, numPersistentStores,
             maxHeapSize, containerThreadPoolSize, "0", executionEnvContainerId, taskClassVersion, samzaVersion,
             hostname, diagnosticsSystemStream, mockSystemProducer, terminationDuration, mockExecutorService,
-            autosizingEnabled);
+            autosizingEnabled, deploymentType, apiType, numContainers,
+            hostAffinityEnabled, sspGrouperFactory, containerRetryCount, containerRetryWindowMs, maxConcurrency);
 
     diagnosticsManager.stop();
 
@@ -134,7 +145,8 @@ public class TestDiagnosticsManager {
         new DiagnosticsManager(jobName, jobId, containerModels, containerMb, containerNumCores, numPersistentStores,
             maxHeapSize, containerThreadPoolSize, "0", executionEnvContainerId, taskClassVersion, samzaVersion,
             hostname, diagnosticsSystemStream, mockSystemProducer, terminationDuration, mockExecutorService,
-            autosizingEnabled);
+            autosizingEnabled, deploymentType, apiType, numContainers,
+            hostAffinityEnabled, sspGrouperFactory, containerRetryCount, containerRetryWindowMs, maxConcurrency);
 
     diagnosticsManager.stop();
 
@@ -252,7 +264,17 @@ public class TestDiagnosticsManager {
     Assert.assertEquals(metricsSnapshot.getHeader().getSamzaVersion(), samzaVersion);
     Assert.assertEquals(metricsSnapshot.getHeader().getHost(), hostname);
     Assert.assertEquals(metricsSnapshot.getHeader().getSource(), DiagnosticsManager.class.getName());
-
+    Assert.assertEquals(metricsSnapshot.getHeader().getDeploymentType(), deploymentType);
+    Assert.assertEquals(metricsSnapshot.getHeader().getApiType(), apiType);
+    Assert.assertEquals(metricsSnapshot.getHeader().getNumContainers(), numContainers);
+    Assert.assertEquals(metricsSnapshot.getHeader().getContainerMemoryMb(), containerMb);
+    Assert.assertEquals(metricsSnapshot.getHeader().getContainerCpuCores(), containerNumCores);
+    Assert.assertEquals(metricsSnapshot.getHeader().getContainerThreadPoolSize(), containerThreadPoolSize);
+    Assert.assertEquals(metricsSnapshot.getHeader().getHostAffinity(), hostAffinityEnabled);
+    Assert.assertEquals(metricsSnapshot.getHeader().getSspGrouper(), sspGrouperFactory);
+    Assert.assertEquals(metricsSnapshot.getHeader().getMaxContainerRetryCount(), containerRetryCount);
+    Assert.assertEquals(metricsSnapshot.getHeader().getContainerRetryWindowMs(), containerRetryWindowMs);
+    Assert.assertEquals(metricsSnapshot.getHeader().getTaskMaxConcurrency(), maxConcurrency);
   }
 
   private void validateOutgoingMessageEnvelope(OutgoingMessageEnvelope outgoingMessageEnvelope) {

--- a/samza-core/src/test/java/org/apache/samza/diagnostics/TestDiagnosticsStreamMessage.java
+++ b/samza-core/src/test/java/org/apache/samza/diagnostics/TestDiagnosticsStreamMessage.java
@@ -50,7 +50,10 @@ public class TestDiagnosticsStreamMessage {
   private DiagnosticsStreamMessage getDiagnosticsStreamMessage() {
     DiagnosticsStreamMessage diagnosticsStreamMessage =
         new DiagnosticsStreamMessage(jobName, jobId, containerName, executionEnvContainerId, taskClassVersion,
-            samzaVersion, hostname, timestamp, resetTimestamp);
+            samzaVersion, hostname, timestamp, resetTimestamp, "test deployment type", "test api type",
+            1, 1024, 2, 1, false,
+            "org.apache.samza.container.grouper.stream.GroupByPartitionFactory", 8,
+            300000, 1, 756);
 
     diagnosticsStreamMessage.addContainerMb(1024);
     diagnosticsStreamMessage.addContainerNumCores(2);

--- a/samza-core/src/test/java/org/apache/samza/metrics/TestMetricsSnapshotReporter.java
+++ b/samza-core/src/test/java/org/apache/samza/metrics/TestMetricsSnapshotReporter.java
@@ -178,7 +178,10 @@ public class TestMetricsSnapshotReporter {
 
   private MetricsSnapshotReporter getMetricsSnapshotReporter(String blacklist) {
     return new MetricsSnapshotReporter(producer, SYSTEM_STREAM, REPORTING_INTERVAL, JOB_NAME, JOB_ID, CONTAINER_NAME,
-        TASK_VERSION, SAMZA_VERSION, HOSTNAME, serializer, new Some<>(blacklist), getClock());
+        TASK_VERSION, SAMZA_VERSION, HOSTNAME, serializer, new Some<>(blacklist), "test deployment type",
+        "test api type", 1, 1024, 1, 1,
+        false, "org.apache.samza.container.grouper.stream.GroupByPartitionFactory",
+        8, 300000, 1, 756, getClock());
   }
 
   private AbstractFunction0<Object> getClock() {

--- a/samza-core/src/test/java/org/apache/samza/serializers/model/serializers/TestMetricsSnapshotSerdeV2.java
+++ b/samza-core/src/test/java/org/apache/samza/serializers/model/serializers/TestMetricsSnapshotSerdeV2.java
@@ -38,7 +38,9 @@ public class TestMetricsSnapshotSerdeV2 {
   public void testSerde() {
     MetricsHeader metricsHeader =
         new MetricsHeader("jobName", "i001", "container 0", "test container ID", "source", "300.14.25.1", "1", "1", 1,
-            1);
+            1, "test deployment type", "test api type", 1, 1024, 1,
+            1, false, "org.apache.samza.container.grouper.stream.GroupByPartitionFactory",
+            8, 300000, 1, 756);
 
     BoundedList boundedList = new BoundedList<DiagnosticsExceptionEvent>("exceptions");
     DiagnosticsExceptionEvent diagnosticsExceptionEvent1 =

--- a/samza-core/src/test/scala/org/apache/samza/serializers/TestMetricsSnapshotSerde.scala
+++ b/samza-core/src/test/scala/org/apache/samza/serializers/TestMetricsSnapshotSerde.scala
@@ -34,7 +34,11 @@ class TestMetricsSnapshotSerde {
   @Ignore
   @Test
   def testMetricsSerdeShouldSerializeAndDeserializeAMetric {
-    val header = new MetricsHeader("test-jobName", "testjobid", "samza-container-0", "test exec env container id", "test source", "version", "samzaversion", "host", 1L, 2L)
+    val header = new MetricsHeader("test-jobName", "testjobid", "samza-container-0", "test exec env container id",
+      "test source", "version", "samzaversion", "host", 1L, 2L,
+    "test deployment type", "test api type", 1, 1024, 1,
+      1, false, "org.apache.samza.container.grouper.stream.GroupByPartitionFactory",
+      8, 300000, 1, 756)
     val metricsMap = new HashMap[String, Object]()
     metricsMap.put("test2", "foo")
     val metricsGroupMap = new HashMap[String, Map[String, Object]]()


### PR DESCRIPTION
Issues: Currently, the MetricsHeader object emitted by the SamzaContainer does not exclude basic job level information.
Changes: Added a few features of the job to be emitted by the MetricsHeader
API Changes: With this change, the MetricsHeader class will emit other properties of the job like number of containers used, number of cores used, etc.
Upgrade instructions: None
Usage instructions: None
Tests: Modified existing tests to work with this change.