### PR TITLE
Fix StorageConfig bug from newly introduced BlobStoreRestore factory config

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/StorageConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/StorageConfig.java
@@ -74,7 +74,8 @@ public class StorageConfig extends MapConfig {
       KAFKA_STATE_BACKEND_FACTORY);
   public static final String STORE_BACKUP_FACTORIES = STORE_PREFIX + "%s.backup.factories";
   // TODO BLOCKER dchen make this per store
-  public static final String STORE_RESTORE_FACTORY = STORE_PREFIX + "restore.factory";
+  public static final String RESTORE_FACTORY_SUFFIX = "restore.factory";
+  public static final String STORE_RESTORE_FACTORY = STORE_PREFIX + RESTORE_FACTORY_SUFFIX;
 
   static final String CHANGELOG_SYSTEM = "job.changelog.system";
   static final String CHANGELOG_DELETE_RETENTION_MS = STORE_PREFIX + "%s.changelog.delete.retention.ms";
@@ -100,7 +101,8 @@ public class StorageConfig extends MapConfig {
     for (String key : subConfig.keySet()) {
       if (key.endsWith(SIDE_INPUT_PROCESSOR_FACTORY_SUFFIX)) {
         storeNames.add(key.substring(0, key.length() - SIDE_INPUT_PROCESSOR_FACTORY_SUFFIX.length()));
-      } else if (key.endsWith(FACTORY_SUFFIX)) {
+      } else if (key.endsWith(FACTORY_SUFFIX) && !key.equals(RESTORE_FACTORY_SUFFIX)) {
+        // TODO HIGH dchen STORE_RESTORE_FACTORY added here to be ignored. Update/remove after changing restore factory -> factories
         storeNames.add(key.substring(0, key.length() - FACTORY_SUFFIX.length()));
       }
     }
@@ -153,10 +155,6 @@ public class StorageConfig extends MapConfig {
   }
 
   public Optional<String> getStorageFactoryClassName(String storeName) {
-    //TODO HIGH dchen remove this after changing restore factory to factories.
-    if (String.format(FACTORY, storeName).equals(STORE_RESTORE_FACTORY)) {
-      return Optional.empty();
-    }
     return Optional.ofNullable(get(String.format(FACTORY, storeName)));
   }
 

--- a/samza-core/src/main/java/org/apache/samza/config/StorageConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/StorageConfig.java
@@ -153,6 +153,10 @@ public class StorageConfig extends MapConfig {
   }
 
   public Optional<String> getStorageFactoryClassName(String storeName) {
+    //TODO HIGH dchen remove this after changing restore factory to factories.
+    if (String.format(FACTORY, storeName).equals(STORE_RESTORE_FACTORY)) {
+      return Optional.empty();
+    }
     return Optional.ofNullable(get(String.format(FACTORY, storeName)));
   }
 

--- a/samza-core/src/main/java/org/apache/samza/storage/KafkaChangelogStateBackendFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/KafkaChangelogStateBackendFactory.java
@@ -48,6 +48,18 @@ import org.apache.samza.util.Clock;
 
 public class KafkaChangelogStateBackendFactory implements StateBackendFactory {
   private StreamMetadataCache streamCache;
+  /*
+   * This keeps track of the changelog SSPs that are associated with the whole container. This is used so that we can
+   * prefetch the metadata about the all of the changelog SSPs associated with the container whenever we need the
+   * metadata about some of the changelog SSPs.
+   * An example use case is when Samza writes offset files for stores ({@link TaskStorageManager}). Each task is
+   * responsible for its own offset file, but if we can do prefetching, then most tasks will already have cached
+   * metadata by the time they need the offset metadata.
+   * Note: By using all changelog streams to build the sspsToPrefetch, any fetches done for persisted stores will
+   * include the ssps for non-persisted stores, so this is slightly suboptimal. However, this does not increase the
+   * actual number of calls to the {@link SystemAdmin}, and we can decouple this logic from the per-task objects (e.g.
+   * {@link TaskStorageManager}).
+   */
   private SSPMetadataCache sspCache;
 
   @Override

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -346,23 +346,6 @@ object SamzaContainer extends Logging {
 
     info("Got change log system streams: %s" format storeChangelogs)
 
-    /*
-     * This keeps track of the changelog SSPs that are associated with the whole container. This is used so that we can
-     * prefetch the metadata about the all of the changelog SSPs associated with the container whenever we need the
-     * metadata about some of the changelog SSPs.
-     * An example use case is when Samza writes offset files for stores ({@link TaskStorageManager}). Each task is
-     * responsible for its own offset file, but if we can do prefetching, then most tasks will already have cached
-     * metadata by the time they need the offset metadata.
-     * Note: By using all changelog streams to build the sspsToPrefetch, any fetches done for persisted stores will
-     * include the ssps for non-persisted stores, so this is slightly suboptimal. However, this does not increase the
-     * actual number of calls to the {@link SystemAdmin}, and we can decouple this logic from the per-task objects (e.g.
-     * {@link TaskStorageManager}).
-     */
-    val changelogSSPMetadataCache = new SSPMetadataCache(systemAdmins,
-      Duration.ofSeconds(5),
-      SystemClock.instance,
-      getChangelogSSPsForContainer(containerModel, storeChangelogs).asJava)
-
     val intermediateStreams = streamConfig
       .getStreamIds()
       .asScala

--- a/samza-core/src/test/java/org/apache/samza/config/TestStorageConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestStorageConfig.java
@@ -70,6 +70,28 @@ public class TestStorageConfig {
     assertEquals(expectedStoreNames, ImmutableSet.copyOf(actual));
   }
 
+  /**
+   * Test verifies that the {@link StorageConfig#STORE_RESTORE_FACTORY} which matches pattern for store.%s.factory
+   * is not picked up as in store names list
+   */
+  @Test
+  public void testGetStoreNamesIgnoreStateRestoreFactory() {
+    // empty config, so no stores
+    assertEquals(Collections.emptyList(), new StorageConfig(new MapConfig()).getStoreNames());
+
+    Set<String> expectedStoreNames = ImmutableSet.of(STORE_NAME0, STORE_NAME1);
+    // has stores
+    StorageConfig storageConfig = new StorageConfig(new MapConfig(
+        ImmutableMap.of(String.format(StorageConfig.FACTORY, STORE_NAME0), "store0.factory.class",
+            String.format(StorageConfig.FACTORY, STORE_NAME1), "store1.factory.class",
+            STORE_RESTORE_FACTORY, "org.apache.class")));
+
+    List<String> actual = storageConfig.getStoreNames();
+    // ordering shouldn't matter
+    assertEquals(2, actual.size());
+    assertEquals(expectedStoreNames, ImmutableSet.copyOf(actual));
+  }
+
   @Test
   public void testGetChangelogStream() {
     // empty config, so no changelog stream


### PR DESCRIPTION
Description:
Newly introduced config `store.restore.factory` falls in the same pattern as StorageEngine config defined by `store.<store_name>.factory`. This fix ignores `store.restore.factory` from `getStorageFactoryClassName` for now. A follow up TODO is added to change this later when restore factory is changed to restore factories. 