### PR TITLE
Bump log4j2 version to 2.12.1 to be compatible with latest container and util

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -38,7 +38,7 @@
   junitVersion = "4.12"
   kafkaVersion = "2.3.1"
   log4jVersion = "1.2.17"
-  log4j2Version = "2.12.0"
+  log4j2Version = "2.12.1"
   metricsVersion = "2.2.0"
   mockitoVersion = "1.10.19"
   powerMockVersion = "1.6.6"


### PR DESCRIPTION
Problem: building any samza codebase within LinkedIn starts failing with log4j version issue, because container and util requires higher version of log4j2.

On master branch & 1.6:
> - (ERROR) com.linkedin.container:container-logging-impl:38.4.222 requires org.apache.logging.log4j:log4j-core:2.12.1 or above. Found 2.12.0. Please upgrade org.apache.logging.log4j to 2.12.1+.
> - (ERROR) com.linkedin.util:util-log:27.0.26 requires org.apache.logging.log4j:log4j-core:2.12.1 or above. Found 2.12.0. Please upgrade org.apache.logging.log4j to 2.12.1+.

Solution: bump log4j2 to 2.12.1+.
