### PR TITLE
SAMZA-2579: Force restart feature for Container Placements

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerManager.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerManager.java
@@ -404,7 +404,8 @@ public class ContainerManager {
 
     /*
      * When destination host is {@code FORCE_RESTART_LAST_SEEN} its treated as eqvivalent to kill -9 operation for the container
-     * In this scenario container is stopped first and we fallback to normal restart path
+     * In this scenario container is stopped first and we fallback to normal restart path so the policy here is
+     * stop - reserve - move
      */
     if (destinationHost.equals(FORCE_RESTART_LAST_SEEN)) {
       LOG.info("Issuing a force restart for Processor ID: {} for ContainerPlacement action request {}", processorId, requestMessage);
@@ -416,7 +417,8 @@ public class ContainerManager {
 
     /**
      * When destination host is {@code LAST_SEEN} its treated as a restart request on the host where container is running
-     * on or has been seen last
+     * on or has been seen last, but in this policy would be reserve - stop - move, which means reserve resources first
+     * only if resources are accrued stop the active container and issue a start on it on resource acquired
      */
     if (destinationHost.equals(LAST_SEEN)) {
       String lastSeenHost = getSourceHostForContainer(requestMessage);


### PR DESCRIPTION
**Changes**: The current restart ability for container placements works in the following way:
1. Tries to fetch resources on a host
2. Stops the active container if resources are accrued
3. Tried to start the container on host accrued

In production, we have seen the following observation at Linkedin
1. Some jobs are configured to use resources for the peak which leads to no headroom left on a host for requesting additional resources
2. This leads to restart requests failing due to not able to get resources on that host

A fix to this is to implement a force-restart utility , in this version we will stop the container first and then accrue resources. The upside being we will at least free up the resources on the host before issuing resource request, the downside being it will be a best-effort scenario to bring that container back up on that host

**API Changes:** Added new param values to destinationHost param for container placement request message

LAST_SEEN: Tries to restart a container on last seen host with RESERVE -> STOP -> MOVE policy

FORCE_RESTART_LAST_SEEN: Tries to restart a container on last seen host with STOP -> RESERVE -> MOVE policy

**Tests:** Tested the change with a yarn job

**Upgrade Instructions:** None

**Usage Instructions:** None

