### PR TITLE
SAMZA-2694: Always show stack traces on gradle failures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ apply from: file("gradle/dependency-versions-scala-" + scalaSuffix + ".gradle")
 apply from: file("gradle/release.gradle")
 apply from: file("gradle/rat.gradle")
 apply from: file('gradle/customize.gradle')
+apply from: file('gradle/stacktrace.gradle')
 
 
 rat {

--- a/gradle/stacktrace.gradle
+++ b/gradle/stacktrace.gradle
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * This script enables showing stacktraces whenever the build fails.
+ */
+
+import org.gradle.api.logging.configuration.ShowStacktrace
+
+gradle.startParameter.showStacktrace = ShowStacktrace.ALWAYS_FULL


### PR DESCRIPTION
CI build failures are more useful when they show stack traces by default.