### PR TITLE
SAMZA-2619: yarn.am.container.label should be applied only to AM not to the entire job

### DIFF
--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/ClientHelper.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/ClientHelper.scala
@@ -135,8 +135,10 @@ class ClientHelper(conf: Configuration) extends Logging {
 
     appMasterLabel match {
       case Some(label) => {
-        appCtx.setNodeLabelExpression(label)
-        info("set yarn node label expression to %s" format queueName)
+        val amcontainerResourceRequest = appCtx.getAMContainerResourceRequest();
+        amcontainerResourceRequest.setNodeLabelExpression(label);
+        appCtx.setAMContainerResourceRequest(amcontainerResourceRequest);
+        info("set yarn AM container node label expression to %s" format appMasterLabel)
       }
       case None =>
     }


### PR DESCRIPTION
Symptom: setting yarn.am.container.label applies it to containers (other than AM) also. So no way to apply label only to AM.

Cause: though yarn provides 3 modes of applying labels: only AM, only containers and all of job - samza uses am label and sets it for all of job.

Fix: set am label only for AM in ClientHelper -- when creating request for yarn RM

Tests: cant unit test due to nature of ClientHelper.

Usage:  If yarn.am.container.label="label1" was being used to apply label1 to whole of job -- now add 2 configs yarn.am.container.label="label1" and yarn.container.label="label1".

Upgrade: backwards incompatible. to get same behavior as before - need 2 configs in place of one now.
