### PR TITLE
SAMZA-2599: Introduce config for cluster based job coordinator high availability feature

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -147,6 +147,11 @@ public class JobConfig extends MapConfig {
 
   private static final String JOB_STARTPOINT_ENABLED = "job.startpoint.enabled";
 
+  // Enable ClusterBasedJobCoordinator aka ApplicationMaster High Availability.
+  // High availability allows new AM to establish connection with already running containers
+  public static final String JOB_COORDINATOR_HIGH_AVAILABILITY_ENABLED = "job.coordinator.high-availability.enabled";
+  public static final boolean JOB_COORDINATOR_HIGH_AVAILABILITY_ENABLED_DEFAULT = false;
+
   public JobConfig(Config config) {
     super(config);
   }
@@ -396,6 +401,10 @@ public class JobConfig extends MapConfig {
    */
   public String getCoordinatorStreamFactory() {
     return get(COORDINATOR_STREAM_FACTORY, DEFAULT_COORDINATOR_STREAM_CONFIG_FACTORY);
+  }
+
+  public boolean iscoordinatorHighAvailabilityEnabled() {
+    return getBoolean(JOB_COORDINATOR_HIGH_AVAILABILITY_ENABLED, JOB_COORDINATOR_HIGH_AVAILABILITY_ENABLED_DEFAULT);
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -403,7 +403,7 @@ public class JobConfig extends MapConfig {
     return get(COORDINATOR_STREAM_FACTORY, DEFAULT_COORDINATOR_STREAM_CONFIG_FACTORY);
   }
 
-  public boolean iscoordinatorHighAvailabilityEnabled() {
+  public boolean isJobCoordinatorHighAvailabilityEnabled() {
     return getBoolean(JOB_COORDINATOR_HIGH_AVAILABILITY_ENABLED, JOB_COORDINATOR_HIGH_AVAILABILITY_ENABLED_DEFAULT);
   }
 


### PR DESCRIPTION
**Feature:** Main feature is Cluster based Job coordinator (aka AM) high availability (TODO: sep/doc how?). This feature ensures that the new AM can establish connection with already running containers to avoid restarting all running containers when AM dies. This PR introduces a config behind which all of the code for this feature will be.

**Changes:** New job config 

**Tests:** new config, n/a

**API changes:** config can be set for a job and that will enable AM high availability (HA) feature.

**Usage instructions:** to enable AM HA set config to "true", default value is "false".

**Upgrade instructions:** None
 