### PR TITLE
SAMZA-2658: KafkaCheckpointLogKeySerde should support deserializing unknown keys

### DIFF
--- a/samza-kafka/src/main/java/org/apache/samza/checkpoint/kafka/KafkaCheckpointLogKey.java
+++ b/samza-kafka/src/main/java/org/apache/samza/checkpoint/kafka/KafkaCheckpointLogKey.java
@@ -48,9 +48,6 @@ public class KafkaCheckpointLogKey {
     Preconditions.checkNotNull(type);
     Preconditions.checkState(!grouperFactoryClassName.isEmpty(), "Empty grouper factory class provided");
 
-    Preconditions.checkState(type.equals(CHECKPOINT_KEY_TYPE), String.format("Invalid type provided for checkpoint key. " +
-        "Expected: (%s) Actual: (%s)", CHECKPOINT_KEY_TYPE, type));
-
     this.grouperFactoryClassName = grouperFactoryClassName;
     this.taskName = taskName;
     this.type = type;

--- a/samza-kafka/src/main/java/org/apache/samza/checkpoint/kafka/KafkaCheckpointLogKeySerde.java
+++ b/samza-kafka/src/main/java/org/apache/samza/checkpoint/kafka/KafkaCheckpointLogKeySerde.java
@@ -59,10 +59,6 @@ public class KafkaCheckpointLogKeySerde implements Serde<KafkaCheckpointLogKey> 
     try {
       LinkedHashMap<String, String> deserializedKey = MAPPER.readValue(bytes, LinkedHashMap.class);
 
-      if (!KafkaCheckpointLogKey.CHECKPOINT_KEY_TYPE.equals(deserializedKey.get(TYPE_FIELD))) {
-        throw new IllegalArgumentException(String.format("Invalid key detected. Type of the key is %s", deserializedKey.get(TYPE_FIELD)));
-      }
-
       return new KafkaCheckpointLogKey(deserializedKey.get(TYPE_FIELD), new TaskName(deserializedKey.get(TASK_NAME_FIELD)), deserializedKey.get(SSP_GROUPER_FACTORY_FIELD)
       );
     } catch (Exception e) {

--- a/samza-kafka/src/test/java/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointLogKeySerde.java
+++ b/samza-kafka/src/test/java/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointLogKeySerde.java
@@ -50,4 +50,16 @@ public class TestKafkaCheckpointLogKeySerde {
     // test that deserialize(serialize(k)) == k
     Assert.assertEquals(key, checkpointSerde.fromBytes(checkpointSerde.toBytes(key)));
   }
+
+  @Test
+  public void testForwardsCompatibility() {
+    // Set the key to another value, this is for the future if we want to support multiple checkpoint keys
+    // we do not want to throw in the Serdes layer, but must be validated in the CheckpointManager
+    KafkaCheckpointLogKey key = new KafkaCheckpointLogKey("checkpoint-v2",
+        new TaskName("Partition 0"), GroupByPartitionFactory.class.getCanonicalName());
+    KafkaCheckpointLogKeySerde checkpointSerde = new KafkaCheckpointLogKeySerde();
+
+    // test that deserialize(serialize(k)) == k
+    Assert.assertEquals(key, checkpointSerde.fromBytes(checkpointSerde.toBytes(key)));
+  }
 }


### PR DESCRIPTION
Removed precondition for key value in KafkaCheckpointLogKeySerde and KafkaCheckpointLogKey to support different checkpoint key types for forwards compatibility.

Added tests validating unknown keys are skipped in KafkaCheckpointManager.