### PR TITLE
SAMZA-2660: Add authentication via TokenCredential for AzureBlobSystemProducer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,6 +214,7 @@ project(":samza-azure_$scalaSuffix") {
 
   dependencies {
     compile "com.azure:azure-storage-blob:12.0.1"
+    compile "com.azure:azure-identity:1.0.0"
     compile "com.microsoft.azure:azure-storage:5.3.1"
     compile "com.microsoft.azure:azure-eventhubs:1.0.1"
     compile "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"

--- a/docs/learn/documentation/versioned/jobs/samza-configurations.md
+++ b/docs/learn/documentation/versioned/jobs/samza-configurations.md
@@ -258,7 +258,7 @@ Configs for producing to [Azure Blob Storage](https://azure.microsoft.com/en-us/
 #### <a name="advanced-azure-blob-storage"></a>[Advanced Azure Blob Storage Configurations](#advanced-azure-blob-storage)
 |Name|Default|Description|
 |--- |--- |--- |
-|systems.**_system-name_**.azureblob.proxy.use |false|if true, proxy will be used to connect to Azure.|
+|systems.**_system-name_**.azureblob.proxy.use |false|if true, proxy will be used to connect to Azure for blob creation.|
 |systems.**_system-name_**.azureblob.proxy.hostname| |if proxy.use is true then host name of proxy.|
 |systems.**_system-name_**.azureblob.proxy.port| |if proxy.use is true then port of proxy.|
 |systems.**_system-name_**.azureblob.writer.factory.class|`org.apache.samza.system.`<br>`azureblob.avro.`<br>`AzureBlobAvroWriterFactory`|Fully qualified class name of the `org.apache.samza.system.azureblob.producer.AzureBlobWriter` impl for the system producer.<br><br>The default writer creates blobs that are of type AVRO and require the messages sent to a blob to be AVRO records. The blobs created by the default writer are of type [Block Blobs](https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs#about-block-blobs).|
@@ -272,7 +272,14 @@ Configs for producing to [Azure Blob Storage](https://azure.microsoft.com/en-us/
 |systems.**_system-name_**.azureblob.closeTimeoutMs|300000 (5 mins)|timeout to finish committing all the blobs currently being written to. This does not include the flush timeout per blob.|
 |systems.**_system-name_**.azureblob.suffixRandomStringToBlobName|true|if true, a random string of 8 chars is suffixed to the blob name to prevent name collision when more than one Samza tasks are writing to the same SSP.|
 |systems.**_system-name_**.azureblob.metadataPropertiesGeneratorFactory|`org.apache.samza.system.`<br>`azureblob.utils.`<br>`NullBlobMetadataGeneratorFactory`|Fully qualified class name of the `org.apache.samza.system.azureblob.utils.BlobMetadataGeneratorFactory` impl for the system producer. <br><br>The default metadata generator does not add any metadata to the blob.| 
-|systems.**_system-name_**.azureblob.metadataGeneratorConfig| |Additional configs for the metadata generator should be prefixed with this string which is passed to the generator.<br>For example, to pass a "key":"value" pair to the metadata generator, add config like systems.<system-name>.azureblob.metadataGeneratorConfig.\<key\> with value \<value\>| 
+|systems.**_system-name_**.azureblob.metadataGeneratorConfig| |Additional configs for the metadata generator should be prefixed with this string which is passed to the generator.<br>For example, to pass a "key":"value" pair to the metadata generator, add config like systems.<system-name>.azureblob.metadataGeneratorConfig.\<key\> with value \<value\>|
+|systems.**_system-name_**.azureblob.useTokenCredentialAuthentication|false| if true, then com.azure.core.credential.TokenCredential is used to authenticate with Azure.|
+|systems.**_system-name_**.azureblob.client.id| | if TokenCredential authentication, then the client id to be used for authentication.|
+|systems.**_system-name_**.azureblob.client.secret| | if TokenCredential authentication, then the client secret to be used for authentication.|
+|systems.**_system-name_**.azureblob.tenant.id| | if TokenCredential authentication, then the tenant id to be used for authentication.|
+|systems.**_system-name_**.azureblob.authProxy.use|false| if TokenCredential authentication, then setting this to true will result in using a proxy for authentication.|
+|systems.**_system-name_**.azureblob.authProxy.hostName| |if authProxy.use is true then host name of proxy.|
+|systems.**_system-name_**.azureblob.authProxy.port| |if authProxy.use is true then port of proxy.|
 
 
 ### <a name="state-storage"></a>[4. State Storage](#state-storage)

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobClientBuilder.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobClientBuilder.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.system.azureblob;
+
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.http.ProxyOptions;
+import com.azure.core.http.netty.NettyAsyncHttpClientBuilder;
+import com.azure.core.http.policy.HttpLogDetailLevel;
+import com.azure.core.http.policy.HttpLogOptions;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import com.azure.storage.blob.BlobServiceAsyncClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.common.StorageSharedKeyCredential;
+import java.net.InetSocketAddress;
+import com.azure.core.http.HttpClient;
+import java.util.Locale;
+
+
+public final class AzureBlobClientBuilder {
+  private final String systemName;
+  private final String azureUrlFormat;
+  private final AzureBlobConfig azureBlobConfig;
+  public AzureBlobClientBuilder(String systemName, String azureUrlFormat, AzureBlobConfig azureBlobConfig) {
+    this.systemName = systemName;
+    this.azureUrlFormat = azureUrlFormat;
+    this.azureBlobConfig = azureBlobConfig;
+  }
+  public BlobServiceAsyncClient getBlobServiceAsyncClient() {
+    BlobServiceClientBuilder blobServiceClientBuilder = getBlobServiceClientBuilder();
+
+    if (azureBlobConfig.getUseTokenCredentialAuthentication(systemName)) {
+      // Use your Azure Blob Storage account's name and client details to create a token credential object to access your account.
+      TokenCredential tokenCredential = getTokenCredential();
+      return blobServiceClientBuilder.credential(tokenCredential).buildAsyncClient();
+    }
+
+    // Use your Azure Blob Storage account's name and key to create a credential object to access your account.
+    StorageSharedKeyCredential storageSharedKeyCredential = getStorageSharedKeyCredential();
+    return blobServiceClientBuilder.credential(storageSharedKeyCredential).buildAsyncClient();
+  }
+
+  private BlobServiceClientBuilder getBlobServiceClientBuilder() {
+    // From the Azure portal, get your Storage account blob service AsyncClient endpoint.
+    String endpoint = String.format(Locale.ROOT, azureUrlFormat, azureBlobConfig.getAzureAccountName(systemName));
+
+    HttpLogOptions httpLogOptions = new HttpLogOptions();
+    httpLogOptions.setLogLevel(HttpLogDetailLevel.BASIC);
+
+    BlobServiceClientBuilder blobServiceClientBuilder = new BlobServiceClientBuilder()
+        .httpLogOptions(httpLogOptions)
+        .endpoint(endpoint)
+        .httpClient(getHttpClient());
+
+    return blobServiceClientBuilder;
+  }
+
+  private TokenCredential getTokenCredential() {
+    ClientSecretCredentialBuilder clientSecretCredentialBuilder = new ClientSecretCredentialBuilder()
+        .clientId(azureBlobConfig.getAzureClientId(systemName))
+        .clientSecret(azureBlobConfig.getAzureClientSecret(systemName))
+        .tenantId(azureBlobConfig.getAzureTenantId(systemName));
+
+    if (azureBlobConfig.getUseAuthProxy(systemName)) {
+      return clientSecretCredentialBuilder
+          .proxyOptions(new ProxyOptions(ProxyOptions.Type.HTTP,
+              new InetSocketAddress(azureBlobConfig.getAuthProxyHostName(systemName),
+                  azureBlobConfig.getAuthProxyPort(systemName))))
+          .build();
+    }
+    return clientSecretCredentialBuilder
+        .build();
+  }
+
+  private StorageSharedKeyCredential getStorageSharedKeyCredential() {
+    return new StorageSharedKeyCredential(azureBlobConfig.getAzureAccountName(systemName),
+        azureBlobConfig.getAzureAccountKey(systemName));
+  }
+
+  private HttpClient getHttpClient() {
+    HttpClient httpClient;
+    if (azureBlobConfig.getUseBlobProxy(systemName)) {
+      httpClient = new NettyAsyncHttpClientBuilder()
+          .proxy(new ProxyOptions(ProxyOptions.Type.HTTP,
+              new InetSocketAddress(azureBlobConfig.getAzureBlobProxyHostname(systemName),
+                  azureBlobConfig.getAzureBlobProxyPort(systemName))))
+          .build();
+    } else {
+      httpClient = HttpClient.createDefault();
+    }
+    return httpClient;
+  }
+}

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobConfig.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobConfig.java
@@ -26,86 +26,84 @@ import org.apache.samza.config.ConfigException;
 import org.apache.samza.config.MapConfig;
 
 public class AzureBlobConfig extends MapConfig {
-  private static final String SYSTEM_AZUREBLOB_PREFIX = "systems.%s.azureblob.";
-  //Server Instance Level Property
-
   // The duration after which an Azure request will be logged as a warning.
   public static final String AZURE_BLOB_LOG_SLOW_REQUESTS_MS = "samza.azureblob.log.slowRequestMs";
-  private static final long AZURE_BLOB_LOG_SLOW_REQUESTS_MS_DEFAULT = Duration.ofSeconds(30).toMillis();
+  //Server Instance Level Property
+  public static final String SYSTEM_WRITER_FACTORY_CLASS_NAME_DEFAULT = "org.apache.samza.system.azureblob.avro.AzureBlobAvroWriterFactory";
+  public static final boolean SYSTEM_AZURE_USE_AUTH_PROXY_DEFAULT = false;
+  public static final boolean SYSTEM_AZURE_USE_PROXY_DEFAULT = false;
+  private static final String SYSTEM_AZUREBLOB_PREFIX = "systems.%s.azureblob.";
 
+  // Azure authentication - via a/c name+key or ClientSecretCredential
   // system Level Properties.
   // fully qualified class name of the AzureBlobWriter impl for the producer system
   public static final String SYSTEM_WRITER_FACTORY_CLASS_NAME = SYSTEM_AZUREBLOB_PREFIX + "writer.factory.class";
-  public static final String SYSTEM_WRITER_FACTORY_CLASS_NAME_DEFAULT = "org.apache.samza.system.azureblob.avro.AzureBlobAvroWriterFactory";
+  public static final String SYSTEM_USE_TOKEN_CREDENTIAL_AUTHENTICATION = Config.SENSITIVE_PREFIX + SYSTEM_AZUREBLOB_PREFIX + "useTokenCredentialAuthentication";
 
+  // ClientSecretCredential needs client id, client secret, tenant id, vault name, service principal
+  public static final String SYSTEM_AZURE_CLIENT_ID = Config.SENSITIVE_PREFIX + SYSTEM_AZUREBLOB_PREFIX + "client.id";
+  public static final String SYSTEM_AZURE_CLIENT_SECRET = Config.SENSITIVE_PREFIX + SYSTEM_AZUREBLOB_PREFIX + "client.secret";
+  public static final String SYSTEM_AZURE_TENANT_ID = Config.SENSITIVE_PREFIX + SYSTEM_AZUREBLOB_PREFIX + "tenant.id";
+  // Whether to use proxy while authenticating with Azure
+  public static final String SYSTEM_AZURE_USE_AUTH_PROXY  = SYSTEM_AZUREBLOB_PREFIX + "authProxy.use";
+  // name of the host to be used as auth proxy
+  public static final String SYSTEM_AZURE_AUTH_PROXY_HOSTNAME = SYSTEM_AZUREBLOB_PREFIX + "authProxy.hostname";
+  // port in the auth proxy host to be used
+  public static final String SYSTEM_AZURE_AUTH_PROXY_PORT = SYSTEM_AZUREBLOB_PREFIX + "authProxy.port";
   // Azure Storage Account name under which the Azure container representing this system is.
   // System name = Azure container name
   // (https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names)
   public static final String SYSTEM_AZURE_ACCOUNT_NAME = Config.SENSITIVE_PREFIX + SYSTEM_AZUREBLOB_PREFIX + "account.name";
-
   // Azure Storage Account key associated with the Azure Storage Account
   public static final String SYSTEM_AZURE_ACCOUNT_KEY  = Config.SENSITIVE_PREFIX + SYSTEM_AZUREBLOB_PREFIX + "account.key";
-
   // Whether to use proxy while connecting to Azure Storage
   public static final String SYSTEM_AZURE_USE_PROXY  = SYSTEM_AZUREBLOB_PREFIX + "proxy.use";
-  public static final boolean SYSTEM_AZURE_USE_PROXY_DEFAULT = false;
-
   // name of the host to be used as proxy
   public static final String SYSTEM_AZURE_PROXY_HOSTNAME = SYSTEM_AZUREBLOB_PREFIX + "proxy.hostname";
-
   // port in the proxy host to be used
   public static final String SYSTEM_AZURE_PROXY_PORT = SYSTEM_AZUREBLOB_PREFIX + "proxy.port";
-
   // type of compression to be used before uploading blocks : “none” or “gzip”
   public static final String SYSTEM_COMPRESSION_TYPE = SYSTEM_AZUREBLOB_PREFIX + "compression.type";
-  private static final CompressionType SYSTEM_COMPRESSION_TYPE_DEFAULT = CompressionType.NONE;
-
   // maximum size of uncompressed block in bytes
   public static final String SYSTEM_MAX_FLUSH_THRESHOLD_SIZE = SYSTEM_AZUREBLOB_PREFIX + "maxFlushThresholdSize";
-  private static final int SYSTEM_MAX_FLUSH_THRESHOLD_SIZE_DEFAULT = 10485760;
-
   // maximum size of uncompressed blob in bytes
   public static final String SYSTEM_MAX_BLOB_SIZE = SYSTEM_AZUREBLOB_PREFIX + "maxBlobSize";
-  private static final long SYSTEM_MAX_BLOB_SIZE_DEFAULT = Long.MAX_VALUE; // unlimited
-
   // maximum number of messages in a blob
   public static final String SYSTEM_MAX_MESSAGES_PER_BLOB = SYSTEM_AZUREBLOB_PREFIX + "maxMessagesPerBlob";
-  private static final long SYSTEM_MAX_MESSAGES_PER_BLOB_DEFAULT = Long.MAX_VALUE; // unlimited
-
   // number of threads to asynchronously upload blocks
   public static final String SYSTEM_THREAD_POOL_COUNT = SYSTEM_AZUREBLOB_PREFIX + "threadPoolCount";
-  private static final int SYSTEM_THREAD_POOL_COUNT_DEFAULT = 1;
-
   // size of the queue to hold blocks ready to be uploaded by asynchronous threads.
   // If all threads are busy uploading then blocks are queued and if queue is full then main thread will start uploading
   // which will block processing of incoming messages
   // Default - Thread Pool Count * 2
   public static final String SYSTEM_BLOCKING_QUEUE_SIZE = SYSTEM_AZUREBLOB_PREFIX + "blockingQueueSize";
-
   // timeout to finish uploading all blocks before committing a blob
   public static final String SYSTEM_FLUSH_TIMEOUT_MS = SYSTEM_AZUREBLOB_PREFIX + "flushTimeoutMs";
-  private static final long SYSTEM_FLUSH_TIMEOUT_MS_DEFAULT = Duration.ofMinutes(3).toMillis();
-
   // timeout to finish committing all the blobs currently being written to. This does not include the flush timeout per blob
   public static final String SYSTEM_CLOSE_TIMEOUT_MS = SYSTEM_AZUREBLOB_PREFIX + "closeTimeoutMs";
-  private static final long SYSTEM_CLOSE_TIMEOUT_MS_DEFAULT = Duration.ofMinutes(5).toMillis();
-
   // if true, a random string of 8 chars is suffixed to the blob name to prevent name collision
   // when more than one Samza tasks are writing to the same SSP.
   public static final String SYSTEM_SUFFIX_RANDOM_STRING_TO_BLOB_NAME = SYSTEM_AZUREBLOB_PREFIX + "suffixRandomStringToBlobName";
-  private static final boolean SYSTEM_SUFFIX_RANDOM_STRING_TO_BLOB_NAME_DEFAULT = true;
-
   // full class name of an implementation of org.apache.samza.system.azureblob.utils.BlobMetadataGeneratorFactory
   // this factory should return an implementation of org.apache.samza.system.azureblob.utils.BlobMetadataGenerator
   // this generator will be invoked when a blob is committed to add metadata properties to it
   public static final String SYSTEM_BLOB_METADATA_PROPERTIES_GENERATOR_FACTORY = SYSTEM_AZUREBLOB_PREFIX + "metadataPropertiesGeneratorFactory";
-  private static final String SYSTEM_BLOB_METADATA_PROPERTIES_GENERATOR_FACTORY_DEFAULT =
-      "org.apache.samza.system.azureblob.utils.NullBlobMetadataGeneratorFactory";
-
   // Additional configs for the metadata generator should be prefixed with this string which is passed to the generator.
   // for example, to pass a "key":"value" pair to the metadata generator, add config like
   // systems.<system-name>.azureblob.metadataGeneratorConfig.<key> with value <value>
   public static final String SYSTEM_BLOB_METADATA_GENERATOR_CONFIG_PREFIX = SYSTEM_AZUREBLOB_PREFIX + "metadataGeneratorConfig.";
+  private static final long AZURE_BLOB_LOG_SLOW_REQUESTS_MS_DEFAULT = Duration.ofSeconds(30).toMillis();
+  private static final boolean SYSTEM_USE_TOKEN_CREDENTIAL_AUTHENTICATION_DEFAULT = false;
+  private static final CompressionType SYSTEM_COMPRESSION_TYPE_DEFAULT = CompressionType.NONE;
+  private static final int SYSTEM_MAX_FLUSH_THRESHOLD_SIZE_DEFAULT = 10485760;
+  private static final long SYSTEM_MAX_BLOB_SIZE_DEFAULT = Long.MAX_VALUE; // unlimited
+  private static final long SYSTEM_MAX_MESSAGES_PER_BLOB_DEFAULT = Long.MAX_VALUE; // unlimited
+  private static final int SYSTEM_THREAD_POOL_COUNT_DEFAULT = 1;
+  private static final long SYSTEM_FLUSH_TIMEOUT_MS_DEFAULT = Duration.ofMinutes(3).toMillis();
+  private static final long SYSTEM_CLOSE_TIMEOUT_MS_DEFAULT = Duration.ofMinutes(5).toMillis();
+  private static final boolean SYSTEM_SUFFIX_RANDOM_STRING_TO_BLOB_NAME_DEFAULT = true;
+  private static final String SYSTEM_BLOB_METADATA_PROPERTIES_GENERATOR_FACTORY_DEFAULT =
+      "org.apache.samza.system.azureblob.utils.NullBlobMetadataGeneratorFactory";
 
   public AzureBlobConfig(Config config) {
     super(config);
@@ -127,11 +125,11 @@ public class AzureBlobConfig extends MapConfig {
     return accountName;
   }
 
-  public boolean getUseProxy(String systemName) {
+  public boolean getUseBlobProxy(String systemName) {
     return getBoolean(String.format(SYSTEM_AZURE_USE_PROXY, systemName), SYSTEM_AZURE_USE_PROXY_DEFAULT);
   }
 
-  public String getAzureProxyHostname(String systemName) {
+  public String getAzureBlobProxyHostname(String systemName) {
     String hostname = get(String.format(SYSTEM_AZURE_PROXY_HOSTNAME, systemName));
     if (hostname == null) {
       throw new ConfigException("Azure proxy host name is required.");
@@ -139,7 +137,7 @@ public class AzureBlobConfig extends MapConfig {
     return hostname;
   }
 
-  public int getAzureProxyPort(String systemName) {
+  public int getAzureBlobProxyPort(String systemName) {
     return getInt(String.format(SYSTEM_AZURE_PROXY_PORT, systemName));
   }
 
@@ -206,5 +204,51 @@ public class AzureBlobConfig extends MapConfig {
 
   public Config getSystemBlobMetadataGeneratorConfigs(String systemName) {
     return subset(String.format(SYSTEM_BLOB_METADATA_GENERATOR_CONFIG_PREFIX, systemName));
+  }
+
+  public boolean getUseTokenCredentialAuthentication(String systemName) {
+    return getBoolean(String.format(SYSTEM_USE_TOKEN_CREDENTIAL_AUTHENTICATION, systemName),
+        SYSTEM_USE_TOKEN_CREDENTIAL_AUTHENTICATION_DEFAULT);
+  }
+
+  public boolean getUseAuthProxy(String systemName) {
+    return getBoolean(String.format(SYSTEM_AZURE_USE_AUTH_PROXY, systemName), SYSTEM_AZURE_USE_AUTH_PROXY_DEFAULT);
+  }
+
+  public String getAuthProxyHostName(String systemName) {
+    String hostname = get(String.format(SYSTEM_AZURE_AUTH_PROXY_HOSTNAME, systemName));
+    if (hostname == null) {
+      throw new ConfigException("Azure proxy host name is required.");
+    }
+    return hostname;
+  }
+
+  public int getAuthProxyPort(String systemName) {
+    return getInt(String.format(SYSTEM_AZURE_AUTH_PROXY_PORT, systemName));
+  }
+
+  public String getAzureClientId(String systemName) {
+    String clientId = get(String.format(SYSTEM_AZURE_CLIENT_ID, systemName));
+    if (clientId == null) {
+      throw new ConfigException("Azure Client id is required.");
+    }
+    return clientId;
+  }
+
+  public String getAzureClientSecret(String systemName) {
+    String clientSecret = get(String.format(SYSTEM_AZURE_CLIENT_SECRET, systemName));
+    if (clientSecret == null) {
+      throw new ConfigException("Azure Client secret is required.");
+    }
+    return clientSecret;
+  }
+
+
+  public String getAzureTenantId(String systemName) {
+    String tenantId = get(String.format(SYSTEM_AZURE_TENANT_ID, systemName));
+    if (tenantId == null) {
+      throw new ConfigException("Azure tenant id is required.");
+    }
+    return tenantId;
   }
 }

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobConfig.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobConfig.java
@@ -40,6 +40,7 @@ public class AzureBlobConfig extends MapConfig {
   public static final String SYSTEM_WRITER_FACTORY_CLASS_NAME_DEFAULT = "org.apache.samza.system.azureblob.avro.AzureBlobAvroWriterFactory";
 
   public static final String SYSTEM_USE_TOKEN_CREDENTIAL_AUTHENTICATION = Config.SENSITIVE_PREFIX + SYSTEM_AZUREBLOB_PREFIX + "useTokenCredentialAuthentication";
+  private static final boolean SYSTEM_USE_TOKEN_CREDENTIAL_AUTHENTICATION_DEFAULT = false;
 
   // ClientSecretCredential needs client id, client secret, tenant id, vault name, service principal
   public static final String SYSTEM_AZURE_CLIENT_ID = Config.SENSITIVE_PREFIX + SYSTEM_AZUREBLOB_PREFIX + "client.id";

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobConfig.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobConfig.java
@@ -26,18 +26,19 @@ import org.apache.samza.config.ConfigException;
 import org.apache.samza.config.MapConfig;
 
 public class AzureBlobConfig extends MapConfig {
+  private static final String SYSTEM_AZUREBLOB_PREFIX = "systems.%s.azureblob.";
+  //Server Instance Level Property
+
   // The duration after which an Azure request will be logged as a warning.
   public static final String AZURE_BLOB_LOG_SLOW_REQUESTS_MS = "samza.azureblob.log.slowRequestMs";
-  //Server Instance Level Property
-  public static final String SYSTEM_WRITER_FACTORY_CLASS_NAME_DEFAULT = "org.apache.samza.system.azureblob.avro.AzureBlobAvroWriterFactory";
-  public static final boolean SYSTEM_AZURE_USE_AUTH_PROXY_DEFAULT = false;
-  public static final boolean SYSTEM_AZURE_USE_PROXY_DEFAULT = false;
-  private static final String SYSTEM_AZUREBLOB_PREFIX = "systems.%s.azureblob.";
+  private static final long AZURE_BLOB_LOG_SLOW_REQUESTS_MS_DEFAULT = Duration.ofSeconds(30).toMillis();
 
   // Azure authentication - via a/c name+key or ClientSecretCredential
   // system Level Properties.
   // fully qualified class name of the AzureBlobWriter impl for the producer system
   public static final String SYSTEM_WRITER_FACTORY_CLASS_NAME = SYSTEM_AZUREBLOB_PREFIX + "writer.factory.class";
+  public static final String SYSTEM_WRITER_FACTORY_CLASS_NAME_DEFAULT = "org.apache.samza.system.azureblob.avro.AzureBlobAvroWriterFactory";
+
   public static final String SYSTEM_USE_TOKEN_CREDENTIAL_AUTHENTICATION = Config.SENSITIVE_PREFIX + SYSTEM_AZUREBLOB_PREFIX + "useTokenCredentialAuthentication";
 
   // ClientSecretCredential needs client id, client secret, tenant id, vault name, service principal
@@ -46,6 +47,8 @@ public class AzureBlobConfig extends MapConfig {
   public static final String SYSTEM_AZURE_TENANT_ID = Config.SENSITIVE_PREFIX + SYSTEM_AZUREBLOB_PREFIX + "tenant.id";
   // Whether to use proxy while authenticating with Azure
   public static final String SYSTEM_AZURE_USE_AUTH_PROXY  = SYSTEM_AZUREBLOB_PREFIX + "authProxy.use";
+  public static final boolean SYSTEM_AZURE_USE_AUTH_PROXY_DEFAULT = false;
+
   // name of the host to be used as auth proxy
   public static final String SYSTEM_AZURE_AUTH_PROXY_HOSTNAME = SYSTEM_AZUREBLOB_PREFIX + "authProxy.hostname";
   // port in the auth proxy host to be used
@@ -54,56 +57,69 @@ public class AzureBlobConfig extends MapConfig {
   // System name = Azure container name
   // (https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names)
   public static final String SYSTEM_AZURE_ACCOUNT_NAME = Config.SENSITIVE_PREFIX + SYSTEM_AZUREBLOB_PREFIX + "account.name";
+
   // Azure Storage Account key associated with the Azure Storage Account
   public static final String SYSTEM_AZURE_ACCOUNT_KEY  = Config.SENSITIVE_PREFIX + SYSTEM_AZUREBLOB_PREFIX + "account.key";
+
   // Whether to use proxy while connecting to Azure Storage
   public static final String SYSTEM_AZURE_USE_PROXY  = SYSTEM_AZUREBLOB_PREFIX + "proxy.use";
+  public static final boolean SYSTEM_AZURE_USE_PROXY_DEFAULT = false;
+
   // name of the host to be used as proxy
   public static final String SYSTEM_AZURE_PROXY_HOSTNAME = SYSTEM_AZUREBLOB_PREFIX + "proxy.hostname";
+
   // port in the proxy host to be used
   public static final String SYSTEM_AZURE_PROXY_PORT = SYSTEM_AZUREBLOB_PREFIX + "proxy.port";
+
   // type of compression to be used before uploading blocks : “none” or “gzip”
   public static final String SYSTEM_COMPRESSION_TYPE = SYSTEM_AZUREBLOB_PREFIX + "compression.type";
+  private static final CompressionType SYSTEM_COMPRESSION_TYPE_DEFAULT = CompressionType.NONE;
+
   // maximum size of uncompressed block in bytes
   public static final String SYSTEM_MAX_FLUSH_THRESHOLD_SIZE = SYSTEM_AZUREBLOB_PREFIX + "maxFlushThresholdSize";
+  private static final int SYSTEM_MAX_FLUSH_THRESHOLD_SIZE_DEFAULT = 10485760;
+
   // maximum size of uncompressed blob in bytes
   public static final String SYSTEM_MAX_BLOB_SIZE = SYSTEM_AZUREBLOB_PREFIX + "maxBlobSize";
+  private static final long SYSTEM_MAX_BLOB_SIZE_DEFAULT = Long.MAX_VALUE; // unlimited
+
   // maximum number of messages in a blob
   public static final String SYSTEM_MAX_MESSAGES_PER_BLOB = SYSTEM_AZUREBLOB_PREFIX + "maxMessagesPerBlob";
+  private static final long SYSTEM_MAX_MESSAGES_PER_BLOB_DEFAULT = Long.MAX_VALUE; // unlimited
+
   // number of threads to asynchronously upload blocks
   public static final String SYSTEM_THREAD_POOL_COUNT = SYSTEM_AZUREBLOB_PREFIX + "threadPoolCount";
+  private static final int SYSTEM_THREAD_POOL_COUNT_DEFAULT = 1;
+
   // size of the queue to hold blocks ready to be uploaded by asynchronous threads.
   // If all threads are busy uploading then blocks are queued and if queue is full then main thread will start uploading
   // which will block processing of incoming messages
   // Default - Thread Pool Count * 2
   public static final String SYSTEM_BLOCKING_QUEUE_SIZE = SYSTEM_AZUREBLOB_PREFIX + "blockingQueueSize";
+
   // timeout to finish uploading all blocks before committing a blob
   public static final String SYSTEM_FLUSH_TIMEOUT_MS = SYSTEM_AZUREBLOB_PREFIX + "flushTimeoutMs";
+  private static final long SYSTEM_FLUSH_TIMEOUT_MS_DEFAULT = Duration.ofMinutes(3).toMillis();
+
   // timeout to finish committing all the blobs currently being written to. This does not include the flush timeout per blob
   public static final String SYSTEM_CLOSE_TIMEOUT_MS = SYSTEM_AZUREBLOB_PREFIX + "closeTimeoutMs";
+  private static final long SYSTEM_CLOSE_TIMEOUT_MS_DEFAULT = Duration.ofMinutes(5).toMillis();
+
   // if true, a random string of 8 chars is suffixed to the blob name to prevent name collision
   // when more than one Samza tasks are writing to the same SSP.
   public static final String SYSTEM_SUFFIX_RANDOM_STRING_TO_BLOB_NAME = SYSTEM_AZUREBLOB_PREFIX + "suffixRandomStringToBlobName";
+  private static final boolean SYSTEM_SUFFIX_RANDOM_STRING_TO_BLOB_NAME_DEFAULT = true;
+
   // full class name of an implementation of org.apache.samza.system.azureblob.utils.BlobMetadataGeneratorFactory
   // this factory should return an implementation of org.apache.samza.system.azureblob.utils.BlobMetadataGenerator
   // this generator will be invoked when a blob is committed to add metadata properties to it
   public static final String SYSTEM_BLOB_METADATA_PROPERTIES_GENERATOR_FACTORY = SYSTEM_AZUREBLOB_PREFIX + "metadataPropertiesGeneratorFactory";
+  private static final String SYSTEM_BLOB_METADATA_PROPERTIES_GENERATOR_FACTORY_DEFAULT =
+      "org.apache.samza.system.azureblob.utils.NullBlobMetadataGeneratorFactory";
   // Additional configs for the metadata generator should be prefixed with this string which is passed to the generator.
   // for example, to pass a "key":"value" pair to the metadata generator, add config like
   // systems.<system-name>.azureblob.metadataGeneratorConfig.<key> with value <value>
   public static final String SYSTEM_BLOB_METADATA_GENERATOR_CONFIG_PREFIX = SYSTEM_AZUREBLOB_PREFIX + "metadataGeneratorConfig.";
-  private static final long AZURE_BLOB_LOG_SLOW_REQUESTS_MS_DEFAULT = Duration.ofSeconds(30).toMillis();
-  private static final boolean SYSTEM_USE_TOKEN_CREDENTIAL_AUTHENTICATION_DEFAULT = false;
-  private static final CompressionType SYSTEM_COMPRESSION_TYPE_DEFAULT = CompressionType.NONE;
-  private static final int SYSTEM_MAX_FLUSH_THRESHOLD_SIZE_DEFAULT = 10485760;
-  private static final long SYSTEM_MAX_BLOB_SIZE_DEFAULT = Long.MAX_VALUE; // unlimited
-  private static final long SYSTEM_MAX_MESSAGES_PER_BLOB_DEFAULT = Long.MAX_VALUE; // unlimited
-  private static final int SYSTEM_THREAD_POOL_COUNT_DEFAULT = 1;
-  private static final long SYSTEM_FLUSH_TIMEOUT_MS_DEFAULT = Duration.ofMinutes(3).toMillis();
-  private static final long SYSTEM_CLOSE_TIMEOUT_MS_DEFAULT = Duration.ofMinutes(5).toMillis();
-  private static final boolean SYSTEM_SUFFIX_RANDOM_STRING_TO_BLOB_NAME_DEFAULT = true;
-  private static final String SYSTEM_BLOB_METADATA_PROPERTIES_GENERATOR_FACTORY_DEFAULT =
-      "org.apache.samza.system.azureblob.utils.NullBlobMetadataGeneratorFactory";
 
   public AzureBlobConfig(Config config) {
     super(config);

--- a/samza-azure/src/test/java/org/apache/samza/system/azureblob/producer/TestAzureBlobSystemProducer.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/azureblob/producer/TestAzureBlobSystemProducer.java
@@ -98,14 +98,14 @@ public class TestAzureBlobSystemProducer {
     // use mock writer impl
     setupWriterForProducer(systemProducer, mockAzureWriter, STREAM);
     // bypass Azure connection setup
-    doNothing().when(systemProducer).setupAzureContainer(anyString(), anyString());
+    doNothing().when(systemProducer).setupAzureContainer();
   }
 
   @Test
   public void testStart() {
 
     systemProducer.start();
-    verify(systemProducer).setupAzureContainer(ACCOUNT_NAME, ACCOUNT_KEY);
+    verify(systemProducer).setupAzureContainer();
   }
 
   public void testMultipleStart() {
@@ -264,7 +264,7 @@ public class TestAzureBlobSystemProducer {
         mockMetricsRegistry));
     PowerMockito.whenNew(AzureBlobAvroWriter.class).withAnyArguments().thenThrow(new SystemProducerException("Failed"));
     // bypass Azure connection setup
-    doNothing().when(systemProducer).setupAzureContainer(anyString(), anyString());
+    doNothing().when(systemProducer).setupAzureContainer();
 
     systemProducer.register(SOURCE);
     systemProducer.start();
@@ -315,7 +315,7 @@ public class TestAzureBlobSystemProducer {
 
     AzureBlobSystemProducer systemProducer = spy(new AzureBlobSystemProducer(SYSTEM_NAME, azureBlobConfig, mockMetricsRegistry));
     // bypass Azure connection setup
-    doNothing().when(systemProducer).setupAzureContainer(anyString(), anyString());
+    doNothing().when(systemProducer).setupAzureContainer();
 
     doReturn(mockAzureWriter1).when(systemProducer).getOrCreateWriter(source1, ome1);
     doReturn(mockAzureWriter2).when(systemProducer).getOrCreateWriter(source2, ome2);
@@ -359,7 +359,7 @@ public class TestAzureBlobSystemProducer {
 
     AzureBlobSystemProducer systemProducer = spy(new AzureBlobSystemProducer(SYSTEM_NAME, azureBlobConfig, mockMetricsRegistry));
     // bypass Azure connection setup
-    doNothing().when(systemProducer).setupAzureContainer(anyString(), anyString());
+    doNothing().when(systemProducer).setupAzureContainer();
 
     doReturn(mockAzureWriter1).when(systemProducer).getOrCreateWriter(source1, ome1);
     doReturn(mockAzureWriter2).when(systemProducer).getOrCreateWriter(source2, ome2);
@@ -411,7 +411,7 @@ public class TestAzureBlobSystemProducer {
 
     AzureBlobSystemProducer systemProducer = spy(new AzureBlobSystemProducer(SYSTEM_NAME, azureBlobConfig, mockMetricsRegistry));
     // bypass Azure connection setup
-    doNothing().when(systemProducer).setupAzureContainer(anyString(), anyString());
+    doNothing().when(systemProducer).setupAzureContainer();
 
     systemProducer.register(source1);
     systemProducer.start();
@@ -450,7 +450,7 @@ public class TestAzureBlobSystemProducer {
 
     AzureBlobSystemProducer systemProducer = spy(new AzureBlobSystemProducer(SYSTEM_NAME, azureBlobConfig, mockMetricsRegistry));
     // bypass Azure connection setup
-    doNothing().when(systemProducer).setupAzureContainer(anyString(), anyString());
+    doNothing().when(systemProducer).setupAzureContainer();
 
     setupWriterForProducer(systemProducer, mockAzureWriter1, stream1);
 
@@ -492,7 +492,7 @@ public class TestAzureBlobSystemProducer {
 
     AzureBlobSystemProducer systemProducer = spy(new AzureBlobSystemProducer(SYSTEM_NAME, azureBlobConfig, mockMetricsRegistry));
     // bypass Azure connection setup
-    doNothing().when(systemProducer).setupAzureContainer(anyString(), anyString());
+    doNothing().when(systemProducer).setupAzureContainer();
 
     setupWriterForProducer(systemProducer, mockAzureWriter1, STREAM);
 


### PR DESCRIPTION
Feature: Providing an alternate form of authenticating with Azure Storage to set up the connection. Existing form of authentication is via account name and account key for the Azure Storage. Note that this impacts only the authentication and not the actual blob creation which happens later in the lifecycle of the system producer.

Changes: New way of authenticating via TokenCredential (specifically ClientSecretCredential) provided - it uses other required configs like client.id, client.secret, tenant.id, proxy for authenticating.

Tests: existing tests pass. As this is an authentication with Azure, can not tested in unit tests. Full end-to-end functional testing performed.

API changes: new configs introduced.

- systems.**_system-name_**.azureblob.useTokenCredentialAuthentication default = false
- systems.**_system-name_**.azureblob.client.id
- systems.**_system-name_**.azureblob.client.secret
- systems.**_system-name_**.azureblob.tenant.id
- systems.**_system-name_**.azureblob.authProxy.use defaults = false
- systems.**_system-name_**.azureblob.authProxy.hostName
- systems.**_system-name_**.azureblob.authProxy.port

Upgrade instructions: N/A

Usage Instructions: If wanting to use TokenCredential authentication then set systems.%s.azureblob.useTokenCredentialAuthentication = true and provide appropriate values for rest of the configs - such as authProxy.use, client.id, client.secret..

Backwards compatible: yes, old route of authenticating via account name and key is chosen if this config systems.%s.azureblob.useTokenCredentialAuthentication is not explicitly true. This config defaults to false falling back to the old route.