### PR TITLE
SAMZA-2582: Add a metric to track container failure tracking metric for Samza

### DIFF
--- a/docs/learn/documentation/versioned/operations/monitoring.md
+++ b/docs/learn/documentation/versioned/operations/monitoring.md
@@ -369,6 +369,7 @@ All \<system\>, \<stream\>, \<partition\>, \<store-name\>, \<topic\>, are popula
 | | expired-preferred-host-requests | Number of expired resource-requests-for -preferred-host received by the cluster manager. |
 | | expired-any-host-requests | Number of expired resource-requests-for -any-host received by the cluster manager. |
 | | host-affinity-match-pct | Percentage of non-expired preferred host requests. This measures the % of resource-requests for which host-affinity provided the preferred host. |
+| | \<containerId\>-failure-count | Number of times a container identified by containerId has failed |
 
 | **Group** | **Metric name** | **Meaning** |
 | --- | --- | --- |

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/SamzaApplicationState.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/SamzaApplicationState.java
@@ -115,6 +115,13 @@ public class SamzaApplicationState {
    */
   public final ConcurrentHashMap<String, SamzaResourceStatus> failedProcessors = new ConcurrentHashMap<>(0);
 
+
+  /**
+   *  Map of the Samza processor ID to the count of failed attempts
+   *  Modified by AMRMCallbackThread
+   */
+  public final ConcurrentMap<String, AtomicInteger> perProcessorFailureCount = new ConcurrentHashMap<>(0);
+
   /**
    * Final status of the application. Made to be volatile s.t. changes will be visible in multiple threads.
    */

--- a/samza-core/src/main/scala/org/apache/samza/metrics/ContainerProcessManagerMetrics.scala
+++ b/samza-core/src/main/scala/org/apache/samza/metrics/ContainerProcessManagerMetrics.scala
@@ -64,4 +64,11 @@ class ContainerProcessManagerMetrics(val config: Config,
 
   val mContainerMemoryMb = newGauge("container-memory-mb", () => clusterManagerConfig.getContainerMemoryMb)
   val mContainerCpuCores = newGauge("container-cpu-cores", () => clusterManagerConfig.getNumCores)
+
+
+  val mPerContainerFailureCount = collection.mutable.Map[String, Gauge[Int]]()
+  def registerProcessorFailureCountMetric(containerId: String) {
+    mPerContainerFailureCount.put(containerId, newGauge("container_" + containerId + "-failure-count", () => state.perProcessorFailureCount.get(containerId).get()))
+  }
+
 }


### PR DESCRIPTION
**Changes:** Added a metric to <container-id>-failure-count to track failure count of a single container

**API Changes:** None

**Tests:** Tested the change with a yarn job deploy

**Upgrade Instructions:** None

**Usage Instructions:** None