### PR TITLE
SAMZA-2651:Update failsafe version

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -48,7 +48,7 @@
   yarnVersion = "2.7.1"
   zkClientVersion = "0.11"
   zookeeperVersion = "3.4.13"
-  failsafeVersion = "1.1.0"
+  failsafeVersion = "2.3.1"
   jlineVersion = "3.8.2"
   jnaVersion = "4.5.1"
   couchbaseClientVersion = "2.7.2"

--- a/samza-core/src/main/java/org/apache/samza/table/retry/AsyncRetriableTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/retry/AsyncRetriableTable.java
@@ -52,8 +52,8 @@ public class AsyncRetriableTable<K, V> implements AsyncReadWriteTable<K, V> {
 
   private final String tableId;
   private final AsyncReadWriteTable<K, V> table;
-  private final RetryPolicy readRetryPolicy;
-  private final RetryPolicy writeRetryPolicy;
+  private final RetryPolicy<?> readRetryPolicy;
+  private final RetryPolicy<?> writeRetryPolicy;
   private final ScheduledExecutorService retryExecutor;
 
   @VisibleForTesting
@@ -156,13 +156,13 @@ public class AsyncRetriableTable<K, V> implements AsyncReadWriteTable<K, V> {
 
   private <T> CompletableFuture<T> doRead(Func1<T> func) {
     return readRetryPolicy != null
-        ? failsafe(readRetryPolicy, readRetryMetrics, retryExecutor).future(() -> func.apply())
+        ? failsafe(readRetryPolicy, readRetryMetrics, retryExecutor).getStageAsync(() -> func.apply())
         : func.apply();
   }
 
   private <T> CompletableFuture<T> doWrite(Func1<T> func) {
     return writeRetryPolicy != null
-        ? failsafe(writeRetryPolicy, writeRetryMetrics, retryExecutor).future(() -> func.apply())
+        ? failsafe(writeRetryPolicy, writeRetryMetrics, retryExecutor).getStageAsync(() -> func.apply())
         : func.apply();
   }
 }


### PR DESCRIPTION
Issues: current version of failsafe imported a bug, so we want to update failsafe version to pull in the fix and updates
 
There are some back-incompatible APIs changes, 
Changes: Describe major changes, listing each separately.
    1. updated failsafe from 1.1.0 to 2.3.1
    2. Moved `AsyncFailsafe` to `FailsafeExecutor`. `AsycFailsafe` is deleted in 2.3.1. 
    3. Moved AsyncFailsafe#future to FailsafeExecutor#getStageAsync .
    4. Moved `TimeUnit` to `ChronoUnit` in policies. 
    5. Added maxRetries as -1 when maxRetries is not set. The default behavior in Failsafe changed from -1 to 3, so we have to set it to -1 to keep the same behavior as before.
    6. Moved ExecutionContext#getExecutions to ExecutionContext#getAttemptCount
    7. Moved `retryOn` to `abortOn`.
    8. update retryPolicy before create FailsafeExecutor. The APIs changed: Event listeners that are specific to policies, such as onRetry for RetryPolicy, must now be configured through the policy instance. 
 
Tests: Previous unit tests passed.