### PR TITLE
SAMZA-2701: AzureBlob SystemProducer: bump azure-storage-blob and azure-identity sdks to latest versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -215,8 +215,8 @@ project(":samza-azure_$scalaSuffix") {
   apply plugin: 'java'
 
   dependencies {
-    compile "com.azure:azure-storage-blob:12.10.0"
-    compile "com.azure:azure-identity:1.0.0"
+    compile "com.azure:azure-storage-blob:12.14.0"
+    compile "com.azure:azure-identity:1.3.6"
     compile "com.microsoft.azure:azure-storage:5.3.1"
     compile "com.microsoft.azure:azure-eventhubs:1.0.1"
     compile "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"

--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobClientBuilder.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/AzureBlobClientBuilder.java
@@ -84,7 +84,7 @@ public final class AzureBlobClientBuilder {
     String endpoint = String.format(Locale.ROOT, azureUrlFormat, azureBlobConfig.getAzureAccountName(systemName));
 
     HttpLogOptions httpLogOptions = new HttpLogOptions();
-    httpLogOptions.setLogLevel(HttpLogDetailLevel.BASIC);
+    httpLogOptions.setLogLevel(HttpLogDetailLevel.HEADERS);
 
     BlobServiceClientBuilder blobServiceClientBuilder = new BlobServiceClientBuilder()
         .httpLogOptions(httpLogOptions)


### PR DESCRIPTION
Improvement: bump azure sdk to: azure-storage-blob:12.14.0 and azure-identity:1.3.6

changes: change the sdk versions in build.gradle. Also improve logging to include azure request id. 

tests: performance testing against currently used versions does not show any significant regressions for the system producer metrics (write, write byte, compress byte, upload and commit)

API changes: none

usage instructions: to see the azure request id, the log4j configs need to have debug level logs enabled only for   this logger com.azure.storage.blob.implementation.

upgrade instructions: none
backwards compatible: yes