### PR TITLE
SAMZA-2706: Clean up specific handling of diagnostics-specific metrics reporter

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/runtime/ContainerLaunchUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/ContainerLaunchUtil.java
@@ -22,13 +22,11 @@ package org.apache.samza.runtime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.samza.SamzaException;
 import org.apache.samza.application.descriptors.ApplicationDescriptor;
 import org.apache.samza.application.descriptors.ApplicationDescriptorImpl;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.JobConfig;
-import org.apache.samza.config.MetricsConfig;
 import org.apache.samza.config.ShellCommandConfig;
 import org.apache.samza.container.ContainerHeartbeatMonitor;
 import org.apache.samza.container.ExecutionContainerIdManager;
@@ -48,7 +46,6 @@ import org.apache.samza.logging.LoggingContextHolder;
 import org.apache.samza.metadatastore.MetadataStore;
 import org.apache.samza.metrics.MetricsRegistryMap;
 import org.apache.samza.metrics.MetricsReporter;
-import org.apache.samza.metrics.reporter.MetricsSnapshotReporter;
 import org.apache.samza.startpoint.StartpointManager;
 import org.apache.samza.task.TaskFactory;
 import org.apache.samza.task.TaskFactoryUtil;
@@ -121,12 +118,9 @@ public class ContainerLaunchUtil {
       Map<String, MetricsReporter> metricsReporters = loadMetricsReporters(appDesc, containerId, config);
 
       // Creating diagnostics manager and reporter, and wiring it respectively
-      Optional<Pair<DiagnosticsManager, MetricsSnapshotReporter>> diagnosticsManagerReporterPair = DiagnosticsUtil.buildDiagnosticsManager(jobName, jobId, jobModel, containerId, execEnvContainerIdOptional, config);
-      Option<DiagnosticsManager> diagnosticsManager = Option.empty();
-      if (diagnosticsManagerReporterPair.isPresent()) {
-        diagnosticsManager = Option.apply(diagnosticsManagerReporterPair.get().getKey());
-        metricsReporters.put(MetricsConfig.METRICS_SNAPSHOT_REPORTER_NAME_FOR_DIAGNOSTICS, diagnosticsManagerReporterPair.get().getValue());
-      }
+      Optional<DiagnosticsManager> diagnosticsManager =
+          DiagnosticsUtil.buildDiagnosticsManager(jobName, jobId, jobModel, containerId, execEnvContainerIdOptional,
+              config);
       MetricsRegistryMap metricsRegistryMap = new MetricsRegistryMap();
 
       SamzaContainer container = SamzaContainer$.MODULE$.apply(
@@ -140,7 +134,7 @@ public class ContainerLaunchUtil {
           Option.apply(externalContextOptional.orElse(null)),
           localityManager,
           startpointManager,
-          diagnosticsManager);
+          Option.apply(diagnosticsManager.orElse(null)));
 
       ProcessorLifecycleListener processorLifecycleListener = appDesc.getProcessorLifecycleListenerFactory()
           .createInstance(new ProcessorContext() { }, config);

--- a/samza-core/src/main/java/org/apache/samza/util/MetricsReporterLoader.java
+++ b/samza-core/src/main/java/org/apache/samza/util/MetricsReporterLoader.java
@@ -21,7 +21,6 @@ package org.apache.samza.util;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.samza.SamzaException;
 import org.apache.samza.config.MetricsConfig;
 import org.apache.samza.metrics.MetricsReporter;
@@ -38,16 +37,7 @@ public class MetricsReporterLoader {
 
   public static Map<String, MetricsReporter> getMetricsReporters(MetricsConfig metricsConfig, String containerName) {
     Map<String, MetricsReporter> metricsReporters = new HashMap<>();
-
-    String diagnosticsReporterName = MetricsConfig.METRICS_SNAPSHOT_REPORTER_NAME_FOR_DIAGNOSTICS;
-
-    // Exclude creation of diagnostics-reporter, because it is created manually in SamzaContainer (to allow sharing of
-    // sysProducer between reporter and diagnosticsManager
-    List<String> metricsReporterNames = metricsConfig.getMetricReporterNames()
-        .stream()
-        .filter(reporterName -> !reporterName.equals(diagnosticsReporterName))
-        .collect(Collectors.toList());
-
+    List<String> metricsReporterNames = metricsConfig.getMetricReporterNames();
     for (String metricsReporterName : metricsReporterNames) {
       String metricsFactoryClassName = metricsConfig.getMetricsFactoryClass(metricsReporterName)
           .orElseThrow(() -> new SamzaException(

--- a/samza-core/src/test/java/org/apache/samza/util/TestDiagnosticsUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/util/TestDiagnosticsUtil.java
@@ -22,7 +22,6 @@ package org.apache.samza.util;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.JobConfig;
 import org.apache.samza.config.MapConfig;
@@ -31,8 +30,6 @@ import org.apache.samza.config.SystemConfig;
 import org.apache.samza.diagnostics.DiagnosticsManager;
 import org.apache.samza.job.model.JobModel;
 import org.apache.samza.metrics.MetricsRegistry;
-import org.apache.samza.metrics.MetricsReporterFactory;
-import org.apache.samza.metrics.reporter.MetricsSnapshotReporter;
 import org.apache.samza.system.SystemFactory;
 import org.apache.samza.system.SystemProducer;
 import org.junit.Assert;
@@ -48,7 +45,6 @@ import static org.mockito.Mockito.*;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ReflectionUtil.class})
 public class TestDiagnosticsUtil {
-
   private static final String STREAM_NAME = "someStreamName";
   private static final String JOB_NAME = "someJob";
   private static final String JOB_ID = "someId";
@@ -58,27 +54,20 @@ public class TestDiagnosticsUtil {
   public static final String SYSTEM_FACTORY = "com.foo.system.SomeSystemFactory";
 
   @Test
-  public void testBuildDiagnosticsManagerReturnsConfiguredReporter() {
+  public void testBuildDiagnosticsManager() {
     Config config = new MapConfig(buildTestConfigs());
     JobModel mockJobModel = mock(JobModel.class);
     SystemFactory systemFactory = mock(SystemFactory.class);
     SystemProducer mockProducer = mock(SystemProducer.class);
-    MetricsReporterFactory metricsReporterFactory = mock(MetricsReporterFactory.class);
-    MetricsSnapshotReporter mockReporter = mock(MetricsSnapshotReporter.class);
-
     when(systemFactory.getProducer(anyString(), any(Config.class), any(MetricsRegistry.class), anyString())).thenReturn(mockProducer);
-    when(metricsReporterFactory.getMetricsReporter(anyString(), anyString(), any(Config.class))).thenReturn(
-        mockReporter);
     PowerMockito.mockStatic(ReflectionUtil.class);
-    when(ReflectionUtil.getObj(REPORTER_FACTORY, MetricsReporterFactory.class)).thenReturn(metricsReporterFactory);
     when(ReflectionUtil.getObj(SYSTEM_FACTORY, SystemFactory.class)).thenReturn(systemFactory);
 
-    Optional<Pair<DiagnosticsManager, MetricsSnapshotReporter>> managerReporterPair =
+    Optional<DiagnosticsManager> diagnosticsManager =
         DiagnosticsUtil.buildDiagnosticsManager(JOB_NAME, JOB_ID, mockJobModel, CONTAINER_ID, Optional.of(ENV_ID),
             config);
 
-    Assert.assertTrue(managerReporterPair.isPresent());
-    Assert.assertEquals(mockReporter, managerReporterPair.get().getValue());
+    Assert.assertTrue(diagnosticsManager.isPresent());
   }
 
   private Map<String, String> buildTestConfigs() {


### PR DESCRIPTION
Issues: Specific checks for the `diagnosticsreporter` metrics reporter were making the code for setting up diagnostics and the `diagnosticsreporter` metrics reporter a bit harder to work with. For the new `StaticResourceJobCoordinator`, it made object wiring harder for diagnostics-related components. https://github.com/apache/samza/pull/1021 initially had a reason to have special logic for creating the `diagnosticsreporter` metrics reporter, but https://github.com/apache/samza/pull/1369 made that special logic unnecessary.

Changes:
1. Changed `DiagnosticsUtil.buildDiagnosticsManager` to only return a `DiagnosticsManager` instead of `Pair<DiagnosticsManager, MetricsSnapshotReporter>`.
2. `MetricsReporterLoader.getMetricsReporters` no longer excludes the `diagnosticsreporter` metrics reporter. It just creates all configured reporters.
3. Since `MetricsReporterLoader.getMetricsReporters` returns all reporters, any classes that use that method no longer need to inject the `diagnosticsreporter` explicitly.

Tests:
`./gradlew build`

API changes:
1. In the YARN application master,`diagnosticsreporter` metrics reporter now is given a `processorId` of "ApplicationMaster" instead of "samza-container-ApplicationMaster".
2. When using `MetricsReporterLoader.getMetricsReporters`, if `diagnosticsreporter` is in `metrics.reporters`, then `diagnosticsreporter` metrics reporter is always created.
3. The `diagnosticsreporter` metrics reporter may still be created even if `job.diagnostics.enabled` is set to false. Note that Samza will only automatically create the stream for the `diagnosticsreporter` metrics reporter if diagnostics is enabled (since the `DiagnosticsManager` also uses that same stream), so if there is a case in which `diagnosticsreporter` metrics reporter is needed while diagnostics is disabled, then the stream for the reporter needs to be created through some other means.