### PR TITLE
[Tests] Fix flaky tests and memory leak related to ContainerAllocator tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,7 +206,7 @@ project(":samza-core_$scalaSuffix") {
 
   test {
     // some unit tests use embedded zookeeper, so adding some extra memory for those
-    maxHeapSize = "3072m"
+    maxHeapSize = "1560m"
     jvmArgs = ["-XX:+UseConcMarkSweepGC", "-server"]
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithHostAffinity.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithHostAffinity.java
@@ -410,7 +410,7 @@ public class TestContainerAllocatorWithHostAffinity {
     // State check when host affinity is enabled
     assertTrue(state.matchedResourceRequests.get() == 2);
     assertTrue(state.preferredHostRequests.get() == 2);
-    containerAllocator.stop();
+    spyAllocator.stop();
   }
 
   @Test
@@ -433,7 +433,7 @@ public class TestContainerAllocatorWithHostAffinity {
     spyAllocatorThread.start();
 
     // Let the request expire, expiration timeout is 3 ms
-    Thread.sleep(100);
+    Thread.sleep(1000);
 
     // Verify that all the request that were created as preferred host requests expired
     assertTrue(state.preferredHostRequests.get() == 2);
@@ -453,7 +453,7 @@ public class TestContainerAllocatorWithHostAffinity {
     // Check that atleast 2 ANY_HOST requests were made
     assertTrue(state.matchedResourceRequests.get() == 0);
     assertTrue(state.anyHostRequests.get() > 2);
-    containerAllocator.stop();
+    spyAllocator.stop();
   }
 
   @Test
@@ -481,7 +481,7 @@ public class TestContainerAllocatorWithHostAffinity {
     spyAllocatorThread.start();
 
     // Let the request expire, expiration timeout is 3 ms
-    Thread.sleep(100);
+    Thread.sleep(1000);
 
     // Verify that all the request that were created as preferred host requests expired
     assertEquals(state.expiredPreferredHostRequests.get(), 2);
@@ -506,7 +506,7 @@ public class TestContainerAllocatorWithHostAffinity {
     assertTrue(state.matchedResourceRequests.get() == 0);
     assertTrue(state.preferredHostRequests.get() == 2);
     assertTrue(state.anyHostRequests.get() == 0);
-    containerAllocator.stop();
+    spyAllocator.stop();
   }
 
   @Test(timeout = 5000)
@@ -551,7 +551,7 @@ public class TestContainerAllocatorWithHostAffinity {
         .forEach(resource -> assertEquals(resource.getHost(), "host-0"));
     // Verify resources were released
     assertTrue(mockClusterResourceManager.containsReleasedResource(expiredAllocatedResource));
-    containerAllocator.stop();
+    spyAllocator.stop();
   }
 
   //@Test
@@ -643,7 +643,7 @@ public class TestContainerAllocatorWithHostAffinity {
         put("cluster-manager.container.count", "1");
         put("cluster-manager.container.retry.count", "1");
         put("cluster-manager.container.retry.window.ms", "1999999999");
-        put("cluster-manager.container.request.timeout.ms", "3");
+        put("cluster-manager.container.request.timeout.ms", "500");
         put("cluster-manager.allocator.sleep.ms", "1");
         put("cluster-manager.container.memory.mb", "512");
         put("yarn.package.path", "/foo");

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithoutHostAffinity.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerAllocatorWithoutHostAffinity.java
@@ -95,7 +95,7 @@ public class TestContainerAllocatorWithoutHostAffinity {
   @After
   public void teardown() throws Exception {
     jobModelManager.stop();
-    validateMockitoUsage();
+    containerAllocator.stop();
   }
 
   private static Config getConfig() {

--- a/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerProcessManager.java
+++ b/samza-core/src/test/java/org/apache/samza/clustermanager/TestContainerProcessManager.java
@@ -394,6 +394,7 @@ public class TestContainerProcessManager {
     cpm.onResourceCompleted(new SamzaResourceStatus("id0", "diagnostics", SamzaResourceStatus.SUCCESS));
     verify(cpm, never()).onResourceCompletedWithUnknownStatus(any(SamzaResourceStatus.class), anyString(), anyString(), anyInt());
     assertTrue(cpm.shouldShutdown());
+    cpm.stop();
   }
 
 
@@ -748,6 +749,7 @@ public class TestContainerProcessManager {
     assertFalse(cpm.shouldShutdown());
     assertTrue(state.jobHealthy.get());
     assertEquals(state.redundantNotifications.get(), 1);
+    cpm.stop();
   }
 
   @Test
@@ -781,6 +783,7 @@ public class TestContainerProcessManager {
     manager.onStreamProcessorLaunchFailure(resource, new Exception("cannot launch container!"));
     Assert.assertEquals(clusterResourceManager.resourceRequests.size(), 2);
     Assert.assertEquals(clusterResourceManager.resourceRequests.get(1).getHost(), ResourceRequestState.ANY_HOST);
+    manager.stop();
   }
 
   @Test
@@ -852,6 +855,7 @@ public class TestContainerProcessManager {
     cpm.onStreamProcessorLaunchSuccess(resource3);
 
     assertTrue(state.jobHealthy.get());
+    cpm.stop();
   }
 
   @Test
@@ -923,6 +927,7 @@ public class TestContainerProcessManager {
     assertEquals(2, clusterResourceManager.resourceRequests.size());
     assertEquals(0, clusterResourceManager.releasedResources.size());
     assertTrue(state.jobHealthy.get());
+    cpm.stop();
   }
 
   /**


### PR DESCRIPTION
Issues:
1. `TestContainerAllocatorWithHostAffinity.testExpiredRequestsAreCancelled` fails transiently due to seeing a value of 4 for `cancelledRequests.size()` instead of 3.
2. `samza-core` tests take a lot of heap to run (3GB), but it seems like they shouldn't need that much.

Changes:
1. Change the `cluster-manager.container.request.timeout.ms` to be 500ms instead of 3ms in `TestContainerAllocatorWithHostAffinity` in order to prevent the test from cancelling requests too quickly and causing an extra cancellation to happen before the validation is done.
2. Stop the `ContainerAllocator` and `ContainerPlacementManager` objects in tests so that their corresponding threads can exit. Before, I believe the threads just kept running, and that may have eaten up memory.
3. Reduce the heap needed for `samza-core` tests.

Tests: Ran CI build multiple times

API changes: N/A