### PR TITLE
SAMZA-2697: Increase build time max heap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,7 +206,7 @@ project(":samza-core_$scalaSuffix") {
 
   test {
     // some unit tests use embedded zookeeper, so adding some extra memory for those
-    maxHeapSize = "1560m"
+    maxHeapSize = "2385m"
     jvmArgs = ["-XX:+UseConcMarkSweepGC", "-server"]
   }
 }


### PR DESCRIPTION
Github actions uses the Adopt JDK. The Adopt JDK appears to use a bit
more memory than Hotspot. This change increases the Xmx for the build by
1 GB.