### PR TITLE
[Tests] add more context on flaky testProcessingFutureCompletesAfterTaskTimeout test

### DIFF
--- a/samza-test/src/test/java/org/apache/samza/test/operator/TestAsyncFlatMap.java
+++ b/samza-test/src/test/java/org/apache/samza/test/operator/TestAsyncFlatMap.java
@@ -93,7 +93,8 @@ public class TestAsyncFlatMap {
        * nested within a bunch of other exceptions.
        */
       Throwable rootCause = findRootCause(e);
-      assertTrue(rootCause instanceof SamzaException);
+      assertTrue(String.format("Got exception %s with message %s", rootCause.getClass(), rootCause.getMessage()),
+          rootCause instanceof SamzaException);
       // the "{}" is intentional, since the exception message actually includes it (probably a logging bug)
       assertEquals("Callback for task {} Partition 0 timed out after 100 ms.", rootCause.getMessage());
     }
@@ -112,7 +113,9 @@ public class TestAsyncFlatMap {
        * TestRunner throws SamzaException on failures in general, so check the actual cause. The actual exception is
        * nested within a bunch of other exceptions.
        */
-      assertTrue(findRootCause(e) instanceof ProcessFailureException);
+      Throwable rootCause = findRootCause(e);
+      assertTrue(String.format("Got exception %s with message %s", rootCause.getClass(), rootCause.getMessage()),
+          rootCause instanceof ProcessFailureException);
     }
   }
 
@@ -129,7 +132,9 @@ public class TestAsyncFlatMap {
        * TestRunner throws SamzaException on failures in general, so check the actual cause. The actual exception is
        * nested within a bunch of other exceptions.
        */
-      assertTrue(findRootCause(e) instanceof FilterFailureException);
+      Throwable rootCause = findRootCause(e);
+      assertTrue(String.format("Got exception %s with message %s", rootCause.getClass(), rootCause.getMessage()),
+          rootCause instanceof FilterFailureException);
     }
   }
 


### PR DESCRIPTION
Issues: `TestAsyncFlatMap.testProcessingFutureCompletesAfterTaskTimeout` fails transiently when running the CI build due to the `rootCause` exception type not being the expected `SamzaException`. It's unclear what the actual type of `rootCause` is when the test fails.
Changes: Add extra context message to figure out why this is failing when it does show up again.
Tests: Ran CI build multiple times, but I couldn't reproduce the failure. We can commit this change so that we have the information if it does fail in the future.
API changes: N/A