### PR TITLE
SAMZA-2640: Fixing errors in WindowType examples in High Level API doc

### DIFF
--- a/docs/learn/documentation/versioned/api/high-level-api.md
+++ b/docs/learn/documentation/versioned/api/high-level-api.md
@@ -370,7 +370,7 @@ Examples:
     
     // Group the pageView stream into 30 second tumbling windows keyed by the userId.
     MessageStream<PageView> pageViews = ...
-    MessageStream<WindowPane<String, Collection<PageView>>> = pageViews.window(
+    MessageStream<WindowPane<String, Collection<PageView>>> windowedStream = pageViews.window(
         Windows.keyedTumblingWindow(
             pageView -> pageView.getUserId(), // key extractor
             Duration.ofSeconds(30), // window duration
@@ -397,6 +397,11 @@ Examples:
 
 {% highlight java %}
 
+    // Sessionize a stream of page views with a session gap of 10 seconds
+    MessageStream<PageView> pageViews = …
+    MessageStream<WindowPane<String>, Collection<PageView>> windowedStream = pageViews.window(
+      Windows.keyedSessionWindow(pageView -> pageView.getUserId(), Duration.ofSeconds(10)));
+    
     // Sessionize a stream of page views, and count the number of page-views in a session for every user.
     MessageStream<PageView> pageViews = …
     Supplier<Integer> initialValue = () -> 0
@@ -410,18 +415,6 @@ Examples:
             initialValue, 
             countAggregator,
             new StringSerde(), new IntegerSerde()));
-
-    // Compute the maximum value over tumbling windows of 30 seconds.
-    MessageStream<Integer> integers = …
-    Supplier<Integer> initialValue = () -> Integer.MAX_INT
-    FoldLeftFunction<Integer, Integer> aggregateFunction = (msg, oldValue) -> Math.max(msg, oldValue)
-    
-    MessageStream<WindowPane<Void, Integer>> windowedStream = integers.window(
-        Windows.tumblingWindow(
-            Duration.ofSeconds(30), 
-            initialValue, 
-            aggregateFunction,
-            new IntegerSerde()));
          
 {% endhighlight %}
 


### PR DESCRIPTION
**Issue:**
The Window Types section in the High Level API documentation has a few mistakes:
1. Missing variable name for a Tumbling window example
2. Incorrect example for Session windows (seems like a copy paste issue from Tumbling window example)

**Changes:**
1. Added missing variable name for the Tumbling window example
2. Incorrect code was removed from the Session window section and a new example was added in its place.

**Tests**
NA. Since this is only a doc fix.