### PR TITLE
SAMZA-2639: Samza-sql: Fix ANY type validation for the parsed args

### DIFF
--- a/samza-sql/src/main/java/org/apache/samza/sql/planner/Checker.java
+++ b/samza-sql/src/main/java/org/apache/samza/sql/planner/Checker.java
@@ -98,7 +98,9 @@ class Checker implements SqlOperandTypeChecker {
         if (parsedSqlArgType.getSqlTypeName() == SqlTypeName.CHAR && udfArgumentAsSqlType == SqlTypeName.VARCHAR) {
           return true;
         } else if (!Objects.equals(parsedSqlArgType.getSqlTypeName(), udfArgumentAsSqlType)
-                && !ANY_SQL_TYPE_NAMES.contains(udfArgumentAsSqlType) && hasOneUdfMethod(udfMetadata)) {
+                && !ANY_SQL_TYPE_NAMES.contains(udfArgumentAsSqlType)
+                && !ANY_SQL_TYPE_NAMES.contains(parsedSqlArgType.getSqlTypeName())
+                && hasOneUdfMethod(udfMetadata)) {
           // 3(b). Throw up and fail on mismatch between the SamzaSqlType and CalciteType for any argument.
           String msg = String.format("Type mismatch in udf class: %s at argument index: %d." +
                           "Expected type: %s, actual type: %s.", udfMetadata.getName(),


### PR DESCRIPTION
**Problem**: With fix for SAMZA-2637, we introduced a bug where when the parsed UDF args are for some reason detected as ANY type, the checker fails.

**Fix**: In addition to checking the annotated udf arg types, also check the parsed arg types to see if it belongs to ANY type and skip checks on such types.

**API Changes**: None

**Tests**: Existing functional tests catch this.

**Upgrade Instructions**: None

**Usage Instructions**: None