### PR TITLE
Fix NullPointerException when thread pool size is 0 and thread pool is null for containerActiveThreads and containerThreadPoolSize metrics

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -624,12 +624,17 @@ object SamzaContainer extends Logging {
         val physicalMemoryBytes : Long = sample.getPhysicalMemoryBytes
         val physicalMemoryMb : Float = physicalMemoryBytes / (1024.0F * 1024.0F)
         val memoryUtilization : Float = physicalMemoryMb.toFloat / containerMemoryMb
-        val containerThreadPoolSize : Long = taskThreadPool.asInstanceOf[ThreadPoolExecutor].getPoolSize
-        val containerActiveThreads : Long = taskThreadPool.asInstanceOf[ThreadPoolExecutor].getActiveCount
         logger.debug("Container physical memory utilization (mb): " + physicalMemoryMb)
         logger.debug("Container physical memory utilization: " + memoryUtilization)
         samzaContainerMetrics.physicalMemoryMb.set(physicalMemoryMb)
         samzaContainerMetrics.physicalMemoryUtilization.set(memoryUtilization)
+
+        var containerThreadPoolSize : Long = 0
+        var containerActiveThreads : Long = 0
+        if (taskThreadPool != null) {
+          containerThreadPoolSize = taskThreadPool.asInstanceOf[ThreadPoolExecutor].getPoolSize
+          containerActiveThreads = taskThreadPool.asInstanceOf[ThreadPoolExecutor].getActiveCount
+        }
         samzaContainerMetrics.containerThreadPoolSize.set(containerThreadPoolSize)
         samzaContainerMetrics.containerActiveThreads.set(containerActiveThreads)
       }


### PR DESCRIPTION
Problem: when thread pool size is 0 and thread pool is null, hostStatisticsMonitor will throw NullPointerException when calculating containerActiveThreads and containerThreadPoolSize metrics. This will subsequently lead to the physical memory metrics to be missing as well, which can trigger alerts, lead to undesirable autosizing, etc.

Solution: add a null check for the thread pool before calculating containerActiveThreads and containerThreadPoolSize metrics

![Screen Shot 2021-03-24 at 3 07 30 PM](https://user-images.githubusercontent.com/9065044/112391509-42a4d500-8cb5-11eb-8b3d-edeb24917626.png)
![Screen Shot 2021-03-24 at 3 07 20 PM](https://user-images.githubusercontent.com/9065044/112391523-48021f80-8cb5-11eb-86e1-4b68245795c1.png)
