### PR TITLE
Fix container physical memory monitoring to fetch all children process RSS memory with 1 process

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -66,13 +66,13 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
     processIds.add("$PPID");
     String processIdsJoined = String.join(" ", processIds);
     // returns a list of long values that represent the rss memory of each process.
-    List<String> processMemoryMBArray = getAllCommandOutput(new String[]{"sh", "-c", String.format("ps -o rss= -p %s", processIdsJoined)});
-    long totalPhysicalMemoryMB = 0;
-    for (String processMemory : processMemoryMBArray) {
-      totalPhysicalMemoryMB += Long.parseLong(processMemory.trim());
+    List<String> processMemoryKBArray = getAllCommandOutput(new String[]{"sh", "-c", String.format("ps -o rss= -p %s", processIdsJoined)});
+    long totalPhysicalMemoryKB = 0;
+    for (String processMemory : processMemoryKBArray) {
+      totalPhysicalMemoryKB += Long.parseLong(processMemory.trim());
     }
     //convert to bytes
-    return totalPhysicalMemoryMB * 1024;
+    return totalPhysicalMemoryKB * 1024;
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -20,8 +20,6 @@ package org.apache.samza.container.host;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -90,25 +90,15 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
     List<String> processIds = getAllCommandOutput(new String[]{"sh", "-c", "pgrep -P $PPID"});
     // add the parent process which is the main process that runs the application
     processIds.add("$PPID");
+    String processIdsJoined = String.join(" ", processIds);
+    // returns a list of long values that represent the rss memory of each process.
+    List<String> processMemoryArray = getAllCommandOutput(new String[]{"sh", "-c", String.format("ps -o rss= -p %s", processIdsJoined)});
     long totalPhysicalMemory = 0;
-    for (String processId : processIds) {
-      totalPhysicalMemory += getPhysicalMemory(processId);
+    for (String processMemory : processMemoryArray) {
+      totalPhysicalMemory += Long.parseLong(processMemory.trim());
     }
-    return totalPhysicalMemory;
-  }
-
-  private long getPhysicalMemory(String processId) throws IOException {
-    // returns a single long value that represents the rss memory of the process.
-    String commandOutput = getCommandOutput(new String[]{"sh", "-c", String.format("ps -o rss= -p %s", processId)});
-
-    // this should never happen.
-    if (commandOutput == null) {
-      throw new IOException("ps returned unexpected output: " + commandOutput);
-    }
-
-    long rssMemoryKb = Long.parseLong(commandOutput.trim());
     //convert to bytes
-    return rssMemoryKb * 1024;
+    return totalPhysicalMemory * 1024;
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -18,9 +18,6 @@
  */
 package org.apache.samza.container.host;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,44 +55,10 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
     return psOutput;
   }
 
-  /**
-   * A convenience method to execute shell commands and return all lines of their output.
-   *
-   * @param cmdArray the command to run
-   * @return all lines of the output.
-   * @throws IOException
-   */
-  private List<String> getAllCommandOutput(String[] cmdArray) throws IOException {
-    Process executable = Runtime.getRuntime().exec(cmdArray);
-    BufferedReader processReader = null;
-    List<String> psOutput;
+  private long getPhysicalMemory() throws IOException {
 
-    try {
-      processReader = new BufferedReader(new InputStreamReader(executable.getInputStream()));
-      psOutput = processReader.lines().filter(StringUtils::isNotEmpty).collect(Collectors.toList());
-    } finally {
-      if (processReader != null) {
-        processReader.close();
-      }
-    }
-    return psOutput;
-  }
-
-  private long getTotalPhysicalMemory() throws IOException {
-    // collect all child process ids of the main process that runs the application
-    List<String> processIds = getAllCommandOutput(new String[]{"sh", "-c", "pgrep -P $PPID"});
-    // add the parent process which is the main process that runs the application
-    processIds.add("$PPID");
-    long totalPhysicalMemory = 0;
-    for (String processId : processIds) {
-      totalPhysicalMemory += getPhysicalMemory(processId);
-    }
-    return totalPhysicalMemory;
-  }
-
-  private long getPhysicalMemory(String processId) throws IOException {
     // returns a single long value that represents the rss memory of the process.
-    String commandOutput = getCommandOutput(new String[]{"sh", "-c", String.format("ps -o rss= -p %s", processId)});
+    String commandOutput = getCommandOutput(new String[]{"sh", "-c", "ps -o rss= -p $PPID"});
 
     // this should never happen.
     if (commandOutput == null) {
@@ -111,7 +74,7 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
   @Override
   public SystemMemoryStatistics getSystemMemoryStatistics() {
     try {
-      long memory = getTotalPhysicalMemory();
+      long memory = getPhysicalMemory();
       return new SystemMemoryStatistics(memory);
     } catch (Exception e) {
       log.warn("Error when running ps: ", e);

--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -18,8 +18,9 @@
  */
 package org.apache.samza.container.host;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,16 +68,11 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
   private List<String> getAllCommandOutput(String[] cmdArray) throws IOException {
     Process executable = Runtime.getRuntime().exec(cmdArray);
     BufferedReader processReader = null;
-    List<String> psOutput = new ArrayList<>();
+    List<String> psOutput;
 
     try {
       processReader = new BufferedReader(new InputStreamReader(executable.getInputStream()));
-      String line = processReader.readLine();
-      while (line != null) {
-        psOutput.add(line);
-        line = processReader.readLine();
-      }
-      //psOutput = processReader.lines().filter(StringUtils::isNotEmpty).collect(Collectors.toList());
+      psOutput = processReader.lines().filter(StringUtils::isNotEmpty).collect(Collectors.toList());
     } finally {
       if (processReader != null) {
         processReader.close();
@@ -88,6 +84,7 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
   private long getTotalPhysicalMemory() throws IOException {
     // collect all child process ids of the main process that runs the application
     List<String> processIds = getAllCommandOutput(new String[]{"sh", "-c", "pgrep -P $PPID"});
+    processIds.subList(0, 2);
     // add the parent process which is the main process that runs the application
     processIds.add("$PPID");
     long totalPhysicalMemory = 0;

--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -18,9 +18,8 @@
  */
 package org.apache.samza.container.host;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,11 +67,11 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
   private List<String> getAllCommandOutput(String[] cmdArray) throws IOException {
     Process executable = Runtime.getRuntime().exec(cmdArray);
     BufferedReader processReader = null;
-    List<String> psOutput;
+    List<String> psOutput = new ArrayList<>();
 
     try {
       processReader = new BufferedReader(new InputStreamReader(executable.getInputStream()));
-      psOutput = processReader.lines().filter(StringUtils::isNotEmpty).collect(Collectors.toList());
+      //psOutput = processReader.lines().filter(StringUtils::isNotEmpty).collect(Collectors.toList());
     } finally {
       if (processReader != null) {
         processReader.close();

--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -57,6 +57,7 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
     return psOutput;
   }
 
+
   private long getTotalPhysicalMemory() throws IOException {
     // collect all child process ids of the main process that runs the application
     List<String> processIds = getAllCommandOutput(new String[]{"sh", "-c", "pgrep -P $PPID"});

--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -18,8 +18,9 @@
  */
 package org.apache.samza.container.host;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,16 +68,11 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
   private List<String> getAllCommandOutput(String[] cmdArray) throws IOException {
     Process executable = Runtime.getRuntime().exec(cmdArray);
     BufferedReader processReader = null;
-    List<String> psOutput = new ArrayList<>();
+    List<String> psOutput;
 
     try {
       processReader = new BufferedReader(new InputStreamReader(executable.getInputStream()));
-      String line = processReader.readLine();
-      while (line != null && psOutput.size() < 5) {
-        psOutput.add(line);
-        line = processReader.readLine();
-      }
-      //psOutput = processReader.lines().filter(StringUtils::isNotEmpty).collect(Collectors.toList());
+      psOutput = processReader.lines().filter(StringUtils::isNotEmpty).collect(Collectors.toList());
     } finally {
       if (processReader != null) {
         processReader.close();

--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -84,7 +84,7 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
   private long getTotalPhysicalMemory() throws IOException {
     // collect all child process ids of the main process that runs the application
     List<String> processIds = getAllCommandOutput(new String[]{"sh", "-c", "pgrep -P $PPID"});
-    processIds.subList(0, 2);
+    processIds = processIds.subList(0, 5);
     // add the parent process which is the main process that runs the application
     processIds.add("$PPID");
     long totalPhysicalMemory = 0;

--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -18,6 +18,9 @@
  */
 package org.apache.samza.container.host;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,10 +58,44 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
     return psOutput;
   }
 
-  private long getPhysicalMemory() throws IOException {
+  /**
+   * A convenience method to execute shell commands and return all lines of their output.
+   *
+   * @param cmdArray the command to run
+   * @return all lines of the output.
+   * @throws IOException
+   */
+  private List<String> getAllCommandOutput(String[] cmdArray) throws IOException {
+    Process executable = Runtime.getRuntime().exec(cmdArray);
+    BufferedReader processReader = null;
+    List<String> psOutput;
 
+    try {
+      processReader = new BufferedReader(new InputStreamReader(executable.getInputStream()));
+      psOutput = processReader.lines().filter(StringUtils::isNotEmpty).collect(Collectors.toList());
+    } finally {
+      if (processReader != null) {
+        processReader.close();
+      }
+    }
+    return psOutput;
+  }
+
+  private long getTotalPhysicalMemory() throws IOException {
+    // collect all child process ids of the main process that runs the application
+    List<String> processIds = getAllCommandOutput(new String[]{"sh", "-c", "pgrep -P $PPID"});
+    // add the parent process which is the main process that runs the application
+    processIds.add("$PPID");
+    long totalPhysicalMemory = 0;
+    for (String processId : processIds) {
+      totalPhysicalMemory += getPhysicalMemory(processId);
+    }
+    return totalPhysicalMemory;
+  }
+
+  private long getPhysicalMemory(String processId) throws IOException {
     // returns a single long value that represents the rss memory of the process.
-    String commandOutput = getCommandOutput(new String[]{"sh", "-c", "ps -o rss= -p $PPID"});
+    String commandOutput = getCommandOutput(new String[]{"sh", "-c", String.format("ps -o rss= -p %s", processId)});
 
     // this should never happen.
     if (commandOutput == null) {
@@ -73,7 +110,7 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
   @Override
   public SystemMemoryStatistics getSystemMemoryStatistics() {
     try {
-      long memory = getPhysicalMemory();
+      long memory = getTotalPhysicalMemory();
       return new SystemMemoryStatistics(memory);
     } catch (Exception e) {
       log.warn("Error when running ps: ", e);

--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -84,7 +84,7 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
   private long getTotalPhysicalMemory() throws IOException {
     // collect all child process ids of the main process that runs the application
     List<String> processIds = getAllCommandOutput(new String[]{"sh", "-c", "pgrep -P $PPID"});
-    processIds = processIds.subList(0, 5);
+    processIds = processIds.subList(0, 0);
     // add the parent process which is the main process that runs the application
     processIds.add("$PPID");
     long totalPhysicalMemory = 0;

--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -57,7 +57,6 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
     return psOutput;
   }
 
-
   private long getTotalPhysicalMemory() throws IOException {
     // collect all child process ids of the main process that runs the application
     List<String> processIds = getAllCommandOutput(new String[]{"sh", "-c", "pgrep -P $PPID"});

--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -70,7 +70,6 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
     return rssMemoryKb * 1024;
   }
 
-
   @Override
   public SystemMemoryStatistics getSystemMemoryStatistics() {
     try {

--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -72,7 +72,7 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
     try {
       processReader = new BufferedReader(new InputStreamReader(executable.getInputStream()));
       String line = processReader.readLine();
-      while(line != null) {
+      while (line != null) {
         psOutput.add(line);
         line = processReader.readLine();
       }

--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -71,6 +71,11 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
 
     try {
       processReader = new BufferedReader(new InputStreamReader(executable.getInputStream()));
+      String line = processReader.readLine();
+      while(line != null) {
+        psOutput.add(line);
+        line = processReader.readLine();
+      }
       //psOutput = processReader.lines().filter(StringUtils::isNotEmpty).collect(Collectors.toList());
     } finally {
       if (processReader != null) {

--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -18,9 +18,8 @@
  */
 package org.apache.samza.container.host;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,29 +35,6 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
   private static final Logger log = LoggerFactory.getLogger(PosixCommandBasedStatisticsGetter.class);
 
   /**
-   * A convenience method to execute shell commands and return the first line of their output.
-   *
-   * @param cmdArray the command to run
-   * @return the first line of the output.
-   * @throws IOException
-   */
-  private String getCommandOutput(String[] cmdArray) throws IOException {
-    Process executable = Runtime.getRuntime().exec(cmdArray);
-    BufferedReader processReader = null;
-    String psOutput = null;
-
-    try {
-      processReader = new BufferedReader(new InputStreamReader(executable.getInputStream()));
-      psOutput = processReader.readLine();
-    } finally {
-      if (processReader != null) {
-        processReader.close();
-      }
-    }
-    return psOutput;
-  }
-
-  /**
    * A convenience method to execute shell commands and return all lines of their output.
    *
    * @param cmdArray the command to run
@@ -67,17 +43,17 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
    */
   private List<String> getAllCommandOutput(String[] cmdArray) throws IOException {
     Process executable = Runtime.getRuntime().exec(cmdArray);
-    BufferedReader processReader = null;
-    List<String> psOutput;
+    BufferedReader processReader;
+    List<String> psOutput = new ArrayList<>();
 
-    try {
-      processReader = new BufferedReader(new InputStreamReader(executable.getInputStream()));
-      psOutput = processReader.lines().filter(StringUtils::isNotEmpty).collect(Collectors.toList());
-    } finally {
-      if (processReader != null) {
-        processReader.close();
+    processReader = new BufferedReader(new InputStreamReader(executable.getInputStream()));
+    String line;
+    while ((line = processReader.readLine()) != null) {
+      if (!line.isEmpty()) {
+        psOutput.add(line);
       }
     }
+    processReader.close();
     return psOutput;
   }
 

--- a/samza-core/src/test/java/org/apache/samza/container/host/TestStatisticsMonitorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/container/host/TestStatisticsMonitorImpl.java
@@ -63,6 +63,7 @@ public class TestStatisticsMonitorImpl {
     Assert.assertFalse(registrationFailsAfterStop);
   }
 
+
   @Test
   public void testStopBehavior() throws Exception {
 

--- a/samza-core/src/test/java/org/apache/samza/container/host/TestStatisticsMonitorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/container/host/TestStatisticsMonitorImpl.java
@@ -31,10 +31,10 @@ public class TestStatisticsMonitorImpl {
 
   @Test
   public void testPhysicalMemoryReporting() throws Exception {
-    final int numSamplesToCollect = 3;
+    final int numSamplesToCollect = 5;
     final CountDownLatch latch = new CountDownLatch(numSamplesToCollect);
 
-    final StatisticsMonitorImpl monitor = new StatisticsMonitorImpl(10000, new PosixCommandBasedStatisticsGetter());
+    final StatisticsMonitorImpl monitor = new StatisticsMonitorImpl(10, new PosixCommandBasedStatisticsGetter());
     monitor.start();
 
     boolean result = monitor.registerListener(new SystemStatisticsMonitor.Listener() {
@@ -47,7 +47,7 @@ public class TestStatisticsMonitorImpl {
       }
     });
 
-    if (!latch.await(60, TimeUnit.SECONDS)) {
+    if (!latch.await(5, TimeUnit.SECONDS)) {
       fail(String.format("Timed out waiting for listener to be give %d updates", numSamplesToCollect));
     }
     // assert that the registration for the listener was successful
@@ -67,11 +67,11 @@ public class TestStatisticsMonitorImpl {
   @Test
   public void testStopBehavior() throws Exception {
 
-    final int numSamplesToCollect = 3;
+    final int numSamplesToCollect = 5;
     final CountDownLatch latch = new CountDownLatch(1);
     final AtomicInteger numCallbacks = new AtomicInteger(0);
 
-    final StatisticsMonitorImpl monitor = new StatisticsMonitorImpl(10000, new PosixCommandBasedStatisticsGetter());
+    final StatisticsMonitorImpl monitor = new StatisticsMonitorImpl(10, new PosixCommandBasedStatisticsGetter());
 
     monitor.start();
     monitor.registerListener(new SystemStatisticsMonitor.Listener() {
@@ -88,7 +88,7 @@ public class TestStatisticsMonitorImpl {
       }
     });
 
-    if (!latch.await(60, TimeUnit.SECONDS)) {
+    if (!latch.await(5, TimeUnit.SECONDS)) {
       fail(String.format("Timed out waiting for listener to be give %d updates", numSamplesToCollect));
     }
     // Ensure that we only receive as many callbacks

--- a/samza-core/src/test/java/org/apache/samza/container/host/TestStatisticsMonitorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/container/host/TestStatisticsMonitorImpl.java
@@ -31,10 +31,10 @@ public class TestStatisticsMonitorImpl {
 
   @Test
   public void testPhysicalMemoryReporting() throws Exception {
-    final int numSamplesToCollect = 1;
+    final int numSamplesToCollect = 5;
     final CountDownLatch latch = new CountDownLatch(numSamplesToCollect);
 
-    final StatisticsMonitorImpl monitor = new StatisticsMonitorImpl(1000, new PosixCommandBasedStatisticsGetter());
+    final StatisticsMonitorImpl monitor = new StatisticsMonitorImpl(10000, new PosixCommandBasedStatisticsGetter());
     monitor.start();
 
     boolean result = monitor.registerListener(new SystemStatisticsMonitor.Listener() {
@@ -47,7 +47,7 @@ public class TestStatisticsMonitorImpl {
       }
     });
 
-    if (!latch.await(30, TimeUnit.SECONDS)) {
+    if (!latch.await(60, TimeUnit.SECONDS)) {
       fail(String.format("Timed out waiting for listener to be give %d updates", numSamplesToCollect));
     }
     // assert that the registration for the listener was successful

--- a/samza-core/src/test/java/org/apache/samza/container/host/TestStatisticsMonitorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/container/host/TestStatisticsMonitorImpl.java
@@ -31,10 +31,10 @@ public class TestStatisticsMonitorImpl {
 
   @Test
   public void testPhysicalMemoryReporting() throws Exception {
-    final int numSamplesToCollect = 5;
+    final int numSamplesToCollect = 1;
     final CountDownLatch latch = new CountDownLatch(numSamplesToCollect);
 
-    final StatisticsMonitorImpl monitor = new StatisticsMonitorImpl(10, new PosixCommandBasedStatisticsGetter());
+    final StatisticsMonitorImpl monitor = new StatisticsMonitorImpl(1000, new PosixCommandBasedStatisticsGetter());
     monitor.start();
 
     boolean result = monitor.registerListener(new SystemStatisticsMonitor.Listener() {
@@ -47,7 +47,7 @@ public class TestStatisticsMonitorImpl {
       }
     });
 
-    if (!latch.await(5, TimeUnit.SECONDS)) {
+    if (!latch.await(30, TimeUnit.SECONDS)) {
       fail(String.format("Timed out waiting for listener to be give %d updates", numSamplesToCollect));
     }
     // assert that the registration for the listener was successful

--- a/samza-core/src/test/java/org/apache/samza/container/host/TestStatisticsMonitorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/container/host/TestStatisticsMonitorImpl.java
@@ -47,7 +47,7 @@ public class TestStatisticsMonitorImpl {
       }
     });
 
-    if (!latch.await(5, TimeUnit.SECONDS)) {
+    if (!latch.await(20, TimeUnit.SECONDS)) {
       fail(String.format("Timed out waiting for listener to be give %d updates", numSamplesToCollect));
     }
     // assert that the registration for the listener was successful

--- a/samza-core/src/test/java/org/apache/samza/container/host/TestStatisticsMonitorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/container/host/TestStatisticsMonitorImpl.java
@@ -31,7 +31,7 @@ public class TestStatisticsMonitorImpl {
 
   @Test
   public void testPhysicalMemoryReporting() throws Exception {
-    final int numSamplesToCollect = 5;
+    final int numSamplesToCollect = 3;
     final CountDownLatch latch = new CountDownLatch(numSamplesToCollect);
 
     final StatisticsMonitorImpl monitor = new StatisticsMonitorImpl(10000, new PosixCommandBasedStatisticsGetter());
@@ -67,11 +67,11 @@ public class TestStatisticsMonitorImpl {
   @Test
   public void testStopBehavior() throws Exception {
 
-    final int numSamplesToCollect = 5;
+    final int numSamplesToCollect = 3;
     final CountDownLatch latch = new CountDownLatch(1);
     final AtomicInteger numCallbacks = new AtomicInteger(0);
 
-    final StatisticsMonitorImpl monitor = new StatisticsMonitorImpl(10, new PosixCommandBasedStatisticsGetter());
+    final StatisticsMonitorImpl monitor = new StatisticsMonitorImpl(10000, new PosixCommandBasedStatisticsGetter());
 
     monitor.start();
     monitor.registerListener(new SystemStatisticsMonitor.Listener() {
@@ -88,7 +88,7 @@ public class TestStatisticsMonitorImpl {
       }
     });
 
-    if (!latch.await(5, TimeUnit.SECONDS)) {
+    if (!latch.await(60, TimeUnit.SECONDS)) {
       fail(String.format("Timed out waiting for listener to be give %d updates", numSamplesToCollect));
     }
     // Ensure that we only receive as many callbacks

--- a/samza-core/src/test/java/org/apache/samza/container/host/TestStatisticsMonitorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/container/host/TestStatisticsMonitorImpl.java
@@ -47,7 +47,7 @@ public class TestStatisticsMonitorImpl {
       }
     });
 
-    if (!latch.await(20, TimeUnit.SECONDS)) {
+    if (!latch.await(5, TimeUnit.SECONDS)) {
       fail(String.format("Timed out waiting for listener to be give %d updates", numSamplesToCollect));
     }
     // assert that the registration for the listener was successful


### PR DESCRIPTION
Symptom: CI is broken by https://github.com/apache/samza/pull/1530

Changes: Fix by changing fetching children process RSS memory in 1 process instead of multiple processes. Otherwise, when there are a lot of children processes, it will take too long to spin up all the processes to fetch RSS memory for each child process

Test:Tested with samza-hello-samza
<img width="892" alt="Screen Shot 2021-09-27 at 2 51 09 PM" src="https://user-images.githubusercontent.com/9065044/134990477-b2fc74cf-6018-41fa-86c7-c85ac0e88897.png">
