### PR TITLE
SAMZA-2654: Allow coordinator url port to be configurable

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/ClusterManagerConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ClusterManagerConfig.java
@@ -142,6 +142,11 @@ public class ClusterManagerConfig extends MapConfig {
    * information such as job model and locality.
    * If the value is set to 0, then the port will be dynamically allocated from the available free ports on the node.
    * The default value of this config is 0.
+   *
+   * Be careful when using this configuration. If the configured port is already in use on the node, then the job
+   * coordinator will fail to start.
+   *
+   * This configuration is experimental, and it might be removed in a future release.
    */
   private static final String JOB_COORDINATOR_URL_PORT = "cluster-manager.jobcoordinator.url.port";
   private static final int DEFAULT_JOB_COORDINATOR_URL_PORT = 0;

--- a/samza-core/src/main/java/org/apache/samza/config/ClusterManagerConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ClusterManagerConfig.java
@@ -137,6 +137,15 @@ public class ClusterManagerConfig extends MapConfig {
   private static final String AM_JMX_ENABLED = "yarn.am.jmx.enabled";
   private static final String CLUSTER_MANAGER_JMX_ENABLED = "cluster-manager.jobcoordinator.jmx.enabled";
 
+  /**
+   * Use this to configure a static port for the job coordinator url for a Samza job. This url is used to provide
+   * information such as job model and locality.
+   * If the value is set to 0, then the port will be dynamically allocated from the available free ports on the node.
+   * The default value of this config is 0.
+   */
+  private static final String JOB_COORDINATOR_URL_PORT = "cluster-manager.jobcoordinator.url.port";
+  private static final int DEFAULT_JOB_COORDINATOR_URL_PORT = 0;
+
   public ClusterManagerConfig(Config config) {
       super(config);
   }
@@ -279,5 +288,9 @@ public class ClusterManagerConfig extends MapConfig {
     } else {
       return true;
     }
+  }
+
+  public int getCoordinatorUrlPort() {
+    return getInt(JOB_COORDINATOR_URL_PORT, DEFAULT_JOB_COORDINATOR_URL_PORT);
   }
 }

--- a/samza-core/src/main/scala/org/apache/samza/coordinator/JobModelManager.scala
+++ b/samza-core/src/main/scala/org/apache/samza/coordinator/JobModelManager.scala
@@ -100,7 +100,8 @@ object JobModelManager extends Logging {
 
       updateTaskAssignments(jobModel, taskAssignmentManager, taskPartitionAssignmentManager, grouperMetadata)
 
-      val server = new HttpServer
+      val clusterManagerConfig = new ClusterManagerConfig(config)
+      val server = new HttpServer(port = clusterManagerConfig.getCoordinatorUrlPort)
       server.addServlet("/", new JobServlet(serializedJobModelRef))
       server.addServlet("/locality", new LocalityServlet(localityManager))
 


### PR DESCRIPTION
Issues: Currently, the port for the job coordinator url (for accessing job model) is always dynamically allocated. In some cases, it is helpful to be able to hardcode a port.

Changes: When `JobModelManager` is setting up the `HttpServer` which serves the coordinator url, read a config to set the port.

Tests:
1. `./bin/integration-tests.sh /tmp/samza-tests yarn-integration-tests --nopassword`
2. Ran a job with `ProcessJobFactory` and verified the job started up.

API changes:
Set the config `cluster-manager.jobcoordinator.url.port` to the port number to use for the coordinator url. This is backwards compatible because the default is to use a value of 0 (to dynamically allocate an unused port), and a value of 0 was the value used before this change was made.
If the specified port is unavailable, then an exception will be thrown at startup. Therefore, this configuration should only be used when a specific port is needed and it is known that the port is not already in use. In many cases, using dynamic port allocations (i.e. not setting `cluster-manager.jobcoordinator.url.port`) will be the best way to go, since it will prevent failures due to port conflicts.

More context about how this can be used:
When using Kubernetes, we can create a "Service" which provides a consistent coordinator url, even when the job coordinator switches pods. The port is one piece of information needed to create this "Service". If we want to use a Kubernetes controller to create the "Service" (per the Kubernetes operator pattern), then we don't need to retrieve the port from the job coordinator in order to create the "Service".
When using Kubernetes, ports only need to be unique within a pod (as opposed to a host). This is due to the Kubernetes networking model. Therefore, port conflict issues are less likely when hardcoding ports. Being able to hardcode a port makes it easier to build the coordinator url since Kubernetes can also set up a "service name" for the coordinator instead of using the physical host name.