### PR TITLE
SAMZA-2676: Pass parameter into subset, not format  (StreamConfig.getSerdeStreams)

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/StreamConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/StreamConfig.java
@@ -278,7 +278,7 @@ public class StreamConfig extends MapConfig {
    * Returns a list of all SystemStreams that have a serde defined from the config file.
    */
   public Set<SystemStream> getSerdeStreams(String systemName) {
-    Config subConf = subset(String.format("systems.%s.streams.", systemName, true));
+    Config subConf = subset(String.format("systems.%s.streams.", systemName), true);
     Set<SystemStream> legacySystemStreams = subConf.keySet().stream()
       .filter(k -> k.endsWith(MSG_SERDE) || k.endsWith(KEY_SERDE))
       .map(k -> {


### PR DESCRIPTION
There is an unused parameter on this format string. Removing it should
preserve the existing behavior.