### PR TITLE
SAMZA-2614:Fix NPE at KafkaCheckpointManager.start in standby containers

### DIFF
--- a/samza-kafka/src/main/scala/org/apache/samza/checkpoint/kafka/KafkaCheckpointManager.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/checkpoint/kafka/KafkaCheckpointManager.scala
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
 import com.google.common.annotations.VisibleForTesting
-import com.google.common.base.Preconditions
 import org.apache.samza.checkpoint.{Checkpoint, CheckpointManager}
 import org.apache.samza.config.{Config, JobConfig, TaskConfig}
 import org.apache.samza.container.TaskName
@@ -67,13 +66,13 @@ class KafkaCheckpointManager(checkpointSpec: KafkaStreamSpec,
   val checkpointSsp: SystemStreamPartition = new SystemStreamPartition(checkpointSystem, checkpointTopic, new Partition(0))
   val expectedGrouperFactory: String = new JobConfig(config).getSystemStreamPartitionGrouperFactory
 
-  var systemConsumer: SystemConsumer = _
-  var systemAdmin: SystemAdmin = _
+  val systemConsumer = systemFactory.getConsumer(checkpointSystem, config, metricsRegistry, this.getClass.getSimpleName)
+  val systemAdmin =  systemFactory.getAdmin(checkpointSystem, config, this.getClass.getSimpleName)
 
   var taskNames: Set[TaskName] = Set[TaskName]()
   var taskNamesToCheckpoints: Map[TaskName, Checkpoint] = _
 
-  var producerRef: AtomicReference[SystemProducer] = _
+  val producerRef: AtomicReference[SystemProducer] = new AtomicReference[SystemProducer](getSystemProducer())
   val producerCreationLock: Object = new Object
 
   // if true, systemConsumer can be safely closed after the first call to readLastCheckpoint.
@@ -86,21 +85,19 @@ class KafkaCheckpointManager(checkpointSpec: KafkaStreamSpec,
     *
     */
   override def createResources(): Unit = {
-    val systemAdmin = systemFactory.getAdmin(checkpointSystem, config, this.getClass.getSimpleName)
-    Preconditions.checkNotNull(systemAdmin)
-
-    systemAdmin.start()
+    val createResourcesSystemAdmin =  systemFactory.getAdmin(checkpointSystem, config, this.getClass.getSimpleName + "createResource")
+    createResourcesSystemAdmin.start()
     try {
       info(s"Creating checkpoint stream: ${checkpointSpec.getPhysicalName} with " +
         s"partition count: ${checkpointSpec.getPartitionCount}")
-      systemAdmin.createStream(checkpointSpec)
+      createResourcesSystemAdmin.createStream(checkpointSpec)
 
       if (validateCheckpoint) {
         info(s"Validating checkpoint stream")
-        systemAdmin.validateStream(checkpointSpec)
+        createResourcesSystemAdmin.validateStream(checkpointSpec)
       }
     } finally {
-      systemAdmin.stop()
+      createResourcesSystemAdmin.stop()
     }
   }
 
@@ -124,10 +121,6 @@ class KafkaCheckpointManager(checkpointSpec: KafkaStreamSpec,
     * @inheritdoc
     */
   override def register(taskName: TaskName) {
-    systemConsumer = systemFactory.getConsumer(checkpointSystem, config, metricsRegistry, this.getClass.getSimpleName)
-    systemAdmin =  systemFactory.getAdmin(checkpointSystem, config, this.getClass.getSimpleName)
-    producerRef = new AtomicReference[SystemProducer](getSystemProducer())
-
     debug(s"Registering taskName: $taskName")
     producerRef.get().register(taskName.getTaskName)
     taskNames += taskName

--- a/samza-kafka/src/main/scala/org/apache/samza/checkpoint/kafka/KafkaCheckpointManager.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/checkpoint/kafka/KafkaCheckpointManager.scala
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
 import com.google.common.annotations.VisibleForTesting
+import com.google.common.base.Preconditions
 import org.apache.samza.checkpoint.{Checkpoint, CheckpointManager}
 import org.apache.samza.config.{Config, JobConfig, TaskConfig}
 import org.apache.samza.container.TaskName
@@ -86,6 +87,7 @@ class KafkaCheckpointManager(checkpointSpec: KafkaStreamSpec,
     */
   override def createResources(): Unit = {
     val createResourcesSystemAdmin =  systemFactory.getAdmin(checkpointSystem, config, this.getClass.getSimpleName + "createResource")
+    Preconditions.checkNotNull(createResourcesSystemAdmin)
     createResourcesSystemAdmin.start()
     try {
       info(s"Creating checkpoint stream: ${checkpointSpec.getPhysicalName} with " +

--- a/samza-kafka/src/test/scala/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.scala
+++ b/samza-kafka/src/test/scala/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.scala
@@ -84,7 +84,7 @@ class TestKafkaCheckpointManager extends KafkaServerTestHarness {
     val checkPointManager = Mockito.spy(new KafkaCheckpointManager(spec, new MockSystemFactory, false, config, new NoOpMetricsRegistry))
     val newKafkaProducer: SystemProducer = Mockito.mock(classOf[SystemProducer])
 
-    Mockito.when(checkPointManager.getSystemProducer()).thenReturn(mockKafkaProducer).thenReturn(newKafkaProducer)
+    Mockito.doReturn(newKafkaProducer).when(checkPointManager).getSystemProducer()
 
     checkPointManager.register(taskName)
     checkPointManager.start


### PR DESCRIPTION
Symptom: 
Met error when standby container is starting:
SamzaContainer [ERROR] Caught exception/error while initializing container.
java.lang.NullPointerException: null at org.apache.samza.checkpoint.kafka.KafkaCheckpointManager.start(KafkaCheckpointManager.scala:113)

Cause: Standby containers don't really checkpoint or consume input so its possible that there is no checkpointing going on. So the SSP may not be registered by kafkaCheckpointManager after creating kafkaCheckpointManager, which caused the error.
Changes: Creating kafka clients when initializing the kafkaCheckpointManager.

Tests: Unit tests and running local test jobs.
API Changes: N/A
Upgrade Instructions: N/A
Usage Instructions: N/A