### PR TITLE
SAMZA-2569: Add features into StreamAppender

### DIFF
--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppenderMetrics.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppenderMetrics.java
@@ -34,10 +34,22 @@ public class StreamAppenderMetrics extends MetricsBase {
   /** The number of log messages dropped e.g. because of buffer overflow. Does not include recursive calls. */
   public final Counter logMessagesDropped;
 
+  /** The number of log messages cannot be sent out due to errors e.g. serialization errors, system producer send errors. */
+  public final Counter logMessagesErrors;
+
+  /** The size of log messages sent out to SystemProducer. */
+  public final Counter logMessagesBytesSent;
+
+  /** The number of log messages sent out to SystemProducer. */
+  public final Counter logMessagesCountSent;
+
   public StreamAppenderMetrics(String prefix, MetricsRegistry registry) {
-    super(prefix, registry);
+    super(prefix + "-", registry);
     bufferFillPct = newGauge("buffer-fill-percent", 0);
     recursiveCalls = newCounter("recursive-calls");
     logMessagesDropped = newCounter("log-messages-dropped");
+    logMessagesErrors = newCounter("log-messages-errors");
+    logMessagesBytesSent = newCounter("log-messages-bytes-sent");
+    logMessagesCountSent = newCounter("log-messages-count-sent");
   }
 }

--- a/samza-log4j2/src/test/java/org/apache/samza/logging/log4j2/TestStreamAppender.java
+++ b/samza-log4j2/src/test/java/org/apache/samza/logging/log4j2/TestStreamAppender.java
@@ -68,13 +68,12 @@ public class TestStreamAppender {
   @Test
   public void testNonDefaultSerde() {
     System.setProperty("samza.container.name", "samza-container-1");
-    String streamName = StreamAppender.getStreamName("log4jTest", "1");
     Map<String, String> map = new HashMap<String, String>();
     map.put("job.name", "log4jTest");
     map.put("job.id", "1");
     map.put("serializers.registry.log4j-string.class", LoggingEventStringSerdeFactory.class.getCanonicalName());
     map.put("systems.mock.samza.factory", MockSystemFactory.class.getCanonicalName());
-    map.put("systems.mock.streams." + streamName + ".samza.msg.serde", "log4j-string");
+    map.put("systems.mock.streams.__samza_log4jTest_1_logs.samza.msg.serde", "log4j-string");
     map.put("task.log4j.system", "mock");
     PatternLayout layout = PatternLayout.newBuilder().withPattern("%m").build();
     MockSystemProducerAppender systemProducerAppender = MockSystemProducerAppender.createAppender("testName", null, layout, false, new MapConfig(map), null);


### PR DESCRIPTION
Feature:
1. Make StreamAppender extend-friendly. 
2. Add metrics reporter into StreamAppender to report collected local metrics.
3. Add log message count and bytes metrics in StreamAppender

Changes:
1. Rewrite StreamAppender to expose private members/functions as protected and split some heavy functions into small trunks.
2. Add metrics reporter to report the metrics we collect locally
3. Add those new metrics into StreamAppender

Tests:
1. Unit tests pass for updated StreamAppender
2. ./gradlew build.

API Changes: two new metrics will be introduced in StreamAppender and will get reported if metrics reporter is set. This applies to application that uses StreamAppender in log4j2.xml

Upgrade/usage instructions:
1. If users write new appender or extends existing StreamAppender for own use cases, feel free to update their appender code to extend new StreamAppender to make code neater.
2. If users want to report these collected metrics through metrics reporter, add metrics reporter related configs (See MetricsConfig.java for more details)