### PR TITLE
SAMZA-2597: Maintain traversal order for registered operators

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImpl.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 
@@ -109,9 +109,9 @@ public abstract class OperatorImpl<M, RM> {
     }
 
     this.highResClock = createHighResClock(context.getJobContext().getConfig());
-    registeredOperators = new HashSet<>();
-    prevOperators = new HashSet<>();
-    inputStreams = new HashSet<>();
+    registeredOperators = new LinkedHashSet<>();
+    prevOperators = new LinkedHashSet<>();
+    inputStreams = new LinkedHashSet<>();
 
     final ContainerContext containerContext = context.getContainerContext();
     final MetricsRegistry metricsRegistry = containerContext.getContainerMetricsRegistry();

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImpl.java
@@ -20,6 +20,7 @@ package org.apache.samza.operators.impl;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -39,6 +40,9 @@ import org.apache.samza.task.TaskCoordinator;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
@@ -78,6 +82,31 @@ public class TestOperatorImpl {
     opImpl.registerNextOperator(mock(OperatorImpl.class));
   }
 
+  @Test
+  public void testRegisterOperatorMaintainsInsertionOrder() {
+    OperatorImpl<Object, Object> opImpl = new TestOpImpl(mock(Object.class));
+    opImpl.init(this.internalTaskContext);
+
+    OperatorImpl<Object, Object> firstOp = mock(OperatorImpl.class);
+    OperatorImpl<Object, Object> secondOp = mock(OperatorImpl.class);
+    OperatorImpl<Object, Object> thirdOp = mock(OperatorImpl.class);
+
+    opImpl.registerNextOperator(firstOp);
+    opImpl.registerNextOperator(secondOp);
+    opImpl.registerNextOperator(thirdOp);
+
+    Iterator<OperatorImpl<Object, ?>> iterator = opImpl.registeredOperators.iterator();
+    assertTrue("Expecting non-empty iterator", iterator.hasNext());
+    assertEquals("Expecting first operator to be returned", firstOp, iterator.next());
+
+    assertTrue("Expecting non-empty iterator", iterator.hasNext());
+    assertEquals("Expecting second operator to be returned", secondOp, iterator.next());
+
+    assertTrue("Expecting non-empty iterator", iterator.hasNext());
+    assertEquals("Expecting third operator to be returned", thirdOp, iterator.next());
+
+    assertFalse("Expecting no more registered operators", iterator.hasNext());
+  }
   @Test
   public void testOnMessagePropagatesResults() {
     Object mockTestOpImplOutput = mock(Object.class);


### PR DESCRIPTION
**Problem**: Currently, we have a deterministic way of creating the operator DAG by having a `LinkedHashMap` so that during our runtime, we ensure the lifecycle of operators follow a deterministic order.

While we use the same order to traverse the graph and create the DAG, we lose the order within the sub DAG as the registered operators is a `HashSet`. The implication is result of an operator is dispatched non-deterministically to its sub-DAG. i.e

```
Op A --> Op B --> Op C
   | --> Op D --> Op E
```

Output of Op A can be dispatched to Op B or Op D depending how we iterate the `registeredOperators` set of Op A. 

While this is not a guarantee Samza provides to applications, we want to be consistent with graph traversal order, DAG insertion order and DAG traversal order.

**Change**: Use `LinkedHashSet` instead of `HashSet` to make it consistent.
**Tests**: Added unit test to ensure insertion order is maintained during traversal
**API Changes**: None
**Usage Instructions**: None
**Upgrade Instructions**: None