### PR TITLE
make MonitorPartition thread a daemon

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/coordinator/StreamPartitionCountMonitor.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/StreamPartitionCountMonitor.java
@@ -238,7 +238,9 @@ public class StreamPartitionCountMonitor {
     private static final AtomicInteger INSTANCE_NUM = new AtomicInteger();
 
     public Thread newThread(Runnable runnable) {
-      return new Thread(runnable, PREFIX + INSTANCE_NUM.getAndIncrement());
+      Thread thread = new Thread(runnable, PREFIX + INSTANCE_NUM.getAndIncrement());
+      thread.setDaemon(true);
+      return thread;
     }
   }
 }


### PR DESCRIPTION
The monitor needs to shutdown whenever the applications shuts down regardless of its state.