### PR TITLE
SAMZA-2596: Replace String.format() calls to avoid MissingFormatArgumentException

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/table/caching/CachingTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/caching/CachingTable.java
@@ -194,7 +194,7 @@ public class CachingTable<K, V> extends BaseReadWriteTable<K, V>
     long startNs = clock.nanoTime();
     return table.putAsync(key, value, args).handle((result, e) -> {
       if (e != null) {
-        throw new SamzaException(String.format("Failed to put a record, key=%s, value=%s", key, value), e);
+        throw new SamzaException("Failed to put a record, key=" + key + ", value=" + value, e);
       } else if (!isWriteAround) {
         if (value == null) {
           cache.delete(key, args);

--- a/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTable.java
@@ -196,7 +196,7 @@ public final class RemoteTable<K, V> extends BaseReadWriteTable<K, V>
   public CompletableFuture<Map<K, V>> getAllAsync(List<K> keys, Object ... args) {
     Preconditions.checkNotNull(keys, "null keys");
     if (keys.isEmpty()) {
-      return CompletableFuture.completedFuture(Collections.EMPTY_MAP);
+      return CompletableFuture.completedFuture(Collections.emptyMap());
     }
     return instrument(() -> asyncTable.getAllAsync(keys, args), metrics.numGetAlls, metrics.getAllNs)
         .handle((result, e) -> {
@@ -219,7 +219,7 @@ public final class RemoteTable<K, V> extends BaseReadWriteTable<K, V>
 
   @Override
   public <T> CompletableFuture<T> readAsync(int opId, Object ... args) {
-    return (CompletableFuture<T>) instrument(() -> asyncTable.readAsync(opId, args), metrics.numReads, metrics.readNs)
+    return instrument(() -> asyncTable.<T>readAsync(opId, args), metrics.numReads, metrics.readNs)
         .exceptionally(e -> {
           throw new SamzaException(String.format("Failed to read, opId=%d", opId), e);
         });
@@ -244,7 +244,7 @@ public final class RemoteTable<K, V> extends BaseReadWriteTable<K, V>
 
     return instrument(() -> asyncTable.putAsync(key, value, args), metrics.numPuts, metrics.putNs)
         .exceptionally(e -> {
-          throw new SamzaException("Failed to put a record with key=" + key, (Throwable) e);
+          throw new SamzaException("Failed to put a record with key=" + key, e);
         });
   }
 
@@ -282,7 +282,7 @@ public final class RemoteTable<K, V> extends BaseReadWriteTable<K, V>
         instrument(() -> asyncTable.putAllAsync(putRecords, args), metrics.numPutAlls, metrics.putAllNs))
         .exceptionally(e -> {
           String strKeys = records.stream().map(r -> r.getKey().toString()).collect(Collectors.joining(","));
-          throw new SamzaException(String.format("Failed to put records with keys=" + strKeys), e);
+          throw new SamzaException("Failed to put records with keys=" + strKeys, e);
         });
   }
 
@@ -301,7 +301,7 @@ public final class RemoteTable<K, V> extends BaseReadWriteTable<K, V>
     Preconditions.checkNotNull(key, "null key");
     return instrument(() -> asyncTable.deleteAsync(key, args), metrics.numDeletes, metrics.deleteNs)
         .exceptionally(e -> {
-          throw new SamzaException(String.format("Failed to delete the record for " + key), (Throwable) e);
+          throw new SamzaException("Failed to delete the record for " + key, e);
         });
   }
 
@@ -324,7 +324,7 @@ public final class RemoteTable<K, V> extends BaseReadWriteTable<K, V>
 
     return instrument(() -> asyncTable.deleteAllAsync(keys, args), metrics.numDeleteAlls, metrics.deleteAllNs)
         .exceptionally(e -> {
-          throw new SamzaException(String.format("Failed to delete records for " + keys), e);
+          throw new SamzaException("Failed to delete records for " + keys, e);
         });
   }
 
@@ -339,7 +339,7 @@ public final class RemoteTable<K, V> extends BaseReadWriteTable<K, V>
 
   @Override
   public <T> CompletableFuture<T> writeAsync(int opId, Object... args) {
-    return (CompletableFuture<T>) instrument(() -> asyncTable.writeAsync(opId, args), metrics.numWrites, metrics.writeNs)
+    return instrument(() -> asyncTable.<T>writeAsync(opId, args), metrics.numWrites, metrics.writeNs)
         .exceptionally(e -> {
           throw new SamzaException(String.format("Failed to write, opId=%d", opId), e);
         });


### PR DESCRIPTION
Symptom: String.format("..." + key) would through MissingFormatArgumentException if the key string contains something like "%3A" or "%d". And original exception would be hidden by this new exception.
 
Cause: We have no control on what the key can be. Should avoid using String.format().
 
Changes: Simply remove the String.format() should be enough.
 
Tests: No test since it's a minor change.

API Changes: No API change.

Upgrade Instructions: No backward-compatibility issue. No need to upgrade.

Usage Instructions: User won't use this code directly.