### PR TITLE
[Tests] Updating memory for test task for samza-core and samza-test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,7 +206,7 @@ project(":samza-core_$scalaSuffix") {
 
   test {
     // some unit tests use embedded zookeeper, so adding some extra memory for those
-    maxHeapSize = "2385m"
+    maxHeapSize = "2048m"
     jvmArgs = ["-XX:+UseConcMarkSweepGC", "-server"]
   }
 }
@@ -810,8 +810,7 @@ project(":samza-test_$scalaSuffix") {
 
   test {
     // Bump up the heap so we can run KV store tests.
-    minHeapSize = "1560m"
-    maxHeapSize = "1560m"
+    maxHeapSize = "2048m"
     jvmArgs = ["-XX:+UseConcMarkSweepGC", "-server"]
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -206,7 +206,7 @@ project(":samza-core_$scalaSuffix") {
 
   test {
     // some unit tests use embedded zookeeper, so adding some extra memory for those
-    maxHeapSize = "2048m"
+    maxHeapSize = "3072m"
     jvmArgs = ["-XX:+UseConcMarkSweepGC", "-server"]
   }
 }
@@ -810,7 +810,8 @@ project(":samza-test_$scalaSuffix") {
 
   test {
     // Bump up the heap so we can run KV store tests.
-    maxHeapSize = "2048m"
+    minHeapSize = "1560m"
+    maxHeapSize = "1560m"
     jvmArgs = ["-XX:+UseConcMarkSweepGC", "-server"]
   }
 


### PR DESCRIPTION
Issues: CI runs have been flaky lately, and I have seen OOM errors more frequently. This issue might be related to https://github.com/apache/samza/pull/1538 (which bumped memory for https://github.com/apache/samza/pull/1525) or https://github.com/apache/samza/pull/1545.
Changes: Increase the heap memory for `samza-core` tests