### PR TITLE
SAMZA-2593: Update task callback to store only necessary fields instead of the message envelope

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
+++ b/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
@@ -621,16 +621,17 @@ public class RunLoop implements Runnable, Throttleable {
             TaskCallbackImpl callbackImpl = (TaskCallbackImpl) callback;
             containerMetrics.processNs().update(clock.nanoTime() - callbackImpl.getTimeCreatedNs());
             log.trace("Got callback complete for task {}, ssp {}",
-                callbackImpl.getTaskName(), callbackImpl.getEnvelope().getSystemStreamPartition());
+                callbackImpl.getTaskName(), callbackImpl.getSystemStreamPartition());
 
             List<TaskCallbackImpl> callbacksToUpdate = callbackManager.updateCallback(callbackImpl);
             for (TaskCallbackImpl callbackToUpdate : callbacksToUpdate) {
-              IncomingMessageEnvelope envelope = callbackToUpdate.getEnvelope();
-              log.trace("Update offset for ssp {}, offset {}", envelope.getSystemStreamPartition(), envelope.getOffset());
+              log.trace("Update offset for ssp {}, offset {}", callbackToUpdate.getSystemStreamPartition(),
+                  callbackToUpdate.getOffset());
 
               // update offset
               if (task.offsetManager() != null) {
-                task.offsetManager().update(task.taskName(), envelope.getSystemStreamPartition(), envelope.getOffset());
+                task.offsetManager().update(task.taskName(), callbackToUpdate.getSystemStreamPartition(),
+                    callbackToUpdate.getOffset());
               }
 
               // update coordinator

--- a/samza-core/src/main/java/org/apache/samza/task/TaskCallbackImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/task/TaskCallbackImpl.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.samza.SamzaException;
 import org.apache.samza.container.TaskName;
 import org.apache.samza.system.IncomingMessageEnvelope;
+import org.apache.samza.system.SystemStreamPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,13 +39,16 @@ public class TaskCallbackImpl implements TaskCallback, Comparable<TaskCallbackIm
   private static final Logger log = LoggerFactory.getLogger(TaskCallbackImpl.class);
 
   final TaskName taskName;
-  final IncomingMessageEnvelope envelope;
   final ReadableCoordinator coordinator;
   final long timeCreatedNs;
+
   private final AtomicBoolean isComplete = new AtomicBoolean(false);
-  private final TaskCallbackListener listener;
-  private ScheduledFuture scheduledFuture = null;
   private final long seqNum;
+  private final TaskCallbackListener listener;
+  private final String offset;
+  private final SystemStreamPartition systemStreamPartition;
+
+  private ScheduledFuture scheduledFuture = null;
 
   public TaskCallbackImpl(TaskCallbackListener listener,
       TaskName taskName,
@@ -54,7 +58,8 @@ public class TaskCallbackImpl implements TaskCallback, Comparable<TaskCallbackIm
       long timeCreatedNs) {
     this.listener = listener;
     this.taskName = taskName;
-    this.envelope = envelope;
+    this.offset = envelope.getOffset();
+    this.systemStreamPartition = envelope.getSystemStreamPartition();
     this.coordinator = coordinator;
     this.seqNum = seqNum;
     this.timeCreatedNs = timeCreatedNs;
@@ -64,8 +69,12 @@ public class TaskCallbackImpl implements TaskCallback, Comparable<TaskCallbackIm
     return taskName;
   }
 
-  public IncomingMessageEnvelope getEnvelope() {
-    return envelope;
+  public String getOffset() {
+    return offset;
+  }
+  
+  public SystemStreamPartition getSystemStreamPartition() {
+    return systemStreamPartition;
   }
 
   public ReadableCoordinator getCoordinator() {
@@ -82,13 +91,13 @@ public class TaskCallbackImpl implements TaskCallback, Comparable<TaskCallbackIm
       scheduledFuture.cancel(true);
     }
     log.trace("Callback complete for task {}, ssp {}, offset {}.",
-        new Object[] {taskName, envelope.getSystemStreamPartition(), envelope.getOffset()});
+        new Object[] {taskName, systemStreamPartition, offset});
 
     if (isComplete.compareAndSet(false, true)) {
       listener.onComplete(this);
     } else {
       String msg = String.format("Callback complete was invoked after completion for task %s, ssp %s, offset %s.",
-          taskName, envelope.getSystemStreamPartition(), envelope.getOffset());
+          taskName, systemStreamPartition, offset);
       listener.onFailure(this, new IllegalStateException(msg));
     }
   }
@@ -101,11 +110,11 @@ public class TaskCallbackImpl implements TaskCallback, Comparable<TaskCallbackIm
 
     if (isComplete.compareAndSet(false, true)) {
       String msg = String.format("Callback failed for task %s, ssp %s, offset %s.",
-          taskName, envelope.getSystemStreamPartition(), envelope.getOffset());
+          taskName, systemStreamPartition, offset);
       listener.onFailure(this, new SamzaException(msg, t));
     } else {
       String msg = String.format("Task callback failure was invoked after completion for task %s, ssp %s, offset %s.",
-          taskName, envelope.getSystemStreamPartition(), envelope.getOffset());
+          taskName, systemStreamPartition, offset);
       listener.onFailure(this, new IllegalStateException(msg, t));
     }
   }

--- a/samza-core/src/main/java/org/apache/samza/task/TaskCallbackImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/task/TaskCallbackImpl.java
@@ -19,6 +19,7 @@
 
 package org.apache.samza.task;
 
+import com.google.common.base.Preconditions;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -56,6 +57,7 @@ public class TaskCallbackImpl implements TaskCallback, Comparable<TaskCallbackIm
       ReadableCoordinator coordinator,
       long seqNum,
       long timeCreatedNs) {
+    Preconditions.checkNotNull(envelope, "Incoming message envelope cannot be null");
     this.listener = listener;
     this.taskName = taskName;
     this.offset = envelope.getOffset();
@@ -72,7 +74,7 @@ public class TaskCallbackImpl implements TaskCallback, Comparable<TaskCallbackIm
   public String getOffset() {
     return offset;
   }
-  
+
   public SystemStreamPartition getSystemStreamPartition() {
     return systemStreamPartition;
   }

--- a/samza-core/src/test/java/org/apache/samza/task/TestTaskCallbackManager.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestTaskCallbackManager.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 
 public class TestTaskCallbackManager {

--- a/samza-core/src/test/java/org/apache/samza/task/TestTaskCallbackManager.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestTaskCallbackManager.java
@@ -71,8 +71,8 @@ public class TestTaskCallbackManager {
     assertEquals(1, callbacksToUpdate.size());
     TaskCallbackImpl callback = callbacksToUpdate.get(0);
     assertTrue(callback.matchSeqNum(0));
-    assertEquals(ssp, callback.envelope.getSystemStreamPartition());
-    assertEquals("0", callback.envelope.getOffset());
+    assertEquals(ssp, callback.getSystemStreamPartition());
+    assertEquals("0", callback.getOffset());
 
     IncomingMessageEnvelope envelope1 = new IncomingMessageEnvelope(ssp, "1", null, null);
     TaskCallbackImpl callback1 = new TaskCallbackImpl(listener, taskName, envelope1, coordinator, 1, 0);
@@ -80,8 +80,8 @@ public class TestTaskCallbackManager {
     assertEquals(1, callbacksToUpdate.size());
     callback = callbacksToUpdate.get(0);
     assertTrue(callback.matchSeqNum(1));
-    assertEquals(ssp, callback.envelope.getSystemStreamPartition());
-    assertEquals("1", callback.envelope.getOffset());
+    assertEquals(ssp, callback.getSystemStreamPartition());
+    assertEquals("1", callback.getOffset());
   }
 
   @Test
@@ -107,18 +107,18 @@ public class TestTaskCallbackManager {
     assertEquals(3, callbacksToUpdate.size());
     TaskCallbackImpl callback = callbacksToUpdate.get(0);
     assertTrue(callback.matchSeqNum(0));
-    assertEquals(ssp, callback.envelope.getSystemStreamPartition());
-    assertEquals("0", callback.envelope.getOffset());
+    assertEquals(ssp, callback.getSystemStreamPartition());
+    assertEquals("0", callback.getOffset());
 
     callback = callbacksToUpdate.get(1);
     assertTrue(callback.matchSeqNum(1));
-    assertEquals(ssp, callback.envelope.getSystemStreamPartition());
-    assertEquals("1", callback.envelope.getOffset());
+    assertEquals(ssp, callback.getSystemStreamPartition());
+    assertEquals("1", callback.getOffset());
 
     callback = callbacksToUpdate.get(2);
     assertTrue(callback.matchSeqNum(2));
-    assertEquals(ssp, callback.envelope.getSystemStreamPartition());
-    assertEquals("2", callback.envelope.getOffset());
+    assertEquals(ssp, callback.getSystemStreamPartition());
+    assertEquals("2", callback.getOffset());
   }
 
   @Test
@@ -150,14 +150,14 @@ public class TestTaskCallbackManager {
     //Check for envelope0
     TaskCallbackImpl taskCallback = callbacksToUpdate.get(0);
     assertTrue(taskCallback.matchSeqNum(0));
-    assertEquals(ssp, taskCallback.envelope.getSystemStreamPartition());
-    assertEquals("0", taskCallback.envelope.getOffset());
+    assertEquals(ssp, taskCallback.getSystemStreamPartition());
+    assertEquals("0", taskCallback.getOffset());
 
     //Check for envelope1
     taskCallback = callbacksToUpdate.get(1);
     assertTrue(taskCallback.matchSeqNum(1));
-    assertEquals(ssp, taskCallback.envelope.getSystemStreamPartition());
-    assertEquals("1", taskCallback.envelope.getOffset());
+    assertEquals(ssp, taskCallback.getSystemStreamPartition());
+    assertEquals("1", taskCallback.getOffset());
   }
 
   @Test
@@ -199,12 +199,12 @@ public class TestTaskCallbackManager {
     assertEquals(2, callbacksToUpdate.size());
     TaskCallbackImpl callback = callbacksToUpdate.get(0);
     assertTrue(callback.matchSeqNum(0));
-    assertEquals(envelope0.getSystemStreamPartition(), callback.envelope.getSystemStreamPartition());
-    assertEquals(envelope0.getOffset(), callback.envelope.getOffset());
+    assertEquals(envelope0.getSystemStreamPartition(), callback.getSystemStreamPartition());
+    assertEquals(envelope0.getOffset(), callback.getOffset());
 
     callback = callbacksToUpdate.get(1);
     assertTrue(callback.matchSeqNum(1));
-    assertEquals(envelope1.getSystemStreamPartition(), callback.envelope.getSystemStreamPartition());
-    assertEquals(envelope1.getOffset(), callback.envelope.getOffset());
+    assertEquals(envelope1.getSystemStreamPartition(), callback.getSystemStreamPartition());
+    assertEquals(envelope1.getOffset(), callback.getOffset());
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/task/TestTaskCallbackManager.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestTaskCallbackManager.java
@@ -31,6 +31,8 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
 
 public class TestTaskCallbackManager {
   TaskCallbackManager callbackManager = null;
@@ -52,10 +54,10 @@ public class TestTaskCallbackManager {
 
   @Test
   public void testCreateCallback() {
-    TaskCallbackImpl callback = callbackManager.createCallback(new TaskName("Partition 0"), null, null);
+    TaskCallbackImpl callback = callbackManager.createCallback(new TaskName("Partition 0"), mock(IncomingMessageEnvelope.class), null);
     assertTrue(callback.matchSeqNum(0));
 
-    callback = callbackManager.createCallback(new TaskName("Partition 0"), null, null);
+    callback = callbackManager.createCallback(new TaskName("Partition 0"), mock(IncomingMessageEnvelope.class), null);
     assertTrue(callback.matchSeqNum(1));
   }
 


### PR DESCRIPTION
**Problem**: TaskCallbackImpl currently stores the entire message envelope. In case of jobs that have 1000s of pending callbacks, this adds up to significant memory pressure. The only use for message envelope is to trace the SSP information and the offset associated with it so that we commit the right offset during our commit cycle.

![image](https://user-images.githubusercontent.com/46942335/94072332-4e691a80-fdaa-11ea-8e5b-556c586da838.png)

**Changes**: Modify TaskCallbackImpl to only store SSP and Offset information.
**API Changes**: None
**Tests**: None
**Upgrade Instructions**: None
**Usage Instructions**: None