### PR TITLE
SAMZA-2644: ContainerLaunchUtil swallows exception and does not even log them if an exception occurs while setting up a Samza container or invoking run on it

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/runtime/ContainerLaunchUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/ContainerLaunchUtil.java
@@ -174,6 +174,8 @@ public class ContainerLaunchUtil {
         log.error("Container stopped with Exception. Exiting process now.", containerRunnerException);
         System.exit(1);
       }
+    } catch (Throwable e) {
+      log.error("Container stopped with Exception. ", containerRunnerException);
     } finally {
       coordinatorStreamStore.close();
     }


### PR DESCRIPTION
***Feature/Issue:***
- ContainerLaunchUtil swallows exceptions while setting up and running a container, does not even log the Exception

***Changes:***
- Log exception when there is an exception thrown in setting up the container or running it

***API Changes: None***

***Tests:*** Locally tested with a job

***Upgrade instructions: None***
 