### PR TITLE
SAMZA-2585: Modify shutdown sequence to handle orphaned AMs

### DIFF
--- a/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnClusterResourceManager.java
+++ b/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnClusterResourceManager.java
@@ -386,13 +386,14 @@ public class YarnClusterResourceManager extends ClusterResourceManager implement
    */
   @Override
   public void stop(SamzaApplicationState.SamzaAppStatus status) {
-    log.info("Stopping AM client.");
+    log.info("Stopping the AM client on shutdown request.");
     lifecycle.onShutdown(status);
     amClient.stop();
-    log.info("Stopping the AM service.");
+    log.info("Stopping the NM client on shutdown request.");
     nmClientAsync.stop();
-    log.info("Stopping the NM service.");
+    log.info("Stopping the SamzaYarnAppMasterService service on shutdown request.");
     service.onShutdown();
+    log.info("Stopping SamzaAppMasterMetrics on shutdown request.");
     metrics.stop();
 
     if (status != SamzaApplicationState.SamzaAppStatus.UNDEFINED) {
@@ -485,15 +486,7 @@ public class YarnClusterResourceManager extends ClusterResourceManager implement
   //nodes being updated. We always return 0 when asked for progress by Yarn.
   @Override
   public void onShutdownRequest() {
-    log.info("Stopping the AM client on shutdown request.");
-    lifecycle.onShutdown(SamzaApplicationState.SamzaAppStatus.FAILED);
-    amClient.stop();
-    log.info("Stopping the NM client on shutdown request.");
-    nmClientAsync.stop();
-    log.info("Stopping the SamzaYarnAppMasterService service on shutdown request.");
-    service.onShutdown();
-    log.info("Stopping SamzaAppMasterMetrics on shutdown request.");
-    metrics.stop();
+    stop(SamzaApplicationState.SamzaAppStatus.FAILED);
   }
 
   @Override

--- a/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnClusterResourceManager.java
+++ b/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnClusterResourceManager.java
@@ -485,7 +485,15 @@ public class YarnClusterResourceManager extends ClusterResourceManager implement
   //nodes being updated. We always return 0 when asked for progress by Yarn.
   @Override
   public void onShutdownRequest() {
-    //not implemented currently.
+    log.info("Stopping the AM client on shutdown request.");
+    lifecycle.onShutdown(SamzaApplicationState.SamzaAppStatus.FAILED);
+    amClient.stop();
+    log.info("Stopping the NM client on shutdown request.");
+    nmClientAsync.stop();
+    log.info("Stopping the SamzaYarnAppMasterService service on shutdown request.");
+    service.onShutdown();
+    log.info("Stopping SamzaAppMasterMetrics on shutdown request.");
+    metrics.stop();
   }
 
   @Override

--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/SamzaYarnAppMasterLifecycle.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/SamzaYarnAppMasterLifecycle.scala
@@ -76,7 +76,7 @@ class SamzaYarnAppMasterLifecycle(containerMem: Int, containerCpu: Int, samzaApp
         info("Unregister complete.")
       } catch {
         case ex: InvalidApplicationMasterRequestException =>
-          // Once the AM dies, the corresponding app attempt ID is removed from the RM cache so that the RM can spin up a new AM and its containers.
+          // Once the NM dies, the corresponding app attempt ID is removed from the RM cache so that the RM can spin up a new AM and its containers.
           // Hence, this throws InvalidApplicationMasterRequestException since that AM is unregistered with the RM already.
           info("Removed application attempt from RM cache because the AM died. Unregister complete.")
         case ex @ (_ : YarnException | _ : IOException) =>

--- a/samza-yarn/src/test/java/org/apache/samza/job/yarn/TestYarnClusterResourceManager.java
+++ b/samza-yarn/src/test/java/org/apache/samza/job/yarn/TestYarnClusterResourceManager.java
@@ -103,4 +103,28 @@ public class TestYarnClusterResourceManager {
 
     Assert.assertTrue(yarnClusterResourceManager.isResourceExpired(allocatedResource));
   }
+
+  @Test
+  public void testAMShutdownOnRMCallback() {
+    // create mocks
+    final int samzaContainerId = 1;
+    YarnConfiguration yarnConfiguration = mock(YarnConfiguration.class);
+    SamzaAppMasterMetrics metrics = mock(SamzaAppMasterMetrics.class);
+    Config config = mock(Config.class);
+    AMRMClientAsync asyncClient = mock(AMRMClientAsync.class);
+    YarnAppState yarnAppState = new YarnAppState(0, mock(ContainerId.class), "host", 8080, 8081);
+    SamzaYarnAppMasterLifecycle lifecycle = mock(SamzaYarnAppMasterLifecycle.class);
+    SamzaYarnAppMasterService service = mock(SamzaYarnAppMasterService.class);
+    NMClientAsync asyncNMClient = mock(NMClientAsync.class);
+    ClusterResourceManager.Callback callback = mock(ClusterResourceManager.Callback.class);
+
+    // start the cluster manager
+    YarnClusterResourceManager yarnClusterResourceManager = new YarnClusterResourceManager(asyncClient, asyncNMClient,
+        callback, yarnAppState, lifecycle, service, metrics, yarnConfiguration, config);
+
+    yarnClusterResourceManager.onShutdownRequest();
+
+    verify(asyncClient, times(1)).stop();
+    verify(asyncNMClient, times(1)).stop();
+  }
 }

--- a/samza-yarn/src/test/java/org/apache/samza/job/yarn/TestYarnClusterResourceManager.java
+++ b/samza-yarn/src/test/java/org/apache/samza/job/yarn/TestYarnClusterResourceManager.java
@@ -43,8 +43,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.*;
 

--- a/samza-yarn/src/test/java/org/apache/samza/job/yarn/TestYarnClusterResourceManager.java
+++ b/samza-yarn/src/test/java/org/apache/samza/job/yarn/TestYarnClusterResourceManager.java
@@ -19,11 +19,13 @@
 
 package org.apache.samza.job.yarn;
 
+import java.io.IOException;
 import java.time.Duration;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.Resource;
@@ -31,16 +33,21 @@ import org.apache.hadoop.yarn.api.records.Token;
 import org.apache.hadoop.yarn.client.api.async.AMRMClientAsync;
 import org.apache.hadoop.yarn.client.api.async.NMClientAsync;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.hadoop.yarn.exceptions.InvalidApplicationMasterRequestException;
+import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.samza.clustermanager.ClusterResourceManager;
 import org.apache.samza.clustermanager.SamzaApplicationState;
 import org.apache.samza.clustermanager.SamzaResource;
 import org.apache.samza.config.Config;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyObject;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.*;
+
 
 public class TestYarnClusterResourceManager {
 
@@ -59,24 +66,19 @@ public class TestYarnClusterResourceManager {
     ClusterResourceManager.Callback callback = mock(ClusterResourceManager.Callback.class);
 
     // start the cluster manager
-    YarnClusterResourceManager yarnClusterResourceManager = new YarnClusterResourceManager(asyncClient, asyncNMClient,
-        callback, yarnAppState, lifecycle, service, metrics, yarnConfiguration, config);
+    YarnClusterResourceManager yarnClusterResourceManager =
+        new YarnClusterResourceManager(asyncClient, asyncNMClient, callback, yarnAppState, lifecycle, service, metrics,
+            yarnConfiguration, config);
 
-    yarnAppState.pendingProcessors.put(String.valueOf(samzaContainerId),
-        new YarnContainer(Container.newInstance(
-            ContainerId.newContainerId(
-                ApplicationAttemptId.newInstance(
-                    ApplicationId.newInstance(10000L, 1), 1), 1),
-            NodeId.newInstance("host1", 8088), "http://host1",
-            Resource.newInstance(1024, 1), Priority.newInstance(1),
-            Token.newInstance("id".getBytes(), "read", "password".getBytes(), "service"))));
+    yarnAppState.pendingProcessors.put(String.valueOf(samzaContainerId), new YarnContainer(Container.newInstance(
+        ContainerId.newContainerId(ApplicationAttemptId.newInstance(ApplicationId.newInstance(10000L, 1), 1), 1),
+        NodeId.newInstance("host1", 8088), "http://host1", Resource.newInstance(1024, 1), Priority.newInstance(1),
+        Token.newInstance("id".getBytes(), "read", "password".getBytes(), "service"))));
 
     yarnClusterResourceManager.start();
     assertEquals(1, yarnAppState.pendingProcessors.size());
 
-    yarnClusterResourceManager.onStartContainerError(ContainerId.newContainerId(
-        ApplicationAttemptId.newInstance(
-            ApplicationId.newInstance(10000L, 1), 1), 1),
+    yarnClusterResourceManager.onStartContainerError(ContainerId.newContainerId(ApplicationAttemptId.newInstance(ApplicationId.newInstance(10000L, 1), 1), 1),
         new Exception());
 
     assertEquals(0, yarnAppState.pendingProcessors.size());
@@ -96,8 +98,9 @@ public class TestYarnClusterResourceManager {
     ClusterResourceManager.Callback callback = mock(ClusterResourceManager.Callback.class);
 
     // start the cluster manager
-    YarnClusterResourceManager yarnClusterResourceManager = new YarnClusterResourceManager(asyncClient, asyncNMClient,
-        callback, yarnAppState, lifecycle, service, metrics, yarnConfiguration, config);
+    YarnClusterResourceManager yarnClusterResourceManager =
+        new YarnClusterResourceManager(asyncClient, asyncNMClient, callback, yarnAppState, lifecycle, service, metrics,
+            yarnConfiguration, config);
 
     SamzaResource allocatedResource = mock(SamzaResource.class);
     when(allocatedResource.getTimestamp()).thenReturn(System.currentTimeMillis() - Duration.ofMinutes(10).toMillis());
@@ -106,25 +109,57 @@ public class TestYarnClusterResourceManager {
   }
 
   @Test
-  public void testAMShutdownOnRMCallback() {
+  public void testAMShutdownOnRMCallback() throws IOException, YarnException {
     // create mocks
     YarnConfiguration yarnConfiguration = mock(YarnConfiguration.class);
     SamzaAppMasterMetrics metrics = mock(SamzaAppMasterMetrics.class);
     Config config = mock(Config.class);
     AMRMClientAsync asyncClient = mock(AMRMClientAsync.class);
     YarnAppState yarnAppState = new YarnAppState(0, mock(ContainerId.class), "host", 8080, 8081);
-    SamzaYarnAppMasterLifecycle lifecycle = mock(SamzaYarnAppMasterLifecycle.class);
+    SamzaYarnAppMasterLifecycle lifecycle = Mockito.spy(new SamzaYarnAppMasterLifecycle(512, 2, mock(SamzaApplicationState.class), yarnAppState, asyncClient));
     SamzaYarnAppMasterService service = mock(SamzaYarnAppMasterService.class);
     NMClientAsync asyncNMClient = mock(NMClientAsync.class);
     ClusterResourceManager.Callback callback = mock(ClusterResourceManager.Callback.class);
 
     // start the cluster manager
-    YarnClusterResourceManager yarnClusterResourceManager = new YarnClusterResourceManager(asyncClient, asyncNMClient,
-        callback, yarnAppState, lifecycle, service, metrics, yarnConfiguration, config);
+    YarnClusterResourceManager yarnClusterResourceManager =
+        new YarnClusterResourceManager(asyncClient, asyncNMClient, callback, yarnAppState, lifecycle, service, metrics,
+            yarnConfiguration, config);
 
     yarnClusterResourceManager.onShutdownRequest();
 
     verify(lifecycle, times(1)).onShutdown(SamzaApplicationState.SamzaAppStatus.FAILED);
+    verify(asyncClient, times(1)).unregisterApplicationMaster(FinalApplicationStatus.FAILED, null, null);
+    verify(asyncClient, times(1)).stop();
+    verify(asyncNMClient, times(1)).stop();
+    verify(service, times(1)).onShutdown();
+    verify(metrics, times(1)).stop();
+  }
+
+  @Test
+  public void testAMShutdownThrowingExceptionOnRMCallback() throws IOException, YarnException {
+    // create mocks
+    YarnConfiguration yarnConfiguration = mock(YarnConfiguration.class);
+    SamzaAppMasterMetrics metrics = mock(SamzaAppMasterMetrics.class);
+    Config config = mock(Config.class);
+    AMRMClientAsync asyncClient = mock(AMRMClientAsync.class);
+    YarnAppState yarnAppState = new YarnAppState(0, mock(ContainerId.class), "host", 8080, 8081);
+    SamzaYarnAppMasterLifecycle lifecycle = Mockito.spy(new SamzaYarnAppMasterLifecycle(512, 2, mock(SamzaApplicationState.class), yarnAppState, asyncClient));
+    SamzaYarnAppMasterService service = mock(SamzaYarnAppMasterService.class);
+    NMClientAsync asyncNMClient = mock(NMClientAsync.class);
+    ClusterResourceManager.Callback callback = mock(ClusterResourceManager.Callback.class);
+
+    doThrow(InvalidApplicationMasterRequestException.class).when(asyncClient).unregisterApplicationMaster(FinalApplicationStatus.FAILED, null, null);
+
+    // start the cluster manager
+    YarnClusterResourceManager yarnClusterResourceManager =
+        new YarnClusterResourceManager(asyncClient, asyncNMClient, callback, yarnAppState, lifecycle, service, metrics,
+            yarnConfiguration, config);
+
+    yarnClusterResourceManager.onShutdownRequest();
+
+    verify(lifecycle, times(1)).onShutdown(SamzaApplicationState.SamzaAppStatus.FAILED);
+    verify(asyncClient, times(1)).unregisterApplicationMaster(FinalApplicationStatus.FAILED, null, null);
     verify(asyncClient, times(1)).stop();
     verify(asyncNMClient, times(1)).stop();
     verify(service, times(1)).onShutdown();

--- a/samza-yarn/src/test/java/org/apache/samza/job/yarn/TestYarnClusterResourceManager.java
+++ b/samza-yarn/src/test/java/org/apache/samza/job/yarn/TestYarnClusterResourceManager.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.yarn.client.api.async.AMRMClientAsync;
 import org.apache.hadoop.yarn.client.api.async.NMClientAsync;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.samza.clustermanager.ClusterResourceManager;
+import org.apache.samza.clustermanager.SamzaApplicationState;
 import org.apache.samza.clustermanager.SamzaResource;
 import org.apache.samza.config.Config;
 import org.junit.Assert;
@@ -107,7 +108,6 @@ public class TestYarnClusterResourceManager {
   @Test
   public void testAMShutdownOnRMCallback() {
     // create mocks
-    final int samzaContainerId = 1;
     YarnConfiguration yarnConfiguration = mock(YarnConfiguration.class);
     SamzaAppMasterMetrics metrics = mock(SamzaAppMasterMetrics.class);
     Config config = mock(Config.class);
@@ -124,7 +124,10 @@ public class TestYarnClusterResourceManager {
 
     yarnClusterResourceManager.onShutdownRequest();
 
+    verify(lifecycle, times(1)).onShutdown(SamzaApplicationState.SamzaAppStatus.FAILED);
     verify(asyncClient, times(1)).stop();
     verify(asyncNMClient, times(1)).stop();
+    verify(service, times(1)).onShutdown();
+    verify(metrics, times(1)).stop();
   }
 }


### PR DESCRIPTION
**Changes**: Modified the shutdown sequence inside YarnClusterResourceManager in order to bring down the AM when the NM on which it resides dies. This prevents the existence of orphaned AMs.
**API Changes**: None
**Tests**: Tested the change by manually bringing down the NM on which the AM resided with a yarn job deploy and LXC
**Upgrade Instructions**: None
**Usage Instructions**: None