### PR TITLE
SAMZA-2587: IntermediateMessageSerde exception handling

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/serializers/IntermediateMessageSerde.java
+++ b/samza-core/src/main/java/org/apache/samza/serializers/IntermediateMessageSerde.java
@@ -92,7 +92,7 @@ public class IntermediateMessageSerde implements Serde<Object> {
       // For these cases, we WILL NOT fall back to user-provided serde. Thus, we are not compatible with upgrade
       // directly from samza version older than 0.13.1.
       LOGGER.error("Error deserializing with intermediate message serde. If you are upgrading from samza version older"
-          + "than 0.13.1, please upgrade to samza 1.5 first.");
+          + " than 0.13.1, please upgrade to samza 1.5 first.");
       throw e;
     }
   }

--- a/samza-core/src/main/java/org/apache/samza/serializers/IntermediateMessageSerde.java
+++ b/samza-core/src/main/java/org/apache/samza/serializers/IntermediateMessageSerde.java
@@ -73,13 +73,14 @@ public class IntermediateMessageSerde implements Serde<Object> {
       } catch (ArrayIndexOutOfBoundsException e) {
         // The message type was introduced in samza 0.13.1. For samza 0.13.0 or older versions, the first byte of
         // MessageType doesn't exist in the bytes. Thus, upgrading from those versions will get this exception.
-        // There are two ways to solve this issue:
-        // a) Reset checkpoint or clean all messages for the intermediate topic
-        // b) Run the application in any version between 0.13.1 and 1.5 until all old messages in intermediate topic
+        // There are three ways to solve this issue:
+        // a) Reset checkpoint to consume from newest message in the intermediate stream
+        // b) clean all existing messages in the intermediate stream
+        // c) Run the application in any version between 0.13.1 and 1.5 until all old messages in intermediate stream
         // has reached retention time.
         throw new SamzaException("Error reading the message type from intermediate message. This may happen if you "
             + "have recently upgraded from samza version older than 0.13.1 or there are still old messages in the "
-            + "intermediate topic.", e);
+            + "intermediate stream.", e);
       }
       final byte[] data = Arrays.copyOfRange(bytes, 1, bytes.length);
       switch (type) {

--- a/samza-core/src/test/java/org/apache/samza/serializers/model/serializers/TestIntermediateMessageSerde.java
+++ b/samza-core/src/test/java/org/apache/samza/serializers/model/serializers/TestIntermediateMessageSerde.java
@@ -25,7 +25,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
-import org.apache.samza.SamzaException;
 import org.apache.samza.serializers.IntermediateMessageSerde;
 import org.apache.samza.serializers.Serde;
 import org.apache.samza.system.EndOfStreamMessage;

--- a/samza-core/src/test/java/org/apache/samza/serializers/model/serializers/TestIntermediateMessageSerde.java
+++ b/samza-core/src/test/java/org/apache/samza/serializers/model/serializers/TestIntermediateMessageSerde.java
@@ -24,7 +24,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import org.apache.samza.SamzaException;
 import org.apache.samza.serializers.IntermediateMessageSerde;
+import org.apache.samza.serializers.JsonSerdeV2;
 import org.apache.samza.serializers.Serde;
 import org.apache.samza.system.EndOfStreamMessage;
 import org.apache.samza.system.MessageType;
@@ -125,5 +127,15 @@ public class TestIntermediateMessageSerde {
     assertEquals(MessageType.of(de), MessageType.END_OF_STREAM);
     assertEquals(de.getTaskName(), taskName);
     assertEquals(de.getVersion(), 1);
+  }
+
+  @Test (expected = SamzaException.class)
+  public void testUserMessageSerdeException() {
+    IntermediateMessageSerde imserde = new IntermediateMessageSerde(new ObjectSerde());
+    IntermediateMessageSerde imserde2 = new IntermediateMessageSerde(new JsonSerdeV2<>());
+    String msg = "this is a test message";
+    TestUserMessage userMessage = new TestUserMessage(msg, 0, System.currentTimeMillis());
+    byte[] bytes = imserde.toBytes(userMessage);
+    imserde2.fromBytes(bytes);
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/serializers/model/serializers/TestIntermediateMessageSerde.java
+++ b/samza-core/src/test/java/org/apache/samza/serializers/model/serializers/TestIntermediateMessageSerde.java
@@ -133,7 +133,7 @@ public class TestIntermediateMessageSerde {
     assertEquals(de.getVersion(), 1);
   }
 
-  @Test(expected = SamzaException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void testUserMessageSerdeException() {
     Serde<?> mockUserMessageSerde = mock(Serde.class);
     when(mockUserMessageSerde.fromBytes(anyObject())).then(new Answer<Object>() {
@@ -141,10 +141,11 @@ public class TestIntermediateMessageSerde {
       public Object answer(InvocationOnMock invocation) throws Throwable {
         byte[] bytes = invocation.getArgumentAt(0, byte[].class);
         if (Arrays.equals(bytes, new byte[]{1, 2})) {
-          throw new SamzaException("User message serde failed to deserialize this message.");
+          throw new IllegalArgumentException("User message serde failed to deserialize this message.");
         } else {
-          throw new IllegalArgumentException(
-              "Intermediate message serde shouldn't try to deserialize user message with wrong bytes");
+          // Intermediate message serde shouldn't try to deserialize user message with wrong bytes
+          Assert.fail();
+          return null;
         }
       }
     });


### PR DESCRIPTION
Symptom: The user provided serde failed to deserialize a message. Then, IntermediateMessageSerde tried to deserialize the message for the second time, which caused OOM and container died.
 
Direct cause: The user provided serde would construct an array based on the encoded array size. Given wrong size, the serde constructed a huge array and caused OOM. The exception was hidden by OOM and it was hard to debug.

Root cause: In samza 0.13.1, we added a byte to the head of the payload. The byte represents the message type (event|watermark|EOS). During deserialization, IntermediateMessageSerde will read the first byte, then deserialize the message according to the message byte. For compatibility, if it fails to read the message type, it will try to deserialize again with all bytes (including the first byte). More details in this PR: https://github.com/apache/samza/pull/207
 
Changes: In the case when the type byte exists but user serde fails to deserialize the message, we shouldn't pass invalid data to user serde and try to deserialize again. The second deserialization may cause unpredictable results. Considering 0.13 is a very old version and intermediate streams usually have retention time, we should be safe to remove the second try. This will make upgrades from 0.13 to master to fail. Workaround is upgrading to 1.4/1.5 instead or resetting the checkpoint of intermediate topic to newest.
 
Tests: Added unit test: TestIntermediateMessageSerde.testUserMessageSerdeException()

Upgrade Instructions: For users that are upgrading directly from samza version 0.13.0 or older versions: A message type of intermediate messages was introduced in samza 0.13.1. For samza 0.13.0 or older versions, the first byte of MessageType doesn't exist in the bytes. Thus, upgrading from those versions will fail. There are three ways to fix this issue:
a) Reset checkpoint to consume from newest message in the intermediate stream
b) Clean all existing messages in the intermediate stream
c) Run the application in any version between 0.13.1 and 1.5 until all old messages in intermediate stream has reached retention time.