### PR TITLE
SAMZA-2618: Add per-container metric for memory-utilization

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -617,13 +617,18 @@ object SamzaContainer extends Logging {
       taskConfig,
       clock)
 
+    val containerMemoryMb : Int = new ClusterManagerConfig(config).getContainerMemoryMb
+
     val memoryStatisticsMonitor : SystemStatisticsMonitor = new StatisticsMonitorImpl()
     memoryStatisticsMonitor.registerListener(new SystemStatisticsMonitor.Listener {
       override def onUpdate(sample: SystemMemoryStatistics): Unit = {
         val physicalMemoryBytes : Long = sample.getPhysicalMemoryBytes
         val physicalMemoryMb : Double = physicalMemoryBytes / (1024.0 * 1024.0)
+        val memoryUtilization : Float = physicalMemoryMb.toFloat / containerMemoryMb
         logger.debug("Container physical memory utilization (mb): " + physicalMemoryMb)
+        logger.debug("Container memory utilization: " + memoryUtilization)
         samzaContainerMetrics.physicalMemoryMb.set(physicalMemoryMb)
+        samzaContainerMetrics.containerMemoryUtilization.set(memoryUtilization);
       }
     })
 

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
@@ -47,6 +47,7 @@ class SamzaContainerMetrics(
   val diskQuotaBytes = newGauge("disk-quota-bytes", Long.MaxValue)
   val executorWorkFactor = newGauge("executor-work-factor", 1.0)
   val physicalMemoryMb = newGauge[Double]("physical-memory-mb", 0.0F)
+  val containerMemoryUtilization = newGauge("container-memory-utilization", 0.0F)
   val containerThreadPoolSize = newGauge("container-thread-pool-size", 0L)
 
   val taskStoreRestorationMetrics: util.Map[TaskName, Gauge[Long]] = new util.HashMap[TaskName, Gauge[Long]]()

--- a/samza-kv-inmemory/src/main/java/org/apache/samza/storage/kv/inmemory/InMemoryKeyValueStore.java
+++ b/samza-kv-inmemory/src/main/java/org/apache/samza/storage/kv/inmemory/InMemoryKeyValueStore.java
@@ -87,8 +87,6 @@ public class InMemoryKeyValueStore implements KeyValueStore<byte[], byte[]> {
 
   @Override
   public void delete(byte[] key) {
-    // TODO Bug: SAMZA-2563: This double counts deletes for metrics, because put also counts a delete
-    metrics.deletes().inc();
     put(key, null);
   }
 

--- a/samza-kv-inmemory/src/main/java/org/apache/samza/storage/kv/inmemory/InMemoryKeyValueStore.java
+++ b/samza-kv-inmemory/src/main/java/org/apache/samza/storage/kv/inmemory/InMemoryKeyValueStore.java
@@ -88,6 +88,7 @@ public class InMemoryKeyValueStore implements KeyValueStore<byte[], byte[]> {
   @Override
   public void delete(byte[] key) {
     // TODO Bug: SAMZA-2563: This double counts deletes for metrics, because put also counts a delete
+    // TODO
     metrics.deletes().inc();
     put(key, null);
   }

--- a/samza-kv-inmemory/src/main/java/org/apache/samza/storage/kv/inmemory/InMemoryKeyValueStore.java
+++ b/samza-kv-inmemory/src/main/java/org/apache/samza/storage/kv/inmemory/InMemoryKeyValueStore.java
@@ -88,7 +88,6 @@ public class InMemoryKeyValueStore implements KeyValueStore<byte[], byte[]> {
   @Override
   public void delete(byte[] key) {
     // TODO Bug: SAMZA-2563: This double counts deletes for metrics, because put also counts a delete
-    // TODO
     metrics.deletes().inc();
     put(key, null);
   }

--- a/samza-kv-inmemory/src/test/java/org/apache/samza/storage/kv/inmemory/TestInMemoryKeyValueStore.java
+++ b/samza-kv-inmemory/src/test/java/org/apache/samza/storage/kv/inmemory/TestInMemoryKeyValueStore.java
@@ -239,11 +239,7 @@ public class TestInMemoryKeyValueStore {
     this.inMemoryKeyValueStore.delete(key(0));
     assertNull(this.inMemoryKeyValueStore.get(key(0)));
 
-    /*
-     * There is a bug in which deletes are double counted in metrics. This deletesCounter should only be invoked once
-     * when the bug is fixed.
-     */
-    verify(this.deletesCounter, times(2)).inc();
+    verify(this.deletesCounter, times(1)).inc();
   }
 
   @Test
@@ -251,11 +247,8 @@ public class TestInMemoryKeyValueStore {
     this.inMemoryKeyValueStore.delete(key(0));
 
     assertNull(this.inMemoryKeyValueStore.get(key(0)));
-    /*
-     * There is a bug in which deletes are double counted in metrics. This deletesCounter should only be invoked once
-     * when the bug is fixed.
-     */
-    verify(this.deletesCounter, times(2)).inc();
+
+    verify(this.deletesCounter, times(1)).inc();
   }
 
   @Test


### PR DESCRIPTION
Feature: Add a metric to measure the fraction of physical memory used out of the total memory of the container. During autosizing, the container-count and size can change as traffic changes, so only monitoring the phsical-memory-mb does not provide enough information for alerting. We need a fraction or % metric to allow for easy monitoring and alerting

Changes: Add a metric to measure the fraction of physical memory used out of the total memory of the container.
 
Tests: unit tests & integration tests (TODO: check how to do integration tests and verify this in debug log)