### PR TITLE
SAMZA-2626:  NoOp serde configured for a local table or a storage engine based table is skipped while generating store configs

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/execution/JobNodeConfigurationGenerator.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/JobNodeConfigurationGenerator.java
@@ -47,7 +47,6 @@ import org.apache.samza.operators.spec.OperatorSpec;
 import org.apache.samza.operators.spec.StatefulOperatorSpec;
 import org.apache.samza.operators.spec.StoreDescriptor;
 import org.apache.samza.operators.spec.WindowOperatorSpec;
-import org.apache.samza.serializers.NoOpSerde;
 import org.apache.samza.serializers.Serde;
 import org.apache.samza.serializers.SerializableSerde;
 import org.apache.samza.table.TableConfigGenerator;

--- a/samza-core/src/main/java/org/apache/samza/execution/JobNodeConfigurationGenerator.java
+++ b/samza-core/src/main/java/org/apache/samza/execution/JobNodeConfigurationGenerator.java
@@ -351,10 +351,10 @@ import org.slf4j.LoggerFactory;
   private void addSerdes(KV<Serde, Serde> serdes, String streamId, Map<String, Serde> keySerdeMap,
       Map<String, Serde> msgSerdeMap) {
     if (serdes != null) {
-      if (serdes.getKey() != null && !(serdes.getKey() instanceof NoOpSerde)) {
+      if (serdes.getKey() != null) {
         keySerdeMap.put(streamId, serdes.getKey());
       }
-      if (serdes.getValue() != null && !(serdes.getValue() instanceof NoOpSerde)) {
+      if (serdes.getValue() != null) {
         msgSerdeMap.put(streamId, serdes.getValue());
       }
     }

--- a/samza-test/src/test/java/org/apache/samza/test/framework/StreamApplicationIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/framework/StreamApplicationIntegrationTest.java
@@ -153,6 +153,10 @@ public class StreamApplicationIntegrationTest {
           new RocksDbTableDescriptor<Integer, TestTableData.Profile>("profile-view-store",
               KVSerde.of(new IntegerSerde(), new TestTableData.ProfileJsonSerde())));
 
+      Table<KV<Integer, TestTableData.Profile>> table2 = appDescriptor.getTable(
+          new RocksDbTableDescriptor<>("profile-view-store-no-op",
+              KVSerde.of(new NoOpSerde<>(), new NoOpSerde<>())));
+
       KafkaSystemDescriptor ksd = new KafkaSystemDescriptor("test");
 
       KafkaInputDescriptor<KV<String, TestTableData.Profile>> profileISD =


### PR DESCRIPTION
**Issues:** JobNodeConfigurationGenerator assumes that a Table based on a StorageEngine API cannot have a NoOpSerde, and while generating store configs for tables NoOpSerde is treated equivalent to null (not present cast) for both key & msg serdes

If we want to add a new KeyValueStorageEngine for Samza which itself handles serialization/deserialization of KeyValue messages the type of Serde you want to use with it is No-Op. Since No-op is assumed the same as null while constructing the KYStorageEngine BaseKeyValueStorageEngineFactory throws a null / serde not found exception 

**Changes:** Fixed the JobNodeConfigurationGenerator to not ignore a NoOpSerde configuration for store-based of local tables

**Tests:** Added a unit test

**API Changes:** None
**Upgrade Instructions:** None
**Usage Instructions:** None