### PR TITLE
SAMZA-2683: Bump Scalatra Version

### DIFF
--- a/gradle/dependency-versions-scala-2.11.gradle
+++ b/gradle/dependency-versions-scala-2.11.gradle
@@ -24,5 +24,5 @@ ext {
   // -language:implicitConversions: Allow the use of implicit conversions without warning or library import
   // -language:reflectiveCalls: Allow the automatic use of reflection to access fields without warning or library import
   scalaOptions = ["-feature", "-language:implicitConversions", "-language:reflectiveCalls"]
-  scalatraVersion = "2.5.0"
+  scalatraVersion = "2.7.1"
 }

--- a/gradle/dependency-versions-scala-2.12.gradle
+++ b/gradle/dependency-versions-scala-2.12.gradle
@@ -24,5 +24,5 @@ ext {
   // -language:implicitConversions: Allow the use of implicit conversions without warning or library import
   // -language:reflectiveCalls: Allow the automatic use of reflection to access fields without warning or library import
   scalaOptions = ["-feature", "-language:implicitConversions", "-language:reflectiveCalls"]
-  scalatraVersion = "2.5.0"
+  scalatraVersion = "2.7.1"
 }

--- a/samza-yarn/src/main/resources/scalate/WEB-INF/views/index.scaml
+++ b/samza-yarn/src/main/resources/scalate/WEB-INF/views/index.scaml
@@ -125,7 +125,7 @@
             %th Up Time
             %th JMX access
         %tbody
-          - for((processorId, container) <- state.runningProcessors)
+          - for((processorId, container) <- state.runningProcessors.asScala)
             %tr
               %td #{processorId.toString}
               %td
@@ -147,7 +147,7 @@
             %th Exit code
             %th Message
         %tbody
-          - for((containerId, containerStatus) <- state.failedContainersStatus)
+          - for((containerId, containerStatus) <- state.failedContainersStatus.asScala)
             %tr
               %td
                 #{containerId}
@@ -176,13 +176,13 @@
             %th SystemStreamPartitions
             %th Container
         %tbody
-          - for((processorId, container) <- state.runningProcessors)
+          - for((processorId, container) <- state.runningProcessors.asScala)
             - val containerModel = samzaAppState.jobModelManager.jobModel.getContainers.get(processorId)
-            - for((taskName, taskModel) <- containerModel.getTasks)
+            - for((taskName, taskModel) <- containerModel.getTasks.asScala)
               %tr
                 %td= processorId
                 %td= taskName
-                %td= taskModel.getSystemStreamPartitions.map(_.toString).toList.sorted.mkString(", ")
+                %td= taskModel.getSystemStreamPartitions.asScala.map(_.toString).toList.sorted.mkString(", ")
                 %td
                   %a(target="_blank" href="http://#{container.nodeHttpAddress}/node/containerlogs/#{container.id.toString}/#{username}")= container.id.toString
 
@@ -197,7 +197,7 @@
               %th Key
               %th Value
           %tbody.searchable
-            - for(entrySet <- new java.util.TreeMap[String, String](config.asInstanceOf[Map[String, String]]).entrySet)
+            - for(entrySet <- config.asInstanceOf[Map[String, String]])
               %tr
                 %td.key= entrySet.getKey
                 %td= entrySet.getValue


### PR DESCRIPTION
Bumped to the latest Scalatra version so to we have to latest versions; Scalatra 2.5.0 depends on log4j:1.2.14 which has security vulnerability (More details in ticket).

Although we pin log4j:1.2.17, this still prevent our internal automated dependency validation to allow samza-yarn to pass the security check.

Testing: Passing existing tests after scalatra dashboard template is fixed to work with new version.

@xinyuiscool @prateekm @kw2542 