### PR TITLE
SAMZA-2570: Add app.env into configs

### DIFF
--- a/docs/learn/documentation/versioned/jobs/configuration-table.html
+++ b/docs/learn/documentation/versioned/jobs/configuration-table.html
@@ -129,6 +129,15 @@
                 </tr>
 
                 <tr>
+                    <td class="property" id="app-env">app.env</td>
+                    <td class="default"></td>
+                    <td class="description">
+                        If you run several applications across multiple environments (e.g. test, production), you can give
+                        each application a different <code>app.env</code> to differentiate them.
+                    </td>
+                </tr>
+
+                <tr>
                     <td class="property" id="app-id">app.id</td>
                     <td class="default">1</td>
                     <td class="description">

--- a/samza-core/src/main/java/org/apache/samza/config/ApplicationConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ApplicationConfig.java
@@ -53,6 +53,7 @@ public class ApplicationConfig extends MapConfig {
    */
   public static final String APP_PROCESSOR_ID_GENERATOR_CLASS = "app.processor-id-generator.class";
   public static final String APP_NAME = "app.name";
+  public static final String APP_ENV = "app.env";
   public static final String APP_ID = "app.id";
   public static final String APP_CLASS = "app.class";
   public static final String APP_MODE = "app.mode";
@@ -70,6 +71,10 @@ public class ApplicationConfig extends MapConfig {
 
   public String getAppName() {
     return get(APP_NAME, get(JobConfig.JOB_NAME));
+  }
+
+  public String getAppEnv() {
+    return get(APP_ENV, null);
   }
 
   public String getAppId() {

--- a/samza-core/src/main/java/org/apache/samza/util/Util.java
+++ b/samza-core/src/main/java/org/apache/samza/util/Util.java
@@ -51,6 +51,10 @@ public class Util {
         .replace("`", "\\`");
   }
 
+  public static String getAppEnv(Config config) {
+    return new ApplicationConfig(config).getAppEnv();
+  }
+
   public static String getSamzaVersion() {
     return Optional.ofNullable(Util.class.getPackage().getImplementationVersion()).orElseGet(() -> {
       LOG.warn("Unable to find implementation samza version in jar's meta info. Defaulting to {}", FALLBACK_VERSION);


### PR DESCRIPTION
Feature:
1. New Samza config app.env:  application environment. If you run several applications across multiple environments (e.g. test, production), you can give each application a different app.env to differentiate them.

Change:

1. Add app.env getter in ApplicationConfig.java
2. Wire ApplicationConfig's getEnv function into Util.java 

Tests:
1. ./gradlew build.

API Changes: app.env can be now officially obtained either from Util.java or ApplicationConfig.java. This applies to application that adds app.env into their configs

Upgrade/usage instructions:

If users want to use application environment config in the code, they can add app.env into config file.