### PR TITLE
SAMZA-2633: Rolling upgrades cause downtime to upgraded processors for the entire deployment window

### DIFF
--- a/docs/learn/documentation/versioned/jobs/samza-configurations.md
+++ b/docs/learn/documentation/versioned/jobs/samza-configurations.md
@@ -373,6 +373,7 @@ Samza supports both standalone and clustered ([YARN](yarn-jobs.html)) [deploymen
 |job.coordinator.zk.connection.timeout.ms|60000|Zookeeper connection timeout in milliseconds. Zk connection timeout controls how long client tries to connect to ZK server before giving up.|
 |job.coordinator.zk.consensus.timeout.ms|40000|Zookeeper-based coordination. How long each processor will wait for all the processors to report acceptance of the new job model before rolling back.|
 |job.debounce.time.ms|20000|Zookeeper-based coordination. How long the Leader processor will wait before recalculating the JobModel on change of registered processors.|
+|job.coordinator.zk.enable-startup-with-active-job-model|false|Enable stream processors to run with the active job model version on startup without waiting for leader to trigger rebalance. It is useful in scenarios where processors leave the quorum and comeback within debounce time and the work assignment for new quorum remains unchanged. If disabled, processors will wait for leader to generate and notify work assignment.
 
 ### <a name="metrics"></a>[6. Metrics](#metrics)
 |Name|Default|Description|

--- a/samza-core/src/main/java/org/apache/samza/config/ZkConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ZkConfig.java
@@ -20,6 +20,7 @@
 package org.apache.samza.config;
 
 public class ZkConfig extends MapConfig {
+  public static final String STARTUP_WITH_ACTIVE_JOB_MODEL = "job.coordinator.zk.enable-startup-with-active-job-model";
   // Connection string for ZK, format: :<hostname>:<port>,..."
   public static final String ZK_CONNECT = "job.coordinator.zk.connect";
   public static final String ZK_SESSION_TIMEOUT_MS = "job.coordinator.zk.session.timeout.ms";
@@ -32,6 +33,10 @@ public class ZkConfig extends MapConfig {
 
   public ZkConfig(Config config) {
     super(config);
+  }
+
+  public boolean getEnableStartupWithActiveJobModel() {
+    return getBoolean(STARTUP_WITH_ACTIVE_JOB_MODEL, false);
   }
 
   public String getZkConnect() {

--- a/samza-core/src/main/java/org/apache/samza/job/model/JobModelUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/job/model/JobModelUtil.java
@@ -18,12 +18,12 @@
  */
 package org.apache.samza.job.model;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -138,18 +138,17 @@ public class JobModelUtil {
       return false;
     }
 
-    return compareContainerModel(first.getContainers().get(processorId), second.getContainers().get(processorId));
+    return Objects.equals(first.getContainers().get(processorId), second.getContainers().get(processorId));
   }
 
   /**
-   * Helper method to compare the two input {@link ContainerModel}s.
-   * @param first first container model
-   * @param second second container model
-   * @return true - if two input {@link ContainerModel} are equal
+   * Compares the {@link ContainerModel}s across the two {@link JobModel}s.
+   * @param first first job model
+   * @param second second job model
+   * @return true - if {@link ContainerModel}s are the same across {@link JobModel}s
    *         false - otherwise
    */
-  @VisibleForTesting
-  static boolean compareContainerModel(ContainerModel first, ContainerModel second) {
+  public static boolean compareContainerModels(JobModel first, JobModel second) {
     if (first == second) {
       return true;
     }
@@ -158,7 +157,7 @@ public class JobModelUtil {
       return false;
     }
 
-    return first.equals(second);
+    return Objects.equals(first.getContainers(), second.getContainers());
   }
 
   private static String getJobModelKey(String version) {

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
@@ -81,6 +81,8 @@ public class ZkJobCoordinator implements JobCoordinator {
   private static final int METADATA_CACHE_TTL_MS = 5000;
   private static final int NUM_VERSIONS_TO_LEAVE = 10;
 
+  // Action name when the processor starts with last agreed job model upon start
+  private static final String START_WORK_WITH_LAST_ACTIVE_JOB_MODEL = "StartWorkWithLastActiveJobModel";
   // Action name when the JobModel version changes
   private static final String JOB_MODEL_VERSION_CHANGE = "JobModelVersionChange";
 
@@ -163,12 +165,19 @@ public class ZkJobCoordinator implements JobCoordinator {
   public void start() {
     ZkKeyBuilder keyBuilder = zkUtils.getKeyBuilder();
     zkUtils.validateZkVersion();
-    zkUtils.validatePaths(new String[]{keyBuilder.getProcessorsPath(), keyBuilder.getJobModelVersionPath(), keyBuilder.getJobModelPathPrefix(), keyBuilder.getTaskLocalityPath()});
+    zkUtils.validatePaths(new String[]{
+        keyBuilder.getProcessorsPath(),
+        keyBuilder.getJobModelVersionPath(),
+        keyBuilder.getActiveJobModelVersionPath(),
+        keyBuilder.getJobModelPathPrefix(),
+        keyBuilder.getTaskLocalityPath()});
 
     this.jobModelMetadataStore.init();
     systemAdmins.start();
     leaderElector.tryBecomeLeader();
     zkUtils.subscribeToJobModelVersionChange(new ZkJobModelVersionChangeHandler(zkUtils));
+    debounceTimer.scheduleAfterDebounceTime(START_WORK_WITH_LAST_ACTIVE_JOB_MODEL, 0,
+        this::startWorkWithLastActiveJobModel);
   }
 
   @Override
@@ -273,6 +282,20 @@ public class ZkJobCoordinator implements JobCoordinator {
     // Generate the JobModel
     LOG.info("Generating new JobModel with processors: {}.", currentProcessorIds);
     JobModel newJobModel = generateNewJobModel(processorNodes);
+
+    /*
+     * Leader skips the rebalance even if there are changes in the quorum as long as the work assignment remains the same
+     * across all the processors. The optimization is useful in the following scenarios
+     *   1. The processor in the quorum restarts within the debounce window. Originally, this would trigger rebalance
+     *      across the processors stopping and starting their work assignment which is detrimental to availability of
+     *      the system. e.g. common scenario during rolling upgrades
+     *   2. Processors in the quorum which don't have work assignment and their failures/restarts don't impact the
+     *      quorum.
+     */
+    if (newJobModel.equals(activeJobModel)) {
+      LOG.info("Skipping rebalance since there are no changes in work assignment");
+      return;
+    }
 
     // Create checkpoint and changelog streams if they don't exist
     if (!hasLoadedMetadataResources) {
@@ -475,8 +498,52 @@ public class ZkJobCoordinator implements JobCoordinator {
   }
 
   @VisibleForTesting
+  void setDebounceTimer(ScheduleAfterDebounceTime scheduleAfterDebounceTime) {
+    debounceTimer = scheduleAfterDebounceTime;
+  }
+
+  @VisibleForTesting
   void setZkBarrierUpgradeForVersion(ZkBarrierForVersionUpgrade barrierUpgradeForVersion) {
     barrier = barrierUpgradeForVersion;
+  }
+
+  /**
+   * Start the processor with the last known active job model. It is safe to start with last active job model
+   * version in all the scenarios unless the event of concurrent rebalance. We define safe as a way to ensure that no
+   * two processors in the quorum have overlapping work assignments.
+   * In case of a concurrent rebalance there two scenarios
+   *   1. Job model version update happens before processor registration
+   *   2. Job model version update happens after processor registration
+   * ZK guarantees FIFO order for client operations, the processor is guaranteed to see all the state up until its
+   * own registration.
+   * For scenario 1, due to above guarantee, the processor will not start with old assignment due to mismatch in
+   * latest vs last active. (If there is no mismatch, the scenario reduces to one of the safe scenarios)
+   *
+   * For scenario 2, it is possible for the processor to not see the writes by the leader about job model version change
+   * but will eventually receive a notification on the job model version change and act on it (potentially stop
+   * the work assignment if its not part of the job model).
+   *
+   * In the scenario where the processor doesn't start with last active job model version, it will continue to follow
+   * the old protocol where leader should get notified about the processor registration and potentially trigger
+   * rebalance and notify about changes in work assignment after consensus.
+   * TODO: SAMZA-2635: Rebalances in standalone doesn't handle DAG changes for restarted processor
+   */
+  @VisibleForTesting
+  void startWorkWithLastActiveJobModel() {
+    LOG.info("Starting the processor with the recent active job model");
+    String lastActiveJobModelVersion = zkUtils.getLastActiveJobModelVersion();
+    String latestJobModelVersion = zkUtils.getJobModelVersion();
+
+    if (lastActiveJobModelVersion != null && lastActiveJobModelVersion.equals(latestJobModelVersion)) {
+      final JobModel lastActiveJobModel = readJobModelFromMetadataStore(lastActiveJobModelVersion);
+
+      /*
+       * TODO: A temporary workaround since job model can be started only if the stream processor is in the rebalance
+       *  state but not in starting state. All our current flows expect job model expired is invoked first.
+       */
+      checkAndExpireJobModel(lastActiveJobModel);
+      onNewJobModel(lastActiveJobModel);
+    }
   }
 
   /**
@@ -554,6 +621,9 @@ public class ZkJobCoordinator implements JobCoordinator {
       if (ZkBarrierForVersionUpgrade.State.DONE.equals(state)) {
         debounceTimer.scheduleAfterDebounceTime(barrierAction, 0, () -> {
           LOG.info("pid=" + processorId + "new version " + version + " of the job model got confirmed");
+          if (leaderElector.amILeader()) {
+            zkUtils.publishActiveJobModelVersion(version);
+          }
           onNewJobModel(getJobModel());
         });
       } else {

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkJobCoordinator.java
@@ -511,7 +511,7 @@ public class ZkJobCoordinator implements JobCoordinator {
 
   /**
    * Start the processor with the last known active job model. It is safe to start with last active job model
-   * version in all the scenarios unless the event of concurrent rebalance. We define safe as a way to ensure that no
+   * version in all the scenarios unless in the event of concurrent rebalance. We define safe as a way to ensure that no
    * two processors in the quorum have overlapping work assignments.
    * In case of a concurrent rebalance there two scenarios
    *   1. Job model version update happens before processor registration

--- a/samza-core/src/main/java/org/apache/samza/zk/ZkKeyBuilder.java
+++ b/samza-core/src/main/java/org/apache/samza/zk/ZkKeyBuilder.java
@@ -27,6 +27,7 @@ import com.google.common.base.Strings;
  *   - /
  *      |- groupId/
  *          |- JobModelGeneration/
+ *              |- activeJobModelVersion (data contains the most recent active job model version)
  *              |- jobModelVersion (data contains the version)
  *              |- jobModelUpgradeBarrier/ (contains barrier related data)
  *              |- jobModels/
@@ -42,7 +43,6 @@ import com.google.common.base.Strings;
  * This class provides helper methods to easily generate/parse the path in the ZK hierarchy.
  */
 public class ZkKeyBuilder {
-
   static final String PROCESSORS_PATH = "processors";
   static final String JOBMODEL_GENERATION_PATH = "jobModelGeneration";
   static final String JOB_MODEL_UPGRADE_BARRIER_PATH = "jobModelUpgradeBarrier";
@@ -87,6 +87,16 @@ public class ZkKeyBuilder {
 
   String getJobModelVersionPath() {
     return String.format("%s/%s/jobModelVersion", getRootPath(), JOBMODEL_GENERATION_PATH);
+  }
+
+  /**
+   * Denotes the path where the most recent active job model version is stored. The version of the job model is the
+   * most recent agreed upon version by the quorum. It differs from the <i>jobModelVersion</i> path which may
+   * have a newer version of job model published by the leader in during rebalance before consensus is achieved.
+   * @return the path where most recent active job model is stored
+   */
+  String getActiveJobModelVersionPath() {
+    return String.format("%s/%s/activeJobModelVersion", getRootPath(), JOBMODEL_GENERATION_PATH);
   }
 
   String getJobModelPathPrefix() {

--- a/samza-core/src/test/java/org/apache/samza/job/model/TestJobModelUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/job/model/TestJobModelUtil.java
@@ -38,15 +38,28 @@ public class TestJobModelUtil {
   private static final String PROCESSOR_ID = "testProcessor";
 
   @Test
-  public void testCompareContainerModel() {
-    assertTrue("Expecting null container models to return true", JobModelUtil.compareContainerModel(null, null));
-
-    assertFalse("Expecting false for two different container model",
-        JobModelUtil.compareContainerModel(mock(ContainerModel.class), mock(ContainerModel.class)));
-
+  public void testCompareContainerModels() {
     final ContainerModel mockContainerModel = mock(ContainerModel.class);
-    assertTrue("Expecting true for same container model",
-        JobModelUtil.compareContainerModel(mockContainerModel, mockContainerModel));
+    final JobModel first = mock(JobModel.class);
+    final JobModel second = mock(JobModel.class);
+    final String TEST_PROCESSOR = "testProcessor2";
+
+    when(first.getContainers()).thenReturn(ImmutableMap.of(PROCESSOR_ID, mockContainerModel));
+    when(second.getContainers()).thenReturn(ImmutableMap.of(PROCESSOR_ID, mockContainerModel));
+
+    assertTrue("Expecting null job models to return true", JobModelUtil.compareContainerModels(null, null));
+    assertTrue("Expecting true for job model with same container model",
+        JobModelUtil.compareContainerModels(first, second));
+
+    when(second.getContainers()).thenReturn(ImmutableMap.of(PROCESSOR_ID, mock(ContainerModel.class)));
+    assertFalse("Expecting false for two different job model",
+        JobModelUtil.compareContainerModels(first, second));
+
+    when(second.getContainers()).thenReturn(ImmutableMap.of(PROCESSOR_ID, mockContainerModel, TEST_PROCESSOR,
+        mock(ContainerModel.class)));
+    assertFalse("Expecting false for two different job model",
+        JobModelUtil.compareContainerModels(first, second));
+
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/samza-core/src/test/java/org/apache/samza/job/model/TestJobModelUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/job/model/TestJobModelUtil.java
@@ -42,7 +42,7 @@ public class TestJobModelUtil {
     final ContainerModel mockContainerModel = mock(ContainerModel.class);
     final JobModel first = mock(JobModel.class);
     final JobModel second = mock(JobModel.class);
-    final String TEST_PROCESSOR = "testProcessor2";
+    final String testProcessor2 = "testProcessor2";
 
     when(first.getContainers()).thenReturn(ImmutableMap.of(PROCESSOR_ID, mockContainerModel));
     when(second.getContainers()).thenReturn(ImmutableMap.of(PROCESSOR_ID, mockContainerModel));
@@ -55,7 +55,7 @@ public class TestJobModelUtil {
     assertFalse("Expecting false for two different job model",
         JobModelUtil.compareContainerModels(first, second));
 
-    when(second.getContainers()).thenReturn(ImmutableMap.of(PROCESSOR_ID, mockContainerModel, TEST_PROCESSOR,
+    when(second.getContainers()).thenReturn(ImmutableMap.of(PROCESSOR_ID, mockContainerModel, testProcessor2,
         mock(ContainerModel.class)));
     assertFalse("Expecting false for two different job model",
         JobModelUtil.compareContainerModels(first, second));

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
@@ -608,7 +608,8 @@ public class TestZkLocalApplicationRunner extends IntegrationTestHarness {
     String newJobModelVersion = zkUtils.getJobModelVersion();
     JobModel newJobModel = JobModelUtil.readJobModel(newJobModelVersion, zkMetadataStore);
 
-    assertEquals(Integer.parseInt(jobModelVersion) + 1, Integer.parseInt(newJobModelVersion));
+    // leader should skip rebalance because of no change in work assignment
+    assertEquals(Integer.parseInt(jobModelVersion), Integer.parseInt(newJobModelVersion));
     assertEquals(jobModel.getContainers(), newJobModel.getContainers());
 
     appRunner2.kill();

--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
@@ -608,8 +608,7 @@ public class TestZkLocalApplicationRunner extends IntegrationTestHarness {
     String newJobModelVersion = zkUtils.getJobModelVersion();
     JobModel newJobModel = JobModelUtil.readJobModel(newJobModelVersion, zkMetadataStore);
 
-    // leader should skip rebalance because of no change in work assignment
-    assertEquals(Integer.parseInt(jobModelVersion), Integer.parseInt(newJobModelVersion));
+    assertEquals(Integer.parseInt(jobModelVersion) + 1, Integer.parseInt(newJobModelVersion));
     assertEquals(jobModel.getContainers(), newJobModel.getContainers());
 
     appRunner2.kill();


### PR DESCRIPTION
**Description**: During rolling upgrades, the current debounce timer gets extended every time when there is a quorum change notification. As a result, processors that were upgraded earlier in the deployment window remain unavailable waiting for work assignment. In some scenarios, this cause processors to be unavailable for 20 minutes or so depending on the size of the quorum and the debounce time configuration. Refer to [SAMZA-2633](https://issues.apache.org/jira/browse/SAMZA-2633) for more information.

**Changes**:
- Optimize the leader workflow to skip rebalance if there is no changes to work assignment
- Make processors start with most recent agreed job model on startup
- Leader persists the active job model version in ZK to enable change [2]
- Introduce config for applications to opt-in for the optimization

**Tests**: 
- Added unit tests to `ZkJobCoordinator`
- Validated the rolling upgrade behavior with quorum size = 8, 24 and 32 with debounce time = upgrade time with various upgrade concurrency (25%, 10%, 75%, 100%)

**API Changes**: None

**Upgrade Instructions**: None

**Usage Instructions**: 
- Set `job.coordinator.zk.enable-startup-with-active-job-model` to true as part of the application configuration to enable processor use the recent active job model during startup and also enable leader to skip rebalances if the work assignment remains the same.