### PR TITLE
SAMZA-2611: [AM-HA] heartbeat reestablish causes container's heartbeat thread to die

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/container/ContainerHeartbeatMonitor.java
+++ b/samza-core/src/main/java/org/apache/samza/container/ContainerHeartbeatMonitor.java
@@ -153,7 +153,7 @@ public class ContainerHeartbeatMonitor {
   private void forceExit(String message, int timeout) {
     scheduler.schedule(() -> {
       LOG.error(message);
-      ThreadUtil.logThreadDump("Thread dump at heartbeat monitor: due to "+ message);
+      ThreadUtil.logThreadDump("Thread dump at heartbeat monitor: due to " + message);
       System.exit(1);
     }, timeout, TimeUnit.MILLISECONDS);
     onContainerExpired.run();

--- a/samza-core/src/main/scala/org/apache/samza/util/CoordinatorStreamUtil.scala
+++ b/samza-core/src/main/scala/org/apache/samza/util/CoordinatorStreamUtil.scala
@@ -24,6 +24,7 @@ import java.util
 
 import org.apache.samza.SamzaException
 import org.apache.samza.config._
+import org.apache.samza.coordinator.CoordinationConstants
 import org.apache.samza.coordinator.metadatastore.NamespaceAwareCoordinatorStreamStore
 import org.apache.samza.coordinator.stream.{CoordinatorStreamSystemConsumer, CoordinatorStreamSystemProducer, CoordinatorStreamValueSerde}
 import org.apache.samza.coordinator.stream.messages.{Delete, SetConfig}
@@ -196,6 +197,11 @@ object CoordinatorStreamUtil extends Logging {
       if (jobConfig.getAutosizingEnabled) {
         // If autosizing is enabled, we retain auto-sizing related configs
         keysToRemove = keysToRemove.filter(configKey => !JobConfig.isAutosizingConfig(configKey))
+      }
+
+      if (jobConfig.getApplicationMasterHighAvailabilityEnabled) {
+        // if AM HA is enabled then retain AM url as running containers are fetching it from c-stream until new AM publishes new AM url.
+        keysToRemove = keysToRemove.filter(configKey => !(configKey.equals(CoordinationConstants.YARN_COORDINATOR_URL)))
       }
 
       info("Deleting old configs that are no longer defined: %s".format(keysToRemove))


### PR DESCRIPTION
Symptom: When new AM takes a long time to to start up, already running container's heartbeat thread silently dies and does not make any heartbeat requests to the new AM. 

Cause: AM url (yarn.am.tracking.url) key-value is removed from Coordinator stream when new AM is starting up - as this config is present in old config (aka coordinator stream) but not in the new AM generated config. This causes the running container to fetch a null when its constantly fetching value for this key and thus throws NPE.

Changes: When AMHA is enabled, do not remove this config

Tests: works with hello-samza. Trying to write a unit test but CoordinatorStreamUtil  is tricky to mock and inject stuff.

Usage Instructions: N/A

Upgrade Instructions: N/A

