### PR TITLE
SAMZA-2678: Configure Github Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: CI
+
+on: [pull_request,push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          key: samza-ci-gradle-cache
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Build with Gradle
+        run: ./gradlew build


### PR DESCRIPTION
This introduces CI using Github Actions. Note that this will run concurrently with travis-ci on pull requests -- removing travis-ci support (or not) should be a separate change.

It appears to be free for public projects. Details on pricing may be found at:

https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions

Example runs of this change may be found at:

https://github.com/bringhurst/samza/actions (note that some of the failures shown are unrelated to this change)