### PR TITLE
SAMZA-2583: Fix NPE in update SamzaHistogram Gauge values

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/metrics/SamzaHistogram.java
+++ b/samza-api/src/main/java/org/apache/samza/metrics/SamzaHistogram.java
@@ -81,6 +81,10 @@ public class SamzaHistogram {
      * and do not have MetricsReporter to update the values.
      */
     public Double getValue() {
+      /*
+       * We cannot updateGaugeValues if the histogram gauges are being instantiated
+       * and getValue is called in this context.
+       */
       if (gauges == null) {
         return 0.0;
       }

--- a/samza-api/src/main/java/org/apache/samza/metrics/SamzaHistogram.java
+++ b/samza-api/src/main/java/org/apache/samza/metrics/SamzaHistogram.java
@@ -81,6 +81,10 @@ public class SamzaHistogram {
      * and do not have MetricsReporter to update the values.
      */
     public Double getValue() {
+      if (gauges == null) {
+        return 0.0;
+      }
+
       updateGaugeValues(percentile);
       return super.getValue();
     }

--- a/samza-api/src/test/java/org/apache/samza/metrics/TestSamzaHistogram.java
+++ b/samza-api/src/test/java/org/apache/samza/metrics/TestSamzaHistogram.java
@@ -1,0 +1,50 @@
+package org.apache.samza.metrics;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class TestSamzaHistogram {
+  private static final String GROUP = "Group0";
+  private static final String METRIC_NAME = "Metric1";
+
+  private MockMetricRegistry metricsRegistry;
+
+  @Test
+  public void testCreateHistogramGaugeNullCheck() {
+    metricsRegistry = new MockMetricRegistry();
+    SamzaHistogram histogram = new SamzaHistogram(metricsRegistry, GROUP, METRIC_NAME);
+    assertNotNull(histogram);
+  }
+
+  private class MockMetricRegistry implements MetricsRegistry {
+    @Override
+    public Counter newCounter(String group, String name) {
+      return null;
+    }
+
+    @Override
+    public Counter newCounter(String group, Counter counter) {
+      return null;
+    }
+
+    @Override
+    public <T> Gauge<T> newGauge(String group, String name, T value) {
+      return null;
+    }
+
+    @Override
+    public <T> Gauge<T> newGauge(String group, Gauge<T> value) {
+      return new Gauge(group, value.getValue());
+    }
+
+    @Override
+    public Timer newTimer(String group, String name) {
+      return null;
+    }
+
+    @Override
+    public Timer newTimer(String group, Timer timer) {
+      return null;
+    }
+  }
+}

--- a/samza-api/src/test/java/org/apache/samza/metrics/TestSamzaHistogram.java
+++ b/samza-api/src/test/java/org/apache/samza/metrics/TestSamzaHistogram.java
@@ -22,8 +22,11 @@ package org.apache.samza.metrics;
 import org.junit.Test;
 import org.mockito.stubbing.Answer;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
 public class TestSamzaHistogram {
   private static final String GROUP = "Group0";

--- a/samza-api/src/test/java/org/apache/samza/metrics/TestSamzaHistogram.java
+++ b/samza-api/src/test/java/org/apache/samza/metrics/TestSamzaHistogram.java
@@ -1,50 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.samza.metrics;
 
 import org.junit.Test;
+import org.mockito.stubbing.Answer;
+
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 public class TestSamzaHistogram {
   private static final String GROUP = "Group0";
   private static final String METRIC_NAME = "Metric1";
 
-  private MockMetricRegistry metricsRegistry;
+  private MetricsRegistry metricsRegistry;
 
   @Test
   public void testCreateHistogramGaugeNullCheck() {
-    metricsRegistry = new MockMetricRegistry();
+    metricsRegistry = mock(MetricsRegistry.class);
+
+    doAnswer((Answer<Gauge<Double>>) invocation -> {
+      Object[] args = invocation.getArguments();
+      return new Gauge<>((String) args[0], (Double) ((Gauge) args[1]).getValue());
+    }).when(metricsRegistry).newGauge(anyString(), any(Gauge.class));
+
     SamzaHistogram histogram = new SamzaHistogram(metricsRegistry, GROUP, METRIC_NAME);
     assertNotNull(histogram);
-  }
-
-  private class MockMetricRegistry implements MetricsRegistry {
-    @Override
-    public Counter newCounter(String group, String name) {
-      return null;
-    }
-
-    @Override
-    public Counter newCounter(String group, Counter counter) {
-      return null;
-    }
-
-    @Override
-    public <T> Gauge<T> newGauge(String group, String name, T value) {
-      return null;
-    }
-
-    @Override
-    public <T> Gauge<T> newGauge(String group, Gauge<T> value) {
-      return new Gauge(group, value.getValue());
-    }
-
-    @Override
-    public Timer newTimer(String group, String name) {
-      return null;
-    }
-
-    @Override
-    public Timer newTimer(String group, Timer timer) {
-      return null;
-    }
   }
 }


### PR DESCRIPTION
SamzaHistogram gauges are instantiated via passed in metric registry
newGauge api. The new Gauge api in turn tries to instantiate
HistogramGauge. The newGauge api calls getValue on HistogramGauge
which in turn tries to update the Histogram Gauge values. This means
we are updating Histogram Gauge values in process of creating it.
As a fix, we add  null check in Gauge getValue to avoid NPE.