### PR TITLE
SAMZA-2589: Consolidate Beam and High/Low Samza Apps launch workflow

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -36,7 +36,7 @@
   jerseyVersion = "2.22.1"
   jettyVersion = "9.4.20.v20190813"
   jodaTimeVersion = "2.2"
-  joptSimpleVersion = "3.2"
+  joptSimpleVersion = "5.0.4"
   junitVersion = "4.12"
   kafkaVersion = "2.0.1"
   log4jVersion = "1.2.17"

--- a/samza-core/src/main/java/org/apache/samza/clustermanager/DefaultApplicationMain.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/DefaultApplicationMain.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.clustermanager;
+
+import com.google.common.annotations.VisibleForTesting;
+import joptsimple.OptionSet;
+import org.apache.samza.application.ApplicationUtil;
+import org.apache.samza.config.Config;
+import org.apache.samza.runtime.ApplicationRunnerMain;
+import org.apache.samza.util.ConfigUtil;
+
+
+public class DefaultApplicationMain {
+
+  public static void main(String[] args) {
+    run(args);
+  }
+
+  @VisibleForTesting
+  static void run(String[] args) {
+    // This branch is ONLY for Yarn deployments, standalone apps uses offspring
+    final ApplicationRunnerMain.ApplicationRunnerCommandLine cmdLine = new ApplicationRunnerMain.ApplicationRunnerCommandLine();
+    cmdLine.parser().allowsUnrecognizedOptions();
+
+    final OptionSet options = cmdLine.parser().parse(args);
+    // load full job config with ConfigLoader
+    final Config originalConfig = ConfigUtil.loadConfig(cmdLine.loadConfig(options));
+
+    JobCoordinatorLaunchUtil.run(ApplicationUtil.fromConfig(originalConfig), originalConfig);
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/config/ApplicationConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ApplicationConfig.java
@@ -19,6 +19,7 @@
 package org.apache.samza.config;
 
 import java.util.Optional;
+import org.apache.samza.clustermanager.DefaultApplicationMain;
 import org.apache.samza.runtime.UUIDGenerator;
 
 
@@ -104,8 +105,8 @@ public class ApplicationConfig extends MapConfig {
     return Optional.ofNullable(get(APP_MAIN_ARGS));
   }
 
-  public Optional<String> getAppMainClass() {
-    return Optional.ofNullable(get(APP_MAIN_CLASS));
+  public String getAppMainClass() {
+    return get(APP_MAIN_CLASS, DefaultApplicationMain.class.getName());
   }
 
 }

--- a/samza-core/src/main/java/org/apache/samza/config/ApplicationConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ApplicationConfig.java
@@ -18,7 +18,6 @@
  */
 package org.apache.samza.config;
 
-import java.util.Optional;
 import org.apache.samza.clustermanager.DefaultApplicationMain;
 import org.apache.samza.runtime.UUIDGenerator;
 
@@ -99,10 +98,6 @@ public class ApplicationConfig extends MapConfig {
 
   public ApplicationMode getAppMode() {
     return ApplicationMode.valueOf(get(APP_MODE, ApplicationMode.STREAM.name()).toUpperCase());
-  }
-
-  public Optional<String> getAppMainArgs() {
-    return Optional.ofNullable(get(APP_MAIN_ARGS));
   }
 
   public String getAppMainClass() {

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestDefaultApplicationMain.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestDefaultApplicationMain.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.clustermanager;
+
+import org.apache.samza.application.ApplicationUtil;
+import org.apache.samza.application.StreamApplication;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.JobConfig;
+import org.apache.samza.config.loaders.PropertiesConfigLoaderFactory;
+import org.apache.samza.util.ConfigUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.powermock.api.mockito.PowerMockito.doNothing;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({
+    ApplicationUtil.class,
+    ConfigUtil.class,
+    JobCoordinatorLaunchUtil.class,
+    ClusterBasedJobCoordinatorRunner.class})
+public class TestDefaultApplicationMain {
+
+  @Test
+  public void testRun() throws Exception {
+    String[] args = new String[] {
+        "--config",
+        JobConfig.CONFIG_LOADER_FACTORY + "=" + PropertiesConfigLoaderFactory.class.getName(),
+        "--config",
+        PropertiesConfigLoaderFactory.CONFIG_LOADER_PROPERTIES_PREFIX + "path=" + getClass().getResource("/test.properties").getPath()
+    };
+
+    StreamApplication mockApplication = mock(StreamApplication.class);
+    Config mockConfig = mock(Config.class);
+    mockStatic(JobCoordinatorLaunchUtil.class, ApplicationUtil.class, ConfigUtil.class);
+
+    when(ApplicationUtil.fromConfig(any()))
+        .thenReturn(mockApplication);
+    when(ConfigUtil.loadConfig(any()))
+        .thenReturn(mockConfig);
+    doNothing()
+        .when(JobCoordinatorLaunchUtil.class, "run",
+            mockApplication, mockConfig);
+    DefaultApplicationMain.run(args);
+
+    verifyStatic(times(1));
+    JobCoordinatorLaunchUtil.run(mockApplication, mockConfig);
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestDefaultApplicationMain.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestDefaultApplicationMain.java
@@ -26,13 +26,10 @@ import org.apache.samza.config.loaders.PropertiesConfigLoaderFactory;
 import org.apache.samza.util.ConfigUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.mock;


### PR DESCRIPTION
Issues: app.main.class is only set for Beam apps which causes different workflow on AM when launching a job.
Changes:
1. Introduce DefaultApplicationMain to capture launch workflow for High/Low level jobs so on AM, all jobs are launched in the same way: ClusterBasedJobCoordinatorRunner#main -> app.main.class -> JobCoordinatorLaunchUtil
2. Update ApplicationConfig#getAppMainClass to default to DefaultApplicationMain

Tests:
1. Unit Tests
2. Deployed hello samza job successfully with the change following instructions on http://samza.apache.org/startup/hello-samza/latest/

API Changes: None
Upgrade Instructions: None
Usage Instructions: None