### PR TITLE
SAMZA-2626:  Push the keySerde msgSerde null check down to RocksDbKey…ValueStorageEngine factory rather than BaseKeyValueStorageEngineFactory since not all storage engine type have serdes applicable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -647,6 +647,7 @@ project(":samza-kv-rocksdb_$scalaSuffix") {
     compile "org.scala-lang:scala-library:$scalaVersion"
     compile "org.rocksdb:rocksdbjni:$rocksdbVersion"
     testCompile "junit:junit:$junitVersion"
+    testCompile "org.mockito:mockito-core:$mockitoVersion"
     testCompile "org.scalatest:scalatest_$scalaSuffix:$scalaTestVersion"
   }
 }

--- a/samza-kv-inmemory/src/main/java/org/apache/samza/storage/kv/inmemory/InMemoryKeyValueStorageEngineFactory.java
+++ b/samza-kv-inmemory/src/main/java/org/apache/samza/storage/kv/inmemory/InMemoryKeyValueStorageEngineFactory.java
@@ -22,6 +22,7 @@ import java.io.File;
 import org.apache.samza.context.ContainerContext;
 import org.apache.samza.context.JobContext;
 import org.apache.samza.metrics.MetricsRegistry;
+import org.apache.samza.serializers.Serde;
 import org.apache.samza.storage.kv.BaseKeyValueStorageEngineFactory;
 import org.apache.samza.storage.kv.KeyValueStore;
 import org.apache.samza.storage.kv.KeyValueStoreMetrics;
@@ -29,14 +30,11 @@ import org.apache.samza.system.SystemStreamPartition;
 
 
 public class InMemoryKeyValueStorageEngineFactory<K, V> extends BaseKeyValueStorageEngineFactory<K, V> {
+
   @Override
-  protected KeyValueStore<byte[], byte[]> getKVStore(String storeName,
-      File storeDir,
-      MetricsRegistry registry,
-      SystemStreamPartition changeLogSystemStreamPartition,
-      JobContext jobContext,
-      ContainerContext containerContext,
-      StoreMode storeMode) {
+  protected KeyValueStore<byte[], byte[]> getKVStore(String storeName, Serde<K> keySerde, Serde<V> msgSerde,
+      File storeDir, MetricsRegistry registry, SystemStreamPartition changeLogSystemStreamPartition,
+      JobContext jobContext, ContainerContext containerContext, StoreMode storeMode) {
     KeyValueStoreMetrics metrics = new KeyValueStoreMetrics(storeName, registry);
     return new InMemoryKeyValueStore(metrics);
   }

--- a/samza-kv-rocksdb/src/test/scala/org/apache/samza/storage/kv/TestRocksDbKeyValueStorageEngineFactory.scala
+++ b/samza-kv-rocksdb/src/test/scala/org/apache/samza/storage/kv/TestRocksDbKeyValueStorageEngineFactory.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.storage.kv
+
+import java.io.File
+
+import org.apache.samza.SamzaException
+import org.apache.samza.context.{ContainerContext, JobContext}
+import org.apache.samza.metrics.MetricsRegistry
+import org.apache.samza.serializers.Serde
+import org.apache.samza.storage.StorageEngineFactory.StoreMode
+import org.apache.samza.system.SystemStreamPartition
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+
+class TestRocksDbKeyValueStorageEngineFactory {
+
+  @Mock private val storeDir = mock(classOf[File])
+  @Mock private val keySerde = mock(classOf[Serde[String]])
+  @Mock private val msgSerde = mock(classOf[Serde[String]])
+  @Mock private val metricsRegistry = mock(classOf[MetricsRegistry])
+  @Mock private val ssp = mock(classOf[SystemStreamPartition])
+  @Mock private val jobContext = mock(classOf[JobContext])
+  @Mock private val containerContext = mock(classOf[ContainerContext])
+
+  @Test(expected = classOf[SamzaException]) def testMissingKeySerde(): Unit = {
+    val rocksDb = new MockRocksDbKeyValueStorageEngineFactory("mock", null, msgSerde, storeDir, metricsRegistry, ssp, jobContext, containerContext, StoreMode.BulkLoad)
+  }
+
+  @Test(expected = classOf[SamzaException]) def testMissingValueSerde(): Unit = {
+    val rocksDb = new MockRocksDbKeyValueStorageEngineFactory("mock", keySerde, null, storeDir, metricsRegistry, ssp, jobContext, containerContext, StoreMode.ReadWrite)
+  }
+
+  class MockRocksDbKeyValueStorageEngineFactory(
+    storeName: String,
+    keySerde: Serde[String],
+    msgSerde: Serde[String],
+    storeDir: File,
+    registry: MetricsRegistry,
+    changeLogSystemStreamPartition: SystemStreamPartition,
+    jobContext: JobContext,
+    containerContext: ContainerContext,
+    storeMode: StoreMode
+  ) extends RocksDbKeyValueStorageEngineFactory[String, String] {
+    getKVStore(storeName, keySerde, msgSerde, storeDir, registry, changeLogSystemStreamPartition, jobContext, containerContext, storeMode)
+  }
+
+}

--- a/samza-kv/src/main/java/org/apache/samza/storage/kv/BaseKeyValueStorageEngineFactory.java
+++ b/samza-kv/src/main/java/org/apache/samza/storage/kv/BaseKeyValueStorageEngineFactory.java
@@ -64,6 +64,8 @@ public abstract class BaseKeyValueStorageEngineFactory<K, V> implements StorageE
    * @return A raw KeyValueStore instance
    */
   protected abstract KeyValueStore<byte[], byte[]> getKVStore(String storeName,
+      Serde<K> keySerde,
+      Serde<V> msgSerde,
       File storeDir,
       MetricsRegistry registry,
       SystemStreamPartition changeLogSystemStreamPartition,
@@ -111,17 +113,10 @@ public abstract class BaseKeyValueStorageEngineFactory<K, V> implements StorageE
           String.format("cache.size for store %s cannot be less than batch.size as batched values reside in cache.",
               storeName));
     }
-    if (keySerde == null) {
-      throw new SamzaException(
-          String.format("Must define a key serde when using key value storage for store %s.", storeName));
-    }
-    if (msgSerde == null) {
-      throw new SamzaException(
-          String.format("Must define a message serde when using key value storage for store %s.", storeName));
-    }
 
     KeyValueStore<byte[], byte[]> rawStore =
-        getKVStore(storeName, storeDir, registry, changelogSSP, jobContext, containerContext, storeMode);
+        getKVStore(storeName, keySerde, msgSerde, storeDir, registry, changelogSSP, jobContext, containerContext,
+            storeMode);
     KeyValueStore<byte[], byte[]> maybeLoggedStore = buildMaybeLoggedStore(changelogSSP,
         storeName, registry, storePropertiesBuilder, rawStore, changelogCollector);
     // this also applies serialization and caching layers

--- a/samza-kv/src/test/java/org/apache/samza/storage/kv/MockKeyValueStorageEngineFactory.java
+++ b/samza-kv/src/test/java/org/apache/samza/storage/kv/MockKeyValueStorageEngineFactory.java
@@ -22,6 +22,7 @@ import java.io.File;
 import org.apache.samza.context.ContainerContext;
 import org.apache.samza.context.JobContext;
 import org.apache.samza.metrics.MetricsRegistry;
+import org.apache.samza.serializers.Serde;
 import org.apache.samza.system.SystemStreamPartition;
 
 
@@ -37,9 +38,9 @@ public class MockKeyValueStorageEngineFactory extends BaseKeyValueStorageEngineF
   }
 
   @Override
-  protected KeyValueStore<byte[], byte[]> getKVStore(String storeName, File storeDir, MetricsRegistry registry,
-      SystemStreamPartition changeLogSystemStreamPartition, JobContext jobContext, ContainerContext containerContext,
-      StoreMode storeMode) {
+  protected KeyValueStore<byte[], byte[]> getKVStore(String storeName, Serde<String> keySerde, Serde<String> msgSerde,
+      File storeDir, MetricsRegistry registry, SystemStreamPartition changeLogSystemStreamPartition,
+      JobContext jobContext, ContainerContext containerContext, StoreMode storeMode) {
     return this.rawKeyValueStore;
   }
 }

--- a/samza-kv/src/test/java/org/apache/samza/storage/kv/TestBaseKeyValueStorageEngineFactory.java
+++ b/samza-kv/src/test/java/org/apache/samza/storage/kv/TestBaseKeyValueStorageEngineFactory.java
@@ -103,24 +103,6 @@ public class TestBaseKeyValueStorageEngineFactory {
     callGetStorageEngine(config, null);
   }
 
-  @Test(expected = SamzaException.class)
-  public void testMissingKeySerde() {
-    Config config = new MapConfig(BASE_CONFIG);
-    when(this.jobContext.getConfig()).thenReturn(config);
-    new MockKeyValueStorageEngineFactory(this.rawKeyValueStore).getStorageEngine(STORE_NAME, this.storeDir, null,
-        this.msgSerde, this.changelogCollector, this.metricsRegistry, null, this.jobContext, this.containerContext,
-        STORE_MODE);
-  }
-
-  @Test(expected = SamzaException.class)
-  public void testMissingValueSerde() {
-    Config config = new MapConfig(BASE_CONFIG);
-    when(this.jobContext.getConfig()).thenReturn(config);
-    new MockKeyValueStorageEngineFactory(this.rawKeyValueStore).getStorageEngine(STORE_NAME, this.storeDir,
-        this.keySerde, null, this.changelogCollector, this.metricsRegistry, null, this.jobContext,
-        this.containerContext, STORE_MODE);
-  }
-
   @Test
   public void testInMemoryKeyValueStore() {
     Config config = new MapConfig(DISABLE_CACHE, ImmutableMap.of(String.format(StorageConfig.FACTORY, STORE_NAME),


### PR DESCRIPTION
**Issue:** BaseKeyValueStorageEngine does a null check on keySerde and msgSerde, however this null check might only apply to some StorageEngine like RocksDbStorageEngine

If we want to add a new KeyValueStorageEngine for Samza which itself handles serialization/deserialization of KeyValue messages the type of Serde you want to use with it is null. Since BaseKeyValueStorageEngine assumes serdes as non-null while constructing the KeyValueStore it throws a null / serde not found exception

**Changes:** Push the non-null serde validation for key and msg serde down to RocksDbKeyValueStorageEngineFactory

**Tests:** Added a unit test

**API Changes:** Yes

BaseKeyValueStorageEngineFactory#getKeyStore has two new serde arguments

```
 protected abstract KeyValueStore<byte[], byte[]> getKVStore(String storeName,
      `Serde<K> keySerde,`
      `Serde<V> msgSerde,`
      File storeDir,
      MetricsRegistry registry,
      SystemStreamPartition changeLogSystemStreamPartition,
      JobContext jobContext,
      ContainerContext containerContext,
      StoreMode storeMode); {

}
```

**Upgrade Instructions:** 

If a user class is extending BaseKeyValueStorageEngineFactory they are required to do a null check for serde in the concrete implementation of StorageEngineFactories


Usage Instructions: None