### PR TITLE
SAMZA-2581: Fix Samza Histogram update to update percentile Gauge values

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/metrics/SamzaHistogram.java
+++ b/samza-api/src/main/java/org/apache/samza/metrics/SamzaHistogram.java
@@ -72,8 +72,17 @@ public class SamzaHistogram {
     }
 
     public void visit(MetricsVisitor visitor) {
-      updateGaugeValues(percentile);
       visitor.gauge(this);
+    }
+
+    /**
+     * We update the percentile gauge values when value is being polled.
+     * This is needed for reporters which do not implement MetricsReporter
+     * and do not have MetricsReporter to update the values.
+     */
+    public Double getValue() {
+      updateGaugeValues(percentile);
+      return super.getValue();
     }
   }
 }


### PR DESCRIPTION
Symptom: Missing metrics. EventSystemConsumer consumer lag latency
metrics are missing.

Cause: Histogram update and percentile gauges are updated in two
different functions. Percentiles are internal to Samza histogram and
hence should be updated internally as part of update.

Changes: Histogram update also updates internal gauges.