### PR TITLE
SAMZA-2588: Fix log4j2 StreamAppender output to emit String instead of Object

### DIFF
--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/serializers/LoggingEventJsonSerde.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/serializers/LoggingEventJsonSerde.java
@@ -114,7 +114,7 @@ public class LoggingEventJsonSerde implements Serde<LogEvent> {
     logstashEvent.put("@version", VERSION);
     logstashEvent.put("@timestamp", dateFormat(timestamp));
     logstashEvent.put("source_host", getHostname());
-    logstashEvent.put("message", loggingEvent.getMessage());
+    logstashEvent.put("message", loggingEvent.getMessage().getFormattedMessage());
 
     if (loggingEvent.getThrown() != null) {
       final Throwable throwableInformation = loggingEvent.getThrown();

--- a/samza-log4j2/src/test/java/org/apache/samza/logging/log4j2/TestStreamAppender.java
+++ b/samza-log4j2/src/test/java/org/apache/samza/logging/log4j2/TestStreamAppender.java
@@ -352,7 +352,7 @@ public class TestStreamAppender {
   }
 
   private String asJsonMessageSegment(String message) {
-    return String.format("\"formatted-message\":\"%s\"", message);
+    return String.format("\"message\":\"%s\"", message);
   }
 
   private void removeAllAppenders() {


### PR DESCRIPTION
Issues: Currently, the log4j2 StreamAppender emits the log message as an Object instead of a String
Changes: Extracted the logging message as a String from the LoggingEvent instead of Object
Upgrade instructions: None
Usage instructions: None
Tests: Modified existing tests to work with this change. Also tested with a test job and checked the result on ELK.