### PR TITLE
SAMZA-2577 : Adding support for Async-Logger in Log4j2 Stream Appender

### DIFF
--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
@@ -57,7 +57,6 @@ import org.apache.samza.coordinator.JobModelManager;
 import org.apache.samza.job.model.JobModel;
 import org.apache.samza.logging.log4j2.serializers.LoggingEventJsonSerdeFactory;
 import org.apache.samza.metrics.MetricsRegistryMap;
-import org.apache.samza.runtime.ContainerLaunchUtil;
 import org.apache.samza.metrics.MetricsReporter;
 import org.apache.samza.serializers.Serde;
 import org.apache.samza.serializers.SerdeFactory;
@@ -89,7 +88,6 @@ public class StreamAppender extends AbstractAppender {
   private SystemStream systemStream = null;
   private SystemProducer systemProducer = null;
   private String key = null;
-  private byte[] keyBytes;// Serialize the key once, since we will use it for every event.
   private String containerName = null;
   private int partitionCount = 0;
   private boolean isApplicationMaster;
@@ -98,7 +96,6 @@ public class StreamAppender extends AbstractAppender {
   private Thread transferThread;
   private Config config = null;
   private String streamName = null;
-  private final boolean usingAsyncLogger;
 
   /**
    * used to detect if this thread is called recursively
@@ -106,16 +103,13 @@ public class StreamAppender extends AbstractAppender {
   private final AtomicBoolean recursiveCall = new AtomicBoolean(false);
 
   protected static final int DEFAULT_QUEUE_SIZE = 100;
-  // LI specific change that systemInitialized is not static.
-  protected volatile boolean systemInitialized = false;
+  protected static volatile boolean systemInitialized = false;
   protected StreamAppenderMetrics metrics;
   protected long queueTimeoutS = DEFAULT_QUEUE_TIMEOUT_S;
 
-  protected StreamAppender(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions,
-      boolean usingAsyncLogger, String streamName) {
+  protected StreamAppender(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions, String streamName) {
     super(name, filter, layout, ignoreExceptions);
     this.streamName = streamName;
-    this.usingAsyncLogger = usingAsyncLogger;
   }
 
   @Override
@@ -129,12 +123,13 @@ public class StreamAppender extends AbstractAppender {
           ". This is used as the key for the log appender, so can't proceed.");
     }
     key = containerName; // use the container name as the key for the logs
-    try {
-      // Serialize the key once, since we will use it for every event.
-      keyBytes = key.getBytes("UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      throw new SamzaException(
-          String.format("Container name: %s could not be encoded to bytes. %s cannot proceed.", key, getName()), e);
+
+    // StreamAppender has to wait until the JobCoordinator is up when the log is in the AM
+    if (isApplicationMaster) {
+      systemInitialized = false;
+    } else {
+      setupSystem();
+      systemInitialized = true;
     }
   }
 
@@ -185,9 +180,8 @@ public class StreamAppender extends AbstractAppender {
       @PluginElement("Filter") final Filter filter,
       @PluginElement("Layout") Layout layout,
       @PluginAttribute(value = "ignoreExceptions", defaultBoolean = true) final boolean ignoreExceptions,
-      @PluginAttribute(value = "usingAsyncLogger", defaultBoolean = false) final boolean usingAsyncLogger,
       @PluginAttribute("streamName") String streamName) {
-    return new StreamAppender(name, filter, layout, ignoreExceptions, usingAsyncLogger, streamName);
+    return new StreamAppender(name, filter, layout, ignoreExceptions, streamName);
   }
 
   @Override
@@ -196,30 +190,40 @@ public class StreamAppender extends AbstractAppender {
       try {
         recursiveCall.set(true);
         if (!systemInitialized) {
-          //StreamAppender has to wait until the JobCoordinator is up when the log is in the AM
-          if (isApplicationMaster && JobModelManager.currentJobModelManager() != null) {
+          if (JobModelManager.currentJobModelManager() != null) {
             // JobCoordinator has been instantiated
-            synchronized (this) {
-              if (!systemInitialized) {
-                setupSystem();
-                systemInitialized = true;
-              }
-            }
-          } else if (!isApplicationMaster && ContainerLaunchUtil.isContainerRunning()) {
-            // Linkedin-specific: StreamAppender has to wait until the Offspring is up when log is in the container,
-            // Please see more details in LISAMZA-14223.
-              synchronized (this) {
-                if (!systemInitialized) {
-                  setupSystem();
-                  systemInitialized = true;
-                }
-              }
+            setupSystem();
+            systemInitialized = true;
           } else {
-            log.trace("Waiting for the JobCoordinator/Container to be instantiated...");
+            log.trace("Waiting for the JobCoordinator to be instantiated...");
           }
         } else {
-          // handle event based on if async or sync logger is being used
-          handleEvent(event);
+          // Serialize the event before adding to the queue to leverage the caller thread
+          // and ensure that the transferThread can keep up.
+          if (!logQueue.offer(encodeLogEventToBytes(event), queueTimeoutS, TimeUnit.SECONDS)) {
+            // Do NOT retry adding system to the queue. Dropping the event allows us to alleviate the unlikely
+            // possibility of a deadlock, which can arise due to a circular dependency between the SystemProducer
+            // which is used for StreamAppender and the log, which uses StreamAppender. Any locks held in the callstack
+            // of those two code paths can cause a deadlock. Dropping the event allows us to proceed.
+
+            // Scenario:
+            // T1: holds L1 and is waiting for L2
+            // T2: holds L2 and is waiting to produce to BQ1 which is drained by T3 (SystemProducer) which is waiting for L1
+
+            // This has happened due to locks in Kafka and log4j (see SAMZA-1537), which are both out of our control,
+            // so dropping events in the StreamAppender is our best recourse.
+
+            // Drain the queue instead of dropping one message just to reduce the frequency of warn logs above.
+            int messagesDropped = logQueue.drainTo(new ArrayList<>()) + 1; // +1 because of the current log event
+            log.warn(String.format("Exceeded timeout %ss while trying to log to %s. Dropping %d log messages.",
+                queueTimeoutS,
+                systemStream.toString(),
+                messagesDropped));
+
+            // Emit a metric which can be monitored to ensure it doesn't happen often.
+            metrics.logMessagesDropped.inc(messagesDropped);
+          }
+          metrics.bufferFillPct.set(Math.round(100f * logQueue.size() / DEFAULT_QUEUE_SIZE));
         }
       } catch (Exception e) {
         if (metrics != null) { // setupSystem() may not have been invoked yet so metrics can be null here.
@@ -233,47 +237,6 @@ public class StreamAppender extends AbstractAppender {
     } else if (metrics != null) { // setupSystem() may not have been invoked yet so metrics can be null here.
       metrics.recursiveCalls.inc();
     }
-  }
-
-  /**
-   * If async-Logger is enabled, the log-event is sent directly to the systemProducer. Else, the event is serialized
-   * and added to a bounded blocking queue, before returning to the "synchronous" caller.
-   * @param event the log event to append
-   * @throws InterruptedException
-   */
-  private void handleEvent(LogEvent event) throws InterruptedException {
-
-    if (usingAsyncLogger) {
-      sendEventToSystemProducer(encodeLogEventToBytes(event));
-      return;
-    }
-
-    // Serialize the event before adding to the queue to leverage the caller thread
-    // and ensure that the transferThread can keep up.
-    if (!logQueue.offer(encodeLogEventToBytes(event), queueTimeoutS, TimeUnit.SECONDS)) {
-      // Do NOT retry adding system to the queue. Dropping the event allows us to alleviate the unlikely
-      // possibility of a deadlock, which can arise due to a circular dependency between the SystemProducer
-      // which is used for StreamAppender and the log, which uses StreamAppender. Any locks held in the callstack
-      // of those two code paths can cause a deadlock. Dropping the event allows us to proceed.
-
-      // Scenario:
-      // T1: holds L1 and is waiting for L2
-      // T2: holds L2 and is waiting to produce to BQ1 which is drained by T3 (SystemProducer) which is waiting for L1
-
-      // This has happened due to locks in Kafka and log4j (see SAMZA-1537), which are both out of our control,
-      // so dropping events in the StreamAppender is our best recourse.
-
-      // Drain the queue instead of dropping one message just to reduce the frequency of warn logs above.
-      int messagesDropped = logQueue.drainTo(new ArrayList<>()) + 1; // +1 because of the current log event
-      log.warn(String.format("Exceeded timeout %ss while trying to log to %s. Dropping %d log messages.",
-          queueTimeoutS,
-          systemStream.toString(),
-          messagesDropped));
-
-      // Emit a metric which can be monitored to ensure it doesn't happen often.
-      metrics.logMessagesDropped.inc(messagesDropped);
-    }
-    metrics.bufferFillPct.set(Math.round(100f * logQueue.size() / DEFAULT_QUEUE_SIZE));
   }
 
   protected byte[] encodeLogEventToBytes(LogEvent event) {
@@ -426,10 +389,23 @@ public class StreamAppender extends AbstractAppender {
   }
 
   private void startTransferThread() {
-    Runnable transferFromQueueToSystem = () -> {
+
+    try {
+      // Serialize the key once, since we will use it for every event.
+      final byte[] keyBytes = key.getBytes("UTF-8");
+
+      Runnable transferFromQueueToSystem = () -> {
         while (!Thread.currentThread().isInterrupted()) {
           try {
-            sendEventToSystemProducer(logQueue.take());
+            byte[] serializedLogEvent = logQueue.take();
+
+            metrics.logMessagesBytesSent.inc(serializedLogEvent.length);
+            metrics.logMessagesCountSent.inc();
+
+            OutgoingMessageEnvelope outgoingMessageEnvelope =
+                new OutgoingMessageEnvelope(systemStream, keyBytes, serializedLogEvent);
+            systemProducer.send(SOURCE, outgoingMessageEnvelope);
+
           } catch (InterruptedException e) {
             // Preserve the interrupted status for the loop condition.
             Thread.currentThread().interrupt();
@@ -444,16 +420,12 @@ public class StreamAppender extends AbstractAppender {
       transferThread.setDaemon(true);
       transferThread.setName("Samza " + getName() + " Producer " + transferThread.getName());
       transferThread.start();
-  }
 
-  /**
-   * Helper method to send a serialized log-event to the systemProducer, and increment respective methods.
-   * @param serializedLogEvent
-   */
-  private void sendEventToSystemProducer(byte[] serializedLogEvent) {
-    metrics.logMessagesBytesSent.inc(serializedLogEvent.length);
-    metrics.logMessagesCountSent.inc();
-    systemProducer.send(SOURCE, new OutgoingMessageEnvelope(systemStream, keyBytes, serializedLogEvent));
+    } catch (UnsupportedEncodingException e) {
+      throw new SamzaException(String.format(
+          "Container name: %s could not be encoded to bytes. %s cannot proceed.", key, getName()),
+          e);
+    }
   }
 
   protected String getStreamName(String jobName, String jobId) {

--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
@@ -88,7 +88,7 @@ public class StreamAppender extends AbstractAppender {
   private SystemStream systemStream = null;
   private SystemProducer systemProducer = null;
   private String key = null;
-  private byte[] keyBytes;// Serialize the key once, since we will use it for every event.
+  private byte[] keyBytes; // Serialize the key once, since we will use it for every event.
   private String containerName = null;
   private int partitionCount = 0;
   private boolean isApplicationMaster;
@@ -145,7 +145,7 @@ public class StreamAppender extends AbstractAppender {
   }
 
   /**
-   * Getter for the StreamName parameter. See also {@link #createAppender(String, Filter, Layout, boolean, String)} for when this is called.
+   * Getter for the StreamName parameter. See also {@link #createAppender(String, Filter, Layout, boolean, boolean, String)} for when this is called.
    * Example: {@literal <param name="StreamName" value="ExampleStreamName"/>}
    * @return The configured stream name.
    */
@@ -164,7 +164,7 @@ public class StreamAppender extends AbstractAppender {
   }
 
   /**
-   * Getter for the number of partitions to create on a new StreamAppender stream. See also {@link #createAppender(String, Filter, Layout, boolean, String)} for when this is called.
+   * Getter for the number of partitions to create on a new StreamAppender stream. See also {@link #createAppender(String, Filter, Layout, boolean, boolean, String)} for when this is called.
    * Example: {@literal <param name="PartitionCount" value="4"/>}
    * @return The configured partition count of the StreamAppender stream. If not set, returns {@link JobConfig#getContainerCount()}.
    */
@@ -176,7 +176,7 @@ public class StreamAppender extends AbstractAppender {
   }
 
   /**
-   * Setter for the number of partitions to create on a new StreamAppender stream. See also {@link #createAppender(String, Filter, Layout, boolean, String)} for when this is called.
+   * Setter for the number of partitions to create on a new StreamAppender stream. See also {@link #createAppender(String, Filter, Layout, boolean, boolean, String)} for when this is called.
    * Example: {@literal <param name="PartitionCount" value="4"/>}
    * @param partitionCount Configurable partition count.
    */

--- a/samza-log4j2/src/test/java/org/apache/samza/logging/log4j2/MockSystemProducerAppender.java
+++ b/samza-log4j2/src/test/java/org/apache/samza/logging/log4j2/MockSystemProducerAppender.java
@@ -41,8 +41,8 @@ import org.apache.samza.config.MapConfig;
 class MockSystemProducerAppender extends StreamAppender {
   private static Config config;
 
-  protected MockSystemProducerAppender(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions, Config config, String streamName) {
-    super(name, filter, layout, ignoreExceptions, false, streamName);
+  protected MockSystemProducerAppender(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions, final boolean usingAsyncLogger, Config config, String streamName) {
+    super(name, filter, layout, ignoreExceptions, usingAsyncLogger, streamName);
   }
 
   @PluginFactory
@@ -51,6 +51,7 @@ class MockSystemProducerAppender extends StreamAppender {
       @PluginElement("Filter") final Filter filter,
       @PluginElement("Layout") Layout<? extends Serializable> layout,
       @PluginAttribute(value = "ignoreExceptions", defaultBoolean = true) final boolean ignoreExceptions,
+      @PluginAttribute(value = "usingAsyncLogger", defaultBoolean = false) final boolean usingAsyncLogger,
       @PluginElement("Config") final Config testConfig,
       @PluginAttribute("streamName") String streamName) {
     if (testConfig == null) {
@@ -58,7 +59,7 @@ class MockSystemProducerAppender extends StreamAppender {
     } else {
       config = testConfig;
     }
-    return new MockSystemProducerAppender(name, filter, layout, ignoreExceptions, config, streamName);
+    return new MockSystemProducerAppender(name, filter, layout, ignoreExceptions, usingAsyncLogger, config, streamName);
   }
 
   @Override

--- a/samza-log4j2/src/test/java/org/apache/samza/logging/log4j2/MockSystemProducerAppender.java
+++ b/samza-log4j2/src/test/java/org/apache/samza/logging/log4j2/MockSystemProducerAppender.java
@@ -42,7 +42,7 @@ class MockSystemProducerAppender extends StreamAppender {
   private static Config config;
 
   protected MockSystemProducerAppender(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions, Config config, String streamName) {
-    super(name, filter, layout, ignoreExceptions, streamName);
+    super(name, filter, layout, ignoreExceptions, false, streamName);
   }
 
   @PluginFactory

--- a/samza-log4j2/src/test/java/org/apache/samza/logging/log4j2/MockSystemProducerAppender.java
+++ b/samza-log4j2/src/test/java/org/apache/samza/logging/log4j2/MockSystemProducerAppender.java
@@ -42,7 +42,7 @@ class MockSystemProducerAppender extends StreamAppender {
   private static Config config;
 
   protected MockSystemProducerAppender(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions, Config config, String streamName) {
-    super(name, filter, layout, ignoreExceptions, false, streamName);
+    super(name, filter, layout, ignoreExceptions, streamName);
   }
 
   @PluginFactory


### PR DESCRIPTION
Problem: 
In both StreamAppender for log4j1 and log4j2 a blocking queue is used to coordinate between the append()-ing threads and a single thread send()-ing to Kafka.
This is a bounded, blocking, lock-synchronized queue.
To avoid deadlock scenarios (see SAMZA-1537), the append()-ing threads have a timeout of 2 seconds, after which the log message is discarded and the queue is drained. 
This means in case of message bursts, threads calling append() may block for upto 2 seconds, and may continually be stuck in this pattern, leading to processing stalls and lowered throughput. 

Solutions for Log4j2 
Solution 1. Enable async logger in log4j2, since they are supported and provided in log4j2.https://logging.apache.org/log4j/2.x/manual/async.html.
In using this capability, the blocking-queue in StreamAppender is not required because the logger itself will be asynchronous, and so append() threads can directly call systemProducer.send(). 
However, if async loggers are not used then this queue based mechanism, to give the append()-ing threads an "async" illusion, is required.

Solution 2. Continue using the blocking bounded lock-based queue, but make the queue size and timeout configurable. Users can then tune this to account for message bursts.

Solution 3. Move to use a lock-less queue, e.g., ConcurrentLinkedQueue (unbounded) or 
implement a bounded lock-less queue, or use [open-source implementations|https://stackoverflow.com/questions/20890554/lock-free-circular-array].
Append()-ing threads will no longer need to block or timeout. However the caller may busy-wait or need a fixed-rate or fixed-sleep-time to avoid busy waits, since a lock-less queue is non blocking. 
It uses CAS operations. 
For log4j2, we will adopt Solution 1.