### PR TITLE
SAMZA-2627: Make StreamAppender extensible for sending messages to SystemProducer

### DIFF
--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
@@ -439,7 +439,7 @@ public class StreamAppender extends AbstractAppender {
    * Helper method to send a serialized log-event to the systemProducer, and increment respective methods.
    * @param serializedLogEvent
    */
-  private void sendEventToSystemProducer(byte[] serializedLogEvent) {
+  protected void sendEventToSystemProducer(byte[] serializedLogEvent) {
     metrics.logMessagesBytesSent.inc(serializedLogEvent.length);
     metrics.logMessagesCountSent.inc();
     systemProducer.send(SOURCE, new OutgoingMessageEnvelope(systemStream, keyBytes, serializedLogEvent));


### PR DESCRIPTION
Issue: StreamAppender sets both partition key and record key = container name for OutgoingMessageEnvelope sent to underlying SystemProducer. This restricts how the classes extending StreamAppender send to SystemProducer.

Change: Mark sendEventToSystemProducer as protected.

Tests: existing tests pass, no functionality change.

API changes: none

Usage, upgrade instructions: none