### PR TITLE
SAMZA-2688: [Elasticity] introduce configs and sub-partition concept aka SystemStreamPartitionKeyHash

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/system/SystemStreamPartitionKeyHash.java
+++ b/samza-api/src/main/java/org/apache/samza/system/SystemStreamPartitionKeyHash.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.system;
+
+import org.apache.samza.Partition;
+
+/**
+ * Aggregate object representing a portion of {@link SystemStreamPartition} consisting of envelopes within the
+ * SystemStreamPartition that have envelope.key % job's elasticity factor = keyHash of this object.
+ */
+public class SystemStreamPartitionKeyHash extends SystemStreamPartition {
+  protected final int keyHash;
+
+  /**
+   * Constructs a Samza stream partition KeyHash object from specified components.
+   * @param system The name of the system of which this stream is associated with.
+   * @param stream The name of the stream as specified in the stream configuration file.
+   * @param partition The partition in the stream of which this object is associated with.
+   * @param keyHash The KeyHash of the partition (aka portion of SSP) this object is associated with.
+   */
+  public SystemStreamPartitionKeyHash(String system, String stream, Partition partition, int keyHash) {
+    super(system, stream, partition);
+    this.keyHash = keyHash;
+  }
+  /**
+   * Constructs a Samza stream partition object based upon an existing Samza stream partition and a keyHash.
+   * @param systemStreamPartition Reference to an already existing Samza stream partition.
+   * @param keyHash the KeyHash of the systemStreamPartition for this object.
+   */
+  public SystemStreamPartitionKeyHash(SystemStreamPartition systemStreamPartition, int keyHash) {
+    super(systemStreamPartition);
+    this.keyHash = keyHash;
+  }
+
+  /**
+   * Constructs a Samza stream partition KeyHash object based upon an existing Samza stream partition keyHash.
+   * @param other Reference to an already existing Samza stream partition KeyHash.
+   */
+  public SystemStreamPartitionKeyHash(SystemStreamPartitionKeyHash other) {
+    this(other.getSystem(), other.getStream(), other.getPartition(), other.keyHash);
+  }
+
+  /**
+   * Constructs a Samza stream partition object based upon another Samza stream and a specified partition.
+   * @param other Reference to an already existing Samza stream.
+   * @param partition Reference to an already existing Samza partition.
+   * @param keyHash  the KeyHash of the systemStreamPartition for this object.
+   */
+  public SystemStreamPartitionKeyHash(SystemStream other, Partition partition, int keyHash) {
+    super(other, partition);
+    this.keyHash = keyHash;
+  }
+
+  public int getKeyHash() {
+    return this.keyHash;
+  }
+
+  @Override
+  public int hashCode() {
+    return hash;
+  }
+
+  private int computeHashCode() {
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + keyHash;
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (!super.equals(obj))
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    SystemStreamPartitionKeyHash other = (SystemStreamPartitionKeyHash) obj;
+    if (keyHash != other.keyHash) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "SystemStreamPartitionKeyHash [" + system + ", " + stream + ", " + partition.getPartitionId() + ", " + keyHash + "]";
+  }
+
+  @Override
+  public int compareTo(SystemStreamPartition that) {
+    SystemStreamPartitionKeyHash other = (SystemStreamPartitionKeyHash) that;
+    if (this.system.compareTo(other.system) < 0) {
+      return -1;
+    } else if (this.system.compareTo(other.system) > 0) {
+      return 1;
+    }
+
+    if (this.stream.compareTo(other.stream) < 0) {
+      return -1;
+    } else if (this.stream.compareTo(other.stream) > 0) {
+      return 1;
+    }
+
+    if (this.partition.compareTo(other.partition) < 0) {
+      return -1;
+    } else if (this.partition.compareTo(other.partition) > 0) {
+      return 1;
+    }
+
+    if (this.keyHash < other.keyHash) {
+      return -1;
+    } else if (this.keyHash > other.keyHash) {
+      return 1;
+    }
+
+    return 0;
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
@@ -136,6 +136,11 @@ public class TaskConfig extends MapConfig {
       "task.transactional.state.retain.existing.state";
   private static final boolean DEFAULT_TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE = true;
 
+  // Job Elasticity related configs
+  // Take effect only when job.elasticity.factor is > 1. otherwise there is no elasticity
+  private static final String TASK_ELASTICITY_FACTOR = "task.elasticity.factor";
+  private static final int TASK_ELASTICITY_FACTOR_DEFAULT = 1;
+
   public TaskConfig(Config config) {
     super(config);
   }
@@ -378,5 +383,9 @@ public class TaskConfig extends MapConfig {
 
   public boolean getTransactionalStateRetainExistingState() {
     return getBoolean(TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE, DEFAULT_TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE);
+  }
+
+  public int getElasticityFactor() {
+    return getInt(TASK_ELASTICITY_FACTOR, TASK_ELASTICITY_FACTOR_DEFAULT);
   }
 }


### PR DESCRIPTION
Feature: Elasticity for Samza job. Throughput via parallelism is tied to the number of tasks which is equal to the partition count of input streams. If a job is facing lag and is already at the max container count = number of tasks = number of input partitions, then the only choice it is left with is to repartition the input. This PR is part of the feature which aims to increase throughput by scaling task count beyond the input partition count. In this PR, the config and basic class for elasticity are introduced. 

Changes:  Introduce config "task.elasticity.factor" which defaults to 1. If factor = X>1 then each task is split into X elastic tasks. Also, introduce SystemStreamPartitionKeyHash which represents the portion of SSP that an elastic task will consume.

Tests: existing tests pass.

API changes: New config "task.elasticity.factor" which if > 1 enables this elasticity feature.

upgrade/usage instructions: add above config with value >1 to enable feature.