### PR TITLE
SAMZA-2696: Set CI timeout to 60 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ on: [pull_request,push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Cache Gradle packages


### PR DESCRIPTION
The Github Actions CI timeout is currently set to 6 hours by default.
However, a typical successful run will take around 30 minutes.

This change lowers the timeout from 6 hours to 60 minutes.