### PR TITLE
[SAMZA-2573] Ensure the top level order column feeding into the sql translation matches Schema

### DIFF
--- a/samza-sql/src/main/java/org/apache/samza/sql/avro/AvroRelConverter.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/avro/AvroRelConverter.java
@@ -99,17 +99,6 @@ public class AvroRelConverter implements SamzaRelConverter {
         new SamzaSqlRelMsgMetadata(0L, 0L));
   }
 
-  /**
-   * Create a SamzaSqlRelMessage for the specified key and Avro record using the schema from the Avro record.
-   *
-   */
-  public static SamzaSqlRelMessage convertToRelMessage(Object key, IndexedRecord record, Schema schema) {
-    List<String> payloadFieldNames = new ArrayList<>();
-    List<Object> payloadFieldValues = new ArrayList<>();
-    fetchFieldNamesAndValuesFromIndexedRecord(record, payloadFieldNames, payloadFieldValues, schema);
-    return new SamzaSqlRelMessage(key, payloadFieldNames, payloadFieldValues, new SamzaSqlRelMsgMetadata(0L, 0L));
-  }
-
   public static void fetchFieldNamesAndValuesFromIndexedRecord(IndexedRecord record, List<String> fieldNames,
       List<Object> fieldValues, Schema cachedSchema) {
     // Please note that record schema and cached schema could be different due to schema evolution.

--- a/samza-sql/src/main/java/org/apache/samza/sql/data/SamzaSqlRelMessage.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/data/SamzaSqlRelMessage.java
@@ -165,48 +165,4 @@ public class SamzaSqlRelMessage implements Serializable {
   public String toString() {
     return "RelMessage: {" + samzaSqlRelRecord + " " + samzaSqlRelMsgMetadata + "}";
   }
-
-  /**
-   * Create composite key from the rel message.
-   * @param message Represents the samza sql rel message to extract the key values from.
-   * @param keyValueIdx list of key values in the form of field indices within the rel message.
-   * @param keyPartNames Represents the key field names.
-   * @return the composite key of the rel message
-   */
-  public static SamzaSqlRelRecord createSamzaSqlCompositeKey(SamzaSqlRelMessage message, List<Integer> keyValueIdx,
-      List<String> keyPartNames) {
-    Validate.isTrue(keyValueIdx.size() == keyPartNames.size(), "Key part name and value list sizes are different");
-    ArrayList<Object> keyPartValues = new ArrayList<>();
-    for (int idx : keyValueIdx) {
-      keyPartValues.add(message.getSamzaSqlRelRecord().getFieldValues().get(idx));
-    }
-    return new SamzaSqlRelRecord(keyPartNames, keyPartValues);
-  }
-
-  /**
-   * Create composite key from the rel message.
-   * @param message Represents the samza sql rel message to extract the key values and names from.
-   * @param relIdx list of keys in the form of field indices within the rel message.
-   * @return the composite key of the rel message
-   */
-  public static SamzaSqlRelRecord createSamzaSqlCompositeKey(SamzaSqlRelMessage message, List<Integer> relIdx) {
-    return createSamzaSqlCompositeKey(message, relIdx,
-        getSamzaSqlCompositeKeyFieldNames(message.getSamzaSqlRelRecord().getFieldNames(), relIdx));
-  }
-
-  /**
-   * Get composite key field names.
-   * @param fieldNames list of field names to extract the key names from.
-   * @param nameIds indices within the field names.
-   * @return list of composite key field names
-   */
-  public static List<String> getSamzaSqlCompositeKeyFieldNames(List<String> fieldNames,
-      List<Integer> nameIds) {
-    List<String> keyPartNames = new ArrayList<>();
-    for (int idx : nameIds) {
-      keyPartNames.add(fieldNames.get(idx));
-    }
-    return keyPartNames;
-  }
-
 }

--- a/samza-sql/src/main/java/org/apache/samza/sql/dsl/SamzaSqlDslConverter.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/dsl/SamzaSqlDslConverter.java
@@ -86,8 +86,7 @@ public class SamzaSqlDslConverter implements DslConverter {
    * @return {@link QueryPlanner}
    */
   public static QueryPlanner getQueryPlanner(SamzaSqlApplicationConfig sqlConfig) {
-    return new QueryPlanner(sqlConfig.getRelSchemaProviders(), sqlConfig.getInputSystemStreamConfigBySource(),
-        sqlConfig.getUdfMetadata(), sqlConfig.isQueryPlanOptimizerEnabled());
+    return QueryPlanner.fromSamzaAppConfig(sqlConfig);
   }
 
   /**

--- a/samza-sql/src/main/java/org/apache/samza/sql/planner/SamzaSqlOperatorTable.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/planner/SamzaSqlOperatorTable.java
@@ -41,6 +41,7 @@ import org.apache.samza.sql.udf.GetNestedField;
 /**
  * List of all operators supported in Samza Sql. This is the subset of all the calcite operators.
  */
+@SuppressWarnings("unused")
 public class SamzaSqlOperatorTable extends ReflectiveSqlOperatorTable {
 
   public static final SqlBinaryOperator AND = SqlStdOperatorTable.AND;

--- a/samza-sql/src/main/java/org/apache/samza/sql/planner/SamzaSqlValidator.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/planner/SamzaSqlValidator.java
@@ -27,6 +27,7 @@ import java.util.Scanner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.type.RelDataType;
@@ -59,6 +60,8 @@ public class SamzaSqlValidator {
   private static final Logger LOG = LoggerFactory.getLogger(SamzaSqlValidator.class);
 
   private final Config config;
+  private final RelSchemaConverter relSchemaConverter = new RelSchemaConverter();
+  private final JavaTypeFactory samzaSqlJavaTypeFactory = new SamzaSqlJavaTypeFactoryImpl();
 
   public SamzaSqlValidator(Config config) {
     this.config = config;
@@ -132,7 +135,7 @@ public class SamzaSqlValidator {
 
     RelRecordType projectRecord = (RelRecordType) project.getRowType();
     RelRecordType outputRecord = (RelRecordType) QueryPlanner.getSourceRelSchema(outputRelSchemaProvider,
-        new RelSchemaConverter());
+        relSchemaConverter);
 
     // Handle any DELETE ops.
     if (projectRecord.getFieldList().stream().anyMatch(f -> f.getName().equalsIgnoreCase(SamzaSqlRelMessage.OP_NAME))) {
@@ -264,7 +267,7 @@ public class SamzaSqlValidator {
     // TODO: Support UDF argument validation. Currently, only return types are validated and argument types are
     //  validated during run-time.
     if (fieldType instanceof RelDataTypeFactoryImpl.JavaType) {
-      sqlFieldType = new SamzaSqlJavaTypeFactoryImpl().toSql(fieldType);
+      sqlFieldType = samzaSqlJavaTypeFactory.toSql(fieldType);
     } else {
       sqlFieldType = fieldType;
     }

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/JoinTranslator.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/JoinTranslator.java
@@ -60,8 +60,8 @@ import org.apache.samza.table.Table;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.samza.sql.data.SamzaSqlRelMessage.createSamzaSqlCompositeKey;
-import static org.apache.samza.sql.data.SamzaSqlRelMessage.getSamzaSqlCompositeKeyFieldNames;
+import static org.apache.samza.sql.translator.SamzaSqlTableJoinFunction.createSamzaSqlCompositeKey;
+import static org.apache.samza.sql.translator.SamzaSqlTableJoinFunction.getSamzaSqlCompositeKeyFieldNames;
 
 
 /**
@@ -167,8 +167,8 @@ class JoinTranslator {
     if (tableNode.isRemoteTable()) {
       String remoteTableName = tableNode.getSourceName();
       MessageStream<SamzaSqlRelMessage> operatorStack = context.getMessageStream(tableNode.getRelNode().getId());
-      final  StreamTableJoinFunction<Object, SamzaSqlRelMessage, KV, SamzaSqlRelMessage> joinFn;
-      if (operatorStack != null && operatorStack instanceof MessageStreamCollector) {
+      final StreamTableJoinFunction<Object, SamzaSqlRelMessage, KV, SamzaSqlRelMessage> joinFn;
+      if (operatorStack instanceof MessageStreamCollector) {
         joinFn = new SamzaSqlRemoteTableJoinFunction(context.getMsgConverter(remoteTableName),
             context.getTableKeyConverter(remoteTableName), streamNode, tableNode, join.getJoinType(), queryId,
             (MessageStreamCollector) operatorStack);

--- a/samza-sql/src/main/java/org/apache/samza/sql/translator/QueryTranslator.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/translator/QueryTranslator.java
@@ -190,9 +190,7 @@ public class QueryTranslator {
    */
   @VisibleForTesting
   void translate(SamzaSqlQueryParser.QueryInfo queryInfo, StreamApplicationDescriptor appDesc, int queryId) {
-    QueryPlanner planner =
-        new QueryPlanner(sqlConfig.getRelSchemaProviders(), sqlConfig.getInputSystemStreamConfigBySource(),
-            sqlConfig.getUdfMetadata(), sqlConfig.isQueryPlanOptimizerEnabled());
+    QueryPlanner planner = QueryPlanner.fromSamzaAppConfig(sqlConfig);
     final RelRoot relRoot = planner.plan(queryInfo.getSelectQuery());
     SamzaSqlExecutionContext executionContext = new SamzaSqlExecutionContext(sqlConfig);
     TranslatorContext translatorContext = new TranslatorContext(appDesc, relRoot, executionContext);

--- a/samza-sql/src/test/java/org/apache/samza/sql/data/TestSamzaSqlRelMessage.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/data/TestSamzaSqlRelMessage.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.samza.sql.SamzaSqlRelRecord;
+import org.apache.samza.sql.translator.SamzaSqlTableJoinFunction;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -70,13 +71,13 @@ public class TestSamzaSqlRelMessage {
     List<String> keyPartNames = Arrays.asList("kfield1", "kfield2");
     SamzaSqlRelMessage message = new SamzaSqlRelMessage(names, values, new SamzaSqlRelMsgMetadata(0L, 0L));
 
-    SamzaSqlRelRecord relRecord1 = SamzaSqlRelMessage.createSamzaSqlCompositeKey(message, Collections.singletonList(0));
+    SamzaSqlRelRecord relRecord1 = SamzaSqlTableJoinFunction.createSamzaSqlCompositeKey(message, Collections.singletonList(0));
     Assert.assertEquals(relRecord1.getFieldNames().size(), 1);
     Assert.assertEquals(relRecord1.getFieldNames().get(0), "field1");
     Assert.assertEquals(relRecord1.getFieldValues().get(0), "value1");
 
-    SamzaSqlRelRecord relRecord2 = SamzaSqlRelMessage.createSamzaSqlCompositeKey(message, Arrays.asList(1, 0),
-        SamzaSqlRelMessage.getSamzaSqlCompositeKeyFieldNames(keyPartNames, Arrays.asList(1, 0)));
+    SamzaSqlRelRecord relRecord2 = SamzaSqlTableJoinFunction.createSamzaSqlCompositeKey(message, Arrays.asList(1, 0),
+        SamzaSqlTableJoinFunction.getSamzaSqlCompositeKeyFieldNames(keyPartNames, Arrays.asList(1, 0)));
     Assert.assertEquals(relRecord2.getFieldNames().size(), 2);
     Assert.assertEquals(relRecord2.getFieldNames().get(0), "kfield2");
     Assert.assertEquals(relRecord2.getFieldValues().get(0), "value2");
@@ -89,7 +90,7 @@ public class TestSamzaSqlRelMessage {
     List<String> keyPartNames = Arrays.asList("kfield1", "kfield2");
     SamzaSqlRelMessage message = new SamzaSqlRelMessage(names, values, new SamzaSqlRelMsgMetadata(0L, 0L));
 
-    SamzaSqlRelRecord relRecord1 = SamzaSqlRelMessage.createSamzaSqlCompositeKey(message, Arrays.asList(1, 0),
-        SamzaSqlRelMessage.getSamzaSqlCompositeKeyFieldNames(keyPartNames, Arrays.asList(1)));
+    SamzaSqlRelRecord relRecord1 = SamzaSqlTableJoinFunction.createSamzaSqlCompositeKey(message, Arrays.asList(1, 0),
+        SamzaSqlTableJoinFunction.getSamzaSqlCompositeKeyFieldNames(keyPartNames, Arrays.asList(1)));
   }
 }

--- a/samza-sql/src/test/java/org/apache/samza/sql/translator/TestSamzaSqlLocalTableJoinFunction.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/translator/TestSamzaSqlLocalTableJoinFunction.java
@@ -48,7 +48,7 @@ public class TestSamzaSqlLocalTableJoinFunction {
     JoinRelType joinRelType = JoinRelType.INNER;
     List<Integer> streamKeyIds = Arrays.asList(0, 1);
     List<Integer> tableKeyIds = Arrays.asList(0, 1);
-    SamzaSqlRelRecord compositeKey = SamzaSqlRelMessage.createSamzaSqlCompositeKey(tableMsg, tableKeyIds);
+    SamzaSqlRelRecord compositeKey = SamzaSqlTableJoinFunction.createSamzaSqlCompositeKey(tableMsg, tableKeyIds);
     KV<SamzaSqlRelRecord, SamzaSqlRelMessage> record = KV.of(compositeKey, tableMsg);
 
     JoinInputNode mockTableInputNode = mock(JoinInputNode.class);
@@ -81,7 +81,7 @@ public class TestSamzaSqlLocalTableJoinFunction {
     JoinRelType joinRelType = JoinRelType.INNER;
     List<Integer> streamKeyIds = Arrays.asList(0, 2);
     List<Integer> tableKeyIds = Arrays.asList(0, 2);
-    SamzaSqlRelRecord compositeKey = SamzaSqlRelMessage.createSamzaSqlCompositeKey(tableMsg, tableKeyIds);
+    SamzaSqlRelRecord compositeKey = SamzaSqlTableJoinFunction.createSamzaSqlCompositeKey(tableMsg, tableKeyIds);
     KV<SamzaSqlRelRecord, SamzaSqlRelMessage> record = KV.of(compositeKey, tableMsg);
 
     JoinInputNode mockTableInputNode = mock(JoinInputNode.class);

--- a/samza-sql/src/test/java/org/apache/samza/sql/util/SampleRelTableKeyConverter.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/util/SampleRelTableKeyConverter.java
@@ -19,7 +19,7 @@
 
 package org.apache.samza.sql.util;
 
-import java.util.stream.Collectors;
+import java.util.Objects;
 import org.apache.samza.sql.SamzaSqlRelRecord;
 import org.apache.samza.sql.interfaces.SamzaRelTableKeyConverter;
 
@@ -30,14 +30,10 @@ import org.apache.samza.sql.interfaces.SamzaRelTableKeyConverter;
 public class SampleRelTableKeyConverter implements SamzaRelTableKeyConverter {
 
   @Override
-  public Object convertToTableKeyFormat(SamzaSqlRelRecord relRecord) {
+  public String convertToTableKeyFormat(SamzaSqlRelRecord relRecord) {
     if (relRecord.getFieldValues().get(0) instanceof SamzaSqlRelRecord) {
       relRecord = (SamzaSqlRelRecord) relRecord.getFieldValues().get(0);
     }
-    return relRecord.getFieldValues()
-        .stream()
-        .map(x -> x == null ? null : x.toString())
-        .collect(Collectors.toList())
-        .get(0);
+    return Objects.toString(relRecord.getFieldValues().get(0), null);
   }
 }

--- a/samza-sql/src/test/java/org/apache/samza/sql/util/SampleRelTableKeyConverter.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/util/SampleRelTableKeyConverter.java
@@ -30,7 +30,7 @@ import org.apache.samza.sql.interfaces.SamzaRelTableKeyConverter;
 public class SampleRelTableKeyConverter implements SamzaRelTableKeyConverter {
 
   @Override
-  public String convertToTableKeyFormat(SamzaSqlRelRecord relRecord) {
+  public Object convertToTableKeyFormat(SamzaSqlRelRecord relRecord) {
     if (relRecord.getFieldValues().get(0) instanceof SamzaSqlRelRecord) {
       relRecord = (SamzaSqlRelRecord) relRecord.getFieldValues().get(0);
     }

--- a/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
@@ -31,7 +31,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.calcite.plan.RelOptUtil;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.MapConfig;
 import org.apache.samza.sql.planner.SamzaSqlValidator;
@@ -422,12 +421,11 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
   }
 
   @Test
-  public void testEndToEndFlatten() throws Exception {
-    int numMessages = 20;
+  public void testEndToEndFlatten() {
+    int numMessages = 21;
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);
 
-    LOG.info(" Class Path : " + RelOptUtil.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath());
     String sql1 =
         "Insert into testavro.outputTopic(string_value, id, bool_value, bytes_value, fixed_value, float_value0) "
             + " select Flatten(array_values) as string_value, id, NOT(id = 5) as bool_value, bytes_value, fixed_value, float_value0 "
@@ -442,11 +440,9 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     List<OutgoingMessageEnvelope> outMessages = new ArrayList<>(TestAvroSystemFactory.messages);
 
-    int expectedMessages = 0;
+    // Test invariant for each input Row with rank i will contain a column array_values with i elements $\sum_1^n{i}$.
+    int expectedMessages = (numMessages * (numMessages - 1)) / 2;
     // Flatten de-normalizes the data. So there is separate record for each entry in the array.
-    for (int index = 1; index < numMessages; index++) {
-      expectedMessages = expectedMessages + Math.max(1, index);
-    }
     Assert.assertEquals(expectedMessages, outMessages.size());
   }
 
@@ -592,7 +588,7 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
   }
 
   @Test
-  public void testEndToEndFlattenWithUdf() throws Exception {
+  public void testEndToEndFlattenWithUdf() {
     int numMessages = 20;
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);
@@ -609,16 +605,14 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     List<OutgoingMessageEnvelope> outMessages = new ArrayList<>(TestAvroSystemFactory.messages);
 
-    int expectedMessages = 0;
+    // Test invariant for each input Row with rank i will contain a column array_values with i elements $\sum_1^n{i}$.
+    int expectedMessages = (numMessages * (numMessages - 1)) / 2;
     // Flatten de-normalizes the data. So there is separate record for each entry in the array.
-    for (int index = 1; index < numMessages; index++) {
-      expectedMessages = expectedMessages + Math.max(1, index);
-    }
     Assert.assertEquals(expectedMessages, outMessages.size());
   }
 
   @Test
-  public void testEndToEndSubQuery() throws Exception {
+  public void testEndToEndSubQuery() {
     int numMessages = 20;
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);
@@ -635,11 +629,9 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     List<OutgoingMessageEnvelope> outMessages = new ArrayList<>(TestAvroSystemFactory.messages);
 
-    int expectedMessages = 0;
+    // Test invariant for each input Row with rank i will contain a column array_values with i elements $\sum_1^n{i}$.
+    int expectedMessages = (numMessages * (numMessages - 1)) / 2;
     // Flatten de-normalizes the data. So there is separate record for each entry in the array.
-    for (int index = 1; index < numMessages; index++) {
-      expectedMessages = expectedMessages + Math.max(1, index);
-    }
     Assert.assertEquals(expectedMessages, outMessages.size());
   }
 

--- a/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.calcite.plan.RelOptUtil;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.MapConfig;
 import org.apache.samza.sql.planner.SamzaSqlValidator;
@@ -421,11 +422,12 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
   }
 
   @Test
-  public void testEndToEndFlatten() {
-    int numMessages = 21;
+  public void testEndToEndFlatten() throws Exception {
+    int numMessages = 20;
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);
 
+    LOG.info(" Class Path : " + RelOptUtil.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath());
     String sql1 =
         "Insert into testavro.outputTopic(string_value, id, bool_value, bytes_value, fixed_value, float_value0) "
             + " select Flatten(array_values) as string_value, id, NOT(id = 5) as bool_value, bytes_value, fixed_value, float_value0 "
@@ -440,9 +442,11 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     List<OutgoingMessageEnvelope> outMessages = new ArrayList<>(TestAvroSystemFactory.messages);
 
-    // Test invariant for each input Row with rank i will contain a column array_values with i elements $\sum_1^n{i}$.
-    int expectedMessages = (numMessages * (numMessages - 1)) / 2;
+    int expectedMessages = 0;
     // Flatten de-normalizes the data. So there is separate record for each entry in the array.
+    for (int index = 1; index < numMessages; index++) {
+      expectedMessages = expectedMessages + Math.max(1, index);
+    }
     Assert.assertEquals(expectedMessages, outMessages.size());
   }
 
@@ -588,7 +592,7 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
   }
 
   @Test
-  public void testEndToEndFlattenWithUdf() {
+  public void testEndToEndFlattenWithUdf() throws Exception {
     int numMessages = 20;
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);
@@ -605,14 +609,16 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     List<OutgoingMessageEnvelope> outMessages = new ArrayList<>(TestAvroSystemFactory.messages);
 
-    // Test invariant for each input Row with rank i will contain a column array_values with i elements $\sum_1^n{i}$.
-    int expectedMessages = (numMessages * (numMessages - 1)) / 2;
+    int expectedMessages = 0;
     // Flatten de-normalizes the data. So there is separate record for each entry in the array.
+    for (int index = 1; index < numMessages; index++) {
+      expectedMessages = expectedMessages + Math.max(1, index);
+    }
     Assert.assertEquals(expectedMessages, outMessages.size());
   }
 
   @Test
-  public void testEndToEndSubQuery() {
+  public void testEndToEndSubQuery() throws Exception {
     int numMessages = 20;
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);
@@ -629,9 +635,11 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
 
     List<OutgoingMessageEnvelope> outMessages = new ArrayList<>(TestAvroSystemFactory.messages);
 
-    // Test invariant for each input Row with rank i will contain a column array_values with i elements $\sum_1^n{i}$.
-    int expectedMessages = (numMessages * (numMessages - 1)) / 2;
+    int expectedMessages = 0;
     // Flatten de-normalizes the data. So there is separate record for each entry in the array.
+    for (int index = 1; index < numMessages; index++) {
+      expectedMessages = expectedMessages + Math.max(1, index);
+    }
     Assert.assertEquals(expectedMessages, outMessages.size());
   }
 


### PR DESCRIPTION
**Issues:** Currently the order of Samza SQL schema and actual physical row coming from Samza is not guarantee to be correct aka the same. That is because the Schema injection layer is totally disconnected form the translation layer.
**Changes:** This work add a map phase to ensure that the order is as expected between the Row Signature and the actual physical row.
**Tests:** To test this I have shifted the order of `__key__` and run all the test to made sure it works.