### PR TITLE
Adding internal table-api config for table-api rate limits

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
+++ b/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
@@ -70,7 +70,9 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
   public static final String READ_FN = "io.read.func";
   public static final String WRITE_FN = "io.write.func";
   public static final String RATE_LIMITER = "io.ratelimiter";
+  //Key name for table api read rate limit
   public static final String READ_CREDITS = "io.read.credits";
+  //Key name for table api write rate limit
   public static final String WRITE_CREDITS = "io.write.credits";
   public static final String READ_CREDIT_FN = "io.read.credit.func";
   public static final String WRITE_CREDIT_FN = "io.write.credit.func";

--- a/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
@@ -76,7 +76,8 @@ public class TestRemoteTableDescriptor {
 
   private void doTestSerialize(RateLimiter rateLimiter, CreditFunction readCredFn, CreditFunction writeCredFn) {
     String tableId = "1";
-    RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId).withReadFunction(createMockTableReadFunction())
+    RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId)
+        .withReadFunction(createMockTableReadFunction())
         .withWriteFunction(createMockTableWriteFunction());
     if (rateLimiter != null) {
       desc.withRateLimiter(rateLimiter, readCredFn, writeCredFn);
@@ -157,10 +158,9 @@ public class TestRemoteTableDescriptor {
   @Test
   public void testSerializeNullWriteFunction() {
     String tableId = "1";
-    RemoteTableDescriptor desc =
-        new RemoteTableDescriptor(tableId)
-            .withReadFunction(createMockTableReadFunction())
-            .withRateLimiterDisabled();
+    RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId)
+        .withReadFunction(createMockTableReadFunction())
+        .withRateLimiterDisabled();
     Map<String, String> tableConfig = desc.toConfig(new MapConfig());
     assertExists(RemoteTableDescriptor.READ_FN, tableId, tableConfig);
     assertEquals(null, RemoteTableDescriptor.WRITE_FN, tableId, tableConfig);
@@ -186,11 +186,10 @@ public class TestRemoteTableDescriptor {
   public void testTablePartToConfigDefault() {
     TableReadFunction readFn = createMockTableReadFunction();
     when(readFn.toConfig(any(), any())).thenReturn(createConfigPair(1));
-    Map<String, String> tableConfig =
-        new RemoteTableDescriptor("1")
-            .withReadFunction(readFn)
-            .withReadRateLimit(100)
-            .toConfig(new MapConfig());
+    Map<String, String> tableConfig = new RemoteTableDescriptor("1")
+        .withReadFunction(readFn)
+        .withReadRateLimit(100)
+        .toConfig(new MapConfig());
     verify(readFn, times(1)).toConfig(any(), any());
     Assert.assertEquals("v1", tableConfig.get("tables.1.io.read.func.k1"));
   }

--- a/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
@@ -76,8 +76,7 @@ public class TestRemoteTableDescriptor {
 
   private void doTestSerialize(RateLimiter rateLimiter, CreditFunction readCredFn, CreditFunction writeCredFn) {
     String tableId = "1";
-    RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId)
-        .withReadFunction(createMockTableReadFunction())
+    RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId).withReadFunction(createMockTableReadFunction())
         .withWriteFunction(createMockTableWriteFunction());
     if (rateLimiter != null) {
       desc.withRateLimiter(rateLimiter, readCredFn, writeCredFn);
@@ -103,16 +102,14 @@ public class TestRemoteTableDescriptor {
   public void testValidateOnlyReadOrWriteFn() {
     // Only read defined
     String tableId = "1";
-    RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId)
-        .withReadFunction(createMockTableReadFunction())
+    RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId).withReadFunction(createMockTableReadFunction())
         .withReadRateLimiterDisabled();
     Map<String, String> tableConfig = desc.toConfig(new MapConfig());
     Assert.assertNotNull(tableConfig);
 
     // Only write defined
     String tableId2 = "2";
-    RemoteTableDescriptor desc2 = new RemoteTableDescriptor(tableId2)
-        .withWriteFunction(createMockTableWriteFunction())
+    RemoteTableDescriptor desc2 = new RemoteTableDescriptor(tableId2).withWriteFunction(createMockTableWriteFunction())
         .withWriteRateLimiterDisabled();
     tableConfig = desc2.toConfig(new MapConfig());
     Assert.assertNotNull(tableConfig);
@@ -128,7 +125,6 @@ public class TestRemoteTableDescriptor {
       Assert.assertTrue(e.getMessage().contains("Must have one of TableReadFunction or TableWriteFunction"));
     }
   }
-
 
   @Test
   public void testSerializeSimple() {
@@ -158,9 +154,8 @@ public class TestRemoteTableDescriptor {
   @Test
   public void testSerializeNullWriteFunction() {
     String tableId = "1";
-    RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId)
-        .withReadFunction(createMockTableReadFunction())
-        .withRateLimiterDisabled();
+    RemoteTableDescriptor desc =
+        new RemoteTableDescriptor(tableId).withReadFunction(createMockTableReadFunction()).withRateLimiterDisabled();
     Map<String, String> tableConfig = desc.toConfig(new MapConfig());
     assertExists(RemoteTableDescriptor.READ_FN, tableId, tableConfig);
     assertEquals(null, RemoteTableDescriptor.WRITE_FN, tableId, tableConfig);
@@ -186,10 +181,8 @@ public class TestRemoteTableDescriptor {
   public void testTablePartToConfigDefault() {
     TableReadFunction readFn = createMockTableReadFunction();
     when(readFn.toConfig(any(), any())).thenReturn(createConfigPair(1));
-    Map<String, String> tableConfig = new RemoteTableDescriptor("1")
-        .withReadFunction(readFn)
-        .withReadRateLimit(100)
-        .toConfig(new MapConfig());
+    Map<String, String> tableConfig =
+        new RemoteTableDescriptor("1").withReadFunction(readFn).withReadRateLimit(100).toConfig(new MapConfig());
     verify(readFn, times(1)).toConfig(any(), any());
     Assert.assertEquals("v1", tableConfig.get("tables.1.io.read.func.k1"));
   }
@@ -254,6 +247,17 @@ public class TestRemoteTableDescriptor {
         "{\"exponentialFactor\":0.0,\"backoffType\":\"NONE\",\"retryPredicate\":{}}");
   }
 
+  @Test
+  public void testReadWriteRateLimitToConfig() {
+    Map<String, String> tableConfig = new RemoteTableDescriptor("1").withReadFunction(createMockTableReadFunction())
+        .withReadRetryPolicy(new TableRetryPolicy())
+        .withWriteRateLimit(1000)
+        .withReadRateLimit(2000)
+        .toConfig(new MapConfig());
+    Assert.assertEquals(String.valueOf(2000), tableConfig.get("tables.1.io.read.ratelimit"));
+    Assert.assertEquals(String.valueOf(1000), tableConfig.get("tables.1.io.write.ratelimit"));
+  }
+
   private Context createMockContext(TableDescriptor tableDescriptor) {
     Context context = mock(Context.class);
 
@@ -294,7 +298,7 @@ public class TestRemoteTableDescriptor {
     int numCalls = 0;
 
     @Override
-    public int getCredits(K key, V value, Object ... args) {
+    public int getCredits(K key, V value, Object... args) {
       numCalls++;
       return 1;
     }
@@ -302,11 +306,11 @@ public class TestRemoteTableDescriptor {
 
   private void doTestDeserializeReadFunctionAndLimiter(boolean rateOnly, boolean rlGets, boolean rlPuts) {
     int numRateLimitOps = (rlGets ? 1 : 0) + (rlPuts ? 1 : 0);
-    RemoteTableDescriptor<String, String> desc = new RemoteTableDescriptor("1")
-        .withReadFunction(createMockTableReadFunction())
-        .withReadRetryPolicy(new TableRetryPolicy().withRetryPredicate((ex) -> false))
-        .withWriteFunction(createMockTableWriteFunction())
-        .withAsyncCallbackExecutorPoolSize(10);
+    RemoteTableDescriptor<String, String> desc =
+        new RemoteTableDescriptor("1").withReadFunction(createMockTableReadFunction())
+            .withReadRetryPolicy(new TableRetryPolicy().withRetryPredicate((ex) -> false))
+            .withWriteFunction(createMockTableWriteFunction())
+            .withAsyncCallbackExecutorPoolSize(10);
 
     if (rateOnly) {
       if (rlGets) {

--- a/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
@@ -102,14 +102,16 @@ public class TestRemoteTableDescriptor {
   public void testValidateOnlyReadOrWriteFn() {
     // Only read defined
     String tableId = "1";
-    RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId).withReadFunction(createMockTableReadFunction())
+    RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId)
+        .withReadFunction(createMockTableReadFunction())
         .withReadRateLimiterDisabled();
     Map<String, String> tableConfig = desc.toConfig(new MapConfig());
     Assert.assertNotNull(tableConfig);
 
     // Only write defined
     String tableId2 = "2";
-    RemoteTableDescriptor desc2 = new RemoteTableDescriptor(tableId2).withWriteFunction(createMockTableWriteFunction())
+    RemoteTableDescriptor desc2 = new RemoteTableDescriptor(tableId2)
+        .withWriteFunction(createMockTableWriteFunction())
         .withWriteRateLimiterDisabled();
     tableConfig = desc2.toConfig(new MapConfig());
     Assert.assertNotNull(tableConfig);
@@ -125,6 +127,7 @@ public class TestRemoteTableDescriptor {
       Assert.assertTrue(e.getMessage().contains("Must have one of TableReadFunction or TableWriteFunction"));
     }
   }
+
 
   @Test
   public void testSerializeSimple() {
@@ -155,7 +158,9 @@ public class TestRemoteTableDescriptor {
   public void testSerializeNullWriteFunction() {
     String tableId = "1";
     RemoteTableDescriptor desc =
-        new RemoteTableDescriptor(tableId).withReadFunction(createMockTableReadFunction()).withRateLimiterDisabled();
+        new RemoteTableDescriptor(tableId)
+            .withReadFunction(createMockTableReadFunction())
+            .withRateLimiterDisabled();
     Map<String, String> tableConfig = desc.toConfig(new MapConfig());
     assertExists(RemoteTableDescriptor.READ_FN, tableId, tableConfig);
     assertEquals(null, RemoteTableDescriptor.WRITE_FN, tableId, tableConfig);
@@ -182,7 +187,10 @@ public class TestRemoteTableDescriptor {
     TableReadFunction readFn = createMockTableReadFunction();
     when(readFn.toConfig(any(), any())).thenReturn(createConfigPair(1));
     Map<String, String> tableConfig =
-        new RemoteTableDescriptor("1").withReadFunction(readFn).withReadRateLimit(100).toConfig(new MapConfig());
+        new RemoteTableDescriptor("1")
+            .withReadFunction(readFn)
+            .withReadRateLimit(100)
+            .toConfig(new MapConfig());
     verify(readFn, times(1)).toConfig(any(), any());
     Assert.assertEquals("v1", tableConfig.get("tables.1.io.read.func.k1"));
   }
@@ -254,8 +262,8 @@ public class TestRemoteTableDescriptor {
         .withWriteRateLimit(1000)
         .withReadRateLimit(2000)
         .toConfig(new MapConfig());
-    Assert.assertEquals(String.valueOf(2000), tableConfig.get("tables.1.io.read.ratelimit"));
-    Assert.assertEquals(String.valueOf(1000), tableConfig.get("tables.1.io.write.ratelimit"));
+    Assert.assertEquals(String.valueOf(2000), tableConfig.get("tables.1.io.read.credits"));
+    Assert.assertEquals(String.valueOf(1000), tableConfig.get("tables.1.io.write.credits"));
   }
 
   private Context createMockContext(TableDescriptor tableDescriptor) {
@@ -298,7 +306,7 @@ public class TestRemoteTableDescriptor {
     int numCalls = 0;
 
     @Override
-    public int getCredits(K key, V value, Object... args) {
+    public int getCredits(K key, V value, Object ... args) {
       numCalls++;
       return 1;
     }
@@ -306,11 +314,11 @@ public class TestRemoteTableDescriptor {
 
   private void doTestDeserializeReadFunctionAndLimiter(boolean rateOnly, boolean rlGets, boolean rlPuts) {
     int numRateLimitOps = (rlGets ? 1 : 0) + (rlPuts ? 1 : 0);
-    RemoteTableDescriptor<String, String> desc =
-        new RemoteTableDescriptor("1").withReadFunction(createMockTableReadFunction())
-            .withReadRetryPolicy(new TableRetryPolicy().withRetryPredicate((ex) -> false))
-            .withWriteFunction(createMockTableWriteFunction())
-            .withAsyncCallbackExecutorPoolSize(10);
+    RemoteTableDescriptor<String, String> desc = new RemoteTableDescriptor("1")
+        .withReadFunction(createMockTableReadFunction())
+        .withReadRetryPolicy(new TableRetryPolicy().withRetryPredicate((ex) -> false))
+        .withWriteFunction(createMockTableWriteFunction())
+        .withAsyncCallbackExecutorPoolSize(10);
 
     if (rateOnly) {
       if (rlGets) {


### PR DESCRIPTION
Issues: currently the table api read/write rate limit is not emitted by samza

Changes:
1. Emit table API read/write rate limit in RemoteTableDescriptor. The names of the new metrics are:
  **tables.table-id.io.read.credits** and **tables.table-io.write.credits**

Tests:
1. Unit Tests

API Changes: None
Upgrade Instructions: None
Usage Instructions: None