### PR TITLE
SAMZA-2592: Add support for handling stop failures for container kill commands

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerManager.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerManager.java
@@ -210,9 +210,13 @@ public class ContainerManager {
         updateContainerPlacementActionStatus(metadata, ContainerPlacementMessage.StatusCode.SUCCEEDED,
             String.format("Successfully stopped the container %s on host %s, falling back to normal restart path",
                 processorId, metadata.getSourceHost()));
-        containerAllocator.requestResourceWithDelay(processorId, preferredHost, preferredHostRetryDelay);
+      } else {
+        // In this case ContainerManager will handle the next step from Allocator
+        return;
       }
-    } else if (standbyContainerManager.isPresent()) {
+    }
+
+    if (standbyContainerManager.isPresent()) {
       standbyContainerManager.get()
           .handleContainerStop(processorId, containerId, preferredHost, exitStatus, containerAllocator,
               preferredHostRetryDelay);


### PR DESCRIPTION
BUG: Currently container placement kill command reports success even then stop container fails because onStreamProcessorStopFailure is not handled by ContainerManager for Container placement kill command only

Changes:  Kill command for container placements (when destinationHost as "FORCE_RESTART_LAST_SEEN") does not handle callbacks for onStreamProcessorStopFailure that is when a container is failed to be stopped by the underlying cluster manager

We handle two cases for kill with this patch
- If the container stop is successful, JobCoordinator will report success and container falls back to normal restart path
- if the container stop is failed, JobCoordinator will report error and container is left untouced 

NOTE: this does not apply to other commands only a known issue when kill is issued  

API Changes: None

Tests: Tested the change with a yarn job deploy

Upgrade Instructions: None

Usage Instructions: None