### PR TITLE
SAMZA-2353: Support side inputs and standby containers with transactional state

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/storage/SideInputTask.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/SideInputTask.java
@@ -28,7 +28,6 @@ import org.apache.samza.scheduler.EpochTimeScheduler;
 import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.system.SystemStreamPartition;
 import org.apache.samza.task.ReadableCoordinator;
-import org.apache.samza.task.TaskCallback;
 import org.apache.samza.task.TaskCallbackFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,15 +63,9 @@ public class SideInputTask implements RunLoopTask {
   @Override
   synchronized public void process(IncomingMessageEnvelope envelope, ReadableCoordinator coordinator,
       TaskCallbackFactory callbackFactory) {
-    TaskCallback callback = callbackFactory.createCallback();
     this.metrics.processes().inc();
-    try {
-      this.taskSideInputHandler.process(envelope);
-      this.metrics.messagesActuallyProcessed().inc();
-      callback.complete();
-    } catch (Exception e) {
-      callback.failure(e);
-    }
+    this.taskSideInputHandler.process(envelope, callbackFactory);
+    this.metrics.messagesActuallyProcessed().inc();
   }
 
   @Override

--- a/samza-core/src/test/java/org/apache/samza/storage/TestTaskSideInputHandler.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/TestTaskSideInputHandler.java
@@ -18,6 +18,7 @@
  */
 package org.apache.samza.storage;
 
+import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
@@ -193,7 +194,7 @@ public class TestTaskSideInputHandler {
           systemAdmins,
           streamMetadataCache,
           new CountDownLatch(1),
-          clock));
+          clock, ImmutableMap.of(), ImmutableMap.of()));
     }
   }
 


### PR DESCRIPTION
**Feature:** Consumption of standby side inputs must honor checkpointed changelog offsets, else customers using standby containers cannot enable transactional state.
 
**Changes:** Adds a thread to ContainerStorageManager to continually poll the checkpoint topic, as well as barrier conditions within TaskSideInputHandler to keep consumption of standby side inputs from continuing past the checkpointed offset.
 
 **Tests:** No tests. TODO.