### PR TITLE
SAMZA-1885: Enable parallel task execution for build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,11 +127,6 @@ subprojects {
     toolVersion = "$checkstyleVersion"
   }
 
-  tasks.withType(ScalaCompile) {
-    // show compile errors in console output
-    logging.setLevel LogLevel.WARN
-  }
-
   tasks.withType(Test) {
     test {
       testLogging {

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,5 @@ org.gradle.jvmargs="-XX:MaxPermSize=512m"
 
 systemProp.file.encoding=utf-8
 checkstyleVersion=6.11.2
+
+org.gradle.parallel=true


### PR DESCRIPTION
Symptom: Parallel builds did not work, so we had it disabled, which slowed down build time.

Cause: There was a cryptic `NullPointerException` which sometimes had no additional context and sometimes showed a stack trace for a "progress tracking" flow in Gradle. It looks like this issue was related to the usage of `logging.setLevel` in `build.gradle`. Removing `logging.setLevel` causes the `NullPointerException` to go away. This `logging.setLevel` has been deprecated since Gradle 2 (https://docs.gradle.org/2.14/release-notes.html), and it doesn't look like it makes any difference in logging anymore anyways. I didn't dig further into Gradle to see exactly why `logging.setLevel` was causing the issue, but my guess is that there is some race condition that is triggered when turning on parallel builds, and that deprecated flow just hasn't been maintained to work with parallel builds since it has been deprecated for so long.

Changes:
1. Remove `logging.setLevel` usage.
2. Enable parallel task execution.

Tests:
./gradlew build

Impact: Reduces build times by about 2-3 minutes. It doesn't speed up the time it takes to run the tests though, and the tests are still taking up a significant amount of time.