### PR TITLE
SAMZA-2674: Change StorageEngine and KeyValueStore init call parameters

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/storage/StorageEngine.java
+++ b/samza-api/src/main/java/org/apache/samza/storage/StorageEngine.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 import org.apache.samza.annotation.InterfaceStability;
 import org.apache.samza.checkpoint.CheckpointId;
+import org.apache.samza.context.Context;
 import org.apache.samza.system.ChangelogSSPIterator;
 
 /**
@@ -37,6 +38,13 @@ import org.apache.samza.system.ChangelogSSPIterator;
  * </p>
  */
 public interface StorageEngine {
+
+  /**
+   * Use for lifecycle management for StorageEngine, ContainerStorageManager after restoring each store issues
+   * init on each configured storage engine
+   * @param context holder for all application and framework defined objects
+   */
+  void init(Context context);
 
   /**
    * Restore the content of this StorageEngine from the changelog. Messages are

--- a/samza-api/src/main/java/org/apache/samza/storage/StorageEngine.java
+++ b/samza-api/src/main/java/org/apache/samza/storage/StorageEngine.java
@@ -24,9 +24,6 @@ import java.nio.file.Path;
 import java.util.Optional;
 import org.apache.samza.annotation.InterfaceStability;
 import org.apache.samza.checkpoint.CheckpointId;
-import org.apache.samza.context.ContainerContext;
-import org.apache.samza.context.ExternalContext;
-import org.apache.samza.context.JobContext;
 import org.apache.samza.system.ChangelogSSPIterator;
 
 /**
@@ -40,11 +37,6 @@ import org.apache.samza.system.ChangelogSSPIterator;
  * </p>
  */
 public interface StorageEngine {
-
-  /**
-   * Initialize the storage engine
-   */
-  default void init(ExternalContext externalContext, JobContext jobContext, ContainerContext containerContext) { };
 
   /**
    * Restore the content of this StorageEngine from the changelog. Messages are

--- a/samza-api/src/main/java/org/apache/samza/storage/kv/KeyValueStore.java
+++ b/samza-api/src/main/java/org/apache/samza/storage/kv/KeyValueStore.java
@@ -26,9 +26,6 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.samza.annotation.InterfaceStability;
 import org.apache.samza.checkpoint.CheckpointId;
-import org.apache.samza.context.ContainerContext;
-import org.apache.samza.context.ExternalContext;
-import org.apache.samza.context.JobContext;
 
 
 /**
@@ -38,15 +35,6 @@ import org.apache.samza.context.JobContext;
  * @param <V> the type of values maintained by this key-value store.
  */
 public interface KeyValueStore<K, V> {
-
-  /**
-   * Initializes the KeyValueStore
-   *
-   * @param externalContext any external store required for initialization
-   * @param jobContext context of the job the KeyValueStore is in
-   * @param containerContext context of the KeyValueStore's container
-   */
-  default void init(ExternalContext externalContext, JobContext jobContext, ContainerContext containerContext) { }
 
   /**
    * Gets the value associated with the specified {@code key}.

--- a/samza-api/src/main/java/org/apache/samza/storage/kv/KeyValueStore.java
+++ b/samza-api/src/main/java/org/apache/samza/storage/kv/KeyValueStore.java
@@ -26,6 +26,9 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.samza.annotation.InterfaceStability;
 import org.apache.samza.checkpoint.CheckpointId;
+import org.apache.samza.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -35,6 +38,16 @@ import org.apache.samza.checkpoint.CheckpointId;
  * @param <V> the type of values maintained by this key-value store.
  */
 public interface KeyValueStore<K, V> {
+
+  static final Logger LOG = LoggerFactory.getLogger(KeyValueStore.class);
+
+  /**
+   * Optional lifecycle management method for each KV store, storage engine invokes this initialization during
+   * {@code org.apache.samza.storage.StorageEngine#init}
+   * @param context holder for application and samza framework objects
+   */
+  default void init(Context context) {
+  }
 
   /**
    * Gets the value associated with the specified {@code key}.

--- a/samza-core/src/test/java/org/apache/samza/storage/MockStorageEngine.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/MockStorageEngine.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.apache.samza.checkpoint.CheckpointId;
+import org.apache.samza.context.Context;
 import org.apache.samza.system.ChangelogSSPIterator;
 import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.system.SystemStreamPartition;
@@ -57,6 +58,10 @@ public class MockStorageEngine implements StorageEngine {
     while (messagesToRestore.hasNext()) {
       incomingMessageEnvelopes.add(messagesToRestore.next());
     }
+  }
+
+  @Override
+  public void init(Context context) {
   }
 
   @Override

--- a/samza-kv/src/main/scala/org/apache/samza/storage/kv/KeyValueStorageEngine.scala
+++ b/samza-kv/src/main/scala/org/apache/samza/storage/kv/KeyValueStorageEngine.scala
@@ -31,6 +31,7 @@ import java.util.Optional
 
 import com.google.common.annotations.VisibleForTesting
 import org.apache.samza.checkpoint.CheckpointId
+import org.apache.samza.context.Context
 
 /**
  * A key value store.
@@ -51,6 +52,11 @@ class KeyValueStorageEngine[K, V](
   metrics: KeyValueStorageEngineMetrics = new KeyValueStorageEngineMetrics,
   batchSize: Int = 500,
   val clock: () => Long = { System.nanoTime }) extends StorageEngine with KeyValueStore[K, V] with TimerUtil with Logging {
+
+  override def init(context: Context): Unit = {
+    info("Calling init for wrapped store: " + storeName)
+    wrapperStore.init(context);
+  }
 
   /* delegate to underlying store */
   def get(key: K): V = {


### PR DESCRIPTION
Update the StorageEngine and KeyValueStore apis to only use Context parameter for custom store types
@Sanil15 @prateekm 