### PR TITLE
SAMZA-2627: Make StreamAppender extensible for sending messages to SystemProducer

### DIFF
--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
@@ -452,7 +452,7 @@ public class StreamAppender extends AbstractAppender {
    * @param messageBytes message bytes
    * @return OutgoingMessageEnvelope that contains the message bytes along with the system stream
    */
-  protected OutgoingMessageEnvelope decorateLogEvent(SystemStream systemStream, byte[] keyBytes,  byte[] messageBytes) {
+  protected OutgoingMessageEnvelope decorateLogEvent(SystemStream systemStream, byte[] keyBytes, byte[] messageBytes) {
     return new OutgoingMessageEnvelope(systemStream, keyBytes, messageBytes);
   }
 

--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
@@ -451,7 +451,7 @@ public class StreamAppender extends AbstractAppender {
    * @return OutgoingMessageEnvelope that contains the message bytes along with the system stream
    */
   protected OutgoingMessageEnvelope decorateLogEvent(byte[] serializedLogEvent) {
-   return new OutgoingMessageEnvelope(systemStream, keyBytes, serializedLogEvent);
+    return new OutgoingMessageEnvelope(systemStream, keyBytes, serializedLogEvent);
   }
 
   protected String getStreamName(String jobName, String jobId) {

--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
@@ -75,7 +75,6 @@ public class StreamAppender extends AbstractAppender {
 
   private static final String JAVA_OPTS_CONTAINER_NAME = "samza.container.name";
   private static final String JOB_COORDINATOR_TAG = "samza-job-coordinator";
-  protected static final String SOURCE = "log4j-log";
 
   // Hidden config for now. Will move to appropriate Config class when ready to.
   private static final String CREATE_STREAM_ENABLED = "task.log4j.create.stream.enabled";
@@ -83,8 +82,6 @@ public class StreamAppender extends AbstractAppender {
   private static final long DEFAULT_QUEUE_TIMEOUT_S = 2; // Abitrary choice
   private final BlockingQueue<byte[]> logQueue = new LinkedBlockingQueue<>(DEFAULT_QUEUE_SIZE);
 
-  protected SystemStream systemStream = null;
-  protected SystemProducer systemProducer = null;
   private String key = null;
   private byte[] keyBytes; // Serialize the key once, since we will use it for every event.
   private String containerName = null;
@@ -104,8 +101,11 @@ public class StreamAppender extends AbstractAppender {
 
   protected static final int DEFAULT_QUEUE_SIZE = 100;
   protected static volatile boolean systemInitialized = false;
+  protected static final String SOURCE = "log4j-log";
   protected StreamAppenderMetrics metrics;
   protected long queueTimeoutS = DEFAULT_QUEUE_TIMEOUT_S;
+  protected SystemStream systemStream = null;
+  protected SystemProducer systemProducer = null;
 
   protected StreamAppender(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions,
       boolean usingAsyncLogger, String streamName) {

--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
@@ -442,17 +442,15 @@ public class StreamAppender extends AbstractAppender {
   private void sendEventToSystemProducer(byte[] serializedLogEvent) {
     metrics.logMessagesBytesSent.inc(serializedLogEvent.length);
     metrics.logMessagesCountSent.inc();
-    systemProducer.send(SOURCE, decorateLogEvent(systemStream, keyBytes, serializedLogEvent));
+    systemProducer.send(SOURCE, decorateLogEvent(serializedLogEvent));
   }
 
   /**
    * Helper method to create an OutgoingMessageEnvelope from the serialized log event.
-   * @param systemStream system and stream for the outgoing message
-   * @param keyBytes key bytes
    * @param messageBytes message bytes
    * @return OutgoingMessageEnvelope that contains the message bytes along with the system stream
    */
-  protected OutgoingMessageEnvelope decorateLogEvent(SystemStream systemStream, byte[] keyBytes, byte[] messageBytes) {
+  protected OutgoingMessageEnvelope decorateLogEvent(byte[] messageBytes) {
     return new OutgoingMessageEnvelope(systemStream, keyBytes, messageBytes);
   }
 

--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
@@ -100,8 +100,8 @@ public class StreamAppender extends AbstractAppender {
   private final AtomicBoolean recursiveCall = new AtomicBoolean(false);
 
   protected static final int DEFAULT_QUEUE_SIZE = 100;
-  protected static volatile boolean systemInitialized = false;
   protected static final String SOURCE = "log4j-log";
+  protected static volatile boolean systemInitialized = false;
   protected StreamAppenderMetrics metrics;
   protected long queueTimeoutS = DEFAULT_QUEUE_TIMEOUT_S;
   protected SystemStream systemStream = null;

--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
@@ -75,7 +75,7 @@ public class StreamAppender extends AbstractAppender {
 
   private static final String JAVA_OPTS_CONTAINER_NAME = "samza.container.name";
   private static final String JOB_COORDINATOR_TAG = "samza-job-coordinator";
-  private static final String SOURCE = "log4j-log";
+  protected static final String SOURCE = "log4j-log";
 
   // Hidden config for now. Will move to appropriate Config class when ready to.
   private static final String CREATE_STREAM_ENABLED = "task.log4j.create.stream.enabled";
@@ -83,8 +83,8 @@ public class StreamAppender extends AbstractAppender {
   private static final long DEFAULT_QUEUE_TIMEOUT_S = 2; // Abitrary choice
   private final BlockingQueue<byte[]> logQueue = new LinkedBlockingQueue<>(DEFAULT_QUEUE_SIZE);
 
-  private SystemStream systemStream = null;
-  private SystemProducer systemProducer = null;
+  protected SystemStream systemStream = null;
+  protected SystemProducer systemProducer = null;
   private String key = null;
   private byte[] keyBytes; // Serialize the key once, since we will use it for every event.
   private String containerName = null;


### PR DESCRIPTION
Issue: StreamAppender sets both partition key and record key = container name for OutgoingMessageEnvelope sent to underlying SystemProducer. This restricts how the classes extending StreamAppender send to SystemProducer.

Change: Introduce method to decorate the serializedLogEvent that can be overridden by extenders of `StreamAppender`

Tests: existing tests pass, no functionality change.

API changes: none

Usage, upgrade instructions: none