### PR TITLE
SAMZA-2638: Skip container stop/restart for processors that have same work assignment across rebalances

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/job/model/JobModelUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/job/model/JobModelUtil.java
@@ -18,6 +18,7 @@
  */
 package org.apache.samza.job.model;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.Collections;
 import java.util.HashMap;
@@ -117,6 +118,47 @@ public class JobModelUtil {
     } catch (Exception e) {
       throw new SamzaException(String.format("Exception occurred when reading JobModel version: %s from metadata store.", jobModelVersion), e);
     }
+  }
+
+  /**
+   * Compares the {@link ContainerModel} for a given <i>processorId</i> across two {@link JobModel}.
+   * @param processorId processor id for which work assignments are compared
+   * @param first first job model
+   * @param second second job model
+   * @return true - if {@link ContainerModel} for the processor is same across the {@link JobModel}
+   *         false - otherwise
+   */
+  public static boolean compareContainerModelForProcessor(String processorId, JobModel first, JobModel second) {
+    Preconditions.checkArgument(StringUtils.isNotBlank(processorId), "Processor id cannot be blank");
+    if (first == second) {
+      return true;
+    }
+
+    if (first == null || second == null) {
+      return false;
+    }
+
+    return compareContainerModel(first.getContainers().get(processorId), second.getContainers().get(processorId));
+  }
+
+  /**
+   * Helper method to compare the two input {@link ContainerModel}s.
+   * @param first first container model
+   * @param second second container model
+   * @return true - if two input {@link ContainerModel} are equal
+   *         false - otherwise
+   */
+  @VisibleForTesting
+  static boolean compareContainerModel(ContainerModel first, ContainerModel second) {
+    if (first == second) {
+      return true;
+    }
+
+    if (first == null || second == null) {
+      return false;
+    }
+
+    return first.equals(second);
   }
 
   private static String getJobModelKey(String version) {

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
@@ -98,7 +98,6 @@ public class ZkJobCoordinator implements JobCoordinator {
   private final String processorId;
 
   private final Config config;
-  private final ZkBarrierForVersionUpgrade barrier;
   private final ZkJobCoordinatorMetrics metrics;
   private final ZkLeaderElector leaderElector;
   private final AtomicBoolean initiatedShutdown = new AtomicBoolean(false);
@@ -111,9 +110,13 @@ public class ZkJobCoordinator implements JobCoordinator {
   private final CoordinatorStreamStore coordinatorStreamStore;
 
   private JobCoordinatorListener coordinatorListener = null;
-  private JobModel newJobModel;
+  // denotes the most recent job model agreed by the quorum
+  private JobModel activeJobModel;
+  // denotes job model that is latest but may have not reached consensus
+  private JobModel latestJobModel;
   private boolean hasLoadedMetadataResources = false;
   private String cachedJobModelVersion = null;
+  private ZkBarrierForVersionUpgrade barrier;
 
   @VisibleForTesting
   ZkSessionMetrics zkSessionMetrics;
@@ -232,7 +235,7 @@ public class ZkJobCoordinator implements JobCoordinator {
 
   @Override
   public JobModel getJobModel() {
-    return newJobModel;
+    return latestJobModel;
   }
 
   @Override
@@ -269,11 +272,11 @@ public class ZkJobCoordinator implements JobCoordinator {
 
     // Generate the JobModel
     LOG.info("Generating new JobModel with processors: {}.", currentProcessorIds);
-    JobModel jobModel = generateNewJobModel(processorNodes);
+    JobModel newJobModel = generateNewJobModel(processorNodes);
 
     // Create checkpoint and changelog streams if they don't exist
     if (!hasLoadedMetadataResources) {
-      loadMetadataResources(jobModel);
+      loadMetadataResources(newJobModel);
       hasLoadedMetadataResources = true;
     }
 
@@ -283,7 +286,7 @@ public class ZkJobCoordinator implements JobCoordinator {
     LOG.info("pid=" + processorId + "Generated new JobModel with version: " + nextJMVersion + " and processors: " + currentProcessorIds);
 
     // Publish the new job model
-    publishJobModelToMetadataStore(jobModel, nextJMVersion);
+    publishJobModelToMetadataStore(newJobModel, nextJMVersion);
 
     // Start the barrier for the job model update
     barrier.create(nextJMVersion, currentProcessorIds);
@@ -393,6 +396,78 @@ public class ZkJobCoordinator implements JobCoordinator {
   }
 
   /**
+   * Check if the new job model contains a different work assignment for the processor compared the last active job
+   * model. In case of different work assignment, expire the current job model by invoking the <i>onJobModelExpired</i>
+   * on the registered {@link JobCoordinatorListener}.
+   * At this phase, the job model is yet to be agreed by the quorum and hence, this optimization helps availability of
+   * the processors in the event no changes in the work assignment.
+   *
+   * @param newJobModel new job model published by the leader
+   */
+  @VisibleForTesting
+  void checkAndExpireJobModel(JobModel newJobModel) {
+    Preconditions.checkNotNull(newJobModel, "JobModel cannot be null");
+    if (coordinatorListener == null) {
+      LOG.info("Skipping job model expiration since there are no active listeners");
+      return;
+    }
+
+    if (JobModelUtil.compareContainerModelForProcessor(processorId, activeJobModel, newJobModel)) {
+      LOG.info("Skipping job model expiration for processor {} due to no change in work assignment.", processorId);
+    } else {
+      coordinatorListener.onJobModelExpired();
+    }
+  }
+
+  /**
+   * Checks if the new job model contains a different work assignment for the processor compared to the last active
+   * job model. In case of different work assignment, update the task locality of the tasks associated with the
+   * processor and notify new job model to the registered {@link JobCoordinatorListener}.
+   *
+   * @param newJobModel new job model agreed by the quorum
+   */
+  @VisibleForTesting
+  void onNewJobModel(JobModel newJobModel) {
+    Preconditions.checkNotNull(newJobModel, "JobModel cannot be null. Failing onNewJobModel");
+    // start the container with the new model
+    if (!JobModelUtil.compareContainerModelForProcessor(processorId, activeJobModel, newJobModel)) {
+      if (newJobModel.getContainers().containsKey(processorId)) {
+        for (TaskName taskName : JobModelUtil.getTaskNamesForProcessor(processorId, newJobModel)) {
+          zkUtils.writeTaskLocality(taskName, locationId);
+        }
+
+        if (coordinatorListener != null) {
+          coordinatorListener.onNewJobModel(processorId, newJobModel);
+        }
+      }
+    } else {
+      LOG.info("Skipping onNewJobModel since there are no changes in work assignment.");
+    }
+
+    /*
+     * Update the last active job model to new job model regardless of whether the work assignment for the processor
+     * has changed or not. It is important to do it so that all the processors has a consistent view what the latest
+     * active job model is.
+     */
+    activeJobModel = newJobModel;
+  }
+
+  @VisibleForTesting
+  JobModel getActiveJobModel() {
+    return activeJobModel;
+  }
+
+  @VisibleForTesting
+  void setActiveJobModel(JobModel jobModel) {
+    activeJobModel = jobModel;
+  }
+
+  @VisibleForTesting
+  void setZkBarrierUpgradeForVersion(ZkBarrierForVersionUpgrade barrierUpgradeForVersion) {
+    barrier = barrierUpgradeForVersion;
+  }
+
+  /**
    * Builds the {@link GrouperMetadataImpl} based upon provided {@param jobModelVersion}
    * and {@param processorNodes}.
    * @param jobModelVersion the most recent jobModelVersion available in the zookeeper.
@@ -467,16 +542,7 @@ public class ZkJobCoordinator implements JobCoordinator {
       if (ZkBarrierForVersionUpgrade.State.DONE.equals(state)) {
         debounceTimer.scheduleAfterDebounceTime(barrierAction, 0, () -> {
           LOG.info("pid=" + processorId + "new version " + version + " of the job model got confirmed");
-
-          // read the new Model
-          JobModel jobModel = getJobModel();
-          // start the container with the new model
-          if (coordinatorListener != null) {
-            for (TaskName taskName : JobModelUtil.getTaskNamesForProcessor(processorId, jobModel)) {
-              zkUtils.writeTaskLocality(taskName, locationId);
-            }
-            coordinatorListener.onNewJobModel(processorId, jobModel);
-          }
+          onNewJobModel(getJobModel());
         });
       } else {
         if (ZkBarrierForVersionUpgrade.State.TIMED_OUT.equals(state)) {
@@ -541,21 +607,11 @@ public class ZkJobCoordinator implements JobCoordinator {
 
         LOG.info("Got a notification for new JobModel version. Path = {} Version = {}", dataPath, data);
 
-        newJobModel = readJobModelFromMetadataStore(jobModelVersion);
-        LOG.info("pid=" + processorId + ": new JobModel is available. Version =" + jobModelVersion + "; JobModel = " + newJobModel);
-
-        if (!newJobModel.getContainers().containsKey(processorId)) {
-          LOG.info("New JobModel does not contain pid={}. Stopping this processor. New JobModel: {}",
-              processorId, newJobModel);
-          stop();
-        } else {
-          // stop current work
-          if (coordinatorListener != null) {
-            coordinatorListener.onJobModelExpired();
-          }
-          // update ZK and wait for all the processors to get this new version
-          barrier.join(jobModelVersion, processorId);
-        }
+        latestJobModel = readJobModelFromMetadataStore(jobModelVersion);
+        LOG.info("pid=" + processorId + ": new JobModel is available. Version =" + jobModelVersion + "; JobModel = " + latestJobModel);
+        checkAndExpireJobModel(latestJobModel);
+        // update ZK and wait for all the processors to get this new version
+        barrier.join(jobModelVersion, processorId);
       });
     }
 


### PR DESCRIPTION
**Problem**:
As part of rebalance, we always expire the current work assignment and proceed to signal consensus and start the container with new work assignment. It is inefficient for the processors to do the above when there is no changes in the work assignment between the active job model & the proposed job model.

**Changes**:
 - Processors perform onJobModelExpired and onNewJobModel only if there are changes to their work assignment across the active and proposed job model.
 - Processors no longer shutdown if they are not part of job model. Refer to the [SAMZA-2638](https://issues.apache.org/jira/browse/SAMZA-2638) for explanations
 - Add helper methods in `JobModelUtil` for work assignment comparison

**Tests**:
 - Unit tests for job model expiration
 - Unit tests for on new job model
 - Unit tests for job model version change flow
 - Unit tests for container model comparison

**API Changes**: None

**Usage Instructions**: None

**Upgrade Instructions**: None