### PR TITLE
Samza-2665: AzureBlob SystemProducer: stop block upload retrying when InterruptedException is thrown

### DIFF
--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobOutputStream.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobOutputStream.java
@@ -273,7 +273,7 @@ public class AzureBlobOutputStream extends OutputStream {
 
   // SAMZA-2476 stubbing BlockBlobAsyncClient.stageBlock was causing flaky tests.
   @VisibleForTesting
-  void stageBlock(String blockIdEncoded, ByteBuffer outputStream, int blockSize) {
+  void stageBlock(String blockIdEncoded, ByteBuffer outputStream, int blockSize) throws InterruptedException {
     blobAsyncClient.stageBlock(blockIdEncoded, Flux.just(outputStream), blockSize).block();
   }
 
@@ -335,6 +335,11 @@ public class AzureBlobOutputStream extends OutputStream {
             // StageBlock generates exception on Failure.
             stageBlock(blockIdEncoded, outputStream, blockSize);
             break;
+          } catch (InterruptedException e) {
+            String msg = "Upload block for blob: " + blobAsyncClient.getBlobUrl().toString()
+                + " failed for blockid: " + blockId + " due to InterruptedException ";
+            LOG.error(msg, e);
+            throw new AzureException("InterruptedException encountered during block upload. Will not retry.", e);
           } catch (Exception e) {
             attemptCount += 1;
             String msg = "Upload block for blob: " + blobAsyncClient.getBlobUrl().toString()

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobOutputStream.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobOutputStream.java
@@ -336,8 +336,8 @@ public class AzureBlobOutputStream extends OutputStream {
             stageBlock(blockIdEncoded, outputStream, blockSize);
             break;
           } catch (InterruptedException e) {
-            String msg = "Upload block for blob: " + blobAsyncClient.getBlobUrl().toString()
-                + " failed for blockid: " + blockId + " due to InterruptedException ";
+            String msg = String.format("Upload block for blob: %s failed for blockid: %s due to InterruptedException.",
+                blobAsyncClient.getBlobUrl().toString(), blockId);
             LOG.error(msg, e);
             throw new AzureException("InterruptedException encountered during block upload. Will not retry.", e);
           } catch (Exception e) {


### PR DESCRIPTION
Symptom: interrupted thread stays stuck for a long time.
Cause: retry several times for all exceptions during block upload. 
Changes: for interrupted exception, stop retry and throw exception that will be bubbled up.
Tests: added unit test
API changes: None
Usage/upgrade instructions: N/A
Backwards compatible:  yes