### PR TITLE
SAMZA-2646: Minor refactor of StreamAppender to support sending formats other than byte[] to SystemProducer

### DIFF
--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
@@ -265,7 +265,7 @@ public class StreamAppender extends AbstractAppender {
     metrics.bufferFillPct.set(Math.round(100f * logQueue.size() / DEFAULT_QUEUE_SIZE));
   }
 
-  protected EncodedLogEvent encodeLogEventToBytes(LogEvent event) {
+  protected EncodedLogEvent encodeLogEvent(LogEvent event) {
     return new ByteArrayEncodedLogEvent(serde.toBytes(subLog(event)));
   }
 

--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
@@ -233,13 +233,13 @@ public class StreamAppender extends AbstractAppender {
    */
   private void handleEvent(LogEvent event) throws InterruptedException {
     if (usingAsyncLogger) {
-      sendEventToSystemProducer(encodeLogEventToBytes(event));
+      sendEventToSystemProducer(encodeLogEvent(event));
       return;
     }
 
     // Serialize the event before adding to the queue to leverage the caller thread
     // and ensure that the transferThread can keep up.
-    if (!logQueue.offer(encodeLogEventToBytes(event), queueTimeoutS, TimeUnit.SECONDS)) {
+    if (!logQueue.offer(encodeLogEvent(event), queueTimeoutS, TimeUnit.SECONDS)) {
       // Do NOT retry adding system to the queue. Dropping the event allows us to alleviate the unlikely
       // possibility of a deadlock, which can arise due to a circular dependency between the SystemProducer
       // which is used for StreamAppender and the log, which uses StreamAppender. Any locks held in the callstack


### PR DESCRIPTION
Issue: StreamAppender is restrictive in explicitly using byte[] for the serialized log event in the OutgoingMessageEnvelope(OME) sent to underlying SystemProducer. This restricts how the classes extending StreamAppender send to SystemProducer as it prevents sending objects (like avro records) to OME.

Change: Introduce a protected interface to hold the encoded log event and a private impl of it for streamappender.

Tests: existing tests pass, no functionality change.

API changes: none

Usage, upgrade instructions: none