### PR TITLE
SAMZA-2675: Fix Jenkins build for Azure-blob-store version not found

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,7 +214,7 @@ project(":samza-azure_$scalaSuffix") {
   apply plugin: 'java'
 
   dependencies {
-    compile "com.azure:azure-storage-blob:12.0.1"
+    compile "com.azure:azure-storage-blob:12.10.0"
     compile "com.azure:azure-identity:1.0.0"
     compile "com.microsoft.azure:azure-storage:5.3.1"
     compile "com.microsoft.azure:azure-eventhubs:1.0.1"


### PR DESCRIPTION
Fix for recent build issues on Jenkins, it seems that azure-storage-blob 12.0.1 is no longer in mvn central
```
* What went wrong:
Execution failed for task ':samza-azure_2.11:compileJava'.
> Could not resolve all files for configuration ':samza-azure_2.11:compileClasspath'.
   > Could not find com.azure:azure-storage-blob:12.0.1.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/com/azure/azure-storage-blob/12.0.1/azure-storage-blob-12.0.1.pom
       - https://repo.maven.apache.org/maven2/com/azure/azure-storage-blob/12.0.1/azure-storage-blob-12.0.1.jar
       - file:/home/travis/.m2/repository/com/azure/azure-storage-blob/12.0.1/azure-storage-blob-12.0.1.pom
       - file:/home/travis/.m2/repository/com/azure/azure-storage-blob/12.0.1/azure-storage-blob-12.0.1.jar
     Required by:
         project :samza-azure_2.11
 ```
`https://repo.maven.apache.org/maven2/com/azure/azure-storage-blob/12.0.1/azure-storage-blob-12.0.1.pom`

@lakshmi-manasa-g 