### PR TITLE
SAMZA-2700: StaticResourceJobCoordinator does not set config for LoggingContextHolder

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/coordinator/staticresource/StaticResourceJobCoordinator.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/staticresource/StaticResourceJobCoordinator.java
@@ -35,6 +35,7 @@ import org.apache.samza.job.JobMetadataChange;
 import org.apache.samza.job.metadata.JobCoordinatorMetadataManager;
 import org.apache.samza.job.model.JobModel;
 import org.apache.samza.job.model.JobModelUtil;
+import org.apache.samza.logging.LoggingContextHolder;
 import org.apache.samza.metrics.MetricsRegistry;
 import org.apache.samza.startpoint.StartpointManager;
 import org.apache.samza.storage.ChangelogStreamManager;
@@ -90,6 +91,7 @@ public class StaticResourceJobCoordinator implements JobCoordinator {
     this.startpointManager.ifPresent(StartpointManager::start);
     try {
       JobModel jobModel = newJobModel();
+      doSetLoggingContextConfig(jobModel.getConfig());
       JobCoordinatorMetadata newMetadata =
           this.jobCoordinatorMetadataManager.generateJobCoordinatorMetadata(jobModel, jobModel.getConfig());
       Set<JobMetadataChange> jobMetadataChanges = checkForMetadataChanges(newMetadata);
@@ -132,6 +134,14 @@ public class StaticResourceJobCoordinator implements JobCoordinator {
 
   private JobModel newJobModel() {
     return this.jobModelHelper.newJobModel(this.config, this.changelogStreamManager.readPartitionMapping());
+  }
+
+  /**
+   * This is a helper method so that we can verify it is called in testing.
+   */
+  @VisibleForTesting
+  void doSetLoggingContextConfig(Config config) {
+    LoggingContextHolder.INSTANCE.setConfig(config);
   }
 
   /**

--- a/samza-core/src/test/java/org/apache/samza/coordinator/staticresource/TestStaticResourceJobCoordinator.java
+++ b/samza-core/src/test/java/org/apache/samza/coordinator/staticresource/TestStaticResourceJobCoordinator.java
@@ -54,6 +54,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -112,6 +113,7 @@ public class TestStaticResourceJobCoordinator {
             this.coordinatorCommunication, this.jobCoordinatorMetadataManager, this.startpointManager,
             this.changelogStreamManager, this.metrics, this.systemAdmins, this.config));
     this.staticResourceJobCoordinator.setListener(this.jobCoordinatorListener);
+    doNothing().when(this.staticResourceJobCoordinator).doSetLoggingContextConfig(any());
   }
 
   @Test
@@ -125,6 +127,7 @@ public class TestStaticResourceJobCoordinator {
     this.staticResourceJobCoordinator.start();
     assertEquals(jobModel, this.staticResourceJobCoordinator.getJobModel());
     verifyStartLifecycle();
+    verify(this.staticResourceJobCoordinator).doSetLoggingContextConfig(jobModelConfig);
     verifyPrepareWorkerExecution(jobModel, metadataResourceUtil, newMetadata, SINGLE_SSP_FANOUT);
     verify(this.jobCoordinatorListener).onNewJobModel(PROCESSOR_ID, jobModel);
   }
@@ -139,6 +142,7 @@ public class TestStaticResourceJobCoordinator {
     this.staticResourceJobCoordinator.start();
     assertEquals(jobModel, this.staticResourceJobCoordinator.getJobModel());
     verifyStartLifecycle();
+    verify(this.staticResourceJobCoordinator).doSetLoggingContextConfig(jobModelConfig);
     verifyPrepareWorkerExecution(jobModel, metadataResourceUtil, null, null);
     verify(this.jobCoordinatorListener).onNewJobModel(PROCESSOR_ID, jobModel);
   }
@@ -154,6 +158,7 @@ public class TestStaticResourceJobCoordinator {
     this.staticResourceJobCoordinator.start();
     assertEquals(jobModel, this.staticResourceJobCoordinator.getJobModel());
     verifyStartLifecycle();
+    verify(this.staticResourceJobCoordinator).doSetLoggingContextConfig(jobModelConfig);
     verifyPrepareWorkerExecution(jobModel, metadataResourceUtil, newMetadata, SINGLE_SSP_FANOUT);
     verify(this.jobCoordinatorListener).onNewJobModel(PROCESSOR_ID, jobModel);
   }
@@ -188,6 +193,7 @@ public class TestStaticResourceJobCoordinator {
     this.staticResourceJobCoordinator.start();
     assertEquals(jobModel, this.staticResourceJobCoordinator.getJobModel());
     verify(this.systemAdmins).start();
+    verify(this.staticResourceJobCoordinator).doSetLoggingContextConfig(jobModelConfig);
     verifyPrepareWorkerExecution(jobModel, metadataResourceUtil, newMetadata, null);
   }
 


### PR DESCRIPTION
Symptom: If using `StaticResourceJobCoordinator`, any logging appenders which need `Config` from `LoggingContextHolder` will not be able to access it, so they won't be able to work properly.
Cause: `LoggingContextHolder.setConfig` is not called in `StaticResourceJobCoordinator`.
Changes: Set the `Config` in `LoggingContextHolder` in `StaticResourceJobCoordinator`.
Tests: `./gradlew build`
API changes: N/A