### PR TITLE
Add a metric to track the number of active threads of a container's thread pool

### DIFF
--- a/docs/learn/documentation/versioned/operations/monitoring.md
+++ b/docs/learn/documentation/versioned/operations/monitoring.md
@@ -394,7 +394,7 @@ All \<system\>, \<stream\>, \<partition\>, \<store-name\>, \<topic\>, are popula
 | | executor-work-factor | The work factor of the run loop. A work factor of 1 indicates full throughput, while a work factor of less than 1 will introduce delays into the execution to approximate the requested work factor. The work factor is set by the disk space monitor in accordance with the disk quota policy. Given the latest percentage of available disk quota, this policy returns the work factor that should be applied. |
 | | physical-memory-mb | The physical memory used by the Samza container process (native + on heap) (in MBs). |
 | | physical-memory-utilization | The ratio between the physical memory used by the Samza container process (native + on heap) and the total physical memory of the Samza container. |
-| | container-thread-pool-utilization | The ratio between the actively used threads and the thread pool size of a Samza container. |
+| | container-active-threads | The approximate actively used threads in a Samza container's thread pool. |
 | | <TaskName\>-<StoreName\>-restore-time | Time taken to restore task stores (per task store). |
 
 

--- a/docs/learn/documentation/versioned/operations/monitoring.md
+++ b/docs/learn/documentation/versioned/operations/monitoring.md
@@ -394,6 +394,7 @@ All \<system\>, \<stream\>, \<partition\>, \<store-name\>, \<topic\>, are popula
 | | executor-work-factor | The work factor of the run loop. A work factor of 1 indicates full throughput, while a work factor of less than 1 will introduce delays into the execution to approximate the requested work factor. The work factor is set by the disk space monitor in accordance with the disk quota policy. Given the latest percentage of available disk quota, this policy returns the work factor that should be applied. |
 | | physical-memory-mb | The physical memory used by the Samza container process (native + on heap) (in MBs). |
 | | physical-memory-utilization | The ratio between the physical memory used by the Samza container process (native + on heap) and the total physical memory of the Samza container. |
+| | container-thread-pool-utilization | The ratio between the actively used threads and the thread pool size of a Samza container. |
 | | <TaskName\>-<StoreName\>-restore-time | Time taken to restore task stores (per task store). |
 
 

--- a/docs/learn/documentation/versioned/operations/monitoring.md
+++ b/docs/learn/documentation/versioned/operations/monitoring.md
@@ -394,6 +394,7 @@ All \<system\>, \<stream\>, \<partition\>, \<store-name\>, \<topic\>, are popula
 | | executor-work-factor | The work factor of the run loop. A work factor of 1 indicates full throughput, while a work factor of less than 1 will introduce delays into the execution to approximate the requested work factor. The work factor is set by the disk space monitor in accordance with the disk quota policy. Given the latest percentage of available disk quota, this policy returns the work factor that should be applied. |
 | | physical-memory-mb | The physical memory used by the Samza container process (native + on heap) (in MBs). |
 | | physical-memory-utilization | The ratio between the physical memory used by the Samza container process (native + on heap) and the total physical memory of the Samza container. |
+| | container-thread-pool-size | The current size of a Samza container's thread pool. It may or may not be the same as job.container.thread.pool.size, depending on the implementation. |
 | | container-active-threads | The approximate actively used threads in a Samza container's thread pool. |
 | | <TaskName\>-<StoreName\>-restore-time | Time taken to restore task stores (per task store). |
 

--- a/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
+++ b/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
@@ -25,10 +25,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -69,6 +71,7 @@ public class RunLoop implements Runnable, Throttleable {
   private final Map<SystemStreamPartition, List<AsyncTaskWorker>> sspToTaskWorkerMapping;
 
   private final ExecutorService threadPool;
+  private final Optional<ThreadPoolExecutor> threadPoolExecutor;
   private final CoordinatorRequests coordinatorRequests;
   private final Object latch;
   private final int maxConcurrency;
@@ -100,6 +103,7 @@ public class RunLoop implements Runnable, Throttleable {
       boolean isAsyncCommitEnabled) {
 
     this.threadPool = threadPool;
+    this.threadPoolExecutor = threadPool instanceof ThreadPoolExecutor ? Optional.of((ThreadPoolExecutor) threadPool) : Optional.empty();
     this.consumerMultiplexer = consumerMultiplexer;
     this.containerMetrics = containerMetrics;
     this.windowMs = windowMs;
@@ -176,6 +180,8 @@ public class RunLoop implements Runnable, Throttleable {
         if (totalNs != 0) {
           // totalNs is not 0 if timer metrics are enabled
           containerMetrics.utilization().set(((double) activeNs) / totalNs);
+          threadPoolExecutor.ifPresent(executor -> containerMetrics.containerThreadPoolUtilization()
+              .set(((double) executor.getActiveCount()) / executor.getCorePoolSize()));
         }
       }
 

--- a/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
+++ b/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
@@ -102,8 +102,7 @@ public class RunLoop implements Runnable, Throttleable {
       boolean isAsyncCommitEnabled) {
 
     this.threadPool = threadPool;
-    this.threadPoolExecutor = ThreadPoolExecutor.class.isAssignableFrom(threadPool.getClass())
-        ? (ThreadPoolExecutor) threadPool : null;
+    this.threadPoolExecutor = threadPool instanceof ThreadPoolExecutor ? (ThreadPoolExecutor) threadPool : null;
     this.consumerMultiplexer = consumerMultiplexer;
     this.containerMetrics = containerMetrics;
     this.windowMs = windowMs;

--- a/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
+++ b/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -70,7 +69,6 @@ public class RunLoop implements Runnable, Throttleable {
   private final Map<SystemStreamPartition, List<AsyncTaskWorker>> sspToTaskWorkerMapping;
 
   private final ExecutorService threadPool;
-  private final ThreadPoolExecutor threadPoolExecutor;
   private final CoordinatorRequests coordinatorRequests;
   private final Object latch;
   private final int maxConcurrency;
@@ -102,7 +100,6 @@ public class RunLoop implements Runnable, Throttleable {
       boolean isAsyncCommitEnabled) {
 
     this.threadPool = threadPool;
-    this.threadPoolExecutor = threadPool instanceof ThreadPoolExecutor ? (ThreadPoolExecutor) threadPool : null;
     this.consumerMultiplexer = consumerMultiplexer;
     this.containerMetrics = containerMetrics;
     this.windowMs = windowMs;
@@ -179,10 +176,6 @@ public class RunLoop implements Runnable, Throttleable {
         if (totalNs != 0) {
           // totalNs is not 0 if timer metrics are enabled
           containerMetrics.utilization().set(((double) activeNs) / totalNs);
-          if (threadPoolExecutor != null) {
-            containerMetrics.containerThreadPoolUtilization()
-                .set(((double) threadPoolExecutor.getActiveCount()) / threadPoolExecutor.getCorePoolSize());
-          }
         }
       }
 

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -625,13 +625,12 @@ object SamzaContainer extends Logging {
         val physicalMemoryBytes : Long = sample.getPhysicalMemoryBytes
         val physicalMemoryMb : Float = physicalMemoryBytes / (1024.0F * 1024.0F)
         val memoryUtilization : Float = physicalMemoryMb.toFloat / containerMemoryMb
-        val threadPoolUtilization : Float = taskThreadPool.asInstanceOf[ThreadPoolExecutor].getActiveCount.toFloat /
-          taskThreadPool.asInstanceOf[ThreadPoolExecutor].getPoolSize
+        val containerActiveThreads : Long = taskThreadPool.asInstanceOf[ThreadPoolExecutor].getActiveCount
         logger.debug("Container physical memory utilization (mb): " + physicalMemoryMb)
         logger.debug("Container physical memory utilization: " + memoryUtilization)
         samzaContainerMetrics.physicalMemoryMb.set(physicalMemoryMb)
         samzaContainerMetrics.physicalMemoryUtilization.set(memoryUtilization)
-        samzaContainerMetrics.containerThreadPoolUtilization.set(threadPoolUtilization)
+        samzaContainerMetrics.containerActiveThreads.set(containerActiveThreads)
       }
     })
 

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -476,7 +476,6 @@ object SamzaContainer extends Logging {
 
     val threadPoolSize = jobConfig.getThreadPoolSize
     info("Got thread pool size: " + threadPoolSize)
-    samzaContainerMetrics.containerThreadPoolSize.set(threadPoolSize)
 
     val taskThreadPool = if (threadPoolSize > 0) {
       Executors.newFixedThreadPool(threadPoolSize,
@@ -625,11 +624,13 @@ object SamzaContainer extends Logging {
         val physicalMemoryBytes : Long = sample.getPhysicalMemoryBytes
         val physicalMemoryMb : Float = physicalMemoryBytes / (1024.0F * 1024.0F)
         val memoryUtilization : Float = physicalMemoryMb.toFloat / containerMemoryMb
+        val containerThreadPoolSize : Long = taskThreadPool.asInstanceOf[ThreadPoolExecutor].getPoolSize
         val containerActiveThreads : Long = taskThreadPool.asInstanceOf[ThreadPoolExecutor].getActiveCount
         logger.debug("Container physical memory utilization (mb): " + physicalMemoryMb)
         logger.debug("Container physical memory utilization: " + memoryUtilization)
         samzaContainerMetrics.physicalMemoryMb.set(physicalMemoryMb)
         samzaContainerMetrics.physicalMemoryUtilization.set(memoryUtilization)
+        samzaContainerMetrics.containerThreadPoolSize.set(containerThreadPoolSize)
         samzaContainerMetrics.containerActiveThreads.set(containerActiveThreads)
       }
     })

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
@@ -49,6 +49,7 @@ class SamzaContainerMetrics(
   val physicalMemoryMb = newGauge("physical-memory-mb", 0.0F)
   val physicalMemoryUtilization = newGauge("physical-memory-utilization", 0.0F)
   val containerThreadPoolSize = newGauge("container-thread-pool-size", 0L)
+  val containerThreadPoolUtilization = newGauge("container-thread-pool-utilization", 0.0F)
 
   val taskStoreRestorationMetrics: util.Map[TaskName, Gauge[Long]] = new util.HashMap[TaskName, Gauge[Long]]()
 

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
@@ -49,7 +49,7 @@ class SamzaContainerMetrics(
   val physicalMemoryMb = newGauge("physical-memory-mb", 0.0F)
   val physicalMemoryUtilization = newGauge("physical-memory-utilization", 0.0F)
   val containerThreadPoolSize = newGauge("container-thread-pool-size", 0L)
-  val containerThreadPoolUtilization = newGauge("container-thread-pool-utilization", 0.0F)
+  val containerActiveThreads = newGauge("container-active-threads", 0L)
 
   val taskStoreRestorationMetrics: util.Map[TaskName, Gauge[Long]] = new util.HashMap[TaskName, Gauge[Long]]()
 


### PR DESCRIPTION
Feature: Add a metric to track the number of active threads of a container's thread pool. This will be used to calculate the thread pool utilization of a job, which will be used as a signal for the autosizing controller to scale up or down the job thread pool size and number of containers.

Changes: 
 - Add a metric to track the number of active threads of a container's thread pool.
 - Update the existing container thread pool size metric to reflect the pool size from the thread pool instead of emitting the static `job.container.thread.pool.size`

Tests: unit tests; end-to-end test with samza-hello-samza and inspect the metrics MBean with JMX Reporter
<img width="904" alt="Screen Shot 2021-03-18 at 11 50 49 PM" src="https://user-images.githubusercontent.com/9065044/111748883-4916f500-884e-11eb-844e-36a63fa63091.png">
