### PR TITLE
SAMZA-2709: Adding partial update api to Table API

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/context/TaskContext.java
+++ b/samza-api/src/main/java/org/apache/samza/context/TaskContext.java
@@ -66,10 +66,11 @@ public interface TaskContext {
    * @param tableId id of the {@link ReadWriteTable} to get
    * @param <K> the type of the key in this table
    * @param <V> the type of the value in this table
+   * @param <U> the type of the update applied to records in this table
    * @return the {@link ReadWriteTable} associated with {@code tableId} for this task
    * @throws IllegalArgumentException if there is no table associated with {@code tableId}
    */
-  <K, V> ReadWriteTable<K, V> getTable(String tableId);
+  <K, V, U> ReadWriteTable<K, V, U> getTable(String tableId);
 
   /**
    * Gets the {@link CallbackScheduler} for this task, which can be used to schedule a callback to be executed

--- a/samza-api/src/main/java/org/apache/samza/context/TaskContext.java
+++ b/samza-api/src/main/java/org/apache/samza/context/TaskContext.java
@@ -25,6 +25,7 @@ import org.apache.samza.scheduler.CallbackScheduler;
 import org.apache.samza.storage.kv.KeyValueStore;
 import org.apache.samza.system.SystemStreamPartition;
 import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 
 
 /**
@@ -61,16 +62,29 @@ public interface TaskContext {
   KeyValueStore<?, ?> getStore(String storeName);
 
   /**
+   * Gets the {@link ReadWriteUpdateTable} corresponding to the {@code tableId} for this task.
+   *
+   * @param tableId id of the {@link ReadWriteUpdateTable} to get
+   * @param <K> the type of the key in this table
+   * @param <V> the type of the value in this table
+   * @param <U> the type of the update applied to records in this table
+   * @return the {@link ReadWriteUpdateTable} associated with {@code tableId} for this task
+   * @throws IllegalArgumentException if there is no table associated with {@code tableId}
+   */
+  <K, V, U> ReadWriteUpdateTable<K, V, U> getUpdatableTable(String tableId);
+
+  /**
    * Gets the {@link ReadWriteTable} corresponding to the {@code tableId} for this task.
+   * This is retained for backward compatibility of the API. Please prefer the use of {@link #getUpdatableTable(String)}
+   * instead as it provides the ability to do updates as well.
    *
    * @param tableId id of the {@link ReadWriteTable} to get
    * @param <K> the type of the key in this table
    * @param <V> the type of the value in this table
-   * @param <U> the type of the update applied to records in this table
    * @return the {@link ReadWriteTable} associated with {@code tableId} for this task
    * @throws IllegalArgumentException if there is no table associated with {@code tableId}
    */
-  <K, V, U> ReadWriteTable<K, V, U> getTable(String tableId);
+  <K, V> ReadWriteTable<K, V> getTable(String tableId);
 
   /**
    * Gets the {@link CallbackScheduler} for this task, which can be used to schedule a callback to be executed

--- a/samza-api/src/main/java/org/apache/samza/operators/MessageStream.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/MessageStream.java
@@ -291,12 +291,11 @@ public interface MessageStream<M> {
    * scheme when propogated to next operator.
    *
    * @param table the table to write messages to
-   * @param args additional arguments passed to the table
    * @param <K> the type of key in the table
    * @param <V> the type of record value in the table
    * @return this {@link MessageStream}
    */
-  <K, V> MessageStream<KV<K, V>> sendTo(Table<KV<K, V>> table, Object ... args);
+  <K, V> MessageStream<KV<K, V>> sendTo(Table<KV<K, V>> table);
 
   /**
    * Allows sending update messages in this {@link MessageStream} to a {@link Table} and then propagates this
@@ -304,20 +303,22 @@ public interface MessageStream<M> {
    * otherwise a {@link ClassCastException} will be thrown. The value is an UpdateMessage- update and default value.
    * Defaults are optional and can be used if the Remote Table integration supports inserting a default through PUT in
    * the event an update fails due to an existing record being absent.
+   * The user also needs to pass UpdateOptions argument which defines whether the update is an update only operation
+   * or a update with default.
    * <p>
    * Note: The update will be written but may not be flushed to the underlying table before its propagated to the
    * chained operators. Whether the message can be read back from the Table in the chained operator depends on whether
    * it was flushed and whether the Table offers read after write consistency. Messages retain the original partitioning
    * scheme when propagated to next operator.
    *
-   * @param table the table to write messages to
-   * @param args additional arguments passed to the table
+   * @param table the table to write update messages to
+   * @param updateOptions The update options which defines how the update will be performed
    * @param <K> the type of key in the table
    * @param <V> the type of record value in the table
    * @param <U> the type of update value for the table
    * @return this {@link MessageStream}
    */
-  <K, V, U> MessageStream<KV<K, UpdateMessage<U, V>>> sendUpdateTo(Table<KV<K, V>> table, Object ... args);
+  <K, V, U> MessageStream<KV<K, UpdateMessage<U, V>>> sendTo(Table<KV<K, V>> table, UpdateOptions updateOptions);
 
   /**
    * Broadcasts messages in this {@link MessageStream} to all instances of its downstream operators..

--- a/samza-api/src/main/java/org/apache/samza/operators/MessageStream.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/MessageStream.java
@@ -299,6 +299,25 @@ public interface MessageStream<M> {
   <K, V> MessageStream<KV<K, V>> sendTo(Table<KV<K, V>> table, Object ... args);
 
   /**
+   * Allows sending messages in this {@link MessageStream} to a {@link Table} and then propagates this
+   * {@link MessageStream} to the next chained operator. The type of input message is expected to be {@link KV},
+   * otherwise a {@link ClassCastException} will be thrown. The value is an update pair- update and an option default.
+   * <p>
+   * Note: The update will be written but may not be flushed to the underlying table before its propagated to the
+   * chained operators. Whether the message can be read back from the Table in the chained operator depends on whether
+   * it was flushed and whether the Table offers read after write consistency. Messages retain the original partitioning
+   * scheme when propagated to next operator.
+   *
+   * @param table the table to write messages to
+   * @param args additional arguments passed to the table
+   * @param <K> the type of key in the table
+   * @param <V> the type of record value in the table
+   * @param <U> the type of update value for the table
+   * @return this {@link MessageStream}
+   */
+  <K, V, U> MessageStream<KV<K, UpdatePair<U, V>>> sendUpdateTo(Table<KV<K, UpdatePair<U, V>>> table, Object ... args);
+
+  /**
    * Broadcasts messages in this {@link MessageStream} to all instances of its downstream operators..
    * @param serde the {@link Serde} to use for (de)serializing the message.
    * @param id id the unique id of this operator in this application

--- a/samza-api/src/main/java/org/apache/samza/operators/MessageStream.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/MessageStream.java
@@ -299,9 +299,11 @@ public interface MessageStream<M> {
   <K, V> MessageStream<KV<K, V>> sendTo(Table<KV<K, V>> table, Object ... args);
 
   /**
-   * Allows sending messages in this {@link MessageStream} to a {@link Table} and then propagates this
+   * Allows sending update messages in this {@link MessageStream} to a {@link Table} and then propagates this
    * {@link MessageStream} to the next chained operator. The type of input message is expected to be {@link KV},
-   * otherwise a {@link ClassCastException} will be thrown. The value is an update pair- update and an option default.
+   * otherwise a {@link ClassCastException} will be thrown. The value is an UpdateMessage- update and default value.
+   * Defaults are optional and can be used if the Remote Table integration supports inserting a default through PUT in
+   * the event an update fails due to an existing record being absent.
    * <p>
    * Note: The update will be written but may not be flushed to the underlying table before its propagated to the
    * chained operators. Whether the message can be read back from the Table in the chained operator depends on whether
@@ -315,7 +317,7 @@ public interface MessageStream<M> {
    * @param <U> the type of update value for the table
    * @return this {@link MessageStream}
    */
-  <K, V, U> MessageStream<KV<K, UpdatePair<U, V>>> sendUpdateTo(Table<KV<K, UpdatePair<U, V>>> table, Object ... args);
+  <K, V, U> MessageStream<KV<K, UpdateMessage<U, V>>> sendUpdateTo(Table<KV<K, V>> table, Object ... args);
 
   /**
    * Broadcasts messages in this {@link MessageStream} to all instances of its downstream operators..

--- a/samza-api/src/main/java/org/apache/samza/operators/MessageStream.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/MessageStream.java
@@ -300,10 +300,10 @@ public interface MessageStream<M> {
   /**
    * Allows sending update messages in this {@link MessageStream} to a {@link Table} and then propagates this
    * {@link MessageStream} to the next chained operator. The type of input message is expected to be {@link KV},
-   * otherwise a {@link ClassCastException} will be thrown. The value is an UpdateMessage- update and default value.
-   * Defaults are optional and can be used if the Remote Table integration supports inserting a default through PUT in
-   * the event an update fails due to an existing record being absent.
-   * The user also needs to pass UpdateOptions argument which defines whether the update is an update only operation
+   * otherwise a {@link ClassCastException} will be thrown. The value is an {@link UpdateMessage}- update and default
+   * value. Defaults are optional and can be used if the Remote Table integration supports inserting a default through
+   * PUT in the event an update fails due to an existing record being absent.
+   * The user also needs to pass {@link UpdateOptions} argument which defines whether the update is an update only operation
    * or a update with default.
    * <p>
    * Note: The update will be written but may not be flushed to the underlying table before its propagated to the
@@ -319,7 +319,6 @@ public interface MessageStream<M> {
    * @return this {@link MessageStream}
    */
   <K, V, U> MessageStream<KV<K, UpdateMessage<U, V>>> sendTo(Table<KV<K, V>> table, UpdateOptions updateOptions);
-
   /**
    * Broadcasts messages in this {@link MessageStream} to all instances of its downstream operators..
    * @param serde the {@link Serde} to use for (de)serializing the message.

--- a/samza-api/src/main/java/org/apache/samza/operators/UpdateMessage.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/UpdateMessage.java
@@ -24,25 +24,25 @@ import javax.annotation.Nullable;
 
 
 /**
- * A UpdatePair representing the update and an optional default record to be inserted for a key,
+ * Represents an update and an optional default record to be inserted for a key,
  * if the update is applied to a non-existent record.
  *
  * @param <U> type of the update record
  * @param <V> type of the default record
  */
-public final class UpdatePair<U, V> {
+public final class UpdateMessage<U, V> {
   private final U update;
   @Nullable private final V defaultValue;
 
-  public static <U, V> UpdatePair<U, V> of(U update, @Nullable V defaultValue) {
-    return new UpdatePair<>(update, defaultValue);
+  public static <U, V> UpdateMessage<U, V> of(U update, @Nullable V defaultValue) {
+    return new UpdateMessage<>(update, defaultValue);
   }
 
-  public static <U, V> UpdatePair<U, V> of(U update) {
-    return new UpdatePair<>(update, null);
+  public static <U, V> UpdateMessage<U, V> of(U update) {
+    return new UpdateMessage<>(update, null);
   }
 
-  private UpdatePair(U update, V defaultValue) {
+  private UpdateMessage(U update, V defaultValue) {
     this.update = update;
     this.defaultValue = defaultValue;
   }
@@ -60,10 +60,10 @@ public final class UpdatePair<U, V> {
     if (this == other) {
       return true;
     }
-    if (!(other instanceof UpdatePair)) {
+    if (!(other instanceof UpdateMessage)) {
       return false;
     }
-    UpdatePair<?, ?> otherPair = (UpdatePair<?, ?>) other;
+    UpdateMessage<?, ?> otherPair = (UpdateMessage<?, ?>) other;
     return Objects.deepEquals(this.update, otherPair.getUpdate())
         && Objects.deepEquals(this.defaultValue, otherPair.getDefault());
   }

--- a/samza-api/src/main/java/org/apache/samza/operators/UpdateMessage.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/UpdateMessage.java
@@ -55,6 +55,10 @@ public final class UpdateMessage<U, V> {
     return defaultValue;
   }
 
+  public boolean hasDefault() {
+    return defaultValue != null;
+  }
+
   @Override
   public boolean equals(Object other) {
     if (this == other) {

--- a/samza-api/src/main/java/org/apache/samza/operators/UpdateOptions.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/UpdateOptions.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.operators;
+
+/**
+ * This class defines the update contract used in the send-to-table-with-update operator.
+ * It tells the operator whether to perform just updates or updates with defaults.
+ * */
+public enum UpdateOptions {
+  /**
+   * Indicates that the sendTo operator will only perform an Update operation for the given key.
+   * */
+  UPDATE_ONLY,
+  /**
+   * Indicates that the sendTo operator will first apply an update for the given key. If the update fails due to
+   * the record not being present for the key, operator will attempt to Put a default and then apply an update.
+   * The following conditions need to be true for this to occur:
+   * 1) User should provide a default value using {@link UpdateMessage#of(Object, Object)}
+   * 2) The Table Integration should throw a {@link org.apache.samza.table.RecordNotFoundException} when update
+   * fails due to no record being found for the key.
+   * Put a default can fail due to an exception due to various reasons- server error, failed conditional put
+   * (failed Put if record already inserted by another process). An update will be re-attempted regardless of the
+   * result of the Put default operation.
+   * */
+  UPDATE_WITH_DEFAULTS;
+}

--- a/samza-api/src/main/java/org/apache/samza/operators/UpdatePair.java
+++ b/samza-api/src/main/java/org/apache/samza/operators/UpdatePair.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.operators;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+
+/**
+ * A UpdatePair representing the update and an optional default record to be inserted for a key,
+ * if the update is applied to a non-existent record.
+ *
+ * @param <U> type of the update record
+ * @param <V> type of the default record
+ */
+public final class UpdatePair<U, V> {
+  private final U update;
+  @Nullable private final V defaultValue;
+
+  public static <U, V> UpdatePair<U, V> of(U update, @Nullable V defaultValue) {
+    return new UpdatePair<>(update, defaultValue);
+  }
+
+  public static <U, V> UpdatePair<U, V> of(U update) {
+    return new UpdatePair<>(update, null);
+  }
+
+  private UpdatePair(U update, V defaultValue) {
+    this.update = update;
+    this.defaultValue = defaultValue;
+  }
+
+  public U getUpdate() {
+    return update;
+  }
+
+  public V getDefault() {
+    return defaultValue;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof UpdatePair)) {
+      return false;
+    }
+    UpdatePair<?, ?> otherPair = (UpdatePair<?, ?>) other;
+    return Objects.deepEquals(this.update, otherPair.getUpdate())
+        && Objects.deepEquals(this.defaultValue, otherPair.getDefault());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(update, defaultValue);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .addValue(update)
+        .addValue(defaultValue)
+        .toString();
+  }
+}

--- a/samza-api/src/main/java/org/apache/samza/table/AsyncReadWriteTable.java
+++ b/samza-api/src/main/java/org/apache/samza/table/AsyncReadWriteTable.java
@@ -112,7 +112,7 @@ public interface AsyncReadWriteTable<K, V, U> extends Table {
    * on the table's implementation.
    *
    * @param updates the key and update mappings.
-   * @param updates the key and default value mappings.
+   * @param defaults the key and default value mappings.
    * @param args additional arguments
    * @throws NullPointerException if any of the specified {@code entries} has {@code null} as key.
    * @return CompletableFuture for the operation

--- a/samza-api/src/main/java/org/apache/samza/table/AsyncReadWriteTable.java
+++ b/samza-api/src/main/java/org/apache/samza/table/AsyncReadWriteTable.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import javax.annotation.Nullable;
 import org.apache.samza.SamzaException;
 import org.apache.samza.context.Context;
 import org.apache.samza.storage.kv.Entry;
@@ -93,31 +92,25 @@ public interface AsyncReadWriteTable<K, V, U> extends Table {
   CompletableFuture<Void> putAllAsync(List<Entry<K, V>> entries, Object ... args);
 
   /**
-   * Asynchronously updates the record associated with the specified update for a given key.
-   * If the update is attempted on a non-existent record, a default value can be inserted in the table depending
-   * on the table's implementation.
+   * Asynchronously updates an existing record for a given key with the specified update.
    *
    * @param key the key with which the specified {@code value} is to be associated.
    * @param update the update applied to the record associated with a given {@code key}.
-   * @param defaultValue the default value that is inserted in the table if the update is applied to a non-existent record.
    * @param args additional arguments
    * @throws NullPointerException if the specified {@code key} is {@code null}.
    * @return CompletableFuture for the operation
    */
-  CompletableFuture<Void> updateAsync(K key, U update, @Nullable V defaultValue, Object ... args);
+  CompletableFuture<Void> updateAsync(K key, U update, Object ... args);
 
   /**
-   * Asynchronously updates the records associated with the specified keys with the specified updates.
-   * If the update is applied to a non-existent record, a default value can be inserted in the table depending
-   * on the table's implementation.
+   * Asynchronously updates the existing records for the given keys with their corresponding updates.
    *
    * @param updates the key and update mappings.
-   * @param defaults the key and default value mappings.
    * @param args additional arguments
    * @throws NullPointerException if any of the specified {@code entries} has {@code null} as key.
    * @return CompletableFuture for the operation
    */
-  CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, @Nullable List<Entry<K, V>> defaults, Object ... args);
+  CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, Object ... args);
 
   /**
    * Asynchronously deletes the mapping for the specified {@code key} from this table (if such mapping exists).

--- a/samza-api/src/main/java/org/apache/samza/table/AsyncReadWriteTable.java
+++ b/samza-api/src/main/java/org/apache/samza/table/AsyncReadWriteTable.java
@@ -22,18 +22,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import javax.annotation.Nullable;
 import org.apache.samza.SamzaException;
 import org.apache.samza.context.Context;
 import org.apache.samza.storage.kv.Entry;
 
 
 /**
- * A table that supports asynchronous get, put and delete by one or more keys
+ * A table that supports asynchronous get, put, update and delete by one or more keys
  *
  * @param <K> the type of the key in this table
  * @param <V> the type of the value in this table
+ * @param <U> the type of the update applied to this table
  */
-public interface AsyncReadWriteTable<K, V> extends Table {
+public interface AsyncReadWriteTable<K, V, U> extends Table {
   /**
    * Asynchronously gets the value associated with the specified {@code key}.
    *
@@ -89,6 +91,33 @@ public interface AsyncReadWriteTable<K, V> extends Table {
    * @return CompletableFuture for the operation
    */
   CompletableFuture<Void> putAllAsync(List<Entry<K, V>> entries, Object ... args);
+
+  /**
+   * Asynchronously updates the record associated with the specified update for a given key.
+   * If the update is attempted on a non-existent record, a default value can be inserted in the table depending
+   * on the table's implementation.
+   *
+   * @param key the key with which the specified {@code value} is to be associated.
+   * @param update the update applied to the record associated with a given {@code key}.
+   * @param defaultValue the default value that is inserted in the table if the update is applied to a non-existent record.
+   * @param args additional arguments
+   * @throws NullPointerException if the specified {@code key} is {@code null}.
+   * @return CompletableFuture for the operation
+   */
+  CompletableFuture<Void> updateAsync(K key, U update, @Nullable V defaultValue, Object ... args);
+
+  /**
+   * Asynchronously updates the records associated with the specified keys with the specified updates.
+   * If the update is applied to a non-existent record, a default value can be inserted in the table depending
+   * on the table's implementation.
+   *
+   * @param updates the key and update mappings.
+   * @param updates the key and default value mappings.
+   * @param args additional arguments
+   * @throws NullPointerException if any of the specified {@code entries} has {@code null} as key.
+   * @return CompletableFuture for the operation
+   */
+  CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, @Nullable List<Entry<K, V>> defaults, Object ... args);
 
   /**
    * Asynchronously deletes the mapping for the specified {@code key} from this table (if such mapping exists).

--- a/samza-api/src/main/java/org/apache/samza/table/AsyncReadWriteUpdateTable.java
+++ b/samza-api/src/main/java/org/apache/samza/table/AsyncReadWriteUpdateTable.java
@@ -34,7 +34,7 @@ import org.apache.samza.storage.kv.Entry;
  * @param <V> the type of the value in this table
  * @param <U> the type of the update applied to this table
  */
-public interface AsyncReadWriteTable<K, V, U> extends Table {
+public interface AsyncReadWriteUpdateTable<K, V, U> extends Table {
   /**
    * Asynchronously gets the value associated with the specified {@code key}.
    *

--- a/samza-api/src/main/java/org/apache/samza/table/AsyncReadWriteUpdateTable.java
+++ b/samza-api/src/main/java/org/apache/samza/table/AsyncReadWriteUpdateTable.java
@@ -96,21 +96,19 @@ public interface AsyncReadWriteUpdateTable<K, V, U> extends Table {
    *
    * @param key the key with which the specified {@code value} is to be associated.
    * @param update the update applied to the record associated with a given {@code key}.
-   * @param args additional arguments
    * @throws NullPointerException if the specified {@code key} is {@code null}.
    * @return CompletableFuture for the operation
    */
-  CompletableFuture<Void> updateAsync(K key, U update, Object ... args);
+  CompletableFuture<Void> updateAsync(K key, U update);
 
   /**
    * Asynchronously updates the existing records for the given keys with their corresponding updates.
    *
    * @param updates the key and update mappings.
-   * @param args additional arguments
    * @throws NullPointerException if any of the specified {@code entries} has {@code null} as key.
    * @return CompletableFuture for the operation
    */
-  CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, Object ... args);
+  CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates);
 
   /**
    * Asynchronously deletes the mapping for the specified {@code key} from this table (if such mapping exists).

--- a/samza-api/src/main/java/org/apache/samza/table/ReadWriteTable.java
+++ b/samza-api/src/main/java/org/apache/samza/table/ReadWriteTable.java
@@ -26,13 +26,14 @@ import org.apache.samza.annotation.InterfaceStability;
 import org.apache.samza.storage.kv.Entry;
 
 /**
- * A table that supports synchronous and asynchronousget, put and delete by one or more keys
+ * A table that supports synchronous and asynchronous get, put and delete by one or more keys
  *
  * @param <K> the type of the key in this table
  * @param <V> the type of the value in this table
+ * @param <U> the type of the update applied to records in this table
  */
 @InterfaceStability.Unstable
-public interface ReadWriteTable<K, V> extends AsyncReadWriteTable<K, V> {
+public interface ReadWriteTable<K, V, U> extends AsyncReadWriteTable<K, V, U> {
 
   /**
    * Gets the value associated with the specified {@code key}.
@@ -66,6 +67,29 @@ public interface ReadWriteTable<K, V> extends AsyncReadWriteTable<K, V> {
   default <T> T read(int opId, Object ... args) {
     throw new SamzaException("Not supported");
   }
+
+  /**
+   * Updates the record associated with a given {@code key} with the specified {@code update}.
+   * Default record {@code defaultValue} is inserted if there is no existing record for the given key.
+   *
+   * @param key the key with which the specified {@code value} is to be associated.
+   * @param update the update to be applied to the record specified by {@code key}.
+   * @param defaultValue the default value to be inserted if no record exists for the given key.
+   * @param args additional arguments
+   * @throws NullPointerException if the specified {@code key} is {@code null}.
+   */
+  void update(K key, U update, V defaultValue, Object ... args);
+
+  /**
+   * Updates the mappings of the specified keys with the updates or inserts the defaults.
+   *
+   * @param updates the updates for the given keys
+   * @param defaults the defaults to be inserted if the updates are applied on non-existant records
+   * @param args additional arguments
+   * @throws NullPointerException if any of the specified {@code entries} has {@code null} as key.
+   */
+  void updateAll(List<Entry<K, U>> updates, List<Entry<K, V>> defaults, Object ... args);
+
 
   /**
    * Updates the mapping of the specified key-value pair;

--- a/samza-api/src/main/java/org/apache/samza/table/ReadWriteTable.java
+++ b/samza-api/src/main/java/org/apache/samza/table/ReadWriteTable.java
@@ -71,20 +71,19 @@ public interface ReadWriteTable<K, V> extends ReadWriteUpdateTable<K, V, Void> {
    * Updates the record associated with a given {@code key} with the specified {@code update}.
    *
    * @param key the key with which the specified {@code value} is to be associated.
-   * @param args additional arguments
    * @throws NullPointerException if the specified {@code key} is {@code null}.
    */
-  default void update(K key, Void update, Object ... args) {
+  default void update(K key, Void update) {
     throw new SamzaException("Not supported");
   }
 
   /**
    * Updates the mappings of the given keys with the corresponding updates.
    *
-   * @param args additional arguments
+   * @param updates the updates for the given keys
    * @throws NullPointerException if any of the specified {@code entries} has {@code null} as key.
    */
-  default void updateAll(List<Entry<K, Void>> updates, Object ... args) {
+  default void updateAll(List<Entry<K, Void>> updates) {
     throw new SamzaException("Not supported");
   }
 

--- a/samza-api/src/main/java/org/apache/samza/table/ReadWriteTable.java
+++ b/samza-api/src/main/java/org/apache/samza/table/ReadWriteTable.java
@@ -26,7 +26,7 @@ import org.apache.samza.annotation.InterfaceStability;
 import org.apache.samza.storage.kv.Entry;
 
 /**
- * A table that supports synchronous and asynchronous get, put and delete by one or more keys
+ * A table that supports synchronous and asynchronous get, put, update and delete by one or more keys
  *
  * @param <K> the type of the key in this table
  * @param <V> the type of the value in this table
@@ -70,25 +70,22 @@ public interface ReadWriteTable<K, V, U> extends AsyncReadWriteTable<K, V, U> {
 
   /**
    * Updates the record associated with a given {@code key} with the specified {@code update}.
-   * Default record {@code defaultValue} is inserted if there is no existing record for the given key.
    *
    * @param key the key with which the specified {@code value} is to be associated.
    * @param update the update to be applied to the record specified by {@code key}.
-   * @param defaultValue the default value to be inserted if no record exists for the given key.
    * @param args additional arguments
    * @throws NullPointerException if the specified {@code key} is {@code null}.
    */
-  void update(K key, U update, V defaultValue, Object ... args);
+  void update(K key, U update, Object ... args);
 
   /**
-   * Updates the mappings of the specified keys with the updates or inserts the defaults.
+   * Updates the mappings of the given keys with the corresponding updates.
    *
    * @param updates the updates for the given keys
-   * @param defaults the defaults to be inserted if the updates are applied on non-existant records
    * @param args additional arguments
    * @throws NullPointerException if any of the specified {@code entries} has {@code null} as key.
    */
-  void updateAll(List<Entry<K, U>> updates, List<Entry<K, V>> defaults, Object ... args);
+  void updateAll(List<Entry<K, U>> updates, Object ... args);
 
 
   /**

--- a/samza-api/src/main/java/org/apache/samza/table/ReadWriteUpdateTable.java
+++ b/samza-api/src/main/java/org/apache/samza/table/ReadWriteUpdateTable.java
@@ -26,13 +26,14 @@ import org.apache.samza.annotation.InterfaceStability;
 import org.apache.samza.storage.kv.Entry;
 
 /**
- * A table that supports synchronous and asynchronous get, put and delete by one or more keys
+ * A table that supports synchronous and asynchronous get, put, update and delete by one or more keys
  *
  * @param <K> the type of the key in this table
  * @param <V> the type of the value in this table
+ * @param <U> the type of the update applied to records in this table
  */
 @InterfaceStability.Unstable
-public interface ReadWriteTable<K, V> extends ReadWriteUpdateTable<K, V, Void> {
+public interface ReadWriteUpdateTable<K, V, U> extends AsyncReadWriteUpdateTable<K, V, U> {
 
   /**
    * Gets the value associated with the specified {@code key}.
@@ -71,22 +72,21 @@ public interface ReadWriteTable<K, V> extends ReadWriteUpdateTable<K, V, Void> {
    * Updates the record associated with a given {@code key} with the specified {@code update}.
    *
    * @param key the key with which the specified {@code value} is to be associated.
+   * @param update the update to be applied to the record specified by {@code key}.
    * @param args additional arguments
    * @throws NullPointerException if the specified {@code key} is {@code null}.
    */
-  default void update(K key, Void update, Object ... args) {
-    throw new SamzaException("Not supported");
-  }
+  void update(K key, U update, Object ... args);
 
   /**
    * Updates the mappings of the given keys with the corresponding updates.
    *
+   * @param updates the updates for the given keys
    * @param args additional arguments
    * @throws NullPointerException if any of the specified {@code entries} has {@code null} as key.
    */
-  default void updateAll(List<Entry<K, Void>> updates, Object ... args) {
-    throw new SamzaException("Not supported");
-  }
+  void updateAll(List<Entry<K, U>> updates, Object ... args);
+
 
   /**
    * Updates the mapping of the specified key-value pair;

--- a/samza-api/src/main/java/org/apache/samza/table/ReadWriteUpdateTable.java
+++ b/samza-api/src/main/java/org/apache/samza/table/ReadWriteUpdateTable.java
@@ -73,19 +73,17 @@ public interface ReadWriteUpdateTable<K, V, U> extends AsyncReadWriteUpdateTable
    *
    * @param key the key with which the specified {@code value} is to be associated.
    * @param update the update to be applied to the record specified by {@code key}.
-   * @param args additional arguments
    * @throws NullPointerException if the specified {@code key} is {@code null}.
    */
-  void update(K key, U update, Object ... args);
+  void update(K key, U update);
 
   /**
    * Updates the mappings of the given keys with the corresponding updates.
    *
    * @param updates the updates for the given keys
-   * @param args additional arguments
    * @throws NullPointerException if any of the specified {@code entries} has {@code null} as key.
    */
-  void updateAll(List<Entry<K, U>> updates, Object ... args);
+  void updateAll(List<Entry<K, U>> updates);
 
 
   /**

--- a/samza-api/src/main/java/org/apache/samza/table/RecordDoesNotExistException.java
+++ b/samza-api/src/main/java/org/apache/samza/table/RecordDoesNotExistException.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table;
+
+/**
+ * Custom exception which can be thrown by implementations of {@link org.apache.samza.table.remote.TableWriteFunction}
+ * when {@link AsyncReadWriteTable#updateAsync(Object, Object, Object...)} fails due an existing record not being
+ * present for the given key. {@link org.apache.samza.operators.MessageStream#sendUpdateTo(Table, Object...)} will
+ * attempt to call {@link AsyncReadWriteTable#putAsync(Object, Object, Object...)} instead to insert a new record if a
+ * default is provided.
+ */
+public class RecordDoesNotExistException extends RuntimeException {
+  private static final long serialVersionUID = 1L;
+
+  public RecordDoesNotExistException() {
+    super();
+  }
+
+  public RecordDoesNotExistException(String s, Throwable t) {
+    super(s, t);
+  }
+
+  public RecordDoesNotExistException(String s) {
+    super(s);
+  }
+
+  public RecordDoesNotExistException(Throwable t) {
+    super(t);
+  }
+}

--- a/samza-api/src/main/java/org/apache/samza/table/RecordNotFoundException.java
+++ b/samza-api/src/main/java/org/apache/samza/table/RecordNotFoundException.java
@@ -22,9 +22,9 @@ package org.apache.samza.table;
 /**
  * Custom exception which can be thrown by implementations of {@link org.apache.samza.table.remote.TableWriteFunction}
  * when {@link AsyncReadWriteTable#updateAsync(Object, Object, Object...)} fails due an existing record not being
- * present for the given key. {@link org.apache.samza.operators.MessageStream#sendUpdateTo(Table, Object...)} will
- * attempt to call {@link AsyncReadWriteTable#putAsync(Object, Object, Object...)} instead to insert a new record if a
- * default is provided.
+ * present for the given key. {@link org.apache.samza.operators.MessageStream#sendTo(Table,
+ * org.apache.samza.operators.UpdateOptions)} will attempt to call {@link AsyncReadWriteTable#putAsync(Object, Object,
+ * Object...)} instead to insert a new record if a default is provided.
  */
 public class RecordNotFoundException extends RuntimeException {
   private static final long serialVersionUID = 1L;

--- a/samza-api/src/main/java/org/apache/samza/table/RecordNotFoundException.java
+++ b/samza-api/src/main/java/org/apache/samza/table/RecordNotFoundException.java
@@ -26,22 +26,22 @@ package org.apache.samza.table;
  * attempt to call {@link AsyncReadWriteTable#putAsync(Object, Object, Object...)} instead to insert a new record if a
  * default is provided.
  */
-public class RecordDoesNotExistException extends RuntimeException {
+public class RecordNotFoundException extends RuntimeException {
   private static final long serialVersionUID = 1L;
 
-  public RecordDoesNotExistException() {
+  public RecordNotFoundException() {
     super();
   }
 
-  public RecordDoesNotExistException(String s, Throwable t) {
+  public RecordNotFoundException(String s, Throwable t) {
     super(s, t);
   }
 
-  public RecordDoesNotExistException(String s) {
+  public RecordNotFoundException(String s) {
     super(s);
   }
 
-  public RecordDoesNotExistException(Throwable t) {
+  public RecordNotFoundException(Throwable t) {
     super(t);
   }
 }

--- a/samza-api/src/main/java/org/apache/samza/table/RecordNotFoundException.java
+++ b/samza-api/src/main/java/org/apache/samza/table/RecordNotFoundException.java
@@ -21,7 +21,7 @@ package org.apache.samza.table;
 
 /**
  * Custom exception which can be thrown by implementations of {@link org.apache.samza.table.remote.TableWriteFunction}
- * when {@link AsyncReadWriteUpdateTable#updateAsync(Object, Object, Object...)} fails due an existing record not being
+ * when {@link AsyncReadWriteUpdateTable#updateAsync(Object, Object)} fails due an existing record not being
  * present for the given key. {@link org.apache.samza.operators.MessageStream#sendTo(Table,
  * org.apache.samza.operators.UpdateOptions)} will attempt to call {@link AsyncReadWriteUpdateTable#putAsync(Object, Object,
  * Object...)} instead to insert a new record if a default is provided.

--- a/samza-api/src/main/java/org/apache/samza/table/RecordNotFoundException.java
+++ b/samza-api/src/main/java/org/apache/samza/table/RecordNotFoundException.java
@@ -21,9 +21,9 @@ package org.apache.samza.table;
 
 /**
  * Custom exception which can be thrown by implementations of {@link org.apache.samza.table.remote.TableWriteFunction}
- * when {@link AsyncReadWriteTable#updateAsync(Object, Object, Object...)} fails due an existing record not being
+ * when {@link AsyncReadWriteUpdateTable#updateAsync(Object, Object, Object...)} fails due an existing record not being
  * present for the given key. {@link org.apache.samza.operators.MessageStream#sendTo(Table,
- * org.apache.samza.operators.UpdateOptions)} will attempt to call {@link AsyncReadWriteTable#putAsync(Object, Object,
+ * org.apache.samza.operators.UpdateOptions)} will attempt to call {@link AsyncReadWriteUpdateTable#putAsync(Object, Object,
  * Object...)} instead to insert a new record if a default is provided.
  */
 public class RecordNotFoundException extends RuntimeException {

--- a/samza-api/src/main/java/org/apache/samza/table/Table.java
+++ b/samza-api/src/main/java/org/apache/samza/table/Table.java
@@ -39,7 +39,7 @@ import org.apache.samza.task.InitableTask;
  * Use a {@link TableDescriptor} to specify the properties of a {@link Table}. For High Level API
  * {@link StreamApplication}s, use {@link StreamApplicationDescriptor#getTable} to obtain the {@link Table} instance for
  * the descriptor that can be used with the {@link MessageStream} operators like {@link MessageStream#sendTo(Table)}.
- * Alternatively, use {@link TaskContext#getTable(String)} in {@link InitableFunction#init} to get the table instance
+ * Alternatively, use {@link TaskContext#getUpdatableTable(String)} in {@link InitableFunction#init} to get the table instance
  * for use within operator functions. For Low Level API {@link TaskApplication}s, use {@link TaskContext#getTable}
  * in {@link InitableTask#init} to get the table instance for use within the Task.
  *

--- a/samza-api/src/main/java/org/apache/samza/table/Table.java
+++ b/samza-api/src/main/java/org/apache/samza/table/Table.java
@@ -38,7 +38,7 @@ import org.apache.samza.task.InitableTask;
  * <p>
  * Use a {@link TableDescriptor} to specify the properties of a {@link Table}. For High Level API
  * {@link StreamApplication}s, use {@link StreamApplicationDescriptor#getTable} to obtain the {@link Table} instance for
- * the descriptor that can be used with the {@link MessageStream} operators like {@link MessageStream#sendTo(Table, Object[])}.
+ * the descriptor that can be used with the {@link MessageStream} operators like {@link MessageStream#sendTo(Table)}.
  * Alternatively, use {@link TaskContext#getTable(String)} in {@link InitableFunction#init} to get the table instance
  * for use within operator functions. For Low Level API {@link TaskApplication}s, use {@link TaskContext#getTable}
  * in {@link InitableTask#init} to get the table instance for use within the Task.

--- a/samza-api/src/main/java/org/apache/samza/table/TableProvider.java
+++ b/samza-api/src/main/java/org/apache/samza/table/TableProvider.java
@@ -34,10 +34,10 @@ public interface TableProvider {
   void init(Context context);
 
   /**
-   * Get an instance of the {@link ReadWriteTable}
+   * Get an instance of the {@link ReadWriteUpdateTable}
    * @return the underlying table
    */
-  ReadWriteTable getTable();
+  ReadWriteUpdateTable getTable();
 
   /**
    * Shutdown the underlying table

--- a/samza-api/src/main/java/org/apache/samza/table/batching/Batch.java
+++ b/samza-api/src/main/java/org/apache/samza/table/batching/Batch.java
@@ -31,15 +31,16 @@ import java.util.concurrent.CompletableFuture;
  *
  * @param <K> The type of the key associated with the {@link Operation}
  * @param <V> The type of the value associated with the {@link Operation}
+ * @param <U> The type of the update associated with the {@link Operation}
  */
-public interface Batch<K, V> {
+public interface Batch<K, V, U> {
   /**
    * Add an operation to the batch.
    *
    * @param operation The operation to be added.
    * @return A {@link CompletableFuture} that indicate the status of the batch.
    */
-  CompletableFuture<Void> addOperation(Operation<K, V> operation);
+  CompletableFuture<Void> addOperation(Operation<K, V, U> operation);
 
   /**
    * Close the bach so that it will not accept more operations.
@@ -54,7 +55,7 @@ public interface Batch<K, V> {
   /**
    * @return The operations buffered by the batch.
    */
-  Collection<Operation<K, V>> getOperations();
+  Collection<Operation<K, V, U>> getOperations();
 
   /**
    * @return The batch max delay.

--- a/samza-api/src/main/java/org/apache/samza/table/batching/BatchProvider.java
+++ b/samza-api/src/main/java/org/apache/samza/table/batching/BatchProvider.java
@@ -24,18 +24,18 @@ import java.time.Duration;
 import org.apache.samza.table.remote.TablePart;
 
 
-public abstract class BatchProvider<K, V> implements TablePart, Serializable {
-  public abstract Batch<K, V> getBatch();
+public abstract class BatchProvider<K, V, U> implements TablePart, Serializable {
+  public abstract Batch<K, V, U> getBatch();
 
   private int maxBatchSize = 100;
   private Duration maxBatchDelay = Duration.ofMillis(100);
 
-  public BatchProvider<K, V> withMaxBatchSize(int maxBatchSize) {
+  public BatchProvider<K, V, U> withMaxBatchSize(int maxBatchSize) {
     this.maxBatchSize = maxBatchSize;
     return this;
   }
 
-  public BatchProvider<K, V> withMaxBatchDelay(Duration maxBatchDelay) {
+  public BatchProvider<K, V, U> withMaxBatchDelay(Duration maxBatchDelay) {
     this.maxBatchDelay = maxBatchDelay;
     return this;
   }

--- a/samza-api/src/main/java/org/apache/samza/table/batching/Operation.java
+++ b/samza-api/src/main/java/org/apache/samza/table/batching/Operation.java
@@ -20,12 +20,13 @@
 package org.apache.samza.table.batching;
 
 /**
- * Interface for operations that can be batched.
+ * Interface for table operations that can be batched.
  *
  * @param <K> The key type associated with the operation.
  * @param <V> The value type associated with the operation.
+ * @param <U> The update type associated with the operation.
  */
-public interface Operation<K, V> {
+public interface Operation<K, V, U> {
   /**
    * @return The key associated with the operation.
    */
@@ -35,6 +36,11 @@ public interface Operation<K, V> {
    * @return The value associated with the operation.
    */
   V getValue();
+
+  /**
+   * @return The update associated with the operation.
+   */
+  U getUpdate();
 
   /**
    * @return The extra arguments associated with the operation.

--- a/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
+++ b/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
@@ -44,8 +44,9 @@ import com.google.common.base.Preconditions;
  *
  * @param <K> the type of the key
  * @param <V> the type of the value
+ * @param <U> the type of the update
  */
-public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, RemoteTableDescriptor<K, V>> {
+public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, RemoteTableDescriptor<K, V, U>> {
 
   public static final String PROVIDER_FACTORY_CLASS_NAME = "org.apache.samza.table.remote.RemoteTableProviderFactory";
 
@@ -67,6 +68,14 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
    */
   public static final String RL_WRITE_TAG = "writeTag";
 
+  /**
+   * Tag to be used for provision credits for rate limiting write operations into the remote table.
+   * Caller can optionally populate the credits with this tag when specifying a custom rate limiter instance
+   * through {@link RemoteTableDescriptor#withRateLimiter(RateLimiter, TableRateLimiter.CreditFunction,
+   * TableRateLimiter.CreditFunction)} and it needs the write functionality.
+   */
+  public static final String RL_UPDATE_TAG = "updateTag";
+
   public static final String READ_FN = "io.read.func";
   public static final String WRITE_FN = "io.write.func";
   public static final String RATE_LIMITER = "io.ratelimiter";
@@ -76,6 +85,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
   public static final String WRITE_CREDITS = "io.write.credits";
   public static final String READ_CREDIT_FN = "io.read.credit.func";
   public static final String WRITE_CREDIT_FN = "io.write.credit.func";
+  public static final String UPDATE_CREDIT_FN = "io.update.credit.func";
   public static final String ASYNC_CALLBACK_POOL_SIZE = "io.async.callback.pool.size";
   public static final String READ_RETRY_POLICY = "io.read.retry.policy";
   public static final String WRITE_RETRY_POLICY = "io.write.retry.policy";
@@ -85,7 +95,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
   private TableReadFunction<K, V> readFn;
 
   // Output support for a specific remote store (optional)
-  private TableWriteFunction<K, V> writeFn;
+  private TableWriteFunction<K, V, U> writeFn;
 
   // Rate limiter for client-side throttling; it is set by withRateLimiter()
   private RateLimiter rateLimiter;
@@ -125,7 +135,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
    * @param readFn read function instance
    * @return this table descriptor instance
    */
-  public RemoteTableDescriptor<K, V> withReadFunction(TableReadFunction<K, V> readFn) {
+  public RemoteTableDescriptor<K, V, U> withReadFunction(TableReadFunction<K, V> readFn) {
     Preconditions.checkNotNull(readFn, "null read function");
     this.readFn = readFn;
     return this;
@@ -136,7 +146,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
    * @param writeFn write function instance
    * @return this table descriptor instance
    */
-  public RemoteTableDescriptor<K, V> withWriteFunction(TableWriteFunction<K, V> writeFn) {
+  public RemoteTableDescriptor<K, V, U> withWriteFunction(TableWriteFunction<K, V, U> writeFn) {
     Preconditions.checkNotNull(writeFn, "null write function");
     this.writeFn = writeFn;
     return this;
@@ -147,7 +157,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
    * @param retryPolicy retry policy for the write function
    * @return this table descriptor instance
    */
-  public RemoteTableDescriptor<K, V> withReadRetryPolicy(TableRetryPolicy retryPolicy) {
+  public RemoteTableDescriptor<K, V, U> withReadRetryPolicy(TableRetryPolicy retryPolicy) {
     Preconditions.checkNotNull(readFn, "null read function");
     Preconditions.checkNotNull(retryPolicy, "null retry policy");
     this.readRetryPolicy = retryPolicy;
@@ -159,7 +169,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
    * @param retryPolicy retry policy for the write function
    * @return this table descriptor instance
    */
-  public RemoteTableDescriptor<K, V> withWriteRetryPolicy(TableRetryPolicy retryPolicy) {
+  public RemoteTableDescriptor<K, V, U> withWriteRetryPolicy(TableRetryPolicy retryPolicy) {
     Preconditions.checkNotNull(writeFn, "null write function");
     Preconditions.checkNotNull(retryPolicy, "null retry policy");
     this.writeRetryPolicy = retryPolicy;
@@ -179,7 +189,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
    * @param writeCreditFn credit function for rate limiting write operations
    * @return this table descriptor instance
    */
-  public RemoteTableDescriptor<K, V> withRateLimiter(RateLimiter rateLimiter,
+  public RemoteTableDescriptor<K, V, U> withRateLimiter(RateLimiter rateLimiter,
       TableRateLimiter.CreditFunction<K, V> readCreditFn,
       TableRateLimiter.CreditFunction<K, V> writeCreditFn) {
     Preconditions.checkNotNull(rateLimiter, "null read rate limiter");
@@ -198,7 +208,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
    *
    * @return this table descriptor instance.
    */
-  public RemoteTableDescriptor<K, V> withRateLimiterDisabled() {
+  public RemoteTableDescriptor<K, V, U> withRateLimiterDisabled() {
     withReadRateLimiterDisabled();
     withWriteRateLimiterDisabled();
     return this;
@@ -209,7 +219,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
    *
    * @return this table descriptor instance.
    */
-  public RemoteTableDescriptor<K, V> withReadRateLimiterDisabled() {
+  public RemoteTableDescriptor<K, V, U> withReadRateLimiterDisabled() {
     this.enableReadRateLimiter = false;
     return this;
   }
@@ -219,7 +229,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
    *
    * @return this table descriptor instance.
    */
-  public RemoteTableDescriptor<K, V> withWriteRateLimiterDisabled() {
+  public RemoteTableDescriptor<K, V, U> withWriteRateLimiterDisabled() {
     this.enableWriteRateLimiter = false;
     return this;
   }
@@ -234,7 +244,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
    * @param creditsPerSec rate limit for read operations; must be positive and greater than total number tasks
    * @return this table descriptor instance
    */
-  public RemoteTableDescriptor<K, V> withReadRateLimit(int creditsPerSec) {
+  public RemoteTableDescriptor<K, V, U> withReadRateLimit(int creditsPerSec) {
     Preconditions.checkArgument(creditsPerSec > 0, "Max read rate must be a positive number.");
     tagCreditsMap.put(RL_READ_TAG, creditsPerSec);
     return this;
@@ -250,7 +260,7 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
    * @param creditsPerSec rate limit for write operations; must be positive and greater than total number tasks
    * @return this table descriptor instance
    */
-  public RemoteTableDescriptor<K, V> withWriteRateLimit(int creditsPerSec) {
+  public RemoteTableDescriptor<K, V, U> withWriteRateLimit(int creditsPerSec) {
     Preconditions.checkArgument(creditsPerSec > 0, "Max write rate must be a positive number.");
     tagCreditsMap.put(RL_WRITE_TAG, creditsPerSec);
     return this;
@@ -267,12 +277,12 @@ public class RemoteTableDescriptor<K, V> extends BaseTableDescriptor<K, V, Remot
    * @param poolSize max number of threads in the executor for async callbacks
    * @return this table descriptor instance
    */
-  public RemoteTableDescriptor<K, V> withAsyncCallbackExecutorPoolSize(int poolSize) {
+  public RemoteTableDescriptor<K, V, U> withAsyncCallbackExecutorPoolSize(int poolSize) {
     this.asyncCallbackPoolSize = poolSize;
     return this;
   }
 
-  public RemoteTableDescriptor<K, V> withBatchProvider(BatchProvider<K, V> batchProvider) {
+  public RemoteTableDescriptor<K, V, U> withBatchProvider(BatchProvider<K, V> batchProvider) {
     this.batchProvider = batchProvider;
     return this;
   }

--- a/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
+++ b/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
@@ -98,7 +98,7 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
   private boolean enableWriteRateLimiter = true;
 
   // Batching support to reduce traffic volume sent to the remote store.
-  private BatchProvider<K, V> batchProvider;
+  private BatchProvider<K, V, U> batchProvider;
 
   // Rates for constructing the default rate limiter when they are non-zero
   private Map<String, Integer> tagCreditsMap = new HashMap<>();
@@ -274,7 +274,10 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
     return this;
   }
 
-  public RemoteTableDescriptor<K, V, U> withBatchProvider(BatchProvider<K, V> batchProvider) {
+  /**
+   * Specifies a batch provider inorder to batch Table operations.
+   * */
+  public RemoteTableDescriptor<K, V, U> withBatchProvider(BatchProvider<K, V, U> batchProvider) {
     this.batchProvider = batchProvider;
     return this;
   }

--- a/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
+++ b/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.apache.samza.SamzaException;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.MapConfig;
+import org.apache.samza.operators.UpdatePair;
 import org.apache.samza.table.batching.BatchProvider;
 import org.apache.samza.table.remote.TablePart;
 import org.apache.samza.table.remote.TableRateLimiter;
@@ -56,7 +57,7 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
    * Tag to be used for provision credits for rate limiting read operations from the remote table.
    * Caller must pre-populate the credits with this tag when specifying a custom rate limiter instance
    * through {@link RemoteTableDescriptor#withRateLimiter(RateLimiter, TableRateLimiter.CreditFunction,
-   * TableRateLimiter.CreditFunction)}
+   * TableRateLimiter.CreditFunction, TableRateLimiter.CreditFunction)}
    */
   public static final String RL_READ_TAG = "readTag";
 
@@ -64,7 +65,7 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
    * Tag to be used for provision credits for rate limiting write operations into the remote table.
    * Caller can optionally populate the credits with this tag when specifying a custom rate limiter instance
    * through {@link RemoteTableDescriptor#withRateLimiter(RateLimiter, TableRateLimiter.CreditFunction,
-   * TableRateLimiter.CreditFunction)} and it needs the write functionality.
+   * TableRateLimiter.CreditFunction, TableRateLimiter.CreditFunction)} and it needs the write functionality.
    */
   public static final String RL_WRITE_TAG = "writeTag";
 
@@ -72,7 +73,7 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
    * Tag to be used for provision credits for rate limiting write operations into the remote table.
    * Caller can optionally populate the credits with this tag when specifying a custom rate limiter instance
    * through {@link RemoteTableDescriptor#withRateLimiter(RateLimiter, TableRateLimiter.CreditFunction,
-   * TableRateLimiter.CreditFunction)} and it needs the write functionality.
+   * TableRateLimiter.CreditFunction, TableRateLimiter.CreditFunction)} and it needs the write functionality.
    */
   public static final String RL_UPDATE_TAG = "updateTag";
 
@@ -83,6 +84,7 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
   public static final String READ_CREDITS = "io.read.credits";
   //Key name for table api write rate limit
   public static final String WRITE_CREDITS = "io.write.credits";
+  public static final String UPDATE_CREDITS = "io.update.credits";
   public static final String READ_CREDIT_FN = "io.read.credit.func";
   public static final String WRITE_CREDIT_FN = "io.write.credit.func";
   public static final String UPDATE_CREDIT_FN = "io.update.credit.func";
@@ -106,6 +108,9 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
   // Indicate whether write rate limiter is enabled or not
   private boolean enableWriteRateLimiter = true;
 
+  // Indicate whether update rate limiter is enabled or not
+  private boolean enableUpdateRateLimiter = true;
+
   // Batching support to reduce traffic volume sent to the remote store.
   private BatchProvider<K, V> batchProvider;
 
@@ -114,6 +119,7 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
 
   private TableRateLimiter.CreditFunction<K, V> readCreditFn;
   private TableRateLimiter.CreditFunction<K, V> writeCreditFn;
+  private TableRateLimiter.CreditFunction<K, UpdatePair<U, V>> updateCreditFn;
 
   private TableRetryPolicy readRetryPolicy;
   private TableRetryPolicy writeRetryPolicy;
@@ -187,30 +193,35 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
    * @param rateLimiter rate limiter instance to be used for throttling
    * @param readCreditFn credit function for rate limiting read operations
    * @param writeCreditFn credit function for rate limiting write operations
+   * @param updateCreditFn credit function for rate limiting update operations
    * @return this table descriptor instance
    */
   public RemoteTableDescriptor<K, V, U> withRateLimiter(RateLimiter rateLimiter,
       TableRateLimiter.CreditFunction<K, V> readCreditFn,
-      TableRateLimiter.CreditFunction<K, V> writeCreditFn) {
+      TableRateLimiter.CreditFunction<K, V> writeCreditFn,
+      TableRateLimiter.CreditFunction<K, UpdatePair<U, V>> updateCreditFn) {
     Preconditions.checkNotNull(rateLimiter, "null read rate limiter");
     this.rateLimiter = rateLimiter;
     this.readCreditFn = readCreditFn;
     this.writeCreditFn = writeCreditFn;
+    this.updateCreditFn = updateCreditFn;
     return this;
   }
 
   /**
    * Disable both read and write rate limiter. If the read rate limiter is enabled, the user must provide a rate limiter
-   * by calling {@link #withRateLimiter(RateLimiter, TableRateLimiter.CreditFunction, TableRateLimiter.CreditFunction)}
-   * or {@link #withReadRateLimit(int)}. If the write rate limiter is enabled, the user must provide a rate limiter
-   * by calling {@link #withRateLimiter(RateLimiter, TableRateLimiter.CreditFunction, TableRateLimiter.CreditFunction)}
-   * or {@link #withWriteRateLimit(int)}. By default, both read and write rate limiters are enabled.
+   * by calling {@link #withRateLimiter(RateLimiter, TableRateLimiter.CreditFunction, TableRateLimiter.CreditFunction,
+   * TableRateLimiter.CreditFunction )} or {@link #withReadRateLimit(int)}. If the write rate limiter is enabled,
+   * the user must provide a rate limiter by calling {@link #withRateLimiter(RateLimiter, TableRateLimiter.CreditFunction,
+   * TableRateLimiter.CreditFunction, TableRateLimiter.CreditFunction)} or {@link #withWriteRateLimit(int)}.
+   * By default, both read and write rate limiters are enabled.
    *
    * @return this table descriptor instance.
    */
   public RemoteTableDescriptor<K, V, U> withRateLimiterDisabled() {
     withReadRateLimiterDisabled();
     withWriteRateLimiterDisabled();
+    withUpdateRateLimiterDisabled();
     return this;
   }
 
@@ -235,9 +246,19 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
   }
 
   /**
+   * Disable the update rate limiter.
+   *
+   * @return this table descriptor instance.
+   */
+  public RemoteTableDescriptor<K, V, U> withUpdateRateLimiterDisabled() {
+    this.enableUpdateRateLimiter = false;
+    return this;
+  }
+
+  /**
    * Specify the rate limit for table read operations. If the read rate limit is set with this method
    * it is invalid to call {@link RemoteTableDescriptor#withRateLimiter(RateLimiter,
-   * TableRateLimiter.CreditFunction, TableRateLimiter.CreditFunction)}
+   * TableRateLimiter.CreditFunction, TableRateLimiter.CreditFunction, TableRateLimiter.CreditFunction)}
    * and vice versa.
    * Note that this is the total credit of rate limit for the entire job, each task will get a per task
    * credit of creditsPerSec/tasksCount. Hence creditsPerSec should be greater than total number of tasks.
@@ -253,7 +274,7 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
   /**
    * Specify the rate limit for table write operations. If the write rate limit is set with this method
    * it is invalid to call {@link RemoteTableDescriptor#withRateLimiter(RateLimiter,
-   * TableRateLimiter.CreditFunction, TableRateLimiter.CreditFunction)}
+   * TableRateLimiter.CreditFunction, TableRateLimiter.CreditFunction, TableRateLimiter.CreditFunction)}
    * and vice versa.
    * Note that this is the total credit of rate limit for the entire job, each task will get a per task
    * credit of creditsPerSec/tasksCount. Hence creditsPerSec should be greater than total number of tasks.
@@ -263,6 +284,12 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
   public RemoteTableDescriptor<K, V, U> withWriteRateLimit(int creditsPerSec) {
     Preconditions.checkArgument(creditsPerSec > 0, "Max write rate must be a positive number.");
     tagCreditsMap.put(RL_WRITE_TAG, creditsPerSec);
+    return this;
+  }
+
+  public RemoteTableDescriptor<K, V, U> withUpdateRateLimit(int creditsPerSec) {
+    Preconditions.checkArgument(creditsPerSec > 0, "Max write rate must be a positive number.");
+    tagCreditsMap.put(RL_UPDATE_TAG, creditsPerSec);
     return this;
   }
 
@@ -309,6 +336,12 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
     if (writeCreditFn != null) {
       addTableConfig(WRITE_CREDIT_FN, SerdeUtils.serialize("write credit function", writeCreditFn), tableConfig);
       addTablePartConfig(WRITE_CREDIT_FN, writeCreditFn, jobConfig, tableConfig);
+    }
+
+    // Handle updateCredit functions
+    if (updateCreditFn != null) {
+      addTableConfig(UPDATE_CREDIT_FN, SerdeUtils.serialize("update credit function", updateCreditFn), tableConfig);
+      addTablePartConfig(UPDATE_CREDIT_FN, updateCreditFn, jobConfig, tableConfig);
     }
 
     // Handle read retry policy
@@ -373,6 +406,9 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
     if (this.enableWriteRateLimiter && tagCreditsMap.containsKey(RL_WRITE_TAG)) {
       addTableConfig(WRITE_CREDITS, String.valueOf(tagCreditsMap.get(RL_WRITE_TAG)), tableConfig);
     }
+    if (this.enableWriteRateLimiter && tagCreditsMap.containsKey(RL_UPDATE_TAG)) {
+      addTableConfig(UPDATE_CREDITS, String.valueOf(tagCreditsMap.get(RL_UPDATE_TAG)), tableConfig);
+    }
   }
 
   @Override
@@ -393,6 +429,11 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
     if (writeFn != null && enableWriteRateLimiter) {
       Preconditions.checkArgument(writeCreditFn != null || tagCreditsMap.containsKey(RL_WRITE_TAG),
           "Write rate limiter is enabled, there is no write rate limiter configured.");
+    }
+
+    if (writeFn != null && enableUpdateRateLimiter) {
+      Preconditions.checkArgument(updateCreditFn != null || tagCreditsMap.containsKey(RL_UPDATE_TAG),
+          "Update rate limiter is enabled, there is no update rate limiter configured.");
     }
   }
 

--- a/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
+++ b/samza-api/src/main/java/org/apache/samza/table/descriptors/RemoteTableDescriptor.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import org.apache.samza.SamzaException;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.MapConfig;
-import org.apache.samza.operators.UpdatePair;
+import org.apache.samza.operators.UpdateMessage;
 import org.apache.samza.table.batching.BatchProvider;
 import org.apache.samza.table.remote.TablePart;
 import org.apache.samza.table.remote.TableRateLimiter;
@@ -70,10 +70,10 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
   public static final String RL_WRITE_TAG = "writeTag";
 
   /**
-   * Tag to be used for provision credits for rate limiting write operations into the remote table.
+   * Tag to be used for provision credits for rate limiting update operations into the remote table.
    * Caller can optionally populate the credits with this tag when specifying a custom rate limiter instance
    * through {@link RemoteTableDescriptor#withRateLimiter(RateLimiter, TableRateLimiter.CreditFunction,
-   * TableRateLimiter.CreditFunction, TableRateLimiter.CreditFunction)} and it needs the write functionality.
+   * TableRateLimiter.CreditFunction, TableRateLimiter.CreditFunction)} and it needs the update functionality.
    */
   public static final String RL_UPDATE_TAG = "updateTag";
 
@@ -84,6 +84,7 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
   public static final String READ_CREDITS = "io.read.credits";
   //Key name for table api write rate limit
   public static final String WRITE_CREDITS = "io.write.credits";
+  //Key name for table api update rate limit
   public static final String UPDATE_CREDITS = "io.update.credits";
   public static final String READ_CREDIT_FN = "io.read.credit.func";
   public static final String WRITE_CREDIT_FN = "io.write.credit.func";
@@ -119,7 +120,7 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
 
   private TableRateLimiter.CreditFunction<K, V> readCreditFn;
   private TableRateLimiter.CreditFunction<K, V> writeCreditFn;
-  private TableRateLimiter.CreditFunction<K, UpdatePair<U, V>> updateCreditFn;
+  private TableRateLimiter.CreditFunction<K, UpdateMessage<U, V>> updateCreditFn;
 
   private TableRetryPolicy readRetryPolicy;
   private TableRetryPolicy writeRetryPolicy;
@@ -199,7 +200,7 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
   public RemoteTableDescriptor<K, V, U> withRateLimiter(RateLimiter rateLimiter,
       TableRateLimiter.CreditFunction<K, V> readCreditFn,
       TableRateLimiter.CreditFunction<K, V> writeCreditFn,
-      TableRateLimiter.CreditFunction<K, UpdatePair<U, V>> updateCreditFn) {
+      TableRateLimiter.CreditFunction<K, UpdateMessage<U, V>> updateCreditFn) {
     Preconditions.checkNotNull(rateLimiter, "null read rate limiter");
     this.rateLimiter = rateLimiter;
     this.readCreditFn = readCreditFn;
@@ -406,7 +407,7 @@ public class RemoteTableDescriptor<K, V, U> extends BaseTableDescriptor<K, V, Re
     if (this.enableWriteRateLimiter && tagCreditsMap.containsKey(RL_WRITE_TAG)) {
       addTableConfig(WRITE_CREDITS, String.valueOf(tagCreditsMap.get(RL_WRITE_TAG)), tableConfig);
     }
-    if (this.enableWriteRateLimiter && tagCreditsMap.containsKey(RL_UPDATE_TAG)) {
+    if (this.enableUpdateRateLimiter && tagCreditsMap.containsKey(RL_UPDATE_TAG)) {
       addTableConfig(UPDATE_CREDITS, String.valueOf(tagCreditsMap.get(RL_UPDATE_TAG)), tableConfig);
     }
   }

--- a/samza-api/src/main/java/org/apache/samza/table/descriptors/TableDescriptor.java
+++ b/samza-api/src/main/java/org/apache/samza/table/descriptors/TableDescriptor.java
@@ -48,10 +48,10 @@ import org.apache.samza.task.InitableTask;
  * </pre>
  * For High Level API {@link StreamApplication}s, use {@link StreamApplicationDescriptor#getTable(TableDescriptor)} to
  * obtain the corresponding {@link Table} instance that can be used with the {@link MessageStream} operators like
- * {@link MessageStream#sendTo(Table)}. Alternatively, use {@link TaskContext#getTable(String)} in
- * {@link InitableFunction#init} to get the table instance for use within operator functions. For Low Level API
- * {@link TaskApplication}s, use {@link TaskContext#getTable(String)} in {@link InitableTask#init} to get the
- * table instance for use within the Task.
+ * {@link MessageStream#sendTo(Table)}. Alternatively, use {@link TaskContext#getTable(String)} or
+ * {@link TaskContext#getUpdatableTable(String)} in {@link InitableFunction#init} to get the table instance for use
+ * within operator functions. For Low Level API {@link TaskApplication}s, use {@link TaskContext#getTable(String)} in
+ * {@link InitableTask#init} to get the table instance for use within the Task.
  *
  * @param <K> the type of the key in this table
  * @param <V> the type of the value in this table

--- a/samza-api/src/main/java/org/apache/samza/table/descriptors/TableDescriptor.java
+++ b/samza-api/src/main/java/org/apache/samza/table/descriptors/TableDescriptor.java
@@ -48,7 +48,7 @@ import org.apache.samza.task.InitableTask;
  * </pre>
  * For High Level API {@link StreamApplication}s, use {@link StreamApplicationDescriptor#getTable(TableDescriptor)} to
  * obtain the corresponding {@link Table} instance that can be used with the {@link MessageStream} operators like
- * {@link MessageStream#sendTo(Table, Object[])}. Alternatively, use {@link TaskContext#getTable(String)} in
+ * {@link MessageStream#sendTo(Table)}. Alternatively, use {@link TaskContext#getTable(String)} in
  * {@link InitableFunction#init} to get the table instance for use within operator functions. For Low Level API
  * {@link TaskApplication}s, use {@link TaskContext#getTable(String)} in {@link InitableTask#init} to get the
  * table instance for use within the Task.

--- a/samza-api/src/main/java/org/apache/samza/table/remote/BaseTableFunction.java
+++ b/samza-api/src/main/java/org/apache/samza/table/remote/BaseTableFunction.java
@@ -40,7 +40,7 @@ package org.apache.samza.table.remote;
 import com.google.common.base.Preconditions;
 
 import org.apache.samza.context.Context;
-import org.apache.samza.table.AsyncReadWriteTable;
+import org.apache.samza.table.AsyncReadWriteUpdateTable;
 
 
 /**
@@ -48,10 +48,10 @@ import org.apache.samza.table.AsyncReadWriteTable;
  */
 abstract public class BaseTableFunction implements TableFunction {
 
-  protected transient AsyncReadWriteTable table;
+  protected transient AsyncReadWriteUpdateTable table;
 
   @Override
-  public void init(Context context, AsyncReadWriteTable table) {
+  public void init(Context context, AsyncReadWriteUpdateTable table) {
     Preconditions.checkNotNull(context, "null context");
     Preconditions.checkNotNull(table, "null table");
     this.table = table;

--- a/samza-api/src/main/java/org/apache/samza/table/remote/TableFunction.java
+++ b/samza-api/src/main/java/org/apache/samza/table/remote/TableFunction.java
@@ -41,7 +41,7 @@ import java.io.Serializable;
 import org.apache.samza.annotation.InterfaceStability;
 import org.apache.samza.context.Context;
 import org.apache.samza.operators.functions.ClosableFunction;
-import org.apache.samza.table.AsyncReadWriteTable;
+import org.apache.samza.table.AsyncReadWriteUpdateTable;
 
 
 /**
@@ -56,7 +56,7 @@ public interface TableFunction extends TablePart, ClosableFunction, Serializable
    * @param context the {@link Context} for this task
    * @param table the {@link TableFunction} which this table function belongs to
    */
-  void init(Context context, AsyncReadWriteTable table);
+  void init(Context context, AsyncReadWriteUpdateTable table);
 
   /**
    * Determine whether the current operation can be retried with the last thrown exception.

--- a/samza-api/src/main/java/org/apache/samza/table/remote/TableWriteFunction.java
+++ b/samza-api/src/main/java/org/apache/samza/table/remote/TableWriteFunction.java
@@ -30,6 +30,7 @@ import org.apache.samza.annotation.InterfaceStability;
 import org.apache.samza.storage.kv.Entry;
 
 import com.google.common.collect.Iterables;
+import org.apache.samza.table.RecordNotFoundException;
 
 
 /**
@@ -123,7 +124,7 @@ public interface TableWriteFunction<K, V, U> extends TableFunction {
    * This method must be thread-safe.
    *
    * If the update operation failed due to the an existing record missing for the key, the implementation can return
-   * a future completed exceptionally with a {@link org.apache.samza.table.RecordDoesNotExistException} which will
+   * a future completed exceptionally with a {@link RecordNotFoundException} which will
    * allow to Put a default value if one is provided.
    *
    * @param key key for the table record
@@ -137,7 +138,7 @@ public interface TableWriteFunction<K, V, U> extends TableFunction {
    * This method must be thread-safe.
    *
    * If the update operation failed due to the an existing record missing for the key, the implementation can return
-   * a future completed exceptionally with a {@link org.apache.samza.table.RecordDoesNotExistException} which will
+   * a future completed exceptionally with a {@link RecordNotFoundException} which will
    * allow to Put a default value if one is provided.
    *
    * @param key key for the table record

--- a/samza-api/src/main/java/org/apache/samza/table/remote/TableWriteFunction.java
+++ b/samza-api/src/main/java/org/apache/samza/table/remote/TableWriteFunction.java
@@ -134,23 +134,6 @@ public interface TableWriteFunction<K, V, U> extends TableFunction {
   CompletableFuture<Void> updateAsync(K key, U update);
 
   /**
-   * Asynchronously update the record with specified {@code key} and additional arguments.
-   * This method must be thread-safe.
-   *
-   * If the update operation failed due to the an existing record missing for the key, the implementation can return
-   * a future completed exceptionally with a {@link RecordNotFoundException} which will
-   * allow to Put a default value if one is provided.
-   *
-   * @param key key for the table record
-   * @param update update record for the given key
-   * @param args additional arguments
-   * @return CompletableFuture for the update request
-   */
-  default CompletableFuture<Void> updateAsync(K key, U update, Object ... args) {
-    throw new SamzaException("Not supported");
-  }
-
-  /**
    * Asynchronously updates the table with {@code records} with specified {@code keys}. This method must be thread-safe.
    * The default implementation calls updateAsync for each entry and return a combined future.
    * @param records updates for the table
@@ -161,16 +144,6 @@ public interface TableWriteFunction<K, V, U> extends TableFunction {
         .map(entry -> updateAsync(entry.getKey(), entry.getValue()))
         .collect(Collectors.toList());
     return CompletableFuture.allOf(Iterables.toArray(updateFutures, CompletableFuture.class));
-  }
-
-  /**
-   * Asynchronously updates the table with {@code records} with specified {@code keys}. This method must be thread-safe.
-   * @param records updates for the table
-   * @param args additional arguments
-   * @return CompletableFuture for the update request
-   */
-  default CompletableFuture<Void> updateAllAsync(Collection<Entry<K, U>> records, Object ... args) {
-    throw new SamzaException("Not supported");
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/context/TaskContextImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/context/TaskContextImpl.java
@@ -27,6 +27,7 @@ import org.apache.samza.storage.kv.KeyValueStore;
 import org.apache.samza.system.StreamMetadataCache;
 import org.apache.samza.system.SystemStreamPartition;
 import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.apache.samza.table.TableManager;
 
 import java.util.Set;
@@ -93,8 +94,14 @@ public class TaskContextImpl implements TaskContext {
   }
 
   @Override
-  public <K, V, U> ReadWriteTable<K, V, U> getTable(String tableId) {
+  public <K, V, U> ReadWriteUpdateTable<K, V, U> getUpdatableTable(String tableId) {
     return this.tableManager.getTable(tableId);
+  }
+
+  @Override
+  public <K, V> ReadWriteTable<K, V> getTable(String tableId) {
+    final ReadWriteUpdateTable table = this.tableManager.getTable(tableId);
+    return (ReadWriteTable) table;
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/context/TaskContextImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/context/TaskContextImpl.java
@@ -93,7 +93,7 @@ public class TaskContextImpl implements TaskContext {
   }
 
   @Override
-  public <K, V> ReadWriteTable<K, V> getTable(String tableId) {
+  public <K, V, U> ReadWriteTable<K, V, U> getTable(String tableId) {
     return this.tableManager.getTable(tableId);
   }
 

--- a/samza-core/src/main/java/org/apache/samza/operators/MessageStreamImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/MessageStreamImpl.java
@@ -42,6 +42,7 @@ import org.apache.samza.operators.spec.OutputOperatorSpec;
 import org.apache.samza.operators.spec.OutputStreamImpl;
 import org.apache.samza.operators.spec.PartitionByOperatorSpec;
 import org.apache.samza.operators.spec.SendToTableOperatorSpec;
+import org.apache.samza.operators.spec.SendUpdateToTableOperatorSpec;
 import org.apache.samza.operators.spec.SinkOperatorSpec;
 import org.apache.samza.operators.spec.StreamOperatorSpec;
 import org.apache.samza.operators.spec.StreamTableJoinOperatorSpec;
@@ -193,6 +194,16 @@ public class MessageStreamImpl<M> implements MessageStream<M> {
     String opId = this.streamAppDesc.getNextOpId(OpCode.SEND_TO);
     SendToTableOperatorSpec<K, V> op =
         OperatorSpecs.createSendToTableOperatorSpec(((TableImpl) table).getTableId(), opId, args);
+    this.operatorSpec.registerNextOperatorSpec(op);
+    return new MessageStreamImpl<>(this.streamAppDesc, op);
+  }
+
+  @Override
+  public <K, V, U> MessageStream<KV<K, UpdatePair<U, V>>> sendUpdateTo(Table<KV<K, UpdatePair<U, V>>> table,
+      Object... args) {
+    String opId = this.streamAppDesc.getNextOpId(OpCode.SEND_UPDATE_TO);
+    SendUpdateToTableOperatorSpec<K, V, U> op =
+        OperatorSpecs.createSendUpdateToTableOperatorSpec(((TableImpl) table).getTableId(), opId, args);
     this.operatorSpec.registerNextOperatorSpec(op);
     return new MessageStreamImpl<>(this.streamAppDesc, op);
   }

--- a/samza-core/src/main/java/org/apache/samza/operators/MessageStreamImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/MessageStreamImpl.java
@@ -199,7 +199,7 @@ public class MessageStreamImpl<M> implements MessageStream<M> {
   }
 
   @Override
-  public <K, V, U> MessageStream<KV<K, UpdatePair<U, V>>> sendUpdateTo(Table<KV<K, UpdatePair<U, V>>> table,
+  public <K, V, U> MessageStream<KV<K, UpdateMessage<U, V>>> sendUpdateTo(Table<KV<K, V>> table,
       Object... args) {
     String opId = this.streamAppDesc.getNextOpId(OpCode.SEND_UPDATE_TO);
     SendUpdateToTableOperatorSpec<K, V, U> op =

--- a/samza-core/src/main/java/org/apache/samza/operators/MessageStreamImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/MessageStreamImpl.java
@@ -42,7 +42,7 @@ import org.apache.samza.operators.spec.OutputOperatorSpec;
 import org.apache.samza.operators.spec.OutputStreamImpl;
 import org.apache.samza.operators.spec.PartitionByOperatorSpec;
 import org.apache.samza.operators.spec.SendToTableOperatorSpec;
-import org.apache.samza.operators.spec.SendUpdateToTableOperatorSpec;
+import org.apache.samza.operators.spec.SendToTableWithUpdateOperatorSpec;
 import org.apache.samza.operators.spec.SinkOperatorSpec;
 import org.apache.samza.operators.spec.StreamOperatorSpec;
 import org.apache.samza.operators.spec.StreamTableJoinOperatorSpec;
@@ -190,20 +190,19 @@ public class MessageStreamImpl<M> implements MessageStream<M> {
   }
 
   @Override
-  public <K, V> MessageStream<KV<K, V>> sendTo(Table<KV<K, V>> table, Object ... args) {
+  public <K, V> MessageStream<KV<K, V>> sendTo(Table<KV<K, V>> table) {
     String opId = this.streamAppDesc.getNextOpId(OpCode.SEND_TO);
     SendToTableOperatorSpec<K, V> op =
-        OperatorSpecs.createSendToTableOperatorSpec(((TableImpl) table).getTableId(), opId, args);
+        OperatorSpecs.createSendToTableOperatorSpec(((TableImpl) table).getTableId(), opId);
     this.operatorSpec.registerNextOperatorSpec(op);
     return new MessageStreamImpl<>(this.streamAppDesc, op);
   }
 
   @Override
-  public <K, V, U> MessageStream<KV<K, UpdateMessage<U, V>>> sendUpdateTo(Table<KV<K, V>> table,
-      Object... args) {
-    String opId = this.streamAppDesc.getNextOpId(OpCode.SEND_UPDATE_TO);
-    SendUpdateToTableOperatorSpec<K, V, U> op =
-        OperatorSpecs.createSendUpdateToTableOperatorSpec(((TableImpl) table).getTableId(), opId, args);
+  public <K, V, U> MessageStream<KV<K, UpdateMessage<U, V>>> sendTo(Table<KV<K, V>> table, UpdateOptions updateOptions) {
+    String opId = this.streamAppDesc.getNextOpId(OpCode.SEND_TO_WITH_UPDATE);
+    SendToTableWithUpdateOperatorSpec<K, V, U> op =
+        OperatorSpecs.createSendToTableWithUpdateOperatorSpec(((TableImpl) table).getTableId(), opId, updateOptions);
     this.operatorSpec.registerNextOperatorSpec(op);
     return new MessageStreamImpl<>(this.streamAppDesc, op);
   }

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImplGraph.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImplGraph.java
@@ -39,6 +39,7 @@ import org.apache.samza.operators.spec.OperatorSpec;
 import org.apache.samza.operators.spec.OutputOperatorSpec;
 import org.apache.samza.operators.spec.PartitionByOperatorSpec;
 import org.apache.samza.operators.spec.SendToTableOperatorSpec;
+import org.apache.samza.operators.spec.SendUpdateToTableOperatorSpec;
 import org.apache.samza.operators.spec.SinkOperatorSpec;
 import org.apache.samza.operators.spec.StreamOperatorSpec;
 import org.apache.samza.operators.spec.StreamTableJoinOperatorSpec;
@@ -236,6 +237,8 @@ public class OperatorImplGraph {
       return new StreamTableJoinOperatorImpl((StreamTableJoinOperatorSpec) operatorSpec, context);
     } else if (operatorSpec instanceof SendToTableOperatorSpec) {
       return new SendToTableOperatorImpl((SendToTableOperatorSpec) operatorSpec, context);
+    } else if (operatorSpec instanceof SendUpdateToTableOperatorSpec) {
+      return new SendUpdateToTableOperatorImpl((SendUpdateToTableOperatorSpec) operatorSpec, context);
     } else if (operatorSpec instanceof BroadcastOperatorSpec) {
       String streamId = ((BroadcastOperatorSpec) operatorSpec).getOutputStream().getStreamId();
       SystemStream systemStream = streamConfig.streamIdToSystemStream(streamId);

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImplGraph.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImplGraph.java
@@ -39,7 +39,7 @@ import org.apache.samza.operators.spec.OperatorSpec;
 import org.apache.samza.operators.spec.OutputOperatorSpec;
 import org.apache.samza.operators.spec.PartitionByOperatorSpec;
 import org.apache.samza.operators.spec.SendToTableOperatorSpec;
-import org.apache.samza.operators.spec.SendUpdateToTableOperatorSpec;
+import org.apache.samza.operators.spec.SendToTableWithUpdateOperatorSpec;
 import org.apache.samza.operators.spec.SinkOperatorSpec;
 import org.apache.samza.operators.spec.StreamOperatorSpec;
 import org.apache.samza.operators.spec.StreamTableJoinOperatorSpec;
@@ -237,8 +237,8 @@ public class OperatorImplGraph {
       return new StreamTableJoinOperatorImpl((StreamTableJoinOperatorSpec) operatorSpec, context);
     } else if (operatorSpec instanceof SendToTableOperatorSpec) {
       return new SendToTableOperatorImpl((SendToTableOperatorSpec) operatorSpec, context);
-    } else if (operatorSpec instanceof SendUpdateToTableOperatorSpec) {
-      return new SendUpdateToTableOperatorImpl((SendUpdateToTableOperatorSpec) operatorSpec, context);
+    } else if (operatorSpec instanceof SendToTableWithUpdateOperatorSpec) {
+      return new SendToTableWithUpdateOperatorImpl((SendToTableWithUpdateOperatorSpec) operatorSpec, context);
     } else if (operatorSpec instanceof BroadcastOperatorSpec) {
       String streamId = ((BroadcastOperatorSpec) operatorSpec).getOutputStream().getStreamId();
       SystemStream systemStream = streamConfig.streamIdToSystemStream(streamId);

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/SendToTableOperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/SendToTableOperatorImpl.java
@@ -26,7 +26,7 @@ import org.apache.samza.operators.KV;
 import org.apache.samza.operators.UpdateMessage;
 import org.apache.samza.operators.spec.OperatorSpec;
 import org.apache.samza.operators.spec.SendToTableOperatorSpec;
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.apache.samza.task.MessageCollector;
 import org.apache.samza.task.TaskCoordinator;
 import java.util.Collection;
@@ -42,11 +42,11 @@ import java.util.Collection;
 public class SendToTableOperatorImpl<K, V> extends OperatorImpl<KV<K, V>, KV<K, V>> {
 
   private final SendToTableOperatorSpec<K, V> sendToTableOpSpec;
-  private final ReadWriteTable<K, V, ?> table;
+  private final ReadWriteUpdateTable<K, V, ?> table;
 
   SendToTableOperatorImpl(SendToTableOperatorSpec<K, V> sendToTableOpSpec, Context context) {
     this.sendToTableOpSpec = sendToTableOpSpec;
-    this.table = context.getTaskContext().getTable(sendToTableOpSpec.getTableId());
+    this.table = context.getTaskContext().getUpdatableTable(sendToTableOpSpec.getTableId());
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/SendToTableWithUpdateOperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/SendToTableWithUpdateOperatorImpl.java
@@ -29,7 +29,7 @@ import org.apache.samza.operators.UpdateOptions;
 import org.apache.samza.operators.UpdateMessage;
 import org.apache.samza.operators.spec.OperatorSpec;
 import org.apache.samza.operators.spec.SendToTableWithUpdateOperatorSpec;
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.apache.samza.table.RecordNotFoundException;
 import org.apache.samza.table.batching.CompactBatchProvider;
 import org.apache.samza.table.remote.RemoteTable;
@@ -53,12 +53,12 @@ public class SendToTableWithUpdateOperatorImpl<K, V, U>
   private static final Logger LOG = LoggerFactory.getLogger(SendToTableWithUpdateOperatorImpl.class);
 
   private final SendToTableWithUpdateOperatorSpec<K, V, U> spec;
-  private final ReadWriteTable<K, V, U> table;
+  private final ReadWriteUpdateTable<K, V, U> table;
 
   public SendToTableWithUpdateOperatorImpl(SendToTableWithUpdateOperatorSpec<K, V, U> spec, Context context) {
     this.spec = spec;
-    this.table = context.getTaskContext().getTable(spec.getTableId());
-    if (context.getTaskContext().getTable(spec.getTableId()) instanceof RemoteTable) {
+    this.table = context.getTaskContext().getUpdatableTable(spec.getTableId());
+    if (context.getTaskContext().getUpdatableTable(spec.getTableId()) instanceof RemoteTable) {
       RemoteTable<K, V, U> remoteTable = (RemoteTable<K, V, U>) table;
       if (remoteTable.getBatchProvider() instanceof CompactBatchProvider) {
         throw new SamzaException("Batching is not supported with Compact Batches for partial updates");

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/SendToTableWithUpdateOperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/SendToTableWithUpdateOperatorImpl.java
@@ -104,7 +104,10 @@ public class SendToTableWithUpdateOperatorImpl<K, V, U>
                           + "The exception encountered is: ", ex);
                   return null;
                 })
-                .thenCompose(res -> table.updateAsync(message.getKey(), message.getValue().getUpdate()));
+                .thenCompose(res -> table.updateAsync(message.getKey(), message.getValue().getUpdate()))
+                .exceptionally(ex -> {
+                  throw new SamzaException("Update after Put default failed with exception: ", ex);
+                });
           } else {
             return CompletableFuture.completedFuture(null);
           }

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/StreamTableJoinOperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/StreamTableJoinOperatorImpl.java
@@ -45,7 +45,7 @@ import java.util.Collections;
 class StreamTableJoinOperatorImpl<K, M, R extends KV, JM> extends OperatorImpl<M, JM> {
 
   private final StreamTableJoinOperatorSpec<K, M, R, JM> joinOpSpec;
-  private final ReadWriteTable<K, ?> table;
+  private final ReadWriteTable<K, ?, ?> table;
 
   StreamTableJoinOperatorImpl(StreamTableJoinOperatorSpec<K, M, R, JM> joinOpSpec, Context context) {
     this.joinOpSpec = joinOpSpec;

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/StreamTableJoinOperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/StreamTableJoinOperatorImpl.java
@@ -25,7 +25,7 @@ import org.apache.samza.context.Context;
 import org.apache.samza.operators.KV;
 import org.apache.samza.operators.spec.OperatorSpec;
 import org.apache.samza.operators.spec.StreamTableJoinOperatorSpec;
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.apache.samza.task.MessageCollector;
 import org.apache.samza.task.TaskCoordinator;
 
@@ -45,11 +45,11 @@ import java.util.Collections;
 class StreamTableJoinOperatorImpl<K, M, R extends KV, JM> extends OperatorImpl<M, JM> {
 
   private final StreamTableJoinOperatorSpec<K, M, R, JM> joinOpSpec;
-  private final ReadWriteTable<K, ?, ?> table;
+  private final ReadWriteUpdateTable<K, ?, ?> table;
 
   StreamTableJoinOperatorImpl(StreamTableJoinOperatorSpec<K, M, R, JM> joinOpSpec, Context context) {
     this.joinOpSpec = joinOpSpec;
-    this.table = context.getTaskContext().getTable(joinOpSpec.getTableId());
+    this.table = context.getTaskContext().getUpdatableTable(joinOpSpec.getTableId());
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/operators/spec/OperatorSpec.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/spec/OperatorSpec.java
@@ -46,6 +46,7 @@ public abstract class OperatorSpec<M, OM> implements Serializable {
     FILTER,
     SINK,
     SEND_TO,
+    SEND_UPDATE_TO,
     JOIN,
     WINDOW,
     MERGE,

--- a/samza-core/src/main/java/org/apache/samza/operators/spec/OperatorSpec.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/spec/OperatorSpec.java
@@ -46,7 +46,7 @@ public abstract class OperatorSpec<M, OM> implements Serializable {
     FILTER,
     SINK,
     SEND_TO,
-    SEND_UPDATE_TO,
+    SEND_TO_WITH_UPDATE,
     JOIN,
     WINDOW,
     MERGE,

--- a/samza-core/src/main/java/org/apache/samza/operators/spec/OperatorSpecs.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/spec/OperatorSpecs.java
@@ -238,6 +238,22 @@ public class OperatorSpecs {
   }
 
   /**
+   * Creates a {@link SendUpdateToTableOperatorSpec} with a key extractor and a value extractor function.
+   *
+   * @param tableId the table Id for the underlying table
+   * @param opId the unique ID of the operator
+   * @param args additional arguments passed to the table
+   * @param <K> the type of the table record key
+   * @param <V> the type of the table record value
+   * @param <U> the type of the table record value
+   * @return the {@link SendToTableOperatorSpec}
+   */
+  public static <K, V, U> SendUpdateToTableOperatorSpec<K, V, U> createSendUpdateToTableOperatorSpec(
+      String tableId, String opId, Object ... args) {
+    return new SendUpdateToTableOperatorSpec<>(tableId, opId, args);
+  }
+
+  /**
    * Creates a {@link BroadcastOperatorSpec} for the Broadcast operator.
    * @param outputStream the {@link OutputStreamImpl} to send messages to
    * @param opId the unique ID of the operator

--- a/samza-core/src/main/java/org/apache/samza/operators/spec/OperatorSpecs.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/spec/OperatorSpecs.java
@@ -20,6 +20,7 @@
 package org.apache.samza.operators.spec;
 
 import org.apache.samza.operators.KV;
+import org.apache.samza.operators.UpdateOptions;
 import org.apache.samza.operators.functions.AsyncFlatMapFunction;
 import org.apache.samza.operators.functions.FilterFunction;
 import org.apache.samza.operators.functions.FlatMapFunction;
@@ -227,30 +228,28 @@ public class OperatorSpecs {
    *
    * @param tableId the table Id for the underlying table
    * @param opId the unique ID of the operator
-   * @param args additional arguments passed to the table
    * @param <K> the type of the table record key
    * @param <V> the type of the table record value
    * @return the {@link SendToTableOperatorSpec}
    */
   public static <K, V> SendToTableOperatorSpec<K, V> createSendToTableOperatorSpec(
-     String tableId, String opId, Object ... args) {
-    return new SendToTableOperatorSpec(tableId, opId, args);
+     String tableId, String opId) {
+    return new SendToTableOperatorSpec(tableId, opId);
   }
 
   /**
-   * Creates a {@link SendUpdateToTableOperatorSpec} with a key extractor and a value extractor function.
+   * Creates a {@link SendToTableWithUpdateOperatorSpec} with a key extractor and a value extractor function.
    *
    * @param tableId the table Id for the underlying table
    * @param opId the unique ID of the operator
-   * @param args additional arguments passed to the table
    * @param <K> the type of the table record key
    * @param <V> the type of the table record value
    * @param <U> the type of the table record value
    * @return the {@link SendToTableOperatorSpec}
    */
-  public static <K, V, U> SendUpdateToTableOperatorSpec<K, V, U> createSendUpdateToTableOperatorSpec(
-      String tableId, String opId, Object ... args) {
-    return new SendUpdateToTableOperatorSpec<>(tableId, opId, args);
+  public static <K, V, U> SendToTableWithUpdateOperatorSpec<K, V, U> createSendToTableWithUpdateOperatorSpec(
+      String tableId, String opId, UpdateOptions updateOptions) {
+    return new SendToTableWithUpdateOperatorSpec<>(tableId, opId, updateOptions);
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/operators/spec/SendToTableOperatorSpec.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/spec/SendToTableOperatorSpec.java
@@ -34,27 +34,20 @@ import org.apache.samza.operators.functions.WatermarkFunction;
 public class SendToTableOperatorSpec<K, V> extends OperatorSpec<KV<K, V>, KV<K, V>> {
 
   private final String tableId;
-  private final Object[] args;
 
   /**
    * Constructor for a {@link SendToTableOperatorSpec}.
    *
    * @param tableId  the Id of the table written to
    * @param opId  the unique ID for this operator
-   * @param args additional arguments passed to the table
    */
-  SendToTableOperatorSpec(String tableId, String opId, Object ... args) {
+  SendToTableOperatorSpec(String tableId, String opId) {
     super(OpCode.SEND_TO, opId);
     this.tableId = tableId;
-    this.args = args;
   }
 
   public String getTableId() {
     return tableId;
-  }
-
-  public Object[] getArgs() {
-    return args;
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/operators/spec/SendToTableWithUpdateOperatorSpec.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/spec/SendToTableWithUpdateOperatorSpec.java
@@ -20,6 +20,7 @@ package org.apache.samza.operators.spec;
 
 import org.apache.samza.annotation.InterfaceStability;
 import org.apache.samza.operators.KV;
+import org.apache.samza.operators.UpdateOptions;
 import org.apache.samza.operators.UpdateMessage;
 import org.apache.samza.operators.functions.ScheduledFunction;
 import org.apache.samza.operators.functions.WatermarkFunction;
@@ -33,29 +34,29 @@ import org.apache.samza.operators.functions.WatermarkFunction;
  * @param <U> the type of the update
  */
 @InterfaceStability.Unstable
-public class SendUpdateToTableOperatorSpec<K, V, U> extends OperatorSpec<KV<K, UpdateMessage<U, V>>, KV<K, UpdateMessage<U, V>>> {
+public class SendToTableWithUpdateOperatorSpec<K, V, U> extends OperatorSpec<KV<K, UpdateMessage<U, V>>, KV<K, UpdateMessage<U, V>>> {
   private final String tableId;
-  private final Object[] args;
+  private final UpdateOptions updateOptions;
 
   /**
    * Constructor for a {@link SendToTableOperatorSpec}.
    *
    * @param tableId  the Id of the table written to
    * @param opId  the unique ID for this operator
-   * @param args additional arguments passed to the table
+   * @param updateOptions  the update options for this operator
    */
-  SendUpdateToTableOperatorSpec(String tableId, String opId, Object ... args) {
-    super(OpCode.SEND_UPDATE_TO, opId);
+  SendToTableWithUpdateOperatorSpec(String tableId, String opId, UpdateOptions updateOptions) {
+    super(OpCode.SEND_TO_WITH_UPDATE, opId);
     this.tableId = tableId;
-    this.args = args;
+    this.updateOptions = updateOptions;
   }
 
   public String getTableId() {
     return tableId;
   }
 
-  public Object[] getArgs() {
-    return args;
+  public UpdateOptions getUpdateOptions() {
+    return updateOptions;
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/operators/spec/SendUpdateToTableOperatorSpec.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/spec/SendUpdateToTableOperatorSpec.java
@@ -20,7 +20,7 @@ package org.apache.samza.operators.spec;
 
 import org.apache.samza.annotation.InterfaceStability;
 import org.apache.samza.operators.KV;
-import org.apache.samza.operators.UpdatePair;
+import org.apache.samza.operators.UpdateMessage;
 import org.apache.samza.operators.functions.ScheduledFunction;
 import org.apache.samza.operators.functions.WatermarkFunction;
 
@@ -33,7 +33,7 @@ import org.apache.samza.operators.functions.WatermarkFunction;
  * @param <U> the type of the update
  */
 @InterfaceStability.Unstable
-public class SendUpdateToTableOperatorSpec<K, V, U> extends OperatorSpec<KV<K, UpdatePair<U, V>>, KV<K, UpdatePair<U, V>>> {
+public class SendUpdateToTableOperatorSpec<K, V, U> extends OperatorSpec<KV<K, UpdateMessage<U, V>>, KV<K, UpdateMessage<U, V>>> {
   private final String tableId;
   private final Object[] args;
 

--- a/samza-core/src/main/java/org/apache/samza/operators/spec/SendUpdateToTableOperatorSpec.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/spec/SendUpdateToTableOperatorSpec.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.operators.spec;
+
+import org.apache.samza.annotation.InterfaceStability;
+import org.apache.samza.operators.KV;
+import org.apache.samza.operators.UpdatePair;
+import org.apache.samza.operators.functions.ScheduledFunction;
+import org.apache.samza.operators.functions.WatermarkFunction;
+
+/**
+ * The spec for operator that writes an update stream to a table by extracting keys, updates and defaults
+ * from the incoming messages.
+ *
+ * @param <K> the type of the table record key
+ * @param <V> the type of the table record value
+ * @param <U> the type of the update
+ */
+@InterfaceStability.Unstable
+public class SendUpdateToTableOperatorSpec<K, V, U> extends OperatorSpec<KV<K, UpdatePair<U, V>>, KV<K, UpdatePair<U, V>>> {
+  private final String tableId;
+  private final Object[] args;
+
+  /**
+   * Constructor for a {@link SendToTableOperatorSpec}.
+   *
+   * @param tableId  the Id of the table written to
+   * @param opId  the unique ID for this operator
+   * @param args additional arguments passed to the table
+   */
+  SendUpdateToTableOperatorSpec(String tableId, String opId, Object ... args) {
+    super(OpCode.SEND_UPDATE_TO, opId);
+    this.tableId = tableId;
+    this.args = args;
+  }
+
+  public String getTableId() {
+    return tableId;
+  }
+
+  public Object[] getArgs() {
+    return args;
+  }
+
+  @Override
+  public WatermarkFunction getWatermarkFn() {
+    return null;
+  }
+
+  @Override
+  public ScheduledFunction getScheduledFn() {
+    return null;
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/table/BaseReadWriteTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/BaseReadWriteTable.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * @param <K> the type of the key in this table
  * @param <V> the type of the value in this table
  */
-abstract public class BaseReadWriteTable<K, V> implements ReadWriteTable<K, V> {
+abstract public class BaseReadWriteTable<K, V, U> implements ReadWriteTable<K, V, U> {
 
   protected final Logger logger;
 

--- a/samza-core/src/main/java/org/apache/samza/table/BaseReadWriteUpdateTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/BaseReadWriteUpdateTable.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * @param <K> the type of the key in this table
  * @param <V> the type of the value in this table
  */
-abstract public class BaseReadWriteTable<K, V, U> implements ReadWriteTable<K, V, U> {
+abstract public class BaseReadWriteUpdateTable<K, V, U> implements ReadWriteUpdateTable<K, V, U> {
 
   protected final Logger logger;
 
@@ -48,7 +48,7 @@ abstract public class BaseReadWriteTable<K, V, U> implements ReadWriteTable<K, V
    * Construct an instance
    * @param tableId Id of the table
    */
-  public BaseReadWriteTable(String tableId) {
+  public BaseReadWriteUpdateTable(String tableId) {
     Preconditions.checkArgument(tableId != null & !tableId.isEmpty(),
         String.format("Invalid table Id: %s", tableId));
     this.tableId = tableId;

--- a/samza-core/src/main/java/org/apache/samza/table/TableManager.java
+++ b/samza-core/src/main/java/org/apache/samza/table/TableManager.java
@@ -54,7 +54,7 @@ public class TableManager {
 
   static class TableCtx {
     private TableProvider tableProvider;
-    private ReadWriteTable table;
+    private ReadWriteUpdateTable table;
   }
 
   private final Logger logger = LoggerFactory.getLogger(TableManager.class.getName());
@@ -119,7 +119,7 @@ public class TableManager {
    * @param tableId Id of the table
    * @return table instance
    */
-  public ReadWriteTable getTable(String tableId) {
+  public ReadWriteUpdateTable getTable(String tableId) {
     Preconditions.checkState(initialized, "TableManager has not been initialized.");
 
     TableCtx ctx = tableContexts.get(tableId);

--- a/samza-core/src/main/java/org/apache/samza/table/batching/AbstractBatch.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/AbstractBatch.java
@@ -23,7 +23,7 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
 
-abstract class AbstractBatch<K, V> implements Batch<K, V> {
+abstract class AbstractBatch<K, V, U> implements Batch<K, V, U> {
   protected final int maxBatchSize;
   protected final Duration maxBatchDelay;
   protected final CompletableFuture<Void> completableFuture;

--- a/samza-core/src/main/java/org/apache/samza/table/batching/AsyncBatchingTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/AsyncBatchingTable.java
@@ -119,18 +119,18 @@ public class AsyncBatchingTable<K, V, U> implements AsyncReadWriteUpdateTable<K,
   }
 
   @Override
-  public CompletableFuture<Void> updateAsync(K key, U update, Object... args) {
+  public CompletableFuture<Void> updateAsync(K key, U update) {
     try {
-      return batchProcessor.processPutDeleteOrUpdateOperations(new UpdateOperation<>(key, update, args));
+      return batchProcessor.processPutDeleteOrUpdateOperations(new UpdateOperation<>(key, update));
     } catch (BatchingNotSupportedException e) {
-      return table.updateAsync(key, update, args);
+      return table.updateAsync(key, update);
     } catch (Exception e) {
       throw new SamzaException(e);
     }
   }
 
   @Override
-  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, Object... args) {
+  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates) {
     return table.updateAllAsync(updates);
   }
 

--- a/samza-core/src/main/java/org/apache/samza/table/batching/AsyncBatchingTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/AsyncBatchingTable.java
@@ -28,13 +28,13 @@ import java.util.concurrent.ScheduledExecutorService;
 import org.apache.samza.SamzaException;
 import org.apache.samza.context.Context;
 import org.apache.samza.storage.kv.Entry;
-import org.apache.samza.table.AsyncReadWriteTable;
+import org.apache.samza.table.AsyncReadWriteUpdateTable;
 import org.apache.samza.table.utils.TableMetricsUtil;
 import org.apache.samza.util.HighResolutionClock;
 
 
 /**
- * A wrapper of a {@link AsyncReadWriteTable} that supports batch operations.
+ * A wrapper of a {@link AsyncReadWriteUpdateTable} that supports batch operations.
  *
  * This batching table does not guarantee any ordering of different operation types within the batch.
  * For instance, query(Q) and put/delete(u) operations arrives in the following sequences, Q1, U1, Q2, U2,
@@ -49,14 +49,14 @@ import org.apache.samza.util.HighResolutionClock;
  *
  * The Batch implementation class can throw {@link BatchingNotSupportedException} if it thinks the operation is
  * not batch-able. When receiving this exception, {@link AsyncBatchingTable} will send the operation to the
- * {@link AsyncReadWriteTable}.
+ * {@link AsyncReadWriteUpdateTable}.
  *
  * @param <K> The type of the key.
  * @param <V> The type of the value.
  * @param <U> the type of the update applied to this table
  */
-public class AsyncBatchingTable<K, V, U> implements AsyncReadWriteTable<K, V, U> {
-  private final AsyncReadWriteTable<K, V, U> table;
+public class AsyncBatchingTable<K, V, U> implements AsyncReadWriteUpdateTable<K, V, U> {
+  private final AsyncReadWriteUpdateTable<K, V, U> table;
   private final String tableId;
   private final BatchProvider<K, V, U> batchProvider;
   private final ScheduledExecutorService batchTimerExecutorService;
@@ -68,7 +68,7 @@ public class AsyncBatchingTable<K, V, U> implements AsyncReadWriteTable<K, V, U>
    * @param batchProvider Batch provider to create a batch instance.
    * @param batchTimerExecutorService Executor service for batch timer.
    */
-  public AsyncBatchingTable(String tableId, AsyncReadWriteTable<K, V, U> table, BatchProvider<K, V, U> batchProvider,
+  public AsyncBatchingTable(String tableId, AsyncReadWriteUpdateTable<K, V, U> table, BatchProvider<K, V, U> batchProvider,
       ScheduledExecutorService batchTimerExecutorService) {
     Preconditions.checkNotNull(tableId);
     Preconditions.checkNotNull(table);

--- a/samza-core/src/main/java/org/apache/samza/table/batching/BatchHandler.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/BatchHandler.java
@@ -27,12 +27,13 @@ import java.util.concurrent.CompletableFuture;
  *
  * @param <K> The key type of the operations
  * @param <V> The value type of the operations.
+ * @param <U> The update type of the operations.
  */
-public interface BatchHandler<K, V> {
+public interface BatchHandler<K, V, U> {
   /**
    *
    * @param batch The batch to be handled
    * @return A {@link CompletableFuture} that indicates the status of the handle process.
    */
-  CompletableFuture<Void> handle(Batch<K, V> batch);
+  CompletableFuture<Void> handle(Batch<K, V, U> batch);
 }

--- a/samza-core/src/main/java/org/apache/samza/table/batching/BatchProcessor.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/BatchProcessor.java
@@ -57,7 +57,7 @@ public class BatchProcessor<K, V> {
    * @param clock A clock used to get the timestamp.
    * @param scheduledExecutorService A scheduled executor service to set timers for the managed batches.
    */
-  public BatchProcessor(BatchMetrics batchMetrics, BatchHandler<K, V> batchHandler, BatchProvider batchProvider,
+  public BatchProcessor(BatchMetrics batchMetrics, BatchHandler<K, V> batchHandler, BatchProvider<K, V> batchProvider,
       HighResolutionClock clock, ScheduledExecutorService scheduledExecutorService) {
     Preconditions.checkNotNull(batchHandler);
     Preconditions.checkNotNull(batchProvider);
@@ -101,12 +101,14 @@ public class BatchProcessor<K, V> {
   }
 
   /**
-   * @param operation The update operation to be added to the batch.
+   * @param operation The Put/Delete/Update operation to be added to the batch.
    * @return A {@link CompletableFuture} to indicate whether the operation is finished.
    */
-  CompletableFuture<Void> processUpdateOperation(Operation<K, V> operation) {
+  CompletableFuture<Void> processPutDeleteOrUpdateOperations(Operation<K, V> operation) {
     Preconditions.checkNotNull(operation);
-    Preconditions.checkArgument(operation instanceof PutOperation || operation instanceof DeleteOperation);
+    Preconditions.checkArgument(operation instanceof PutOperation
+        || operation instanceof DeleteOperation
+        || operation instanceof UpdateOperation);
 
     lock.lock();
     try {

--- a/samza-core/src/main/java/org/apache/samza/table/batching/BatchProcessor.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/BatchProcessor.java
@@ -39,14 +39,14 @@ import org.apache.samza.util.HighResolutionClock;
  * @param <K> The type of the key associated with the {@link Operation}
  * @param <V> The type of the value associated with the {@link Operation}
  */
-public class BatchProcessor<K, V> {
+public class BatchProcessor<K, V, U> {
   private final ScheduledExecutorService scheduledExecutorService;
   private final ReentrantLock lock = new ReentrantLock();
-  private final BatchHandler<K, V> batchHandler;
-  private final BatchProvider<K, V> batchProvider;
+  private final BatchHandler<K, V, U> batchHandler;
+  private final BatchProvider<K, V, U> batchProvider;
   private final BatchMetrics batchMetrics;
   private final HighResolutionClock clock;
-  private Batch<K, V> batch;
+  private Batch<K, V, U> batch;
   private ScheduledFuture<?> scheduledFuture;
   private long batchOpenTimestamp;
 
@@ -57,8 +57,8 @@ public class BatchProcessor<K, V> {
    * @param clock A clock used to get the timestamp.
    * @param scheduledExecutorService A scheduled executor service to set timers for the managed batches.
    */
-  public BatchProcessor(BatchMetrics batchMetrics, BatchHandler<K, V> batchHandler, BatchProvider<K, V> batchProvider,
-      HighResolutionClock clock, ScheduledExecutorService scheduledExecutorService) {
+  public BatchProcessor(BatchMetrics batchMetrics, BatchHandler<K, V, U> batchHandler,
+      BatchProvider<K, V, U> batchProvider, HighResolutionClock clock, ScheduledExecutorService scheduledExecutorService) {
     Preconditions.checkNotNull(batchHandler);
     Preconditions.checkNotNull(batchProvider);
     Preconditions.checkNotNull(clock);
@@ -71,7 +71,7 @@ public class BatchProcessor<K, V> {
     this.clock = clock;
   }
 
-  private CompletableFuture<Void> addOperation(Operation<K, V> operation) {
+  private CompletableFuture<Void> addOperation(Operation<K, V, U> operation) {
     if (batch == null) {
       startNewBatch();
     }
@@ -86,13 +86,13 @@ public class BatchProcessor<K, V> {
    * @param operation The query operation to be added to the batch.
    * @return A {@link CompletableFuture} to indicate whether the operation is finished.
    */
-  CompletableFuture<V> processQueryOperation(Operation<K, V> operation) {
+  CompletableFuture<V> processQueryOperation(Operation<K, V, U> operation) {
     Preconditions.checkNotNull(operation);
     Preconditions.checkArgument(operation instanceof GetOperation);
 
     lock.lock();
     try {
-      GetOperation<K, V> getOperation = (GetOperation) operation;
+      GetOperation<K, V, U> getOperation = (GetOperation<K, V, U>) operation;
       addOperation(getOperation);
       return getOperation.getCompletableFuture();
     } finally {
@@ -104,7 +104,7 @@ public class BatchProcessor<K, V> {
    * @param operation The Put/Delete/Update operation to be added to the batch.
    * @return A {@link CompletableFuture} to indicate whether the operation is finished.
    */
-  CompletableFuture<Void> processPutDeleteOrUpdateOperations(Operation<K, V> operation) {
+  CompletableFuture<Void> processPutDeleteOrUpdateOperations(Operation<K, V, U> operation) {
     Preconditions.checkNotNull(operation);
     Preconditions.checkArgument(operation instanceof PutOperation
         || operation instanceof DeleteOperation
@@ -146,7 +146,7 @@ public class BatchProcessor<K, V> {
   /**
    * Set a timer to close the batch when the batch is older than the max delay.
    */
-  private void setBatchTimer(Batch<K, V> batch) {
+  private void setBatchTimer(Batch<K, V, U> batch) {
     final long maxDelay = batch.getMaxBatchDelay().toMillis();
     if (maxDelay != Integer.MAX_VALUE) {
       scheduledFuture = scheduledExecutorService.schedule(() -> {
@@ -178,17 +178,17 @@ public class BatchProcessor<K, V> {
   }
 
   /**
-   * Get the latest update operation for the specified key.
+   * Get the latest Put/Update/Delete operation for the specified key.
    */
   @VisibleForTesting
-  Operation<K, V> getLastUpdate(K key) {
-    final Collection<Operation<K, V>> operations = batch.getOperations();
-    final Iterator<Operation<K, V>> iterator = operations.iterator();
-    Operation<K, V> lastUpdate = null;
+  Operation<K, V, U> getLatestPutUpdateOrDelete(K key) {
+    final Collection<Operation<K, V, U>> operations = batch.getOperations();
+    final Iterator<Operation<K, V, U>> iterator = operations.iterator();
+    Operation<K, V, U> lastUpdate = null;
     while (iterator.hasNext()) {
-      final Operation<K, V> operation = iterator.next();
-      if ((operation instanceof PutOperation || operation instanceof DeleteOperation)
-          && operation.getKey().equals(key)) {
+      final Operation<K, V, U> operation = iterator.next();
+      if ((operation instanceof PutOperation || operation instanceof DeleteOperation ||
+          operation instanceof UpdateOperation) && operation.getKey().equals(key)) {
         lastUpdate = operation;
       }
     }

--- a/samza-core/src/main/java/org/apache/samza/table/batching/CompactBatch.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/CompactBatch.java
@@ -32,13 +32,15 @@ import java.util.stream.Stream;
 /**
  * A newer put/delete operation will override the value of an earlier one.
  * Consecutive query operations with the same key will be combined as a single query.
+ * Updates are not supported in CompactBatch.
  *
  * @param <K> The type of the key associated with the {@link Operation}
  * @param <V> The type of the value associated with the {@link Operation}
+ * @param <U> The type of the update associated with the {@link Operation}
  */
-class CompactBatch<K, V> extends AbstractBatch<K, V> {
-  private final Map<K, Operation<K, V>> putsDeletes = new LinkedHashMap<>();
-  private final Map<K, Operation<K, V>> queries = new LinkedHashMap<>();
+class CompactBatch<K, V, U> extends AbstractBatch<K, V, U> {
+  private final Map<K, Operation<K, V, U>> putsDeletes = new LinkedHashMap<>();
+  private final Map<K, Operation<K, V, U>> queries = new LinkedHashMap<>();
 
   public CompactBatch(int maxBatchSize, Duration maxBatchDelay) {
     super(maxBatchSize, maxBatchDelay);
@@ -56,10 +58,11 @@ class CompactBatch<K, V> extends AbstractBatch<K, V> {
    * When adding a GetOperation to the batch, mark the GetOperation completed immediately if there is
    * an PutOperation/DeleteOperation for the key, otherwise, adding the operation to a list.
    * When adding a Put/DeleteOperation, if there is a put/delete operation for the same key, the existing
-   * operation will be replaced by the new one.
+   * operation will be replaced by the new one. If an update operation is received, throw a BatchingNotSupportedException
+   * exception.
    */
   @Override
-  public CompletableFuture<Void> addOperation(Operation<K, V> operation) {
+  public CompletableFuture<Void> addOperation(Operation<K, V, U> operation) {
     Preconditions.checkNotNull(operation);
 
     if (operation.getArgs() != null && operation.getArgs().length > 0) {
@@ -80,7 +83,7 @@ class CompactBatch<K, V> extends AbstractBatch<K, V> {
   }
 
   @Override
-  public Collection<Operation<K, V>> getOperations() {
+  public Collection<Operation<K, V, U>> getOperations() {
     return Stream.of(queries.values(), putsDeletes.values()).flatMap(Collection::stream).collect(Collectors.toList());
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/table/batching/CompactBatchProvider.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/CompactBatchProvider.java
@@ -19,9 +19,9 @@
 
 package org.apache.samza.table.batching;
 
-public class CompactBatchProvider<K, V> extends BatchProvider<K, V> {
+public class CompactBatchProvider<K, V, U> extends BatchProvider<K, V, U> {
   @Override
-  public Batch<K, V> getBatch() {
+  public Batch<K, V, U> getBatch() {
     return new CompactBatch<>(getMaxBatchSize(), getMaxBatchDelay());
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/table/batching/CompleteBatch.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/CompleteBatch.java
@@ -32,9 +32,10 @@ import java.util.concurrent.CompletableFuture;
  *
  * @param <K> The type of the key associated with the {@link Operation}
  * @param <V> The type of the value associated with the {@link Operation}
+ * @param <U> The type of the update associated with the {@link Operation}
  */
-class CompleteBatch<K, V> extends AbstractBatch<K, V> {
-  private final List<Operation<K, V>> operations = new ArrayList<>();
+class CompleteBatch<K, V, U> extends AbstractBatch<K, V, U> {
+  private final List<Operation<K, V, U>> operations = new ArrayList<>();
 
   public CompleteBatch(int maxBatchSize, Duration maxBatchDelay) {
     super(maxBatchSize, maxBatchDelay);
@@ -52,7 +53,7 @@ class CompleteBatch<K, V> extends AbstractBatch<K, V> {
    * All operations will be buffered without any compaction.
    */
   @Override
-  public CompletableFuture<Void> addOperation(Operation<K, V> operation) {
+  public CompletableFuture<Void> addOperation(Operation<K, V, U> operation) {
     Preconditions.checkNotNull(operation);
     operations.add(operation);
     if (size() >= maxBatchSize) {
@@ -62,7 +63,7 @@ class CompleteBatch<K, V> extends AbstractBatch<K, V> {
   }
 
   @Override
-  public Collection<Operation<K, V>> getOperations() {
+  public Collection<Operation<K, V, U>> getOperations() {
     return operations;
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/table/batching/CompleteBatchProvider.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/CompleteBatchProvider.java
@@ -19,9 +19,9 @@
 
 package org.apache.samza.table.batching;
 
-public class CompleteBatchProvider<K, V> extends BatchProvider<K, V> {
+public class CompleteBatchProvider<K, V, U> extends BatchProvider<K, V, U> {
   @Override
-  public Batch<K, V> getBatch() {
+  public Batch<K, V, U> getBatch() {
     return new CompleteBatch<>(getMaxBatchSize(), getMaxBatchDelay());
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/table/batching/DeleteOperation.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/DeleteOperation.java
@@ -27,7 +27,7 @@ import com.google.common.base.Preconditions;
  *
  * @param <K> The type of the key.
  */
-public class DeleteOperation<K, V> implements Operation<K, V> {
+public class DeleteOperation<K, V, U> implements Operation<K, V, U> {
   final K key;
   final Object[] args;
 
@@ -51,6 +51,14 @@ public class DeleteOperation<K, V> implements Operation<K, V> {
    */
   @Override
   public V getValue() {
+    return null;
+  }
+
+  /**
+   * @return null.
+   */
+  @Override
+  public U getUpdate() {
     return null;
   }
 

--- a/samza-core/src/main/java/org/apache/samza/table/batching/GetOperation.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/GetOperation.java
@@ -28,7 +28,7 @@ import java.util.concurrent.CompletableFuture;
  *
  * @param <K> The type of the key.
  */
-public class GetOperation<K, V> implements Operation<K, V> {
+public class GetOperation<K, V, U> implements Operation<K, V, U> {
   final K key;
   final Object[] args;
   final CompletableFuture<V> completableFuture = new CompletableFuture<>();
@@ -56,6 +56,14 @@ public class GetOperation<K, V> implements Operation<K, V> {
    */
   @Override
   public V getValue() {
+    return null;
+  }
+
+  /**
+   * @return null.
+   */
+  @Override
+  public U getUpdate() {
     return null;
   }
 

--- a/samza-core/src/main/java/org/apache/samza/table/batching/PutOperation.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/PutOperation.java
@@ -28,7 +28,7 @@ import com.google.common.base.Preconditions;
  * @param <K> The type of the key.
  * @param <V> The type of the value
  */
-public class PutOperation<K, V> implements Operation<K, V> {
+public class PutOperation<K, V, U> implements Operation<K, V, U> {
   final private K key;
   final private V val;
   final private Object[] args;
@@ -56,6 +56,14 @@ public class PutOperation<K, V> implements Operation<K, V> {
   @Override
   public V getValue() {
     return val;
+  }
+
+  /**
+   * @return null.
+   */
+  @Override
+  public U getUpdate() {
+    return null;
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/table/batching/TableBatchHandler.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/TableBatchHandler.java
@@ -36,8 +36,9 @@ import org.apache.samza.table.AsyncReadWriteTable;
  *
  * @param <K> The key type of the operation.
  * @param <V> The value type of the operation.
+ * @param <U> The update type of the operation.
  */
-public class TableBatchHandler<K, V, U> implements BatchHandler<K, V> {
+public class TableBatchHandler<K, V, U> implements BatchHandler<K, V, U> {
   private final AsyncReadWriteTable<K, V, U> table;
 
   public TableBatchHandler(AsyncReadWriteTable<K, V, U> table) {
@@ -52,7 +53,7 @@ public class TableBatchHandler<K, V, U> implements BatchHandler<K, V> {
    * @param operations The batch get operations.
    * @return A CompletableFuture to represent the status of the batch operation.
    */
-  private CompletableFuture<?> handleBatchGet(Collection<Operation<K, V>> operations) {
+  private CompletableFuture<?> handleBatchGet(Collection<Operation<K, V, U>> operations) {
     Preconditions.checkNotNull(operations);
     final List<K> gets = getOperationKeys(operations);
     if (gets.isEmpty()) {
@@ -65,7 +66,7 @@ public class TableBatchHandler<K, V, U> implements BatchHandler<K, V> {
 
     getsFuture.whenComplete((map, throwable) -> {
       operations.forEach(operation -> {
-        GetOperation<K, V> getOperation = (GetOperation<K, V>) operation;
+        GetOperation<K, V, U> getOperation = (GetOperation<K, V, U>) operation;
         if (throwable != null) {
           getOperation.completeExceptionally(throwable);
         } else {
@@ -82,7 +83,7 @@ public class TableBatchHandler<K, V, U> implements BatchHandler<K, V> {
    * @param operations The batch get operations.
    * @return A CompletableFuture to represent the status of the batch operation.
    */
-  private CompletableFuture<?> handleBatchPut(Collection<Operation<K, V>> operations) {
+  private CompletableFuture<?> handleBatchPut(Collection<Operation<K, V, U>> operations) {
     Preconditions.checkNotNull(operations);
 
     final List<Entry<K, V>> puts = operations.stream()
@@ -102,11 +103,11 @@ public class TableBatchHandler<K, V, U> implements BatchHandler<K, V> {
    * @param operations The batch update operations.
    * @return A CompletableFuture to represent the status of the batch update operation.
    */
-  private CompletableFuture<?> handleBatchUpdate(Collection<Operation<K, U>> operations) {
+  private CompletableFuture<?> handleBatchUpdate(Collection<Operation<K, V, U>> operations) {
     Preconditions.checkNotNull(operations);
 
     final List<Entry<K, U>> updates = operations.stream()
-        .map(op -> new Entry<>(op.getKey(), op.getValue()))
+        .map(op -> new Entry<>(op.getKey(), op.getUpdate()))
         .collect(Collectors.toList());
     if (updates.isEmpty()) {
       return CompletableFuture.completedFuture(Collections.EMPTY_MAP);
@@ -121,7 +122,7 @@ public class TableBatchHandler<K, V, U> implements BatchHandler<K, V> {
    * @param operations The batch get operations.
    * @return A CompletableFuture to represent the status of the batch operation.
    */
-  private CompletableFuture<?> handleBatchDelete(Collection<Operation<K, V>> operations) {
+  private CompletableFuture<?> handleBatchDelete(Collection<Operation<K, V, U>> operations) {
     Preconditions.checkNotNull(operations);
 
     final List<K> deletes = getOperationKeys(operations);
@@ -132,11 +133,11 @@ public class TableBatchHandler<K, V, U> implements BatchHandler<K, V> {
     return args == null ? table.deleteAllAsync(deletes) : table.deleteAllAsync(deletes, args);
   }
 
-  private List<K> getOperationKeys(Collection<Operation<K, V>> operations) {
+  private List<K> getOperationKeys(Collection<Operation<K, V, U>> operations) {
     return operations.stream().map(op -> op.getKey()).collect(Collectors.toList());
   }
 
-  private <KEY, VAL> Object[] getOperationArgs(Collection<Operation<KEY, VAL>> operations) {
+  private Object[] getOperationArgs(Collection<Operation<K, V, U>> operations) {
     if (!operations.stream().anyMatch(operation -> operation.getArgs() != null && operation.getArgs().length > 0)) {
       return null;
     }
@@ -145,22 +146,22 @@ public class TableBatchHandler<K, V, U> implements BatchHandler<K, V> {
     return argsList.toArray();
   }
 
-  private List<Operation<K, V>> getQueryOperations(Batch<K, V> batch) {
+  private List<Operation<K, V, U>> getQueryOperations(Batch<K, V, U> batch) {
     return batch.getOperations().stream().filter(op -> op instanceof GetOperation)
         .collect(Collectors.toList());
   }
 
-  private List<Operation<K, V>> getPutOperations(Batch<K, V> batch) {
+  private List<Operation<K, V, U>> getPutOperations(Batch<K, V, U> batch) {
     return batch.getOperations().stream().filter(op -> op instanceof PutOperation)
         .collect(Collectors.toList());
   }
 
-  private List<Operation<K, U>> getUpdateOperations(Batch<K, U> batch) {
+  private List<Operation<K, V, U>> getUpdateOperations(Batch<K, V, U> batch) {
     return batch.getOperations().stream().filter(op -> op instanceof UpdateOperation)
         .collect(Collectors.toList());
   }
 
-  private List<Operation<K, V>> getDeleteOperations(Batch<K, V> batch) {
+  private List<Operation<K, V, U>> getDeleteOperations(Batch<K, V, U> batch) {
     return batch.getOperations().stream().filter(op -> op instanceof DeleteOperation)
         .collect(Collectors.toList());
   }
@@ -168,12 +169,11 @@ public class TableBatchHandler<K, V, U> implements BatchHandler<K, V> {
   /**
    * Perform batch operations.
    */
-  @SuppressWarnings("unchecked")
   @Override
-  public CompletableFuture<Void> handle(Batch<K, V> batch) {
+  public CompletableFuture<Void> handle(Batch<K, V, U> batch) {
     return CompletableFuture.allOf(
         handleBatchPut(getPutOperations(batch)),
-        handleBatchUpdate(getUpdateOperations((Batch<K, U>) batch)),
+        handleBatchUpdate(getUpdateOperations(batch)),
         handleBatchDelete(getDeleteOperations(batch)),
         handleBatchGet(getQueryOperations(batch)))
         .whenComplete((val, throwable) -> {

--- a/samza-core/src/main/java/org/apache/samza/table/batching/TableBatchHandler.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/TableBatchHandler.java
@@ -112,8 +112,7 @@ public class TableBatchHandler<K, V, U> implements BatchHandler<K, V, U> {
     if (updates.isEmpty()) {
       return CompletableFuture.completedFuture(Collections.EMPTY_MAP);
     }
-    final Object[] args = getOperationArgs(operations);
-    return args == null ? table.updateAllAsync(updates) : table.updateAllAsync(updates, args);
+    return table.updateAllAsync(updates);
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/table/batching/TableBatchHandler.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/TableBatchHandler.java
@@ -28,7 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import com.google.common.base.Preconditions;
 import java.util.stream.Collectors;
 import org.apache.samza.storage.kv.Entry;
-import org.apache.samza.table.AsyncReadWriteTable;
+import org.apache.samza.table.AsyncReadWriteUpdateTable;
 
 
 /**
@@ -39,9 +39,9 @@ import org.apache.samza.table.AsyncReadWriteTable;
  * @param <U> The update type of the operation.
  */
 public class TableBatchHandler<K, V, U> implements BatchHandler<K, V, U> {
-  private final AsyncReadWriteTable<K, V, U> table;
+  private final AsyncReadWriteUpdateTable<K, V, U> table;
 
-  public TableBatchHandler(AsyncReadWriteTable<K, V, U> table) {
+  public TableBatchHandler(AsyncReadWriteUpdateTable<K, V, U> table) {
     Preconditions.checkNotNull(table);
 
     this.table = table;

--- a/samza-core/src/main/java/org/apache/samza/table/batching/UpdateOperation.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/UpdateOperation.java
@@ -20,22 +20,19 @@
 package org.apache.samza.table.batching;
 
 import com.google.common.base.Preconditions;
-import org.apache.samza.operators.UpdatePair;
-
 
 /**
  * Update operation.
  *
  * @param <K> The type of the key.
- * @param <V> The type of the default value
  * @param <U> The type of the update
  */
-public class UpdateOperation<K, V, U> implements Operation<K, UpdatePair<U, V>> {
+public class UpdateOperation<K, U> implements Operation<K, U> {
   final private K key;
-  final private UpdatePair<U, V> val;
+  final private U val;
   final private Object[] args;
 
-  public UpdateOperation(K key, UpdatePair<U, V> val, Object ... args) {
+  public UpdateOperation(K key, U val, Object ... args) {
     Preconditions.checkNotNull(key);
     Preconditions.checkNotNull(val);
     Preconditions.checkNotNull(args);
@@ -50,7 +47,7 @@ public class UpdateOperation<K, V, U> implements Operation<K, UpdatePair<U, V>> 
   }
 
   @Override
-  public UpdatePair<U, V> getValue() {
+  public U getValue() {
     return val;
   }
 

--- a/samza-core/src/main/java/org/apache/samza/table/batching/UpdateOperation.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/UpdateOperation.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.table.batching;
+
+import com.google.common.base.Preconditions;
+import org.apache.samza.operators.UpdatePair;
+
+
+/**
+ * Update operation.
+ *
+ * @param <K> The type of the key.
+ * @param <V> The type of the default value
+ * @param <U> The type of the update
+ */
+public class UpdateOperation<K, V, U> implements Operation<K, UpdatePair<U, V>> {
+  final private K key;
+  final private UpdatePair<U, V> val;
+  final private Object[] args;
+
+  public UpdateOperation(K key, UpdatePair<U, V> val, Object ... args) {
+    Preconditions.checkNotNull(key);
+    Preconditions.checkNotNull(val);
+    Preconditions.checkNotNull(args);
+    this.key = key;
+    this.val = val;
+    this.args = args;
+  }
+
+  @Override
+  public K getKey() {
+    return key;
+  }
+
+  @Override
+  public UpdatePair<U, V> getValue() {
+    return val;
+  }
+
+  @Override
+  public Object[] getArgs() {
+    return args;
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/table/batching/UpdateOperation.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/UpdateOperation.java
@@ -27,28 +27,42 @@ import com.google.common.base.Preconditions;
  * @param <K> The type of the key.
  * @param <U> The type of the update
  */
-public class UpdateOperation<K, U> implements Operation<K, U> {
+public class UpdateOperation<K, V, U> implements Operation<K, V, U> {
   final private K key;
-  final private U val;
+  final private U update;
   final private Object[] args;
 
-  public UpdateOperation(K key, U val, Object ... args) {
+  public UpdateOperation(K key, U update, Object ... args) {
     Preconditions.checkNotNull(key);
-    Preconditions.checkNotNull(val);
+    Preconditions.checkNotNull(update);
     Preconditions.checkNotNull(args);
     this.key = key;
-    this.val = val;
+    this.update = update;
     this.args = args;
   }
 
+  /**
+   * @return The key to be updated in the table.
+   */
   @Override
   public K getKey() {
     return key;
   }
 
+  /**
+   * @return null.
+   */
   @Override
-  public U getValue() {
-    return val;
+  public V getValue() {
+    return null;
+  }
+
+  /**
+   * @return The Update to be applied to the table for the key.
+   */
+  @Override
+  public U getUpdate() {
+    return update;
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/table/batching/UpdateOperation.java
+++ b/samza-core/src/main/java/org/apache/samza/table/batching/UpdateOperation.java
@@ -30,15 +30,12 @@ import com.google.common.base.Preconditions;
 public class UpdateOperation<K, V, U> implements Operation<K, V, U> {
   final private K key;
   final private U update;
-  final private Object[] args;
 
-  public UpdateOperation(K key, U update, Object ... args) {
+  public UpdateOperation(K key, U update) {
     Preconditions.checkNotNull(key);
     Preconditions.checkNotNull(update);
-    Preconditions.checkNotNull(args);
     this.key = key;
     this.update = update;
-    this.args = args;
   }
 
   /**
@@ -67,6 +64,6 @@ public class UpdateOperation<K, V, U> implements Operation<K, V, U> {
 
   @Override
   public Object[] getArgs() {
-    return args;
+    return null;
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/table/caching/CachingTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/caching/CachingTable.java
@@ -234,22 +234,22 @@ public class CachingTable<K, V, U> extends BaseReadWriteUpdateTable<K, V, U>
   }
 
   @Override
-  public void update(K key, U update, Object... args) {
+  public void update(K key, U update) {
     throw new SamzaException("Caching not supported with updates");
   }
 
   @Override
-  public void updateAll(List<Entry<K, U>> updates, Object... args) {
+  public void updateAll(List<Entry<K, U>> updates) {
     throw new SamzaException("Caching not supported with updates");
   }
 
   @Override
-  public CompletableFuture<Void> updateAsync(K key, U update, Object... args) {
+  public CompletableFuture<Void> updateAsync(K key, U update) {
     throw new SamzaException("Caching not supported with updates");
   }
 
   @Override
-  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, Object... args) {
+  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates) {
     throw new SamzaException("Caching not supported with updates");
   }
 

--- a/samza-core/src/main/java/org/apache/samza/table/caching/CachingTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/caching/CachingTable.java
@@ -234,22 +234,22 @@ public class CachingTable<K, V, U> extends BaseReadWriteTable<K, V, U>
   }
 
   @Override
-  public void update(K key, U update, V defaultValue, Object... args) {
+  public void update(K key, U update, Object... args) {
     throw new SamzaException("Caching not supported with updates");
   }
 
   @Override
-  public void updateAll(List<Entry<K, U>> updates, List<Entry<K, V>> defaults, Object... args) {
+  public void updateAll(List<Entry<K, U>> updates, Object... args) {
     throw new SamzaException("Caching not supported with updates");
   }
 
   @Override
-  public CompletableFuture<Void> updateAsync(K key, U update, V defaultValue, Object... args) {
+  public CompletableFuture<Void> updateAsync(K key, U update, Object... args) {
     throw new SamzaException("Caching not supported with updates");
   }
 
   @Override
-  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, List<Entry<K, V>> defaults, Object... args) {
+  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, Object... args) {
     throw new SamzaException("Caching not supported with updates");
   }
 

--- a/samza-core/src/main/java/org/apache/samza/table/caching/CachingTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/caching/CachingTable.java
@@ -62,18 +62,18 @@ import static org.apache.samza.table.utils.TableMetricsUtil.updateTimer;
  * @param <K> type of the table key
  * @param <V> type of the table value
  */
-public class CachingTable<K, V> extends BaseReadWriteTable<K, V>
-    implements ReadWriteTable<K, V> {
+public class CachingTable<K, V, U> extends BaseReadWriteTable<K, V, U>
+    implements ReadWriteTable<K, V, U> {
 
-  private final ReadWriteTable<K, V> table;
-  private final ReadWriteTable<K, V> cache;
+  private final ReadWriteTable<K, V, U> table;
+  private final ReadWriteTable<K, V, U> cache;
   private final boolean isWriteAround;
 
   // Common caching stats
   private AtomicLong hitCount = new AtomicLong();
   private AtomicLong missCount = new AtomicLong();
 
-  public CachingTable(String tableId, ReadWriteTable<K, V> table, ReadWriteTable<K, V> cache, boolean isWriteAround) {
+  public CachingTable(String tableId, ReadWriteTable<K, V, U> table, ReadWriteTable<K, V, U> cache, boolean isWriteAround) {
     super(tableId);
     this.table = table;
     this.cache = cache;
@@ -231,6 +231,26 @@ public class CachingTable<K, V> extends BaseReadWriteTable<K, V>
       updateTimer(metrics.putAllNs, clock.nanoTime() - startNs);
       return result;
     });
+  }
+
+  @Override
+  public void update(K key, U update, V defaultValue, Object... args) {
+    throw new SamzaException("Caching not supported with updates");
+  }
+
+  @Override
+  public void updateAll(List<Entry<K, U>> updates, List<Entry<K, V>> defaults, Object... args) {
+    throw new SamzaException("Caching not supported with updates");
+  }
+
+  @Override
+  public CompletableFuture<Void> updateAsync(K key, U update, V defaultValue, Object... args) {
+    throw new SamzaException("Caching not supported with updates");
+  }
+
+  @Override
+  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, List<Entry<K, V>> defaults, Object... args) {
+    throw new SamzaException("Caching not supported with updates");
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/table/caching/CachingTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/caching/CachingTable.java
@@ -23,8 +23,8 @@ import com.google.common.base.Preconditions;
 import org.apache.samza.SamzaException;
 import org.apache.samza.context.Context;
 import org.apache.samza.storage.kv.Entry;
-import org.apache.samza.table.BaseReadWriteTable;
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.BaseReadWriteUpdateTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.apache.samza.table.utils.TableMetricsUtil;
 
 import java.util.ArrayList;
@@ -41,7 +41,7 @@ import static org.apache.samza.table.utils.TableMetricsUtil.updateTimer;
 
 /**
  * A hybrid table incorporating a cache with a Samza table. The cache is
- * represented as a {@link ReadWriteTable}.
+ * represented as a {@link ReadWriteUpdateTable}.
  *
  * The intented use case is to optimize the latency of accessing the actual table, e.g.
  * remote tables, when eventual consistency between cache and table is acceptable.
@@ -62,18 +62,18 @@ import static org.apache.samza.table.utils.TableMetricsUtil.updateTimer;
  * @param <K> type of the table key
  * @param <V> type of the table value
  */
-public class CachingTable<K, V, U> extends BaseReadWriteTable<K, V, U>
-    implements ReadWriteTable<K, V, U> {
+public class CachingTable<K, V, U> extends BaseReadWriteUpdateTable<K, V, U>
+    implements ReadWriteUpdateTable<K, V, U> {
 
-  private final ReadWriteTable<K, V, U> table;
-  private final ReadWriteTable<K, V, U> cache;
+  private final ReadWriteUpdateTable<K, V, U> table;
+  private final ReadWriteUpdateTable<K, V, U> cache;
   private final boolean isWriteAround;
 
   // Common caching stats
   private AtomicLong hitCount = new AtomicLong();
   private AtomicLong missCount = new AtomicLong();
 
-  public CachingTable(String tableId, ReadWriteTable<K, V, U> table, ReadWriteTable<K, V, U> cache, boolean isWriteAround) {
+  public CachingTable(String tableId, ReadWriteUpdateTable<K, V, U> table, ReadWriteUpdateTable<K, V, U> cache, boolean isWriteAround) {
     super(tableId);
     this.table = table;
     this.cache = cache;

--- a/samza-core/src/main/java/org/apache/samza/table/caching/guava/GuavaCacheTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/caching/guava/GuavaCacheTable.java
@@ -23,8 +23,8 @@ import com.google.common.cache.Cache;
 import org.apache.samza.SamzaException;
 import org.apache.samza.context.Context;
 import org.apache.samza.storage.kv.Entry;
-import org.apache.samza.table.BaseReadWriteTable;
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.BaseReadWriteUpdateTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.apache.samza.table.utils.TableMetricsUtil;
 
 import java.util.ArrayList;
@@ -40,8 +40,8 @@ import java.util.concurrent.CompletableFuture;
  * @param <K> type of the key in the cache
  * @param <V> type of the value in the cache
  */
-public class GuavaCacheTable<K, V, U> extends BaseReadWriteTable<K, V, U>
-    implements ReadWriteTable<K, V, U> {
+public class GuavaCacheTable<K, V, U> extends BaseReadWriteUpdateTable<K, V, U>
+    implements ReadWriteUpdateTable<K, V, U> {
 
   private final Cache<K, V> cache;
 

--- a/samza-core/src/main/java/org/apache/samza/table/caching/guava/GuavaCacheTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/caching/guava/GuavaCacheTable.java
@@ -20,6 +20,7 @@
 package org.apache.samza.table.caching.guava;
 
 import com.google.common.cache.Cache;
+import javax.annotation.Nullable;
 import org.apache.samza.SamzaException;
 import org.apache.samza.context.Context;
 import org.apache.samza.storage.kv.Entry;
@@ -40,8 +41,8 @@ import java.util.concurrent.CompletableFuture;
  * @param <K> type of the key in the cache
  * @param <V> type of the value in the cache
  */
-public class GuavaCacheTable<K, V> extends BaseReadWriteTable<K, V>
-    implements ReadWriteTable<K, V> {
+public class GuavaCacheTable<K, V, U> extends BaseReadWriteTable<K, V, U>
+    implements ReadWriteTable<K, V, U> {
 
   private final Cache<K, V> cache;
 
@@ -154,6 +155,27 @@ public class GuavaCacheTable<K, V> extends BaseReadWriteTable<K, V>
       future.completeExceptionally(e);
     }
     return future;
+  }
+
+  @Override
+  public void update(K key, U update, V defaultValue, Object... args) {
+    throw new SamzaException("Cache tables do not support update operations");
+  }
+
+  @Override
+  public CompletableFuture<Void> updateAsync(K key, U update, @Nullable V defaultValue, Object... args) {
+    throw new SamzaException("Cache tables do not support update operations");
+  }
+
+  @Override
+  public void updateAll(List<Entry<K, U>> updates, List<Entry<K, V>> defaults, Object... args) {
+    throw new SamzaException("Cache tables do not support update operations");
+  }
+
+  @Override
+  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, @Nullable List<Entry<K, V>> defaults,
+      Object... args) {
+    throw new SamzaException("Cache tables do not support update operations");
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/table/caching/guava/GuavaCacheTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/caching/guava/GuavaCacheTable.java
@@ -20,7 +20,6 @@
 package org.apache.samza.table.caching.guava;
 
 import com.google.common.cache.Cache;
-import javax.annotation.Nullable;
 import org.apache.samza.SamzaException;
 import org.apache.samza.context.Context;
 import org.apache.samza.storage.kv.Entry;
@@ -158,23 +157,22 @@ public class GuavaCacheTable<K, V, U> extends BaseReadWriteTable<K, V, U>
   }
 
   @Override
-  public void update(K key, U update, V defaultValue, Object... args) {
+  public void update(K key, U update, Object... args) {
     throw new SamzaException("Cache tables do not support update operations");
   }
 
   @Override
-  public CompletableFuture<Void> updateAsync(K key, U update, @Nullable V defaultValue, Object... args) {
+  public CompletableFuture<Void> updateAsync(K key, U update, Object... args) {
     throw new SamzaException("Cache tables do not support update operations");
   }
 
   @Override
-  public void updateAll(List<Entry<K, U>> updates, List<Entry<K, V>> defaults, Object... args) {
+  public void updateAll(List<Entry<K, U>> updates, Object... args) {
     throw new SamzaException("Cache tables do not support update operations");
   }
 
   @Override
-  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, @Nullable List<Entry<K, V>> defaults,
-      Object... args) {
+  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, Object... args) {
     throw new SamzaException("Cache tables do not support update operations");
   }
 

--- a/samza-core/src/main/java/org/apache/samza/table/caching/guava/GuavaCacheTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/caching/guava/GuavaCacheTable.java
@@ -157,22 +157,22 @@ public class GuavaCacheTable<K, V, U> extends BaseReadWriteUpdateTable<K, V, U>
   }
 
   @Override
-  public void update(K key, U update, Object... args) {
+  public void update(K key, U update) {
     throw new SamzaException("Cache tables do not support update operations");
   }
 
   @Override
-  public CompletableFuture<Void> updateAsync(K key, U update, Object... args) {
+  public CompletableFuture<Void> updateAsync(K key, U update) {
     throw new SamzaException("Cache tables do not support update operations");
   }
 
   @Override
-  public void updateAll(List<Entry<K, U>> updates, Object... args) {
+  public void updateAll(List<Entry<K, U>> updates) {
     throw new SamzaException("Cache tables do not support update operations");
   }
 
   @Override
-  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, Object... args) {
+  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates) {
     throw new SamzaException("Cache tables do not support update operations");
   }
 

--- a/samza-core/src/main/java/org/apache/samza/table/caching/guava/GuavaCacheTableProvider.java
+++ b/samza-core/src/main/java/org/apache/samza/table/caching/guava/GuavaCacheTableProvider.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.samza.config.JavaTableConfig;
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.apache.samza.table.BaseTableProvider;
 import org.apache.samza.table.descriptors.GuavaCacheTableDescriptor;
 import org.apache.samza.table.utils.SerdeUtils;
@@ -44,7 +44,7 @@ public class GuavaCacheTableProvider extends BaseTableProvider {
   }
 
   @Override
-  public ReadWriteTable getTable() {
+  public ReadWriteUpdateTable getTable() {
     Preconditions.checkNotNull(context, String.format("Table %s not initialized", tableId));
     JavaTableConfig tableConfig = new JavaTableConfig(context.getJobContext().getConfig());
     Cache guavaCache = SerdeUtils.deserialize(GuavaCacheTableDescriptor.GUAVA_CACHE,

--- a/samza-core/src/main/java/org/apache/samza/table/ratelimit/AsyncRateLimitedTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/ratelimit/AsyncRateLimitedTable.java
@@ -28,12 +28,12 @@ import java.util.concurrent.ExecutorService;
 import org.apache.samza.config.MetricsConfig;
 import org.apache.samza.context.Context;
 import org.apache.samza.storage.kv.Entry;
-import org.apache.samza.table.AsyncReadWriteTable;
+import org.apache.samza.table.AsyncReadWriteUpdateTable;
 import org.apache.samza.table.remote.TableRateLimiter;
 import org.apache.samza.table.utils.TableMetricsUtil;
 
-import static org.apache.samza.table.BaseReadWriteTable.Func0;
-import static org.apache.samza.table.BaseReadWriteTable.Func1;
+import static org.apache.samza.table.BaseReadWriteUpdateTable.Func0;
+import static org.apache.samza.table.BaseReadWriteUpdateTable.Func1;
 
 /**
  * A composable read and/or write rate limited asynchronous table implementation
@@ -42,16 +42,16 @@ import static org.apache.samza.table.BaseReadWriteTable.Func1;
  * @param <V> the type of the value in this table
  * @param <U> the type of the update applied to records in this table
  */
-public class AsyncRateLimitedTable<K, V, U> implements AsyncReadWriteTable<K, V, U> {
+public class AsyncRateLimitedTable<K, V, U> implements AsyncReadWriteUpdateTable<K, V, U> {
 
   private final String tableId;
-  private final AsyncReadWriteTable<K, V, U> table;
+  private final AsyncReadWriteUpdateTable<K, V, U> table;
   private final TableRateLimiter<K, V> readRateLimiter;
   private final TableRateLimiter<K, V> writeRateLimiter;
   private final TableRateLimiter<K, U> updateRateLimiter;
   private final ExecutorService rateLimitingExecutor;
 
-  public AsyncRateLimitedTable(String tableId, AsyncReadWriteTable<K, V, U> table, TableRateLimiter<K, V> readRateLimiter,
+  public AsyncRateLimitedTable(String tableId, AsyncReadWriteUpdateTable<K, V, U> table, TableRateLimiter<K, V> readRateLimiter,
       TableRateLimiter<K, V> writeRateLimiter, TableRateLimiter<K, U> updateRateLimiter,
       ExecutorService rateLimitingExecutor) {
     Preconditions.checkNotNull(tableId, "null tableId");

--- a/samza-core/src/main/java/org/apache/samza/table/ratelimit/AsyncRateLimitedTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/ratelimit/AsyncRateLimitedTable.java
@@ -103,17 +103,17 @@ public class AsyncRateLimitedTable<K, V, U> implements AsyncReadWriteUpdateTable
   }
 
   @Override
-  public CompletableFuture<Void> updateAsync(K key, U update, Object... args) {
+  public CompletableFuture<Void> updateAsync(K key, U update) {
     return doUpdate(
-      () -> updateRateLimiter.throttle(key, update, args),
-      () -> table.updateAsync(key, update, args));
+      () -> updateRateLimiter.throttle(key, update),
+      () -> table.updateAsync(key, update));
   }
 
   @Override
-  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, Object... args) {
+  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates) {
     return doUpdate(
       () -> updateRateLimiter.throttleRecords(updates),
-      () -> table.updateAllAsync(updates, args));
+      () -> table.updateAllAsync(updates));
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/table/remote/AsyncRemoteTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/AsyncRemoteTable.java
@@ -88,19 +88,15 @@ public class AsyncRemoteTable<K, V, U> implements AsyncReadWriteUpdateTable<K, V
   }
 
   @Override
-  public CompletableFuture<Void> updateAsync(K key, U update, Object... args) {
+  public CompletableFuture<Void> updateAsync(K key, U update) {
     Preconditions.checkNotNull(writeFn, "null writeFn");
-    return args.length > 0
-        ? writeFn.updateAsync(key, update, args)
-        : writeFn.updateAsync(key, update);
+    return writeFn.updateAsync(key, update);
   }
 
   @Override
-  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, Object... args) {
+  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates) {
     Preconditions.checkNotNull(writeFn, "null writeFn");
-    return args.length > 0
-        ? writeFn.updateAllAsync(updates, args)
-        : writeFn.updateAllAsync(updates);
+    return writeFn.updateAllAsync(updates);
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/table/remote/AsyncRemoteTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/AsyncRemoteTable.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import javax.annotation.Nullable;
 import org.apache.samza.context.Context;
 import org.apache.samza.storage.kv.Entry;
 import org.apache.samza.table.AsyncReadWriteTable;
@@ -89,20 +88,19 @@ public class AsyncRemoteTable<K, V, U> implements AsyncReadWriteTable<K, V, U> {
   }
 
   @Override
-  public CompletableFuture<Void> updateAsync(K key, U update, @Nullable V defaultValue, Object... args) {
+  public CompletableFuture<Void> updateAsync(K key, U update, Object... args) {
     Preconditions.checkNotNull(writeFn, "null writeFn");
     return args.length > 0
-        ? writeFn.updateAsync(key, update, defaultValue, args)
-        : writeFn.updateAsync(key, update, defaultValue);
+        ? writeFn.updateAsync(key, update, args)
+        : writeFn.updateAsync(key, update);
   }
 
   @Override
-  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, @Nullable List<Entry<K, V>> defaults,
-      Object... args) {
+  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, Object... args) {
     Preconditions.checkNotNull(writeFn, "null writeFn");
     return args.length > 0
-        ? writeFn.updateAllAsync(updates, defaults, args)
-        : writeFn.updateAllAsync(updates, defaults);
+        ? writeFn.updateAllAsync(updates, args)
+        : writeFn.updateAllAsync(updates);
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/table/remote/AsyncRemoteTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/AsyncRemoteTable.java
@@ -26,7 +26,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.apache.samza.context.Context;
 import org.apache.samza.storage.kv.Entry;
-import org.apache.samza.table.AsyncReadWriteTable;
+import org.apache.samza.table.AsyncReadWriteUpdateTable;
 
 
 /**
@@ -37,7 +37,7 @@ import org.apache.samza.table.AsyncReadWriteTable;
  * @param <V> the type of the value in this table
  * @param <U> the type of the update applied to this table
  */
-public class AsyncRemoteTable<K, V, U> implements AsyncReadWriteTable<K, V, U> {
+public class AsyncRemoteTable<K, V, U> implements AsyncReadWriteUpdateTable<K, V, U> {
 
   private final TableReadFunction<K, V> readFn;
   private final TableWriteFunction<K, V, U> writeFn;

--- a/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTable.java
@@ -294,30 +294,30 @@ public final class RemoteTable<K, V, U> extends BaseReadWriteUpdateTable<K, V, U
 
 
   @Override
-  public void update(K key, U update, Object... args) {
+  public void update(K key, U update) {
     try {
-      updateAsync(key, update, args).get();
+      updateAsync(key, update).get();
     } catch (Exception e) {
       throw new SamzaException(e);
     }
   }
 
   @Override
-  public void updateAll(List<Entry<K, U>> updates, Object... args) {
+  public void updateAll(List<Entry<K, U>> updates) {
     try {
-      updateAllAsync(updates, args).get();
+      updateAllAsync(updates).get();
     } catch (Exception e) {
       throw new SamzaException(e);
     }
   }
 
   @Override
-  public CompletableFuture<Void> updateAsync(K key, U update, Object... args) {
+  public CompletableFuture<Void> updateAsync(K key, U update) {
     Preconditions.checkNotNull(writeFn, "null write function");
     Preconditions.checkNotNull(key, "null key");
     Preconditions.checkNotNull(update, "null update");
 
-    return instrument(() -> asyncTable.updateAsync(key, update, args), metrics.numUpdates,
+    return instrument(() -> asyncTable.updateAsync(key, update), metrics.numUpdates,
         metrics.updateNs)
         .exceptionally(e -> {
           // rethrow RecordDoesNotExistException instead of wrapping it in SamzaException
@@ -329,14 +329,14 @@ public final class RemoteTable<K, V, U> extends BaseReadWriteUpdateTable<K, V, U
   }
 
   @Override
-  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, Object... args) {
+  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates) {
     Preconditions.checkNotNull(writeFn, "null write function");
     Preconditions.checkNotNull(updates, "null records");
 
     if (updates.isEmpty()) {
       return CompletableFuture.completedFuture(null);
     }
-    return instrument(() -> asyncTable.updateAllAsync(updates, args), metrics.numUpdateAlls,
+    return instrument(() -> asyncTable.updateAllAsync(updates), metrics.numUpdateAlls,
         metrics.updateAllNs)
         .exceptionally(e -> {
           String strKeys = updates.stream().map(r -> r.getKey().toString()).collect(Collectors.joining(","));

--- a/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTable.java
@@ -31,9 +31,9 @@ import org.apache.samza.context.Context;
 import org.apache.samza.metrics.Counter;
 import org.apache.samza.metrics.Timer;
 import org.apache.samza.storage.kv.Entry;
-import org.apache.samza.table.AsyncReadWriteTable;
-import org.apache.samza.table.BaseReadWriteTable;
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.AsyncReadWriteUpdateTable;
+import org.apache.samza.table.BaseReadWriteUpdateTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.apache.samza.table.RecordNotFoundException;
 import org.apache.samza.table.batching.BatchProvider;
 import org.apache.samza.table.batching.AsyncBatchingTable;
@@ -51,7 +51,7 @@ import static org.apache.samza.table.utils.TableMetricsUtil.updateTimer;
 
 
 /**
- * A Samza {@link ReadWriteTable} backed by a remote data-store or service.
+ * A Samza {@link ReadWriteUpdateTable} backed by a remote data-store or service.
  * <p>
  * Many stream-processing applications require to look-up data from remote data sources eg: databases,
  * web-services, RPC systems to process messages in the stream. Such access to adjunct datasets can be
@@ -78,8 +78,8 @@ import static org.apache.samza.table.utils.TableMetricsUtil.updateTimer;
  * @param <V> the type of the value in this table
  * @param <U> the type of the update in this table
  */
-public final class RemoteTable<K, V, U> extends BaseReadWriteTable<K, V, U>
-    implements ReadWriteTable<K, V, U>, AsyncReadWriteTable<K, V, U> {
+public final class RemoteTable<K, V, U> extends BaseReadWriteUpdateTable<K, V, U>
+    implements ReadWriteUpdateTable<K, V, U>, AsyncReadWriteUpdateTable<K, V, U> {
 
   // Read/write functions
   protected final TableReadFunction<K, V> readFn;
@@ -101,7 +101,7 @@ public final class RemoteTable<K, V, U> extends BaseReadWriteTable<K, V, U>
   protected final ExecutorService callbackExecutor;
 
   // The async table to delegate to
-  protected final AsyncReadWriteTable<K, V, U> asyncTable;
+  protected final AsyncReadWriteUpdateTable<K, V, U> asyncTable;
 
   /**
    * Construct a RemoteTable instance
@@ -150,7 +150,7 @@ public final class RemoteTable<K, V, U> extends BaseReadWriteTable<K, V, U>
     this.batchProvider = batchProvider;
     this.batchExecutor = batchExecutor;
 
-    AsyncReadWriteTable table = new AsyncRemoteTable(readFn, writeFn);
+    AsyncReadWriteUpdateTable table = new AsyncRemoteTable(readFn, writeFn);
     if (readRateLimiter != null || writeRateLimiter != null || updateRateLimiter != null) {
       table = new AsyncRateLimitedTable(tableId, table, readRateLimiter, writeRateLimiter, updateRateLimiter,
           rateLimitingExecutor);

--- a/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTable.java
@@ -34,7 +34,7 @@ import org.apache.samza.storage.kv.Entry;
 import org.apache.samza.table.AsyncReadWriteTable;
 import org.apache.samza.table.BaseReadWriteTable;
 import org.apache.samza.table.ReadWriteTable;
-import org.apache.samza.table.RecordDoesNotExistException;
+import org.apache.samza.table.RecordNotFoundException;
 import org.apache.samza.table.batching.BatchProvider;
 import org.apache.samza.table.batching.AsyncBatchingTable;
 import org.apache.samza.table.ratelimit.AsyncRateLimitedTable;
@@ -94,7 +94,7 @@ public final class RemoteTable<K, V, U> extends BaseReadWriteTable<K, V, U>
   protected final TableRetryPolicy writeRetryPolicy;
   protected final ScheduledExecutorService retryExecutor;
   // batch
-  protected final BatchProvider<K, V> batchProvider;
+  protected final BatchProvider<K, V, U> batchProvider;
   protected final ScheduledExecutorService batchExecutor;
 
   // Other
@@ -129,7 +129,7 @@ public final class RemoteTable<K, V, U> extends BaseReadWriteTable<K, V, U>
       TableRetryPolicy readRetryPolicy,
       TableRetryPolicy writeRetryPolicy,
       ScheduledExecutorService retryExecutor,
-      BatchProvider<K, V> batchProvider,
+      BatchProvider<K, V, U> batchProvider,
       ScheduledExecutorService batchExecutor,
       ExecutorService callbackExecutor) {
 
@@ -321,8 +321,8 @@ public final class RemoteTable<K, V, U> extends BaseReadWriteTable<K, V, U>
         metrics.updateNs)
         .exceptionally(e -> {
           // rethrow RecordDoesNotExistException instead of wrapping it in SamzaException
-          if (e.getCause() instanceof RecordDoesNotExistException) {
-            throw (RecordDoesNotExistException) e.getCause();
+          if (e.getCause() instanceof RecordNotFoundException) {
+            throw (RecordNotFoundException) e.getCause();
           }
           throw new SamzaException("Failed to update a record with key=" + key, e);
         });
@@ -458,5 +458,9 @@ public final class RemoteTable<K, V, U> extends BaseReadWriteTable<K, V, U>
       });
     }
     return ioFuture;
+  }
+
+  public BatchProvider<K, V, U> getBatchProvider() {
+    return this.batchProvider;
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTableProvider.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTableProvider.java
@@ -94,9 +94,9 @@ public class RemoteTableProvider extends BaseTableProvider {
     // Update part (reuse write fn)
     TableRateLimiter updateRateLimiter = null;
     if (writeFn != null) {
-      TableRateLimiter.CreditFunction<?, ?> writeCreditFn = deserializeObject(tableConfig, RemoteTableDescriptor.UPDATE_CREDIT_FN);
+      TableRateLimiter.CreditFunction<?, ?> updateCreditFn = deserializeObject(tableConfig, RemoteTableDescriptor.UPDATE_CREDIT_FN);
       updateRateLimiter = rateLimiter != null && rateLimiter.getSupportedTags().contains(RemoteTableDescriptor.RL_UPDATE_TAG)
-          ? new TableRateLimiter(tableId, rateLimiter, writeCreditFn, RemoteTableDescriptor.RL_UPDATE_TAG)
+          ? new TableRateLimiter(tableId, rateLimiter, updateCreditFn, RemoteTableDescriptor.RL_UPDATE_TAG)
           : null;
     }
 
@@ -178,4 +178,3 @@ public class RemoteTableProvider extends BaseTableProvider {
     });
   }
 }
-

--- a/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTableProvider.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTableProvider.java
@@ -116,7 +116,7 @@ public class RemoteTableProvider extends BaseTableProvider {
           }));
     }
 
-    boolean isRateLimited = readRateLimiter != null || writeRateLimiter != null;
+    boolean isRateLimited = readRateLimiter != null || writeRateLimiter != null || updateRateLimiter != null;
     if (isRateLimited) {
       rateLimitingExecutors.computeIfAbsent(tableId, (arg) ->
           Executors.newSingleThreadExecutor(runnable -> {

--- a/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTableProvider.java
+++ b/samza-core/src/main/java/org/apache/samza/table/remote/RemoteTableProvider.java
@@ -22,7 +22,7 @@ package org.apache.samza.table.remote;
 import com.google.common.base.Preconditions;
 
 import org.apache.samza.config.JavaTableConfig;
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.apache.samza.table.batching.BatchProvider;
 import org.apache.samza.table.descriptors.RemoteTableDescriptor;
 import org.apache.samza.table.retry.TableRetryPolicy;
@@ -60,7 +60,7 @@ public class RemoteTableProvider extends BaseTableProvider {
   }
 
   @Override
-  public ReadWriteTable getTable() {
+  public ReadWriteUpdateTable getTable() {
 
     Preconditions.checkNotNull(context, String.format("Table %s not initialized", tableId));
 

--- a/samza-core/src/main/java/org/apache/samza/table/retry/AsyncRetriableTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/retry/AsyncRetriableTable.java
@@ -29,12 +29,12 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Predicate;
 import org.apache.samza.context.Context;
 import org.apache.samza.storage.kv.Entry;
-import org.apache.samza.table.AsyncReadWriteTable;
+import org.apache.samza.table.AsyncReadWriteUpdateTable;
 import org.apache.samza.table.remote.TableReadFunction;
 import org.apache.samza.table.remote.TableWriteFunction;
 import org.apache.samza.table.utils.TableMetricsUtil;
 
-import static org.apache.samza.table.BaseReadWriteTable.Func1;
+import static org.apache.samza.table.BaseReadWriteUpdateTable.Func1;
 import static org.apache.samza.table.retry.FailsafeAdapter.failsafe;
 
 
@@ -46,10 +46,10 @@ import static org.apache.samza.table.retry.FailsafeAdapter.failsafe;
  * @param <V> the type of the value in this table
  * @param <U> the type of the update applied to records in this table
  */
-public class AsyncRetriableTable<K, V, U> implements AsyncReadWriteTable<K, V, U> {
+public class AsyncRetriableTable<K, V, U> implements AsyncReadWriteUpdateTable<K, V, U> {
 
   private final String tableId;
-  private final AsyncReadWriteTable<K, V, U> table;
+  private final AsyncReadWriteUpdateTable<K, V, U> table;
   private final RetryPolicy readRetryPolicy;
   // write retry policy will apply for updates as well
   private final RetryPolicy writeRetryPolicy;
@@ -60,7 +60,7 @@ public class AsyncRetriableTable<K, V, U> implements AsyncReadWriteTable<K, V, U
   @VisibleForTesting
   RetryMetrics writeRetryMetrics;
 
-  public AsyncRetriableTable(String tableId, AsyncReadWriteTable<K, V, U> table,
+  public AsyncRetriableTable(String tableId, AsyncReadWriteUpdateTable<K, V, U> table,
       TableRetryPolicy readRetryPolicy, TableRetryPolicy writeRetryPolicy, ScheduledExecutorService retryExecutor,
       TableReadFunction readFn, TableWriteFunction writeFn) {
 

--- a/samza-core/src/main/java/org/apache/samza/table/retry/AsyncRetriableTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/retry/AsyncRetriableTable.java
@@ -20,7 +20,6 @@ package org.apache.samza.table.retry;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import javax.annotation.Nullable;
 import net.jodah.failsafe.RetryPolicy;
 
 import java.util.List;
@@ -118,14 +117,13 @@ public class AsyncRetriableTable<K, V, U> implements AsyncReadWriteTable<K, V, U
   }
 
   @Override
-  public CompletableFuture<Void> updateAsync(K key, U update, @Nullable V defaultValue, Object... args) {
-    return doWrite(() -> table.updateAsync(key, update, defaultValue, args));
+  public CompletableFuture<Void> updateAsync(K key, U update, Object... args) {
+    return doWrite(() -> table.updateAsync(key, update, args));
   }
 
   @Override
-  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, @Nullable List<Entry<K, V>> defaults,
-      Object... args) {
-    return doWrite(() -> table.updateAllAsync(updates, defaults, args));
+  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, Object... args) {
+    return doWrite(() -> table.updateAllAsync(updates, args));
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/table/retry/AsyncRetriableTable.java
+++ b/samza-core/src/main/java/org/apache/samza/table/retry/AsyncRetriableTable.java
@@ -117,13 +117,13 @@ public class AsyncRetriableTable<K, V, U> implements AsyncReadWriteUpdateTable<K
   }
 
   @Override
-  public CompletableFuture<Void> updateAsync(K key, U update, Object... args) {
-    return doWrite(() -> table.updateAsync(key, update, args));
+  public CompletableFuture<Void> updateAsync(K key, U update) {
+    return doWrite(() -> table.updateAsync(key, update));
   }
 
   @Override
-  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, Object... args) {
-    return doWrite(() -> table.updateAllAsync(updates, args));
+  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates) {
+    return doWrite(() -> table.updateAllAsync(updates));
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/table/utils/TableMetrics.java
+++ b/samza-core/src/main/java/org/apache/samza/table/utils/TableMetrics.java
@@ -42,6 +42,10 @@ public class TableMetrics {
   public final Timer putNs;
   public final Counter numPutAlls;
   public final Timer putAllNs;
+  public final Counter numUpdates;
+  public final Timer updateNs;
+  public final Counter numUpdateAlls;
+  public final Timer updateAllNs;
   public final Counter numDeletes;
   public final Timer deleteNs;
   public final Counter numDeleteAlls;
@@ -73,6 +77,10 @@ public class TableMetrics {
     putNs = tableMetricsUtil.newTimer("put-ns");
     numPutAlls = tableMetricsUtil.newCounter("num-putAlls");
     putAllNs = tableMetricsUtil.newTimer("putAll-ns");
+    numUpdates = tableMetricsUtil.newCounter("update-puts");
+    updateNs = tableMetricsUtil.newTimer("update-ns");
+    numUpdateAlls = tableMetricsUtil.newCounter("num-updateAlls");
+    updateAllNs = tableMetricsUtil.newTimer("updateAll-ns");
     numDeletes = tableMetricsUtil.newCounter("num-deletes");
     deleteNs = tableMetricsUtil.newTimer("delete-ns");
     numDeleteAlls = tableMetricsUtil.newCounter("num-deleteAlls");

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestStreamTableJoinOperatorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestStreamTableJoinOperatorImpl.java
@@ -28,7 +28,7 @@ import org.apache.samza.operators.KV;
 import org.apache.samza.operators.data.TestMessageEnvelope;
 import org.apache.samza.operators.functions.StreamTableJoinFunction;
 import org.apache.samza.operators.spec.StreamTableJoinOperatorSpec;
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.apache.samza.task.MessageCollector;
 import org.apache.samza.task.TaskCoordinator;
 import org.junit.Test;
@@ -74,11 +74,11 @@ public class TestStreamTableJoinOperatorImpl {
             return record.getKey();
           }
         });
-    ReadWriteTable table = mock(ReadWriteTable.class);
+    ReadWriteUpdateTable table = mock(ReadWriteUpdateTable.class);
     when(table.getAsync("1")).thenReturn(CompletableFuture.completedFuture("r1"));
     when(table.getAsync("2")).thenReturn(CompletableFuture.completedFuture(null));
     Context context = new MockContext();
-    when(context.getTaskContext().getTable(tableId)).thenReturn(table);
+    when(context.getTaskContext().getUpdatableTable(tableId)).thenReturn(table);
 
     MessageCollector mockMessageCollector = mock(MessageCollector.class);
     TaskCoordinator mockTaskCoordinator = mock(TaskCoordinator.class);
@@ -125,11 +125,11 @@ public class TestStreamTableJoinOperatorImpl {
           }
         });
 
-    ReadWriteTable table = mock(ReadWriteTable.class);
+    ReadWriteUpdateTable table = mock(ReadWriteUpdateTable.class);
     when(table.getAsync("1")).thenReturn(CompletableFuture.completedFuture("r1"));
 
     Context context = new MockContext();
-    when(context.getTaskContext().getTable(tableId)).thenReturn(table);
+    when(context.getTaskContext().getUpdatableTable(tableId)).thenReturn(table);
 
     MessageCollector mockMessageCollector = mock(MessageCollector.class);
     TaskCoordinator mockTaskCoordinator = mock(TaskCoordinator.class);

--- a/samza-core/src/test/java/org/apache/samza/operators/spec/TestOperatorSpec.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/spec/TestOperatorSpec.java
@@ -313,13 +313,11 @@ public class TestOperatorSpec {
   @Test
   public void testSendToTableOperatorSpec() {
     String tableId = "t1";
-    SendToTableOperatorSpec<String, Integer> sendOpSpec =
-        new SendToTableOperatorSpec<>(tableId, "output-1", 1, null, "3");
+    SendToTableOperatorSpec<String, Integer> sendOpSpec = new SendToTableOperatorSpec<>(tableId, "output-1");
     SendToTableOperatorSpec<String, Integer> sendToCopy = (SendToTableOperatorSpec<String, Integer>) OperatorSpecTestUtils
         .copyOpSpec(sendOpSpec);
     assertNotEquals(sendToCopy, sendOpSpec);
     assertEquals(sendToCopy.getOpId(), sendOpSpec.getOpId());
-    assertArrayEquals(sendToCopy.getArgs(), sendOpSpec.getArgs());
     assertTrue(sendToCopy.getTableId().equals(sendOpSpec.getTableId()));
   }
 

--- a/samza-core/src/test/java/org/apache/samza/table/TestTableManager.java
+++ b/samza-core/src/test/java/org/apache/samza/table/TestTableManager.java
@@ -49,12 +49,12 @@ public class TestTableManager {
 
   public static class DummyTableProviderFactory implements TableProviderFactory {
 
-    static ReadWriteTable table;
+    static ReadWriteUpdateTable table;
     static TableProvider tableProvider;
 
     @Override
     public TableProvider getTableProvider(String tableId) {
-      table = mock(ReadWriteTable.class);
+      table = mock(ReadWriteUpdateTable.class);
       tableProvider = mock(TableProvider.class);
       when(tableProvider.getTable()).thenReturn(table);
       return tableProvider;

--- a/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchProcessor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchProcessor.java
@@ -26,7 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.function.Supplier;
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -42,7 +42,7 @@ public class TestBatchProcessor {
   public static class TestCreate {
     @Test
     public void testCreate() {
-      final ReadWriteTable<Integer, Integer, Integer> table = mock(ReadWriteTable.class);
+      final ReadWriteUpdateTable<Integer, Integer, Integer> table = mock(ReadWriteUpdateTable.class);
       final BatchProcessor<Integer, Integer, Integer> batchProcessor = createBatchProcessor(table,
           3, Integer.MAX_VALUE);
 
@@ -57,7 +57,7 @@ public class TestBatchProcessor {
   public static class TestUpdatesAndLookup {
     @Test
     public void testUpdateAndLookup() {
-      final ReadWriteTable<Integer, Integer, Integer> table = mock(ReadWriteTable.class);
+      final ReadWriteUpdateTable<Integer, Integer, Integer> table = mock(ReadWriteUpdateTable.class);
       final BatchProcessor<Integer, Integer, Integer> batchProcessor =
           createBatchProcessor(table, Integer.MAX_VALUE, Integer.MAX_VALUE);
 
@@ -92,7 +92,7 @@ public class TestBatchProcessor {
         return null;
       };
 
-      final ReadWriteTable<Integer, Integer, Integer> table = mock(ReadWriteTable.class);
+      final ReadWriteUpdateTable<Integer, Integer, Integer> table = mock(ReadWriteUpdateTable.class);
       when(table.putAllAsync(anyList())).thenReturn(CompletableFuture.supplyAsync(tableUpdateSupplier));
 
       final BatchProcessor<Integer, Integer, Integer> batchProcessor =
@@ -122,7 +122,7 @@ public class TestBatchProcessor {
       final int maxBatchDelayMs = 100;
       final int putOperationCount = 100;
 
-      final ReadWriteTable<Integer, Integer, Integer> table = mock(ReadWriteTable.class);
+      final ReadWriteUpdateTable<Integer, Integer, Integer> table = mock(ReadWriteUpdateTable.class);
       when(table.putAllAsync(any())).thenReturn(CompletableFuture.completedFuture(null));
       when(table.deleteAllAsync(anyList())).thenReturn(CompletableFuture.completedFuture(null));
 
@@ -147,7 +147,8 @@ public class TestBatchProcessor {
     }
   }
 
-  private static BatchProcessor<Integer, Integer, Integer> createBatchProcessor(ReadWriteTable<Integer, Integer, Integer> table,
+  private static BatchProcessor<Integer, Integer, Integer> createBatchProcessor(
+      ReadWriteUpdateTable<Integer, Integer, Integer> table,
       int maxSize, int maxDelay) {
     final BatchProvider<Integer, Integer, Integer> batchProvider = new CompactBatchProvider<Integer, Integer, Integer>()
         .withMaxBatchDelay(Duration.ofMillis(maxDelay)).withMaxBatchSize(maxSize);

--- a/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchTable.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
-import org.apache.samza.operators.UpdatePair;
 import org.apache.samza.storage.kv.Entry;
 import org.apache.samza.table.ReadWriteTable;
 import org.junit.After;
@@ -116,9 +115,9 @@ public class TestBatchTable {
     doAnswer(putAsyncAnswer).when(table).putAsync(anyInt(), anyInt());
     doAnswer(putAllAsyncAnswer).when(table).putAllAsync(anyList());
 
-    doAnswer(i -> null).when(table).update(anyInt(), anyInt(), anyInt());
-    doAnswer(i -> CompletableFuture.completedFuture(null)).when(table).updateAsync(anyInt(), anyInt(), anyInt());
-    doAnswer(i -> CompletableFuture.completedFuture(null)).when(table).updateAllAsync(anyList(), anyList());
+    doAnswer(i -> null).when(table).update(anyInt(), anyInt());
+    doAnswer(i -> CompletableFuture.completedFuture(null)).when(table).updateAsync(anyInt(), anyInt());
+    doAnswer(i -> CompletableFuture.completedFuture(null)).when(table).updateAllAsync(anyList());
 
     doAnswer(deleteAnswer).when(table).delete(anyInt());
     doAnswer(deleteAsyncAnswer).when(table).deleteAsync(anyInt());
@@ -191,10 +190,10 @@ public class TestBatchTable {
     // CompactBatch doesn't support batching for updates and instead table's updateAsync is used
     final List<CompletableFuture<Void>> futures = new LinkedList<>();
     for (int i = 0; i < BATCH_SIZE; i++) {
-      futures.add(asyncBatchingTable.updateAsync(i, i, i));
+      futures.add(asyncBatchingTable.updateAsync(i, i));
     }
     futures.forEach(future -> Assert.assertTrue(future.isDone()));
-    verify(table, times(5)).updateAsync(anyInt(), anyInt(), anyInt());
+    verify(table, times(5)).updateAsync(anyInt(), anyInt());
   }
 
   @Test
@@ -208,24 +207,25 @@ public class TestBatchTable {
     // mocking of updateAsync and updateAllAsync of AsyncReadWriteTable table done in setup method
     final List<CompletableFuture<Void>> futures = new LinkedList<>();
     for (int i = 0; i < BATCH_SIZE; i++) {
-      futures.add(asyncBatchingTable.updateAsync(i, i, i));
+      futures.add(asyncBatchingTable.updateAsync(i, i));
     }
     sleep();
 
-    final BatchProcessor<Integer, UpdatePair<Integer, Integer>> updateBatchProcessor =
+    final BatchProcessor<Integer, Integer> updateBatchProcessor =
         asyncBatchingTable.getUpdateBatchProcessor();
 
     // Verify that all async updates are finished.
     futures.forEach(future -> Assert.assertTrue(future.isDone()));
-    verify(table, times(1)).updateAllAsync(anyList(), anyList());
+    verify(table, times(1)).updateAllAsync(anyList());
 
     // There should be no operations in the batch processor.
     Assert.assertEquals(0, updateBatchProcessor.size());
 
-    asyncBatchingTable.updateAsync(BATCH_SIZE, BATCH_SIZE, BATCH_SIZE);
+    asyncBatchingTable.updateAsync(1, 1);
+    asyncBatchingTable.updateAsync(2, 2);
 
-    // Now batch size should be 1.
-    Assert.assertEquals(1, updateBatchProcessor.size());
+    // Now batch size should be 2.
+    Assert.assertEquals(2, updateBatchProcessor.size());
   }
 
   @Test
@@ -238,16 +238,13 @@ public class TestBatchTable {
 
     // mocking of updateAsync and updateAllAsync of AsyncReadWriteTable table done in setup method
     final List<Entry<Integer, Integer>> updates = new LinkedList<>();
-    final List<Entry<Integer, Integer>> defaults = new LinkedList<>();
 
     for (int i = 0; i < BATCH_SIZE; i++) {
       updates.add(new Entry<>(i, i));
-      defaults.add(new Entry<>(i, i));
     }
 
-    CompletableFuture<Void> future = asyncBatchingTable.updateAllAsync(updates, defaults);
-    final BatchProcessor<Integer, UpdatePair<Integer, Integer>> updateBatchProcessor =
-        asyncBatchingTable.getUpdateBatchProcessor();
+    CompletableFuture<Void> future = asyncBatchingTable.updateAllAsync(updates);
+    final BatchProcessor<Integer, Integer> updateBatchProcessor = asyncBatchingTable.getUpdateBatchProcessor();
 
     sleep();
 
@@ -257,10 +254,10 @@ public class TestBatchTable {
     Assert.assertEquals(0, updateBatchProcessor.size());
 
     // The addBatchUpdates batch operations propagates to the table.
-    verify(table, times(1)).updateAllAsync(anyList(), anyList());
+    verify(table, times(1)).updateAllAsync(anyList());
 
     // This new addBatchUpdates will make the batch size to be 1.
-    asyncBatchingTable.updateAsync(BATCH_SIZE, BATCH_SIZE, BATCH_SIZE);
+    asyncBatchingTable.updateAsync(BATCH_SIZE, BATCH_SIZE);
 
     Assert.assertEquals(1, updateBatchProcessor.size());
   }

--- a/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/batching/TestBatchTable.java
@@ -29,7 +29,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import org.apache.samza.storage.kv.Entry;
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -43,7 +43,7 @@ public class TestBatchTable {
   private static final Duration BATCH_DELAY = Duration.ofMillis(Integer.MAX_VALUE);
 
   private AsyncBatchingTable<Integer, Integer, Integer> asyncBatchingTable;
-  private ReadWriteTable<Integer, Integer, Integer> table;
+  private ReadWriteUpdateTable<Integer, Integer, Integer> table;
   private Map<Integer, Integer> tableDb;
 
   @Before
@@ -103,7 +103,7 @@ public class TestBatchTable {
       return CompletableFuture.completedFuture(null);
     };
 
-    table = mock(ReadWriteTable.class);
+    table = mock(ReadWriteUpdateTable.class);
     final BatchMetrics batchMetrics = mock(BatchMetrics.class);
     tableDb = new HashMap<>();
     asyncBatchingTable = new AsyncBatchingTable("id", table, new CompactBatchProvider()

--- a/samza-core/src/test/java/org/apache/samza/table/caching/TestCachingTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/caching/TestCachingTable.java
@@ -31,6 +31,7 @@ import org.apache.samza.metrics.Counter;
 import org.apache.samza.metrics.Gauge;
 import org.apache.samza.metrics.MetricsRegistry;
 import org.apache.samza.metrics.Timer;
+import org.apache.samza.operators.UpdatePair;
 import org.apache.samza.table.descriptors.BaseTableDescriptor;
 import org.apache.samza.table.descriptors.TableDescriptor;
 import org.apache.samza.storage.kv.Entry;
@@ -109,7 +110,7 @@ public class TestCachingTable {
     assertEquals("true", CachingTableDescriptor.WRITE_AROUND, "1", tableConfig);
   }
 
-  private static Pair<ReadWriteTable<String, String>, Map<String, String>> getMockCache() {
+  private static Pair<ReadWriteTable<String, String, String>, Map<String, String>> getMockCache() {
     // To allow concurrent writes for disjoint keys by testConcurrentAccess, we must use CHM here.
     // This is okay because the atomic section in CachingTable covers both cache and table so using
     // CHM for each does not serialize such two-step operation so the atomicity is still tested.
@@ -241,10 +242,10 @@ public class TestCachingTable {
 
   @Test
   public void testNonexistentKeyInTable() {
-    ReadWriteTable<String, String> table = mock(ReadWriteTable.class);
+    ReadWriteTable<String, String, String> table = mock(ReadWriteTable.class);
     doReturn(CompletableFuture.completedFuture(null)).when(table).getAsync(any());
-    ReadWriteTable<String, String> cache = getMockCache().getLeft();
-    CachingTable<String, String> cachingTable = new CachingTable<>("myTable", table, cache, false);
+    ReadWriteTable<String, String, String> cache = getMockCache().getLeft();
+    CachingTable<String, String, String> cachingTable = new CachingTable<>("myTable", table, cache, false);
     initTables(cachingTable);
     Assert.assertNull(cachingTable.get("abc"));
     verify(cache, times(1)).get(any());
@@ -254,12 +255,12 @@ public class TestCachingTable {
 
   @Test
   public void testKeyEviction() {
-    ReadWriteTable<String, String> table = mock(ReadWriteTable.class);
+    ReadWriteTable<String, String, Void> table = mock(ReadWriteTable.class);
     doReturn(CompletableFuture.completedFuture("3")).when(table).getAsync(any());
-    ReadWriteTable<String, String> cache = mock(ReadWriteTable.class);
+    ReadWriteTable<String, String, Void> cache = mock(ReadWriteTable.class);
 
     // no handler added to mock cache so get/put are noop, this can simulate eviction
-    CachingTable<String, String> cachingTable = new CachingTable<>("myTable", table, cache, false);
+    CachingTable<String, String, Void> cachingTable = new CachingTable<>("myTable", table, cache, false);
     initTables(cachingTable);
     cachingTable.get("abc");
     verify(table, times(1)).getAsync(any());
@@ -276,33 +277,34 @@ public class TestCachingTable {
   public void testGuavaCacheAndRemoteTable() throws Exception {
     String tableId = "testGuavaCacheAndRemoteTable";
     Cache<String, String> guavaCache = CacheBuilder.newBuilder().initialCapacity(100).build();
-    final ReadWriteTable<String, String> guavaTable = new GuavaCacheTable<>(tableId + "-cache", guavaCache);
+    final ReadWriteTable<String, String, String> guavaTable = new GuavaCacheTable<>(tableId + "-cache", guavaCache);
 
     // It is okay to share rateLimitHelper and async helper for read/write in test
-    TableRateLimiter<String, String> rateLimitHelper = mock(TableRateLimiter.class);
+    TableRateLimiter<String, String> readRateLimitHelper = mock(TableRateLimiter.class);
+    TableRateLimiter<String, String> writeRateLimitHelper = mock(TableRateLimiter.class);
+    TableRateLimiter<String, UpdatePair<String, String>> updateRateLimitHelper = mock(TableRateLimiter.class);
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
-    TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
-    final RemoteTable<String, String> remoteTable = new RemoteTable<>(
-        tableId + "-remote", readFn, writeFn,
-        rateLimitHelper, rateLimitHelper, Executors.newSingleThreadExecutor(),
-        null, null, null,
-        null, null,
-        Executors.newSingleThreadExecutor());
+    TableWriteFunction<String, String, String> writeFn = mock(TableWriteFunction.class);
 
-    final CachingTable<String, String> cachingTable = new CachingTable<>(
+    final RemoteTable<String, String, String> remoteTable = new RemoteTable<>(tableId + "-remote", readFn,
+        writeFn, readRateLimitHelper, writeRateLimitHelper, updateRateLimitHelper,
+        Executors.newSingleThreadExecutor(), null, null, null, null,
+        null,  Executors.newSingleThreadExecutor());
+
+    final CachingTable<String, String, String> cachingTable = new CachingTable<>(
         tableId, remoteTable, guavaTable, false);
 
     initTables(cachingTable, guavaTable, remoteTable);
 
     // 4 per readable table (12)
-    // 6 per read/write table (18)
-    verify(metricsRegistry, times(30)).newCounter(any(), anyString());
+    // 8 per read/write table (24)
+    verify(metricsRegistry, times(36)).newCounter(any(), anyString());
 
     // 3 per readable table (9)
-    // 6 per read/write table (18)
+    // 8 per read/write table (24)
     // 1 per remote readable table (1)
-    // 1 per remote read/write table (1)
-    verify(metricsRegistry, times(29)).newTimer(any(), anyString());
+    // 2 per remote read/write table (2)
+    verify(metricsRegistry, times(36)).newTimer(any(), anyString());
 
     // 1 per guava table (1)
     // 3 per caching table (2)
@@ -393,25 +395,24 @@ public class TestCachingTable {
     String tableId = "testTimerDisabled";
 
     Cache<String, String> guavaCache = CacheBuilder.newBuilder().initialCapacity(100).build();
-    final ReadWriteTable<String, String> guavaTable = new GuavaCacheTable<>(tableId, guavaCache);
+    final ReadWriteTable<String, String, String> guavaTable = new GuavaCacheTable<>(tableId, guavaCache);
 
-    TableRateLimiter<String, String> rateLimitHelper = mock(TableRateLimiter.class);
-
+    TableRateLimiter<String, String> readRateLimitHelper = mock(TableRateLimiter.class);
+    TableRateLimiter<String, String> writeRateLimitHelper = mock(TableRateLimiter.class);
+    TableRateLimiter<String, UpdatePair<String, String>> updateRateLimitHelper = mock(TableRateLimiter.class);
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
     doReturn(CompletableFuture.completedFuture("")).when(readFn).getAsync(any());
 
-    TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
+    TableWriteFunction<String, String, String> writeFn = mock(TableWriteFunction.class);
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).putAsync(any(), any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).deleteAsync(any());
 
-    final RemoteTable<String, String> remoteTable = new RemoteTable<>(
-        tableId, readFn, writeFn,
-        rateLimitHelper, rateLimitHelper, Executors.newSingleThreadExecutor(),
-        null, null, null,
-        null, null,
-        Executors.newSingleThreadExecutor());
+    final RemoteTable<String, String, String> remoteTable =
+        new RemoteTable<>(tableId, readFn, writeFn, readRateLimitHelper, writeRateLimitHelper, updateRateLimitHelper,
+            Executors.newSingleThreadExecutor(), null, null, null,
+            null, null, Executors.newSingleThreadExecutor());
 
-    final CachingTable<String, String> cachingTable = new CachingTable<>(
+    final CachingTable<String, String, String> cachingTable = new CachingTable<>(
         tableId, remoteTable, guavaTable, false);
 
     initTables(true, cachingTable, guavaTable, remoteTable);

--- a/samza-core/src/test/java/org/apache/samza/table/caching/TestCachingTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/caching/TestCachingTable.java
@@ -31,7 +31,6 @@ import org.apache.samza.metrics.Counter;
 import org.apache.samza.metrics.Gauge;
 import org.apache.samza.metrics.MetricsRegistry;
 import org.apache.samza.metrics.Timer;
-import org.apache.samza.operators.UpdatePair;
 import org.apache.samza.table.descriptors.BaseTableDescriptor;
 import org.apache.samza.table.descriptors.TableDescriptor;
 import org.apache.samza.storage.kv.Entry;
@@ -282,7 +281,7 @@ public class TestCachingTable {
     // It is okay to share rateLimitHelper and async helper for read/write in test
     TableRateLimiter<String, String> readRateLimitHelper = mock(TableRateLimiter.class);
     TableRateLimiter<String, String> writeRateLimitHelper = mock(TableRateLimiter.class);
-    TableRateLimiter<String, UpdatePair<String, String>> updateRateLimitHelper = mock(TableRateLimiter.class);
+    TableRateLimiter<String, String> updateRateLimitHelper = mock(TableRateLimiter.class);
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
     TableWriteFunction<String, String, String> writeFn = mock(TableWriteFunction.class);
 
@@ -399,7 +398,7 @@ public class TestCachingTable {
 
     TableRateLimiter<String, String> readRateLimitHelper = mock(TableRateLimiter.class);
     TableRateLimiter<String, String> writeRateLimitHelper = mock(TableRateLimiter.class);
-    TableRateLimiter<String, UpdatePair<String, String>> updateRateLimitHelper = mock(TableRateLimiter.class);
+    TableRateLimiter<String, String> updateRateLimitHelper = mock(TableRateLimiter.class);
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
     doReturn(CompletableFuture.completedFuture("")).when(readFn).getAsync(any());
 

--- a/samza-core/src/test/java/org/apache/samza/table/descriptors/TestLocalTableDescriptor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/descriptors/TestLocalTableDescriptor.java
@@ -30,7 +30,7 @@ import org.apache.samza.context.Context;
 import org.apache.samza.serializers.IntegerSerde;
 import org.apache.samza.serializers.KVSerde;
 import org.apache.samza.serializers.StringSerde;
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.apache.samza.table.TableProvider;
 import org.apache.samza.table.TableProviderFactory;
 import org.junit.Test;
@@ -143,7 +143,7 @@ public class TestLocalTableDescriptor {
     }
 
     @Override
-    public ReadWriteTable getTable() {
+    public ReadWriteUpdateTable getTable() {
       throw new SamzaException("Not implemented");
     }
 

--- a/samza-core/src/test/java/org/apache/samza/table/ratelimit/TestAsyncRateLimitedTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/ratelimit/TestAsyncRateLimitedTable.java
@@ -26,7 +26,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.samza.storage.kv.Entry;
-import org.apache.samza.table.AsyncReadWriteTable;
+import org.apache.samza.table.AsyncReadWriteUpdateTable;
 import org.apache.samza.table.remote.AsyncRemoteTable;
 import org.apache.samza.table.remote.TableRateLimiter;
 import org.apache.samza.table.remote.TableReadFunction;
@@ -45,10 +45,10 @@ public class TestAsyncRateLimitedTable {
   private final ScheduledExecutorService schedExec = Executors.newSingleThreadScheduledExecutor();
 
   private Map<String, String> readMap = new HashMap<>();
-  private AsyncReadWriteTable readTable;
+  private AsyncReadWriteUpdateTable readTable;
   private TableRateLimiter readRateLimiter;
   private TableReadFunction<String, String> readFn;
-  private AsyncReadWriteTable<String, String, String> writeTable;
+  private AsyncReadWriteUpdateTable<String, String, String> writeTable;
   private TableRateLimiter<String, String> writeRateLimiter;
   private TableWriteFunction<String, String, Void> writeFn;
 
@@ -63,7 +63,7 @@ public class TestAsyncRateLimitedTable {
     doReturn(CompletableFuture.completedFuture(readMap)).when(readFn).getAllAsync(any());
     doReturn(CompletableFuture.completedFuture(readMap)).when(readFn).getAllAsync(any(), any());
     doReturn(CompletableFuture.completedFuture(5)).when(readFn).readAsync(anyInt(), any());
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, null);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, null);
     readTable = new AsyncRateLimitedTable("t1", delegate, readRateLimiter, null, null, schedExec);
     readTable.init(TestRemoteTable.getMockContext());
 
@@ -93,7 +93,7 @@ public class TestAsyncRateLimitedTable {
 
   @Test(expected = NullPointerException.class)
   public void testNotNullTableId() {
-    new AsyncRateLimitedTable(null, mock(AsyncReadWriteTable.class),
+    new AsyncRateLimitedTable(null, mock(AsyncReadWriteUpdateTable.class),
         mock(TableRateLimiter.class), mock(TableRateLimiter.class), mock(TableRateLimiter.class),
         mock(ScheduledExecutorService.class));
   }
@@ -107,14 +107,14 @@ public class TestAsyncRateLimitedTable {
 
   @Test(expected = NullPointerException.class)
   public void testNotNullRateLimitingExecutor() {
-    new AsyncRateLimitedTable("t1", mock(AsyncReadWriteTable.class),
+    new AsyncRateLimitedTable("t1", mock(AsyncReadWriteUpdateTable.class),
         mock(TableRateLimiter.class), mock(TableRateLimiter.class), mock(TableRateLimiter.class),
         null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testNotNullAtLeastOneRateLimiter() {
-    new AsyncRateLimitedTable("t1", mock(AsyncReadWriteTable.class),
+    new AsyncRateLimitedTable("t1", mock(AsyncReadWriteUpdateTable.class),
         null, null, null,
         mock(ScheduledExecutorService.class));
   }
@@ -357,7 +357,7 @@ public class TestAsyncRateLimitedTable {
     TableRateLimiter writeRateLimiter = mock(TableRateLimiter.class);
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
     TableWriteFunction<String, String, String> writeFn = mock(TableWriteFunction.class);
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, writeFn);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, writeFn);
     AsyncRateLimitedTable table = new AsyncRateLimitedTable("t1", delegate,
         readRateLimiter, writeRateLimiter, writeRateLimiter, schedExec);
     table.init(TestRemoteTable.getMockContext());

--- a/samza-core/src/test/java/org/apache/samza/table/ratelimit/TestAsyncRateLimitedTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/ratelimit/TestAsyncRateLimitedTable.java
@@ -82,9 +82,7 @@ public class TestAsyncRateLimitedTable {
 
     // update part
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAsync(any(), any());
-    doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAsync(any(), any(), any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAllAsync(any());
-    doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAllAsync(any(), any());
 
     delegate = new AsyncRemoteTable(readFn, writeFn);
     writeTable = new AsyncRateLimitedTable("t1", delegate, readRateLimiter, writeRateLimiter, writeRateLimiter, schedExec);
@@ -239,22 +237,8 @@ public class TestAsyncRateLimitedTable {
   public void testUpdateAsync() {
     writeTable.updateAsync("foo", "bar").join();
     verify(writeFn, times(1)).updateAsync(any(), any());
-    verify(writeFn, times(0)).updateAsync(any(), any(), any());
     verify(writeRateLimiter, times(0)).throttle(anyString());
     verify(writeRateLimiter, times(1)).throttle(anyString(), anyString());
-    verify(writeRateLimiter, times(0)).throttle(anyCollection());
-    verify(writeRateLimiter, times(0)).throttleRecords(anyCollection());
-    verify(writeRateLimiter, times(0)).throttle(anyInt(), any());
-    verifyReadPartNotCalled();
-  }
-
-  @Test
-  public void testUpdateAsyncWithArgs() {
-    writeTable.updateAsync("foo", "bar", 1).join();
-    verify(writeFn, times(0)).updateAsync(any(), any());
-    verify(writeFn, times(1)).updateAsync(any(), any(), any());
-    verify(writeRateLimiter, times(0)).throttle(anyString());
-    verify(writeRateLimiter, times(1)).throttle(anyString(), anyString(), any());
     verify(writeRateLimiter, times(0)).throttle(anyCollection());
     verify(writeRateLimiter, times(0)).throttleRecords(anyCollection());
     verify(writeRateLimiter, times(0)).throttle(anyInt(), any());
@@ -265,20 +249,6 @@ public class TestAsyncRateLimitedTable {
   public void testUpdateAllAsync() {
     writeTable.updateAllAsync(Arrays.asList(new Entry("1", "2"))).join();
     verify(writeFn, times(1)).updateAllAsync(anyCollection());
-    verify(writeFn, times(0)).updateAllAsync(anyCollection(), any());
-    verify(writeRateLimiter, times(0)).throttle(anyString());
-    verify(writeRateLimiter, times(0)).throttle(anyString(), anyString());
-    verify(writeRateLimiter, times(0)).throttle(anyCollection());
-    verify(writeRateLimiter, times(1)).throttleRecords(anyCollection());
-    verify(writeRateLimiter, times(0)).throttle(anyInt(), any());
-    verifyReadPartNotCalled();
-  }
-
-  @Test
-  public void testUpdateAllAsyncWithArgs() {
-    writeTable.updateAllAsync(Arrays.asList(new Entry("1", "2")), Arrays.asList(0, 1)).join();
-    verify(writeFn, times(0)).updateAllAsync(anyCollection());
-    verify(writeFn, times(1)).updateAllAsync(anyCollection(), any());
     verify(writeRateLimiter, times(0)).throttle(anyString());
     verify(writeRateLimiter, times(0)).throttle(anyString(), anyString());
     verify(writeRateLimiter, times(0)).throttle(anyCollection());
@@ -388,10 +358,6 @@ public class TestAsyncRateLimitedTable {
     verify(writeFn, times(0)).putAsync(any(), any(), any());
     verify(writeFn, times(0)).putAllAsync(any());
     verify(writeFn, times(0)).putAllAsync(any(), any());
-    verify(writeFn, times(0)).updateAsync(any(), any(), any());
-    verify(writeFn, times(0)).updateAsync(any(), any(), any(), any());
-    verify(writeFn, times(0)).updateAllAsync(any(), any());
-    verify(writeFn, times(0)).updateAllAsync(any(), any(), any());
     verify(writeFn, times(0)).deleteAsync(any());
     verify(writeFn, times(0)).deleteAsync(any(), any());
     verify(writeFn, times(0)).deleteAllAsync(any());

--- a/samza-core/src/test/java/org/apache/samza/table/remote/TestAsyncRemoteTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/TestAsyncRemoteTable.java
@@ -132,27 +132,11 @@ public class TestAsyncRemoteTable {
   }
 
   @Test
-  public void testUpdateAsyncWithArgs() {
-    verifyFailure(() -> roTable.updateAsync(1, 2, Arrays.asList(0, 0)));
-    rwTable.updateAsync(1, 2, Arrays.asList(0, 0));
-    verify(writeFn, times(1)).updateAsync(any(), any(), any());
-  }
-
-  @Test
   public void testUpdateAllAsync() {
     List<Entry<Integer, Integer>> updates = Arrays.asList(new Entry<>(1, 100), new Entry<>(2, 200));
     verifyFailure(() -> roTable.updateAllAsync(updates));
     rwTable.updateAllAsync(updates);
     verify(writeFn, times(1)).updateAllAsync(any());
-  }
-
-  @Test
-  public void testUpdateAllAsyncWithArgs() {
-    List<Entry<Integer, Integer>> updates = Arrays.asList(new Entry<>(1, 100), new Entry<>(2, 200));
-    List<Integer> args = Arrays.asList(0, 0);
-    verifyFailure(() -> roTable.updateAllAsync(updates, args));
-    rwTable.updateAllAsync(updates, args);
-    verify(writeFn, times(1)).updateAllAsync(any(), any());
   }
 
   @Test

--- a/samza-core/src/test/java/org/apache/samza/table/remote/TestAsyncRemoteTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/TestAsyncRemoteTable.java
@@ -126,35 +126,33 @@ public class TestAsyncRemoteTable {
 
   @Test
   public void testUpdateAsync() {
-    verifyFailure(() -> roTable.updateAsync(1, 2, 2));
-    rwTable.updateAsync(1, 2, 2);
-    verify(writeFn, times(1)).updateAsync(any(), any(), any());
+    verifyFailure(() -> roTable.updateAsync(1, 2));
+    rwTable.updateAsync(1, 2);
+    verify(writeFn, times(1)).updateAsync(any(), any());
   }
 
   @Test
   public void testUpdateAsyncWithArgs() {
-    verifyFailure(() -> roTable.updateAsync(1, 2, 3, Arrays.asList(0, 0)));
-    rwTable.updateAsync(1, 2, 3, Arrays.asList(0, 0));
-    verify(writeFn, times(1)).updateAsync(any(), any(), any(), any());
+    verifyFailure(() -> roTable.updateAsync(1, 2, Arrays.asList(0, 0)));
+    rwTable.updateAsync(1, 2, Arrays.asList(0, 0));
+    verify(writeFn, times(1)).updateAsync(any(), any(), any());
   }
 
   @Test
   public void testUpdateAllAsync() {
     List<Entry<Integer, Integer>> updates = Arrays.asList(new Entry<>(1, 100), new Entry<>(2, 200));
-    List<Entry<Integer, Integer>> defaults = Arrays.asList(new Entry<>(1, 100), new Entry<>(2, 200));
-    verifyFailure(() -> roTable.updateAllAsync(updates, defaults));
-    rwTable.updateAllAsync(updates, defaults);
-    verify(writeFn, times(1)).updateAllAsync(any(), any());
+    verifyFailure(() -> roTable.updateAllAsync(updates));
+    rwTable.updateAllAsync(updates);
+    verify(writeFn, times(1)).updateAllAsync(any());
   }
 
   @Test
   public void testUpdateAllAsyncWithArgs() {
     List<Entry<Integer, Integer>> updates = Arrays.asList(new Entry<>(1, 100), new Entry<>(2, 200));
-    List<Entry<Integer, Integer>> defaults = Arrays.asList(new Entry<>(1, 100), new Entry<>(2, 200));
     List<Integer> args = Arrays.asList(0, 0);
-    verifyFailure(() -> roTable.updateAllAsync(updates, defaults, args));
-    rwTable.updateAllAsync(updates, defaults, args);
-    verify(writeFn, times(1)).updateAllAsync(any(), any(), any());
+    verifyFailure(() -> roTable.updateAllAsync(updates, args));
+    rwTable.updateAllAsync(updates, args);
+    verify(writeFn, times(1)).updateAllAsync(any(), any());
   }
 
   @Test

--- a/samza-core/src/test/java/org/apache/samza/table/remote/TestAsyncRemoteTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/TestAsyncRemoteTable.java
@@ -20,6 +20,7 @@ package org.apache.samza.table.remote;
 
 import java.util.Arrays;
 
+import java.util.List;
 import org.apache.samza.storage.kv.Entry;
 
 import org.junit.Before;
@@ -38,9 +39,9 @@ import static org.mockito.Mockito.verify;
 public class TestAsyncRemoteTable {
 
   private TableReadFunction<Integer, Integer> readFn;
-  private TableWriteFunction<Integer, Integer> writeFn;
-  private AsyncRemoteTable<Integer, Integer> roTable;
-  private AsyncRemoteTable<Integer, Integer> rwTable;
+  private TableWriteFunction<Integer, Integer, Integer> writeFn;
+  private AsyncRemoteTable<Integer, Integer, Integer> roTable;
+  private AsyncRemoteTable<Integer, Integer, Integer> rwTable;
 
   @Before
   public void prepare() {
@@ -121,6 +122,39 @@ public class TestAsyncRemoteTable {
     verifyFailure(() -> roTable.putAllAsync(Arrays.asList(new Entry(1, 2)), Arrays.asList(0, 0)));
     rwTable.putAllAsync(Arrays.asList(new Entry(1, 2)), Arrays.asList(0, 0));
     verify(writeFn, times(1)).putAllAsync(any(), any());
+  }
+
+  @Test
+  public void testUpdateAsync() {
+    verifyFailure(() -> roTable.updateAsync(1, 2, 2));
+    rwTable.updateAsync(1, 2, 2);
+    verify(writeFn, times(1)).updateAsync(any(), any(), any());
+  }
+
+  @Test
+  public void testUpdateAsyncWithArgs() {
+    verifyFailure(() -> roTable.updateAsync(1, 2, 3, Arrays.asList(0, 0)));
+    rwTable.updateAsync(1, 2, 3, Arrays.asList(0, 0));
+    verify(writeFn, times(1)).updateAsync(any(), any(), any(), any());
+  }
+
+  @Test
+  public void testUpdateAllAsync() {
+    List<Entry<Integer, Integer>> updates = Arrays.asList(new Entry<>(1, 100), new Entry<>(2, 200));
+    List<Entry<Integer, Integer>> defaults = Arrays.asList(new Entry<>(1, 100), new Entry<>(2, 200));
+    verifyFailure(() -> roTable.updateAllAsync(updates, defaults));
+    rwTable.updateAllAsync(updates, defaults);
+    verify(writeFn, times(1)).updateAllAsync(any(), any());
+  }
+
+  @Test
+  public void testUpdateAllAsyncWithArgs() {
+    List<Entry<Integer, Integer>> updates = Arrays.asList(new Entry<>(1, 100), new Entry<>(2, 200));
+    List<Entry<Integer, Integer>> defaults = Arrays.asList(new Entry<>(1, 100), new Entry<>(2, 200));
+    List<Integer> args = Arrays.asList(0, 0);
+    verifyFailure(() -> roTable.updateAllAsync(updates, defaults, args));
+    rwTable.updateAllAsync(updates, defaults, args);
+    verify(writeFn, times(1)).updateAllAsync(any(), any(), any());
   }
 
   @Test

--- a/samza-core/src/test/java/org/apache/samza/table/remote/TestAsyncRemoteTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/TestAsyncRemoteTable.java
@@ -26,7 +26,7 @@ import org.apache.samza.storage.kv.Entry;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.apache.samza.table.BaseReadWriteTable.Func0;
+import org.apache.samza.table.BaseReadWriteUpdateTable.Func0;
 
 import static org.junit.Assert.assertTrue;
 

--- a/samza-core/src/test/java/org/apache/samza/table/remote/TestRemoteTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/TestRemoteTable.java
@@ -25,6 +25,7 @@ import org.apache.samza.metrics.Counter;
 import org.apache.samza.metrics.Gauge;
 import org.apache.samza.metrics.MetricsRegistry;
 import org.apache.samza.metrics.Timer;
+import org.apache.samza.operators.UpdatePair;
 import org.apache.samza.storage.kv.Entry;
 import org.apache.samza.table.AsyncReadWriteTable;
 import org.apache.samza.table.ratelimit.AsyncRateLimitedTable;
@@ -67,16 +68,17 @@ public class TestRemoteTable {
     return context;
   }
 
-  private <K, V, T extends RemoteTable<K, V>> T getTable(String tableId, TableReadFunction<K, V> readFn,
-      TableWriteFunction<K, V> writeFn, boolean retry) {
+  private <K, V, U, T extends RemoteTable<K, V, U>> T getTable(String tableId, TableReadFunction<K, V> readFn,
+      TableWriteFunction<K, V, U> writeFn, boolean retry) {
     return getTable(tableId, readFn, writeFn, null, retry);
   }
 
-  private <K, V, T extends RemoteTable<K, V>> T getTable(String tableId, TableReadFunction<K, V> readFn,
-      TableWriteFunction<K, V> writeFn, ExecutorService cbExecutor, boolean retry) {
+  private <K, V, U, T extends RemoteTable<K, V, U>> T getTable(String tableId, TableReadFunction<K, V> readFn,
+      TableWriteFunction<K, V, U> writeFn, ExecutorService cbExecutor, boolean retry) {
 
     TableRateLimiter<K, V> readRateLimiter = mock(TableRateLimiter.class);
     TableRateLimiter<K, V> writeRateLimiter = mock(TableRateLimiter.class);
+    TableRateLimiter<K, UpdatePair<U, V>> updateRateLimiter = mock(TableRateLimiter.class);
 
     TableRetryPolicy readPolicy = retry ? new TableRetryPolicy() : null;
     TableRetryPolicy writePolicy = retry ? new TableRetryPolicy() : null;
@@ -84,8 +86,8 @@ public class TestRemoteTable {
     ExecutorService rateLimitingExecutor = Executors.newSingleThreadExecutor();
     ScheduledExecutorService retryExecutor = Executors.newSingleThreadScheduledExecutor();
 
-    RemoteTable<K, V> table = new RemoteTable(tableId, readFn, writeFn,
-        readRateLimiter, writeRateLimiter, rateLimitingExecutor,
+    RemoteTable<K, V, U> table = new RemoteTable<>(tableId, readFn, writeFn,
+        readRateLimiter, writeRateLimiter, updateRateLimiter, rateLimitingExecutor,
         readPolicy, writePolicy, retryExecutor, null, null, cbExecutor);
     table.init(getMockContext());
     if (readFn != null) {
@@ -119,7 +121,7 @@ public class TestRemoteTable {
     if (retry) {
       doReturn(true).when(readFn).isRetriable(any());
     }
-    RemoteTable<String, String> table = getTable(tableId, readFn, null, retry);
+    RemoteTable<String, String, Void> table = getTable(tableId, readFn, null, retry);
     Assert.assertEquals("bar", sync ? table.get("foo") : table.getAsync("foo").join());
     verify(table.readRateLimiter, times(error && retry ? 2 : 1)).throttle(anyString());
   }
@@ -131,7 +133,7 @@ public class TestRemoteTable {
 
   @Test
   public void testSucceedValidationOnNullReadFn() {
-    RemoteTable<String, String> table = getTable("tableId", null, mock(TableWriteFunction.class), false);
+    RemoteTable<String, String, Void> table = getTable("tableId", null, mock(TableWriteFunction.class), false);
     Assert.assertNotNull(table);
   }
 
@@ -139,8 +141,8 @@ public class TestRemoteTable {
   public void testInit() {
     String tableId = "testInit";
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
-    TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
-    RemoteTable<String, String> table = getTable(tableId, readFn, writeFn, true);
+    TableWriteFunction<String, String, String> writeFn = mock(TableWriteFunction.class);
+    RemoteTable<String, String, String> table = getTable(tableId, readFn, writeFn, true);
     // AsyncRetriableTable
     AsyncReadWriteTable innerTable = TestUtils.getFieldValue(table, "asyncTable");
     Assert.assertTrue(innerTable instanceof AsyncRetriableTable);
@@ -186,8 +188,8 @@ public class TestRemoteTable {
     doReturn(CompletableFuture.completedFuture("bar1")).when(readFn1).getAsync(anyString());
     doReturn(CompletableFuture.completedFuture("bar2")).when(readFn1).getAsync(anyString());
 
-    RemoteTable<String, String> table1 = getTable("testGetMultipleTables-1", readFn1, null, false);
-    RemoteTable<String, String> table2 = getTable("testGetMultipleTables-2", readFn2, null, false);
+    RemoteTable<String, String, Void> table1 = getTable("testGetMultipleTables-1", readFn1, null, false);
+    RemoteTable<String, String, Void> table2 = getTable("testGetMultipleTables-2", readFn2, null, false);
 
     CompletableFuture<String> future1 = table1.getAsync("foo1");
     CompletableFuture<String> future2 = table2.getAsync("foo2");
@@ -201,7 +203,7 @@ public class TestRemoteTable {
 
   public void doTestRead(boolean sync, boolean error) {
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
-    RemoteTable<String, String> table = getTable("testRead-" + sync + error,
+    RemoteTable<String, String, Void> table = getTable("testRead-" + sync + error,
         readFn, mock(TableWriteFunction.class), false);
     CompletableFuture<?> future;
     if (error) {
@@ -238,8 +240,8 @@ public class TestRemoteTable {
 
   private void doTestPut(boolean sync, boolean error, boolean isDelete, boolean retry) {
     String tableId = "testPut-" + sync + error + isDelete + retry;
-    TableWriteFunction<String, String> mockWriteFn = mock(TableWriteFunction.class);
-    TableWriteFunction<String, String> writeFn = mockWriteFn;
+    TableWriteFunction<String, String, String> mockWriteFn = mock(TableWriteFunction.class);
+    TableWriteFunction<String, String, String> writeFn = mockWriteFn;
     CompletableFuture<Void> successFuture = CompletableFuture.completedFuture(null);
     CompletableFuture<Void> failureFuture = new CompletableFuture();
     failureFuture.completeExceptionally(new RuntimeException("Test exception"));
@@ -264,7 +266,7 @@ public class TestRemoteTable {
         doAnswer(args -> times[0]++ == 0 ? failureFuture : successFuture).when(writeFn).putAsync(any(), any());
       }
     }
-    RemoteTable<String, String> table = getTable(tableId, mock(TableReadFunction.class), writeFn, retry);
+    RemoteTable<String, String, String> table = getTable(tableId, mock(TableReadFunction.class), writeFn, retry);
     if (sync) {
       table.put("foo", isDelete ? null : "bar");
     } else {
@@ -316,9 +318,50 @@ public class TestRemoteTable {
     doTestPut(false, true, false, true);
   }
 
+  public void doTestUpdate(boolean sync, boolean error) {
+    String tableId = "testUpdate-" + sync + error;
+    TableWriteFunction<String, String, String> mockWriteFn = mock(TableWriteFunction.class);
+    TableWriteFunction<String, String, String> writeFn = mockWriteFn;
+    CompletableFuture<Void> successFuture = CompletableFuture.completedFuture(null);
+    CompletableFuture<Void> failureFuture = new CompletableFuture();
+    failureFuture.completeExceptionally(new RuntimeException("Test exception"));
+    if (!error) {
+      doReturn(successFuture).when(writeFn).updateAsync(any(), any(), any());
+    } else {
+      doReturn(failureFuture).when(writeFn).updateAsync(any(), any(), any());
+    }
+
+    RemoteTable<String, String, String> table = getTable(tableId, mock(TableReadFunction.class), writeFn, false);
+    if (sync) {
+      table.update("foo", "bar", "bar");
+    } else {
+      table.updateAsync("foo", "bar", "bar").join();
+    }
+    ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> defaultCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> updateCaptor = ArgumentCaptor.forClass(String.class);
+    verify(mockWriteFn, times(1))
+        .updateAsync(keyCaptor.capture(), updateCaptor.capture(), defaultCaptor.capture());
+  }
+
+  @Test
+  public void testUpdate() {
+    doTestUpdate(true, false);
+  }
+
+  @Test
+  public void testUpdateAsync() {
+    doTestUpdate(false, false);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testUpdateAsyncError() {
+    doTestUpdate(false, true);
+  }
+
   private void doTestDelete(boolean sync, boolean error) {
-    TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
-    RemoteTable<String, String> table = getTable("testDelete-" + sync + error,
+    TableWriteFunction<String, String, String> writeFn = mock(TableWriteFunction.class);
+    RemoteTable<String, String, String> table = getTable("testDelete-" + sync + error,
         mock(TableReadFunction.class), writeFn, false);
     CompletableFuture<Void> future;
     if (error) {
@@ -371,7 +414,7 @@ public class TestRemoteTable {
     }
     // Sync is backed by async so needs to mock the async method
     doReturn(future).when(readFn).getAllAsync(any());
-    RemoteTable<String, String> table = getTable("testGetAll-" + sync + error + partial, readFn, null, false);
+    RemoteTable<String, String, Void> table = getTable("testGetAll-" + sync + error + partial, readFn, null, false);
     Assert.assertEquals(res, sync ? table.getAll(Arrays.asList("foo1", "foo2"))
         : table.getAllAsync(Arrays.asList("foo1", "foo2")).join());
     verify(table.readRateLimiter, times(1)).throttle(anyCollection());
@@ -399,8 +442,8 @@ public class TestRemoteTable {
   }
 
   public void doTestPutAll(boolean sync, boolean error, boolean hasDelete) {
-    TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
-    RemoteTable<String, String> table = getTable("testPutAll-" + sync + error + hasDelete,
+    TableWriteFunction<String, String, Void> writeFn = mock(TableWriteFunction.class);
+    RemoteTable<String, String, Void> table = getTable("testPutAll-" + sync + error + hasDelete,
         mock(TableReadFunction.class), writeFn, false);
     CompletableFuture<Void> future;
     if (error) {
@@ -462,8 +505,8 @@ public class TestRemoteTable {
   }
 
   public void doTestDeleteAll(boolean sync, boolean error) {
-    TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
-    RemoteTable<String, String> table = getTable("testDeleteAll-" + sync + error,
+    TableWriteFunction<String, String, Void> writeFn = mock(TableWriteFunction.class);
+    RemoteTable<String, String, Void> table = getTable("testDeleteAll-" + sync + error,
         mock(TableReadFunction.class), writeFn, false);
     CompletableFuture<Void> future;
     if (error) {
@@ -502,8 +545,8 @@ public class TestRemoteTable {
   }
 
   public void doTestWrite(boolean sync, boolean error) {
-    TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
-    RemoteTable<String, String> table = getTable("testWrite-" + sync + error,
+    TableWriteFunction<String, String, Void> writeFn = mock(TableWriteFunction.class);
+    RemoteTable<String, String, Void> table = getTable("testWrite-" + sync + error,
         mock(TableReadFunction.class), writeFn, false);
     CompletableFuture<?> future;
     if (error) {
@@ -540,8 +583,8 @@ public class TestRemoteTable {
 
   @Test
   public void testFlush() {
-    TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
-    RemoteTable<String, String> table = getTable("testFlush", mock(TableReadFunction.class), writeFn, false);
+    TableWriteFunction<String, String, Void> writeFn = mock(TableWriteFunction.class);
+    RemoteTable<String, String, Void> table = getTable("testFlush", mock(TableReadFunction.class), writeFn, false);
     table.flush();
     verify(writeFn, times(1)).flush();
   }
@@ -551,7 +594,7 @@ public class TestRemoteTable {
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
     // Sync is backed by async so needs to mock the async method
     doReturn(CompletableFuture.completedFuture("bar")).when(readFn).getAsync(anyString());
-    RemoteTable<String, String> table = getTable("testGetWithCallbackExecutor", readFn, null,
+    RemoteTable<String, String, Void> table = getTable("testGetWithCallbackExecutor", readFn, null,
         Executors.newSingleThreadExecutor(), false);
     Thread testThread = Thread.currentThread();
 
@@ -573,7 +616,7 @@ public class TestRemoteTable {
     doReturn(CompletableFuture.completedFuture(result)).when(readFn).getAllAsync(any(), any());
     doReturn(CompletableFuture.completedFuture(5)).when(readFn).readAsync(anyInt(), any());
 
-    RemoteTable<String, String> table = getTable("testGetDelegation", readFn, null,
+    RemoteTable<String, String, Void> table = getTable("testGetDelegation", readFn, null,
         Executors.newSingleThreadExecutor(), true);
     verify(readFn, times(1)).init(any(), any());
 
@@ -604,7 +647,7 @@ public class TestRemoteTable {
   }
 
   @Test
-  public void testPutAndDeleteDelegation() {
+  public void testPutUpdateAndDeleteDelegation() {
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
     TableWriteFunction writeFn = mock(TableWriteFunction.class);
     doReturn(true).when(writeFn).isRetriable(any());
@@ -612,13 +655,17 @@ public class TestRemoteTable {
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).putAsync(any(), any(), any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).putAllAsync(anyCollection());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).putAllAsync(anyCollection(), any());
+    doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAsync(any(), any(), any());
+    doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAsync(any(), any(), any(), any());
+    doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAllAsync(anyCollection(), anyCollection());
+    doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAllAsync(anyCollection(), anyCollection(), any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).deleteAsync(any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).deleteAsync(any(), any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).deleteAllAsync(anyCollection());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).deleteAllAsync(anyCollection(), any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).writeAsync(anyInt(), any());
 
-    RemoteTable<String, String> table = getTable("testGetDelegation", readFn, writeFn,
+    RemoteTable<String, String, String> table = getTable("testGetDelegation", readFn, writeFn,
         Executors.newSingleThreadExecutor(), true);
     verify(readFn, times(1)).init(any(), any());
 
@@ -640,6 +687,31 @@ public class TestRemoteTable {
     table.putAllAsync(Arrays.asList(new Entry("foo", "bar")), 2).join();
     verify(writeFn, times(1)).putAllAsync(anyCollection());
     verify(writeFn, times(1)).putAllAsync(anyCollection(), any());
+
+    // UpdateAsync
+    verify(writeFn, times(0)).updateAsync(any(), any(), any());
+    verify(writeFn, times(0)).updateAsync(any(), any(), any(), any());
+    table.updateAsync("foo", "bar", "bar").join();
+    verify(writeFn, times(1)).updateAsync(any(), any(), any());
+    verify(writeFn, times(0)).updateAsync(any(), any(), any(), any());
+    table.updateAsync("foo", "bar", "bar", 3).join();
+    verify(writeFn, times(1)).updateAsync(any(), any(), any());
+    verify(writeFn, times(1)).updateAsync(any(), any(), any(), any());
+    // UpdateAllAsync
+    verify(writeFn, times(0)).updateAllAsync(anyCollection(), anyCollection());
+    verify(writeFn, times(0)).updateAllAsync(anyCollection(), anyCollection(), any());
+    table.updateAllAsync(
+        Arrays.asList(new Entry<>("foo", "bar")),
+        Arrays.asList(new Entry<>("foo", "bar"))).join();
+    verify(writeFn, times(1)).updateAllAsync(anyCollection(), anyCollection());
+    verify(writeFn, times(0)).updateAllAsync(anyCollection(), anyCollection(), any());
+    table.updateAllAsync(
+        Arrays.asList(new Entry<>("foo", "bar")),
+        Arrays.asList(new Entry<>("foo", "bar")),
+        Arrays.asList(0, 0)).join();
+    verify(writeFn, times(1)).updateAllAsync(anyCollection(), anyCollection());
+    verify(writeFn, times(1)).updateAllAsync(anyCollection(), anyCollection(), any());
+
     // DeleteAsync
     verify(writeFn, times(0)).deleteAsync(any());
     verify(writeFn, times(0)).deleteAsync(any(), any());

--- a/samza-core/src/test/java/org/apache/samza/table/remote/TestRemoteTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/TestRemoteTable.java
@@ -26,7 +26,7 @@ import org.apache.samza.metrics.Gauge;
 import org.apache.samza.metrics.MetricsRegistry;
 import org.apache.samza.metrics.Timer;
 import org.apache.samza.storage.kv.Entry;
-import org.apache.samza.table.AsyncReadWriteTable;
+import org.apache.samza.table.AsyncReadWriteUpdateTable;
 import org.apache.samza.table.ratelimit.AsyncRateLimitedTable;
 import org.apache.samza.table.retry.AsyncRetriableTable;
 import org.apache.samza.table.retry.TableRetryPolicy;
@@ -143,7 +143,7 @@ public class TestRemoteTable {
     TableWriteFunction<String, String, String> writeFn = mock(TableWriteFunction.class);
     RemoteTable<String, String, String> table = getTable(tableId, readFn, writeFn, true);
     // AsyncRetriableTable
-    AsyncReadWriteTable innerTable = TestUtils.getFieldValue(table, "asyncTable");
+    AsyncReadWriteUpdateTable innerTable = TestUtils.getFieldValue(table, "asyncTable");
     Assert.assertTrue(innerTable instanceof AsyncRetriableTable);
     Assert.assertNotNull(TestUtils.getFieldValue(innerTable, "readRetryMetrics"));
     Assert.assertNotNull(TestUtils.getFieldValue(innerTable, "writeRetryMetrics"));

--- a/samza-core/src/test/java/org/apache/samza/table/remote/TestRemoteTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/TestRemoteTable.java
@@ -694,9 +694,7 @@ public class TestRemoteTable {
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).putAllAsync(anyCollection());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).putAllAsync(anyCollection(), any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAsync(any(), any());
-    doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAsync(any(), any(), any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAllAsync(anyCollection());
-    doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAllAsync(anyCollection(), any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).deleteAsync(any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).deleteAsync(any(), any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).deleteAllAsync(anyCollection());
@@ -728,24 +726,12 @@ public class TestRemoteTable {
 
     // UpdateAsync
     verify(writeFn, times(0)).updateAsync(any(), any());
-    verify(writeFn, times(0)).updateAsync(any(), any(), any());
     table.updateAsync("foo", "bar").join();
     verify(writeFn, times(1)).updateAsync(any(), any());
-    verify(writeFn, times(0)).updateAsync(any(), any(), any());
-    table.updateAsync("foo", "bar", 3).join();
-    verify(writeFn, times(1)).updateAsync(any(), any());
-    verify(writeFn, times(1)).updateAsync(any(), any(), any());
     // UpdateAllAsync
     verify(writeFn, times(0)).updateAllAsync(anyCollection());
-    verify(writeFn, times(0)).updateAllAsync(anyCollection(), any());
     table.updateAllAsync(Arrays.asList(new Entry<>("foo", "bar"))).join();
     verify(writeFn, times(1)).updateAllAsync(anyCollection());
-    verify(writeFn, times(0)).updateAllAsync(anyCollection(), any());
-    table.updateAllAsync(
-        Arrays.asList(new Entry<>("foo", "bar")),
-        Arrays.asList(0, 0)).join();
-    verify(writeFn, times(1)).updateAllAsync(anyCollection());
-    verify(writeFn, times(1)).updateAllAsync(anyCollection(), any());
 
     // DeleteAsync
     verify(writeFn, times(0)).deleteAsync(any());

--- a/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
@@ -313,7 +313,7 @@ public class TestRemoteTableDescriptor {
 
   private void doTestDeserializeReadFunctionAndLimiter(boolean rateOnly, boolean rlGets, boolean rlPuts) {
     int numRateLimitOps = (rlGets ? 1 : 0) + (rlPuts ? 1 : 0);
-    RemoteTableDescriptor<String, String> desc = new RemoteTableDescriptor("1")
+    RemoteTableDescriptor<String, String, String> desc = new RemoteTableDescriptor("1")
         .withReadFunction(createMockTableReadFunction())
         .withReadRetryPolicy(new TableRetryPolicy().withRetryPredicate((ex) -> false))
         .withWriteFunction(createMockTableWriteFunction())

--- a/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
@@ -74,22 +74,27 @@ import static org.mockito.Mockito.withSettings;
 
 public class TestRemoteTableDescriptor {
 
-  private void doTestSerialize(RateLimiter rateLimiter, CreditFunction readCredFn, CreditFunction writeCredFn) {
+  private void doTestSerialize(RateLimiter rateLimiter, CreditFunction readCredFn, CreditFunction writeCredFn,
+      CreditFunction updateCredFn) {
     String tableId = "1";
     RemoteTableDescriptor desc = new RemoteTableDescriptor(tableId)
         .withReadFunction(createMockTableReadFunction())
         .withWriteFunction(createMockTableWriteFunction());
     if (rateLimiter != null) {
-      desc.withRateLimiter(rateLimiter, readCredFn, writeCredFn);
+      desc.withRateLimiter(rateLimiter, readCredFn, writeCredFn, updateCredFn);
       if (readCredFn == null) {
         desc.withReadRateLimiterDisabled();
       }
       if (writeCredFn == null) {
         desc.withWriteRateLimiterDisabled();
       }
+      if (updateCredFn == null) {
+        desc.withUpdateRateLimiterDisabled();
+      }
     } else {
       desc.withReadRateLimit(100);
       desc.withWriteRateLimit(200);
+      desc.withUpdateRateLimit(200);
     }
     Map<String, String> tableConfig = desc.toConfig(new MapConfig());
     assertExists(RemoteTableDescriptor.RATE_LIMITER, tableId, tableConfig);
@@ -97,6 +102,8 @@ public class TestRemoteTableDescriptor {
         tableConfig.containsKey(JavaTableConfig.buildKey(tableId, RemoteTableDescriptor.READ_CREDIT_FN)));
     Assert.assertEquals(writeCredFn != null,
         tableConfig.containsKey(JavaTableConfig.buildKey(tableId, RemoteTableDescriptor.WRITE_CREDIT_FN)));
+    Assert.assertEquals(updateCredFn != null,
+        tableConfig.containsKey(JavaTableConfig.buildKey(tableId, RemoteTableDescriptor.UPDATE_CREDIT_FN)));
   }
 
   @Test
@@ -113,7 +120,8 @@ public class TestRemoteTableDescriptor {
     String tableId2 = "2";
     RemoteTableDescriptor desc2 = new RemoteTableDescriptor(tableId2)
         .withWriteFunction(createMockTableWriteFunction())
-        .withWriteRateLimiterDisabled();
+        .withWriteRateLimiterDisabled()
+        .withUpdateRateLimiterDisabled();
     tableConfig = desc2.toConfig(new MapConfig());
     Assert.assertNotNull(tableConfig);
 
@@ -132,27 +140,32 @@ public class TestRemoteTableDescriptor {
 
   @Test
   public void testSerializeSimple() {
-    doTestSerialize(null, null, null);
+    doTestSerialize(null, null, null, null);
   }
 
   @Test
   public void testSerializeWithLimiter() {
-    doTestSerialize(createMockRateLimiter(), new CountingCreditFunction(), new CountingCreditFunction());
+    doTestSerialize(createMockRateLimiter(), new CountingCreditFunction(), new CountingCreditFunction(), new CountingCreditFunction());
   }
 
   @Test
   public void testSerializeWithLimiterAndReadCredFn() {
-    doTestSerialize(createMockRateLimiter(), (k, v, args) -> 1, null);
+    doTestSerialize(createMockRateLimiter(), (k, v, args) -> 1, null, null);
   }
 
   @Test
   public void testSerializeWithLimiterAndWriteCredFn() {
-    doTestSerialize(createMockRateLimiter(), null, (k, v, args) -> 1);
+    doTestSerialize(createMockRateLimiter(), null, (k, v, args) -> 1, null);
   }
 
   @Test
-  public void testSerializeWithLimiterAndReadWriteCredFns() {
-    doTestSerialize(createMockRateLimiter(), (key, value, args) -> 1, (key, value, args) -> 1);
+  public void testSerializeWithLimiterAndUpdateCredFn() {
+    doTestSerialize(createMockRateLimiter(), null, null, (k, v, args) -> 1);
+  }
+
+  @Test
+  public void testSerializeWithLimiterAndReadWriteUpdateCredFns() {
+    doTestSerialize(createMockRateLimiter(), (key, value, args) -> 1, (key, value, args) -> 1, (key, value, args) -> 1);
   }
 
   @Test
@@ -178,7 +191,7 @@ public class TestRemoteTableDescriptor {
     RemoteTableDescriptor desc = new RemoteTableDescriptor("1");
     desc.withReadFunction(createMockTableReadFunction());
     desc.withReadRateLimit(100);
-    desc.withRateLimiter(createMockRateLimiter(), null, null);
+    desc.withRateLimiter(createMockRateLimiter(), null, null, null);
     desc.toConfig(new MapConfig());
   }
 
@@ -214,6 +227,9 @@ public class TestRemoteTableDescriptor {
     CreditFunction writeCredFn = createMockCreditFunction();
     when(writeCredFn.toConfig(any(), any())).thenReturn(createConfigPair(key));
 
+    CreditFunction updateCredFn = createMockCreditFunction();
+    when(updateCredFn.toConfig(any(), any())).thenReturn(createConfigPair(key));
+
     TableRetryPolicy readRetryPolicy = createMockTableRetryPolicy();
     when(readRetryPolicy.toConfig(any(), any())).thenReturn(createConfigPair(key));
 
@@ -222,7 +238,7 @@ public class TestRemoteTableDescriptor {
 
     Map<String, String> tableConfig = new RemoteTableDescriptor("1").withReadFunction(readFn)
         .withWriteFunction(writeFn)
-        .withRateLimiter(rateLimiter, readCredFn, writeCredFn)
+        .withRateLimiter(rateLimiter, readCredFn, writeCredFn, updateCredFn)
         .withReadRetryPolicy(readRetryPolicy)
         .withWriteRetryPolicy(writeRetryPolicy)
         .toConfig(new MapConfig());
@@ -260,9 +276,11 @@ public class TestRemoteTableDescriptor {
         .withReadRetryPolicy(new TableRetryPolicy())
         .withWriteRateLimit(1000)
         .withReadRateLimit(2000)
+        .withUpdateRateLimit(1000)
         .toConfig(new MapConfig());
     Assert.assertEquals(String.valueOf(2000), tableConfig.get("tables.1.io.read.credits"));
     Assert.assertEquals(String.valueOf(1000), tableConfig.get("tables.1.io.write.credits"));
+    Assert.assertEquals(String.valueOf(1000), tableConfig.get("tables.1.io.update.credits"));
   }
 
   private Context createMockContext(TableDescriptor tableDescriptor) {
@@ -311,8 +329,8 @@ public class TestRemoteTableDescriptor {
     }
   }
 
-  private void doTestDeserializeReadFunctionAndLimiter(boolean rateOnly, boolean rlGets, boolean rlPuts) {
-    int numRateLimitOps = (rlGets ? 1 : 0) + (rlPuts ? 1 : 0);
+  private void doTestDeserializeReadFunctionAndLimiter(boolean rateOnly, boolean rlGets, boolean rlPuts, boolean rlUpdates) {
+    int numRateLimitOps = (rlGets ? 1 : 0) + (rlPuts ? 1 : 0) + (rlUpdates ? 1 : 0);
     RemoteTableDescriptor<String, String, String> desc = new RemoteTableDescriptor("1")
         .withReadFunction(createMockTableReadFunction())
         .withReadRetryPolicy(new TableRetryPolicy().withRetryPredicate((ex) -> false))
@@ -330,6 +348,11 @@ public class TestRemoteTableDescriptor {
       } else {
         desc.withWriteRateLimiterDisabled();
       }
+      if (rlUpdates) {
+        desc.withUpdateRateLimit(2000);
+      } else {
+        desc.withUpdateRateLimiterDisabled();
+      }
     } else {
       if (numRateLimitOps > 0) {
         Map<String, Integer> tagCredits = new HashMap<>();
@@ -343,10 +366,16 @@ public class TestRemoteTableDescriptor {
         } else {
           desc.withWriteRateLimiterDisabled();
         }
+        if (rlUpdates) {
+          tagCredits.put(RemoteTableDescriptor.RL_UPDATE_TAG, 2000);
+        } else {
+          desc.withUpdateRateLimiterDisabled();
+        }
 
         // Spy the rate limiter to verify call count
         RateLimiter rateLimiter = spy(new EmbeddedTaggedRateLimiter(tagCredits));
-        desc.withRateLimiter(rateLimiter, new CountingCreditFunction(), new CountingCreditFunction());
+        desc.withRateLimiter(rateLimiter, new CountingCreditFunction(), new CountingCreditFunction(),
+            new CountingCreditFunction());
       } else {
         desc.withRateLimiterDisabled();
       }
@@ -360,7 +389,7 @@ public class TestRemoteTableDescriptor {
 
     AsyncReadWriteTable delegate = TestUtils.getFieldValue(rwTable, "asyncTable");
     Assert.assertTrue(delegate instanceof AsyncRetriableTable);
-    if (rlGets || rlPuts) {
+    if (rlGets || rlPuts || rlUpdates) {
       delegate = TestUtils.getFieldValue(delegate, "table");
       Assert.assertTrue(delegate instanceof AsyncRateLimitedTable);
     }
@@ -370,8 +399,10 @@ public class TestRemoteTableDescriptor {
     if (numRateLimitOps > 0) {
       TableRateLimiter readRateLimiter = TestUtils.getFieldValue(rwTable, "readRateLimiter");
       TableRateLimiter writeRateLimiter = TestUtils.getFieldValue(rwTable, "writeRateLimiter");
+      TableRateLimiter updateRateLimiter = TestUtils.getFieldValue(rwTable, "updateRateLimiter");
       Assert.assertTrue(!rlGets || readRateLimiter != null);
       Assert.assertTrue(!rlPuts || writeRateLimiter != null);
+      Assert.assertTrue(!rlUpdates || updateRateLimiter != null);
     }
 
     ThreadPoolExecutor callbackExecutor = TestUtils.getFieldValue(rwTable, "callbackExecutor");
@@ -380,37 +411,37 @@ public class TestRemoteTableDescriptor {
 
   @Test
   public void testDeserializeReadFunctionNoRateLimit() {
-    doTestDeserializeReadFunctionAndLimiter(false, false, false);
+    doTestDeserializeReadFunctionAndLimiter(false, false, false, false);
   }
 
   @Test
   public void testDeserializeReadFunctionAndLimiterWrite() {
-    doTestDeserializeReadFunctionAndLimiter(false, false, true);
+    doTestDeserializeReadFunctionAndLimiter(false, false, true, false);
   }
 
   @Test
   public void testDeserializeReadFunctionAndLimiterRead() {
-    doTestDeserializeReadFunctionAndLimiter(false, true, false);
+    doTestDeserializeReadFunctionAndLimiter(false, true, false, false);
   }
 
   @Test
   public void testDeserializeReadFunctionAndLimiterReadWrite() {
-    doTestDeserializeReadFunctionAndLimiter(false, true, true);
+    doTestDeserializeReadFunctionAndLimiter(false, true, true, false);
   }
 
   @Test
   public void testDeserializeReadFunctionAndLimiterRateOnlyWrite() {
-    doTestDeserializeReadFunctionAndLimiter(true, false, true);
+    doTestDeserializeReadFunctionAndLimiter(true, false, true, false);
   }
 
   @Test
   public void testDeserializeReadFunctionAndLimiterRateOnlyRead() {
-    doTestDeserializeReadFunctionAndLimiter(true, true, false);
+    doTestDeserializeReadFunctionAndLimiter(true, true, false, false);
   }
 
   @Test
   public void testDeserializeReadFunctionAndLimiterRateOnlyReadWrite() {
-    doTestDeserializeReadFunctionAndLimiter(true, true, true);
+    doTestDeserializeReadFunctionAndLimiter(true, true, true, false);
   }
 
   private RateLimiter createMockRateLimiter() {

--- a/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
+++ b/samza-core/src/test/java/org/apache/samza/table/remote/descriptors/TestRemoteTableDescriptor.java
@@ -35,7 +35,7 @@ import org.apache.samza.job.model.TaskModel;
 import org.apache.samza.metrics.Counter;
 import org.apache.samza.metrics.MetricsRegistry;
 import org.apache.samza.metrics.Timer;
-import org.apache.samza.table.AsyncReadWriteTable;
+import org.apache.samza.table.AsyncReadWriteUpdateTable;
 import org.apache.samza.table.Table;
 import org.apache.samza.table.descriptors.RemoteTableDescriptor;
 import org.apache.samza.table.descriptors.TableDescriptor;
@@ -353,7 +353,7 @@ public class TestRemoteTableDescriptor {
     Assert.assertTrue(table instanceof RemoteTable);
     RemoteTable rwTable = (RemoteTable) table;
 
-    AsyncReadWriteTable delegate = TestUtils.getFieldValue(rwTable, "asyncTable");
+    AsyncReadWriteUpdateTable delegate = TestUtils.getFieldValue(rwTable, "asyncTable");
     Assert.assertTrue(delegate instanceof AsyncRetriableTable);
     if (rlGets || rlPuts) {
       delegate = TestUtils.getFieldValue(delegate, "table");

--- a/samza-core/src/test/java/org/apache/samza/table/retry/TestAsyncRetriableTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/retry/TestAsyncRetriableTable.java
@@ -37,6 +37,7 @@ import org.apache.samza.table.remote.TestRemoteTable;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyCollection;
 import static org.mockito.Mockito.*;
 
 
@@ -275,6 +276,10 @@ public class TestAsyncRetriableTable {
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).putAsync(any(), any(), any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).putAllAsync(any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).putAllAsync(any(), any());
+    doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAsync(any(), any(), any());
+    doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAsync(any(), any(), any(), any());
+    doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAllAsync(any(), any());
+    doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAllAsync(any(), any(), any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).deleteAsync(any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).deleteAsync(any(), any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).deleteAllAsync(any());
@@ -301,6 +306,26 @@ public class TestAsyncRetriableTable {
     table.putAllAsync(Arrays.asList(1), Arrays.asList(1)).join();
     verify(writeFn, times(1)).putAllAsync(anyCollection());
     verify(writeFn, times(1)).putAllAsync(anyCollection(), any());
+
+    // UpdateAsync
+    verify(writeFn, times(0)).updateAsync(any(), any(), any());
+    verify(writeFn, times(0)).updateAsync(any(), any(), any(), any());
+    table.updateAsync(1, 2, 2).join();
+    verify(writeFn, times(1)).updateAsync(any(), any(), any());
+    verify(writeFn, times(0)).updateAsync(any(), any(), any(), any());
+    table.updateAsync(1, 2, 2, Arrays.asList(0, 0)).join();
+    verify(writeFn, times(1)).updateAsync(any(), any(), any());
+    verify(writeFn, times(1)).updateAsync(any(), any(), any(), any());
+    // UpdateAllAsync
+    verify(writeFn, times(0)).updateAllAsync(anyCollection(), anyCollection());
+    verify(writeFn, times(0)).updateAllAsync(anyCollection(), anyCollection(), any());
+    table.updateAllAsync(Arrays.asList(new Entry<>(1, 2)), Arrays.asList(new Entry<>(1, 2))).join();
+    verify(writeFn, times(1)).updateAllAsync(anyCollection(), anyCollection());
+    verify(writeFn, times(0)).updateAllAsync(anyCollection(), anyCollection(), any());
+    table.updateAllAsync(Arrays.asList(new Entry<>(1, 2)), Arrays.asList(new Entry<>(1, 2)), Arrays.asList(1)).join();
+    verify(writeFn, times(1)).updateAllAsync(anyCollection(), anyCollection());
+    verify(writeFn, times(1)).updateAllAsync(anyCollection(), anyCollection(), any());
+
     // DeleteAsync
     verify(writeFn, times(0)).deleteAsync(any());
     verify(writeFn, times(0)).deleteAsync(any(), any());
@@ -367,7 +392,7 @@ public class TestAsyncRetriableTable {
     policy.withFixedBackoff(Duration.ofMillis(10));
     policy.withStopAfterDelay(Duration.ofMillis(100));
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
-    TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
+    TableWriteFunction<String, String, String> writeFn = mock(TableWriteFunction.class);
     doReturn(false).when(writeFn).isRetriable(any());
     CompletableFuture<String> future = new CompletableFuture();
     future.completeExceptionally(new RuntimeException("test exception"));
@@ -394,7 +419,7 @@ public class TestAsyncRetriableTable {
     TableRetryPolicy policy = new TableRetryPolicy();
     policy.withFixedBackoff(Duration.ofMillis(10));
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
-    TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
+    TableWriteFunction<String, String, String> writeFn = mock(TableWriteFunction.class);
     doReturn(true).when(writeFn).isRetriable(any());
 
     AtomicInteger times = new AtomicInteger();
@@ -427,7 +452,7 @@ public class TestAsyncRetriableTable {
     policy.withFixedBackoff(Duration.ofMillis(5));
     policy.withStopAfterDelay(Duration.ofMillis(100));
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
-    TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
+    TableWriteFunction<String, String, String> writeFn = mock(TableWriteFunction.class);
     doReturn(true).when(writeFn).isRetriable(any());
     CompletableFuture<String> future = new CompletableFuture();
     future.completeExceptionally(new RuntimeException("test exception"));
@@ -455,7 +480,7 @@ public class TestAsyncRetriableTable {
     policy.withFixedBackoff(Duration.ofMillis(5));
     policy.withStopAfterAttempts(10);
     TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
-    TableWriteFunction<String, String> writeFn = mock(TableWriteFunction.class);
+    TableWriteFunction<String, String, String> writeFn = mock(TableWriteFunction.class);
     doReturn(true).when(writeFn).isRetriable(any());
     CompletableFuture<String> future = new CompletableFuture();
     future.completeExceptionally(new RuntimeException("test exception"));
@@ -472,6 +497,154 @@ public class TestAsyncRetriableTable {
 
     verify(writeFn, atLeast(11)).putAllAsync(any());
     assertEquals(10, table.writeRetryMetrics.retryCount.getCount());
+    assertEquals(0, table.writeRetryMetrics.successCount.getCount());
+    assertEquals(1, table.writeRetryMetrics.permFailureCount.getCount());
+    assertTrue(table.writeRetryMetrics.retryTimer.getSnapshot().getMax() > 0);
+  }
+
+  @Test
+  public void testUpdateWithoutRetry() {
+    TableRetryPolicy policy = new TableRetryPolicy();
+    policy.withFixedBackoff(Duration.ofMillis(100));
+    TableReadFunction readFn = mock(TableReadFunction.class);
+    TableWriteFunction writeFn = mock(TableWriteFunction.class);
+    doReturn(true).when(writeFn).isRetriable(any());
+    doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAsync(any(), any(), any());
+    doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAllAsync(any(), any());
+    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, writeFn);
+    AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, null, policy, schedExec, readFn, writeFn);
+
+    int times = 0;
+    table.init(TestRemoteTable.getMockContext());
+    verify(readFn, times(0)).init(any(), any());
+    verify(writeFn, times(0)).init(any(), any());
+    table.updateAsync("foo", "bar", "bar").join();
+    verify(writeFn, times(1)).updateAsync(any(), any(), any());
+    assertEquals(++times, table.writeRetryMetrics.successCount.getCount());
+    table.updateAllAsync(Arrays.asList(new Entry<>("1", "2")), Arrays.asList(new Entry<>("1", "2"))).join();
+    verify(writeFn, times(1)).updateAllAsync(any(), any());
+    assertEquals(++times, table.writeRetryMetrics.successCount.getCount());
+    assertEquals(0, table.writeRetryMetrics.retryCount.getCount());
+    assertEquals(0, table.writeRetryMetrics.retryTimer.getSnapshot().getMax());
+    assertEquals(0, table.writeRetryMetrics.permFailureCount.getCount());
+    assertNull(table.readRetryMetrics);
+  }
+
+  @Test
+  public void testUpdateWithRetryDisabled() {
+    TableRetryPolicy policy = new TableRetryPolicy();
+    policy.withFixedBackoff(Duration.ofMillis(10));
+    policy.withStopAfterDelay(Duration.ofMillis(100));
+    TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
+    TableWriteFunction<String, String, String> writeFn = mock(TableWriteFunction.class);
+    doReturn(false).when(writeFn).isRetriable(any());
+    CompletableFuture<String> future = new CompletableFuture();
+    future.completeExceptionally(new RuntimeException("test exception"));
+    doReturn(future).when(writeFn).updateAsync(any(), any(), any());
+    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, writeFn);
+    AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, null, policy, schedExec, readFn, writeFn);
+    table.init(TestRemoteTable.getMockContext());
+
+    try {
+      table.updateAsync("foo", "bar", "bar").join();
+      fail();
+    } catch (Throwable t) {
+    }
+
+    verify(writeFn, times(1)).updateAsync(any(), any(), any());
+    assertEquals(0, table.writeRetryMetrics.retryCount.getCount());
+    assertEquals(0, table.writeRetryMetrics.successCount.getCount());
+    assertEquals(0, table.writeRetryMetrics.permFailureCount.getCount());
+    assertEquals(0, table.writeRetryMetrics.retryTimer.getSnapshot().getMax());
+  }
+
+  @Test
+  public void testUpdateWithOneRetry() {
+    TableRetryPolicy policy = new TableRetryPolicy();
+    policy.withFixedBackoff(Duration.ofMillis(10));
+    TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
+    TableWriteFunction<String, String, String> writeFn = mock(TableWriteFunction.class);
+    doReturn(true).when(writeFn).isRetriable(any());
+
+    AtomicInteger times = new AtomicInteger();
+    doAnswer(invocation -> {
+      CompletableFuture<Map<String, String>> future = new CompletableFuture();
+      if (times.get() > 0) {
+        future.complete(null);
+      } else {
+        times.incrementAndGet();
+        future.completeExceptionally(new RuntimeException("test exception"));
+      }
+      return future;
+    }).when(writeFn).updateAsync(any(), any(), any());
+
+    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, writeFn);
+    AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, null, policy, schedExec, readFn, writeFn);
+    table.init(TestRemoteTable.getMockContext());
+
+    table.updateAsync(1, 2, 2).join();
+    verify(writeFn, times(2)).updateAsync(any(), any(), any());
+    assertEquals(1, table.writeRetryMetrics.retryCount.getCount());
+    assertEquals(0, table.writeRetryMetrics.successCount.getCount());
+    assertEquals(0, table.writeRetryMetrics.permFailureCount.getCount());
+    assertTrue(table.writeRetryMetrics.retryTimer.getSnapshot().getMax() > 0);
+  }
+
+  @Test
+  public void testUpdateAllWithOneRetry() {
+    TableRetryPolicy policy = new TableRetryPolicy();
+    policy.withFixedBackoff(Duration.ofMillis(10));
+    TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
+    TableWriteFunction<String, String, String> writeFn = mock(TableWriteFunction.class);
+    doReturn(true).when(writeFn).isRetriable(any());
+
+    AtomicInteger times = new AtomicInteger();
+    doAnswer(invocation -> {
+      CompletableFuture<Map<String, String>> future = new CompletableFuture();
+      if (times.get() > 0) {
+        future.complete(null);
+      } else {
+        times.incrementAndGet();
+        future.completeExceptionally(new RuntimeException("test exception"));
+      }
+      return future;
+    }).when(writeFn).updateAllAsync(any(), any());
+
+    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, writeFn);
+    AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, null, policy, schedExec, readFn, writeFn);
+    table.init(TestRemoteTable.getMockContext());
+
+    table.updateAllAsync(Arrays.asList(new Entry(1, 2)), Arrays.asList(new Entry(1, 2))).join();
+    verify(writeFn, times(2)).updateAllAsync(any(), any());
+    assertEquals(1, table.writeRetryMetrics.retryCount.getCount());
+    assertEquals(0, table.writeRetryMetrics.successCount.getCount());
+    assertEquals(0, table.writeRetryMetrics.permFailureCount.getCount());
+    assertTrue(table.writeRetryMetrics.retryTimer.getSnapshot().getMax() > 0);
+  }
+
+  @Test
+  public void testUpdateWithPermFailureOnMaxCount() {
+    TableRetryPolicy policy = new TableRetryPolicy();
+    policy.withFixedBackoff(Duration.ofMillis(5));
+    policy.withStopAfterAttempts(5);
+    TableReadFunction<String, String> readFn = mock(TableReadFunction.class);
+    TableWriteFunction<String, String, String> writeFn = mock(TableWriteFunction.class);
+    doReturn(true).when(writeFn).isRetriable(any());
+    CompletableFuture<String> future = new CompletableFuture();
+    future.completeExceptionally(new RuntimeException("test exception"));
+    doReturn(future).when(writeFn).updateAsync(any(), any(), any());
+    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, writeFn);
+    AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, null, policy, schedExec, readFn, writeFn);
+    table.init(TestRemoteTable.getMockContext());
+
+    try {
+      table.updateAsync(1, 2, 2).join();
+      fail();
+    } catch (Throwable t) {
+    }
+
+    verify(writeFn, atLeast(6)).updateAsync(any(), any(), any());
+    assertEquals(5, table.writeRetryMetrics.retryCount.getCount());
     assertEquals(0, table.writeRetryMetrics.successCount.getCount());
     assertEquals(1, table.writeRetryMetrics.permFailureCount.getCount());
     assertTrue(table.writeRetryMetrics.retryTimer.getSnapshot().getMax() > 0);

--- a/samza-core/src/test/java/org/apache/samza/table/retry/TestAsyncRetriableTable.java
+++ b/samza-core/src/test/java/org/apache/samza/table/retry/TestAsyncRetriableTable.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.samza.storage.kv.Entry;
-import org.apache.samza.table.AsyncReadWriteTable;
+import org.apache.samza.table.AsyncReadWriteUpdateTable;
 import org.apache.samza.table.remote.AsyncRemoteTable;
 import org.apache.samza.table.remote.TableReadFunction;
 import org.apache.samza.table.remote.TableWriteFunction;
@@ -47,7 +47,7 @@ public class TestAsyncRetriableTable {
 
   @Test(expected = NullPointerException.class)
   public void testNotNullTableId() {
-    new AsyncRetriableTable(null, mock(AsyncReadWriteTable.class),
+    new AsyncRetriableTable(null, mock(AsyncReadWriteUpdateTable.class),
         mock(TableRetryPolicy.class), mock(TableRetryPolicy.class),
         mock(ScheduledExecutorService.class),
         mock(TableReadFunction.class), mock(TableWriteFunction.class));
@@ -63,14 +63,14 @@ public class TestAsyncRetriableTable {
 
   @Test(expected = NullPointerException.class)
   public void testNotNullExecutorService() {
-    new AsyncRetriableTable("t1", mock(AsyncReadWriteTable.class),
+    new AsyncRetriableTable("t1", mock(AsyncReadWriteUpdateTable.class),
         mock(TableRetryPolicy.class), mock(TableRetryPolicy.class), null,
         mock(TableReadFunction.class), mock(TableWriteFunction.class));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testNotAllRetryPolicyAreNull() {
-    new AsyncRetriableTable("t1", mock(AsyncReadWriteTable.class),
+    new AsyncRetriableTable("t1", mock(AsyncReadWriteUpdateTable.class),
         null, null,
         mock(ScheduledExecutorService.class),
         mock(TableReadFunction.class), mock(TableWriteFunction.class));
@@ -88,7 +88,7 @@ public class TestAsyncRetriableTable {
     doReturn(CompletableFuture.completedFuture(result)).when(readFn).getAllAsync(any());
     doReturn(CompletableFuture.completedFuture(result)).when(readFn).getAllAsync(any(), any());
     doReturn(CompletableFuture.completedFuture(5)).when(readFn).readAsync(anyInt(), any());
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, null);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, null);
     AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, policy, null, schedExec, readFn, null);
 
     table.init(TestRemoteTable.getMockContext());
@@ -130,7 +130,7 @@ public class TestAsyncRetriableTable {
     Map<String, String> result = new HashMap<>();
     result.put("foo", "bar");
     doReturn(CompletableFuture.completedFuture(result)).when(readFn).getAllAsync(any());
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, null);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, null);
     AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, policy, null, schedExec, readFn, null);
 
     int times = 0;
@@ -160,7 +160,7 @@ public class TestAsyncRetriableTable {
     CompletableFuture<String> future = new CompletableFuture();
     future.completeExceptionally(new RuntimeException("test exception"));
     doReturn(future).when(readFn).getAsync(anyString());
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, null);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, null);
     AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, policy, null, schedExec, readFn, null);
     table.init(TestRemoteTable.getMockContext());
 
@@ -199,7 +199,7 @@ public class TestAsyncRetriableTable {
       return future;
     }).when(readFn).getAllAsync(anyCollection());
 
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, null);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, null);
     AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, policy, null, schedExec, readFn, null);
     table.init(TestRemoteTable.getMockContext());
 
@@ -221,7 +221,7 @@ public class TestAsyncRetriableTable {
     CompletableFuture<String> future = new CompletableFuture();
     future.completeExceptionally(new RuntimeException("test exception"));
     doReturn(future).when(readFn).getAsync(anyString());
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, null);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, null);
     AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, policy, null, schedExec, readFn, null);
     table.init(TestRemoteTable.getMockContext());
 
@@ -248,7 +248,7 @@ public class TestAsyncRetriableTable {
     CompletableFuture<String> future = new CompletableFuture();
     future.completeExceptionally(new RuntimeException("test exception"));
     doReturn(future).when(readFn).getAllAsync(any());
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, null);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, null);
     AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, policy, null, schedExec, readFn, null);
     table.init(TestRemoteTable.getMockContext());
 
@@ -285,7 +285,7 @@ public class TestAsyncRetriableTable {
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).deleteAllAsync(any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).deleteAllAsync(any(), any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).writeAsync(anyInt(), any());
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, writeFn);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, writeFn);
     AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, null, policy, schedExec, readFn, writeFn);
 
     // PutAsync
@@ -361,7 +361,7 @@ public class TestAsyncRetriableTable {
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).putAllAsync(any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).deleteAsync(any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).deleteAllAsync(any());
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, writeFn);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, writeFn);
     AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, null, policy, schedExec, readFn, writeFn);
 
     int times = 0;
@@ -397,7 +397,7 @@ public class TestAsyncRetriableTable {
     CompletableFuture<String> future = new CompletableFuture();
     future.completeExceptionally(new RuntimeException("test exception"));
     doReturn(future).when(writeFn).putAsync(any(), any());
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, writeFn);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, writeFn);
     AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, null, policy, schedExec, readFn, writeFn);
     table.init(TestRemoteTable.getMockContext());
 
@@ -434,7 +434,7 @@ public class TestAsyncRetriableTable {
       return future;
     }).when(writeFn).putAllAsync(any());
 
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, writeFn);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, writeFn);
     AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, null, policy, schedExec, readFn, writeFn);
     table.init(TestRemoteTable.getMockContext());
 
@@ -457,7 +457,7 @@ public class TestAsyncRetriableTable {
     CompletableFuture<String> future = new CompletableFuture();
     future.completeExceptionally(new RuntimeException("test exception"));
     doReturn(future).when(readFn).getAsync(anyString());
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, writeFn);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, writeFn);
     AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, null, policy, schedExec, readFn, writeFn);
     table.init(TestRemoteTable.getMockContext());
 
@@ -485,7 +485,7 @@ public class TestAsyncRetriableTable {
     CompletableFuture<String> future = new CompletableFuture();
     future.completeExceptionally(new RuntimeException("test exception"));
     doReturn(future).when(writeFn).putAllAsync(any());
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, writeFn);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, writeFn);
     AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, null, policy, schedExec, readFn, writeFn);
     table.init(TestRemoteTable.getMockContext());
 
@@ -511,7 +511,7 @@ public class TestAsyncRetriableTable {
     doReturn(true).when(writeFn).isRetriable(any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAsync(any(), any());
     doReturn(CompletableFuture.completedFuture(null)).when(writeFn).updateAllAsync(any());
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, writeFn);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, writeFn);
     AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, null, policy, schedExec, readFn, writeFn);
 
     int times = 0;
@@ -541,7 +541,7 @@ public class TestAsyncRetriableTable {
     CompletableFuture<String> future = new CompletableFuture();
     future.completeExceptionally(new RuntimeException("test exception"));
     doReturn(future).when(writeFn).updateAsync(any(), any());
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, writeFn);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, writeFn);
     AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, null, policy, schedExec, readFn, writeFn);
     table.init(TestRemoteTable.getMockContext());
 
@@ -578,7 +578,7 @@ public class TestAsyncRetriableTable {
       return future;
     }).when(writeFn).updateAsync(any(), any(), any());
 
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, writeFn);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, writeFn);
     AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, null, policy, schedExec, readFn, writeFn);
     table.init(TestRemoteTable.getMockContext());
 
@@ -610,7 +610,7 @@ public class TestAsyncRetriableTable {
       return future;
     }).when(writeFn).updateAllAsync(any(), any());
 
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, writeFn);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, writeFn);
     AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, null, policy, schedExec, readFn, writeFn);
     table.init(TestRemoteTable.getMockContext());
 
@@ -633,7 +633,7 @@ public class TestAsyncRetriableTable {
     CompletableFuture<String> future = new CompletableFuture();
     future.completeExceptionally(new RuntimeException("test exception"));
     doReturn(future).when(writeFn).updateAsync(any(), any(), any());
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, writeFn);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, writeFn);
     AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, null, policy, schedExec, readFn, writeFn);
     table.init(TestRemoteTable.getMockContext());
 
@@ -656,7 +656,7 @@ public class TestAsyncRetriableTable {
     policy.withFixedBackoff(Duration.ofMillis(100));
     TableReadFunction readFn = mock(TableReadFunction.class);
     TableWriteFunction writeFn = mock(TableWriteFunction.class);
-    AsyncReadWriteTable delegate = new AsyncRemoteTable(readFn, writeFn);
+    AsyncReadWriteUpdateTable delegate = new AsyncRemoteTable(readFn, writeFn);
     AsyncRetriableTable table = new AsyncRetriableTable("t1", delegate, null, policy, schedExec, readFn, writeFn);
 
     table.flush();

--- a/samza-kv-couchbase/src/main/java/org/apache/samza/table/remote/couchbase/BaseCouchbaseTableFunction.java
+++ b/samza-kv-couchbase/src/main/java/org/apache/samza/table/remote/couchbase/BaseCouchbaseTableFunction.java
@@ -34,7 +34,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.samza.context.Context;
 import org.apache.samza.serializers.Serde;
-import org.apache.samza.table.AsyncReadWriteTable;
+import org.apache.samza.table.AsyncReadWriteUpdateTable;
 import org.apache.samza.table.remote.BaseTableFunction;
 
 
@@ -79,7 +79,7 @@ public abstract class BaseCouchbaseTableFunction<V> extends BaseTableFunction {
   }
 
   @Override
-  public void init(Context context, AsyncReadWriteTable table) {
+  public void init(Context context, AsyncReadWriteUpdateTable table) {
     super.init(context, table);
     bucket = COUCHBASE_BUCKET_REGISTRY.getBucket(bucketName, clusterNodes, environmentConfigs);
   }

--- a/samza-kv-couchbase/src/main/java/org/apache/samza/table/remote/couchbase/CouchbaseTableReadFunction.java
+++ b/samza-kv-couchbase/src/main/java/org/apache/samza/table/remote/couchbase/CouchbaseTableReadFunction.java
@@ -54,7 +54,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import org.apache.samza.SamzaException;
 import org.apache.samza.context.Context;
-import org.apache.samza.table.AsyncReadWriteTable;
+import org.apache.samza.table.AsyncReadWriteUpdateTable;
 import org.apache.samza.table.remote.TableReadFunction;
 
 import org.slf4j.Logger;
@@ -91,7 +91,7 @@ public class CouchbaseTableReadFunction<V> extends BaseCouchbaseTableFunction<V>
   }
 
   @Override
-  public void init(Context context, AsyncReadWriteTable table) {
+  public void init(Context context, AsyncReadWriteUpdateTable table) {
     super.init(context, table);
     LOGGER.info("Read function for bucket {} initialized successfully", bucketName);
   }

--- a/samza-kv-couchbase/src/main/java/org/apache/samza/table/remote/couchbase/CouchbaseTableWriteFunction.java
+++ b/samza-kv-couchbase/src/main/java/org/apache/samza/table/remote/couchbase/CouchbaseTableWriteFunction.java
@@ -27,7 +27,6 @@ import com.couchbase.client.java.document.json.JsonObject;
 import com.google.common.base.Preconditions;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.samza.SamzaException;
 import org.apache.samza.context.Context;
@@ -83,7 +82,7 @@ public class CouchbaseTableWriteFunction<V> extends BaseCouchbaseTableFunction<V
   }
 
   @Override
-  public CompletableFuture<Void> updateAsync(String key, Object updates, @Nullable V record) {
+  public CompletableFuture<Void> updateAsync(String key, Object updates) {
     // TODO Add support for partial updates LISAMZA-21874
     throw new SamzaException("Update is unsupported");
   }

--- a/samza-kv-couchbase/src/main/java/org/apache/samza/table/remote/couchbase/CouchbaseTableWriteFunction.java
+++ b/samza-kv-couchbase/src/main/java/org/apache/samza/table/remote/couchbase/CouchbaseTableWriteFunction.java
@@ -24,12 +24,10 @@ import com.couchbase.client.java.document.BinaryDocument;
 import com.couchbase.client.java.document.Document;
 import com.couchbase.client.java.document.JsonDocument;
 import com.couchbase.client.java.document.json.JsonObject;
-
 import com.google.common.base.Preconditions;
-
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.samza.SamzaException;
 import org.apache.samza.context.Context;
@@ -50,7 +48,7 @@ import rx.SingleSubscriber;
  * @param <V> Type of values to write to Couchbase
  */
 public class CouchbaseTableWriteFunction<V> extends BaseCouchbaseTableFunction<V>
-    implements TableWriteFunction<String, V> {
+    implements TableWriteFunction<String, V, Object> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CouchbaseTableWriteFunction.class);
 
@@ -82,6 +80,12 @@ public class CouchbaseTableWriteFunction<V> extends BaseCouchbaseTableFunction<V
     return asyncWriteHelper(
         bucket.async().upsert(document, timeout.toMillis(), TimeUnit.MILLISECONDS),
         String.format("Failed to insert key %s into bucket %s", key, bucketName));
+  }
+
+  @Override
+  public CompletableFuture<Void> updateAsync(String key, Object updates, @Nullable V record) {
+    // TODO Add support for partial updates LISAMZA-21874
+    throw new SamzaException("Update is unsupported");
   }
 
   @Override
@@ -119,5 +123,4 @@ public class CouchbaseTableWriteFunction<V> extends BaseCouchbaseTableFunction<V
     });
     return future;
   }
-
 }

--- a/samza-kv-couchbase/src/main/java/org/apache/samza/table/remote/couchbase/CouchbaseTableWriteFunction.java
+++ b/samza-kv-couchbase/src/main/java/org/apache/samza/table/remote/couchbase/CouchbaseTableWriteFunction.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.samza.SamzaException;
 import org.apache.samza.context.Context;
-import org.apache.samza.table.AsyncReadWriteTable;
+import org.apache.samza.table.AsyncReadWriteUpdateTable;
 import org.apache.samza.table.remote.TableWriteFunction;
 
 import org.slf4j.Logger;
@@ -63,7 +63,7 @@ public class CouchbaseTableWriteFunction<V> extends BaseCouchbaseTableFunction<V
   }
 
   @Override
-  public void init(Context context, AsyncReadWriteTable table) {
+  public void init(Context context, AsyncReadWriteUpdateTable table) {
     super.init(context, table);
     LOGGER.info("Write function for bucket {} initialized successfully", bucketName);
   }

--- a/samza-kv-couchbase/src/test/java/org/apache/samza/table/remote/couchbase/TestCouchbaseTableReadFunction.java
+++ b/samza-kv-couchbase/src/test/java/org/apache/samza/table/remote/couchbase/TestCouchbaseTableReadFunction.java
@@ -36,7 +36,7 @@ import org.apache.samza.SamzaException;
 import org.apache.samza.context.Context;
 import org.apache.samza.serializers.Serde;
 import org.apache.samza.serializers.StringSerde;
-import org.apache.samza.table.AsyncReadWriteTable;
+import org.apache.samza.table.AsyncReadWriteUpdateTable;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -183,7 +183,7 @@ public class TestCouchbaseTableReadFunction {
         CouchbaseEnvironmentConfigs.class)).toReturn(bucket);
     CouchbaseTableReadFunction<V> readFunction =
         new CouchbaseTableReadFunction<>(DEFAULT_BUCKET_NAME, valueClass, DEFAULT_CLUSTER_NODE).withSerde(serde);
-    readFunction.init(mock(Context.class), mock(AsyncReadWriteTable.class));
+    readFunction.init(mock(Context.class), mock(AsyncReadWriteUpdateTable.class));
     return readFunction;
   }
 }

--- a/samza-kv-couchbase/src/test/java/org/apache/samza/table/remote/couchbase/TestCouchbaseTableWriteFunction.java
+++ b/samza-kv-couchbase/src/test/java/org/apache/samza/table/remote/couchbase/TestCouchbaseTableWriteFunction.java
@@ -34,7 +34,7 @@ import org.apache.samza.SamzaException;
 import org.apache.samza.context.Context;
 import org.apache.samza.serializers.Serde;
 import org.apache.samza.serializers.StringSerde;
-import org.apache.samza.table.AsyncReadWriteTable;
+import org.apache.samza.table.AsyncReadWriteUpdateTable;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -199,7 +199,7 @@ public class TestCouchbaseTableWriteFunction {
         CouchbaseEnvironmentConfigs.class)).toReturn(bucket);
     CouchbaseTableWriteFunction<V> writeFunction =
         new CouchbaseTableWriteFunction<>(DEFAULT_BUCKET_NAME, valueClass, DEFAULT_CLUSTER_NODE).withSerde(serde);
-    writeFunction.init(mock(Context.class), mock(AsyncReadWriteTable.class));
+    writeFunction.init(mock(Context.class), mock(AsyncReadWriteUpdateTable.class));
     return writeFunction;
   }
 }

--- a/samza-kv/src/main/java/org/apache/samza/storage/kv/LocalTable.java
+++ b/samza-kv/src/main/java/org/apache/samza/storage/kv/LocalTable.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
+import org.apache.samza.SamzaException;
 import org.apache.samza.metrics.Counter;
 import org.apache.samza.metrics.Timer;
 import org.apache.samza.table.BaseReadWriteTable;
@@ -39,7 +41,7 @@ import static org.apache.samza.table.utils.TableMetricsUtil.updateTimer;
  * @param <K> the type of the key in this table
  * @param <V> the type of the value in this table
  */
-public final class LocalTable<K, V> extends BaseReadWriteTable<K, V> {
+public final class LocalTable<K, V, U> extends BaseReadWriteTable<K, V, U> {
 
   protected final KeyValueStore<K, V> kvStore;
 
@@ -144,6 +146,27 @@ public final class LocalTable<K, V> extends BaseReadWriteTable<K, V> {
       future.completeExceptionally(e);
     }
     return future;
+  }
+
+  @Override
+  public void update(K key, U update, V defaultValue, Object... args) {
+    throw new SamzaException("Local tables do not support update operations");
+  }
+
+  @Override
+  public CompletableFuture<Void> updateAsync(K key, U update, @Nullable V defaultValue, Object... args) {
+    throw new SamzaException("Local tables do not support update operations");
+  }
+
+  @Override
+  public void updateAll(List<Entry<K, U>> updates, List<Entry<K, V>> defaults, Object... args) {
+    throw new SamzaException("Local tables do not support update operations");
+  }
+
+  @Override
+  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, @Nullable List<Entry<K, V>> defaults,
+      Object... args) {
+    throw new SamzaException("Local tables do not support update operations");
   }
 
   @Override

--- a/samza-kv/src/main/java/org/apache/samza/storage/kv/LocalTable.java
+++ b/samza-kv/src/main/java/org/apache/samza/storage/kv/LocalTable.java
@@ -28,7 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.samza.SamzaException;
 import org.apache.samza.metrics.Counter;
 import org.apache.samza.metrics.Timer;
-import org.apache.samza.table.BaseReadWriteTable;
+import org.apache.samza.table.BaseReadWriteUpdateTable;
 
 import static org.apache.samza.table.utils.TableMetricsUtil.incCounter;
 import static org.apache.samza.table.utils.TableMetricsUtil.updateTimer;
@@ -40,7 +40,7 @@ import static org.apache.samza.table.utils.TableMetricsUtil.updateTimer;
  * @param <K> the type of the key in this table
  * @param <V> the type of the value in this table
  */
-public final class LocalTable<K, V, U> extends BaseReadWriteTable<K, V, U> {
+public final class LocalTable<K, V, U> extends BaseReadWriteUpdateTable<K, V, U> {
 
   protected final KeyValueStore<K, V> kvStore;
 

--- a/samza-kv/src/main/java/org/apache/samza/storage/kv/LocalTable.java
+++ b/samza-kv/src/main/java/org/apache/samza/storage/kv/LocalTable.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import javax.annotation.Nullable;
 import org.apache.samza.SamzaException;
 import org.apache.samza.metrics.Counter;
 import org.apache.samza.metrics.Timer;
@@ -149,23 +148,22 @@ public final class LocalTable<K, V, U> extends BaseReadWriteTable<K, V, U> {
   }
 
   @Override
-  public void update(K key, U update, V defaultValue, Object... args) {
+  public void update(K key, U update, Object... args) {
     throw new SamzaException("Local tables do not support update operations");
   }
 
   @Override
-  public CompletableFuture<Void> updateAsync(K key, U update, @Nullable V defaultValue, Object... args) {
+  public CompletableFuture<Void> updateAsync(K key, U update, Object... args) {
     throw new SamzaException("Local tables do not support update operations");
   }
 
   @Override
-  public void updateAll(List<Entry<K, U>> updates, List<Entry<K, V>> defaults, Object... args) {
+  public void updateAll(List<Entry<K, U>> updates, Object... args) {
     throw new SamzaException("Local tables do not support update operations");
   }
 
   @Override
-  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, @Nullable List<Entry<K, V>> defaults,
-      Object... args) {
+  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, Object... args) {
     throw new SamzaException("Local tables do not support update operations");
   }
 

--- a/samza-kv/src/main/java/org/apache/samza/storage/kv/LocalTable.java
+++ b/samza-kv/src/main/java/org/apache/samza/storage/kv/LocalTable.java
@@ -148,22 +148,22 @@ public final class LocalTable<K, V, U> extends BaseReadWriteUpdateTable<K, V, U>
   }
 
   @Override
-  public void update(K key, U update, Object... args) {
+  public void update(K key, U update) {
     throw new SamzaException("Local tables do not support update operations");
   }
 
   @Override
-  public CompletableFuture<Void> updateAsync(K key, U update, Object... args) {
+  public CompletableFuture<Void> updateAsync(K key, U update) {
     throw new SamzaException("Local tables do not support update operations");
   }
 
   @Override
-  public void updateAll(List<Entry<K, U>> updates, Object... args) {
+  public void updateAll(List<Entry<K, U>> updates) {
     throw new SamzaException("Local tables do not support update operations");
   }
 
   @Override
-  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates, Object... args) {
+  public CompletableFuture<Void> updateAllAsync(List<Entry<K, U>> updates) {
     throw new SamzaException("Local tables do not support update operations");
   }
 

--- a/samza-kv/src/main/java/org/apache/samza/storage/kv/LocalTableProvider.java
+++ b/samza-kv/src/main/java/org/apache/samza/storage/kv/LocalTableProvider.java
@@ -20,7 +20,7 @@ package org.apache.samza.storage.kv;
 
 import com.google.common.base.Preconditions;
 import org.apache.samza.context.Context;
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.apache.samza.table.BaseTableProvider;
 
 /**
@@ -52,11 +52,11 @@ public class LocalTableProvider extends BaseTableProvider {
   }
 
   @Override
-  public ReadWriteTable getTable() {
+  public ReadWriteUpdateTable getTable() {
     Preconditions.checkNotNull(context, String.format("Table %s not initialized", tableId));
     Preconditions.checkNotNull(kvStore, "Store not initialized for table " + tableId);
     @SuppressWarnings("unchecked")
-    ReadWriteTable table = new LocalTable(tableId, kvStore);
+    ReadWriteUpdateTable table = new LocalTable(tableId, kvStore);
     table.init(this.context);
     return table;
   }

--- a/samza-kv/src/test/java/org/apache/samza/storage/kv/TestLocalTableRead.java
+++ b/samza-kv/src/test/java/org/apache/samza/storage/kv/TestLocalTableRead.java
@@ -33,7 +33,7 @@ import org.apache.samza.metrics.Counter;
 import org.apache.samza.metrics.MetricsRegistry;
 import org.apache.samza.metrics.Timer;
 
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -91,7 +91,7 @@ public class TestLocalTableRead {
 
   @Test
   public void testGet() throws Exception {
-    ReadWriteTable table = createTable(false);
+    ReadWriteUpdateTable table = createTable(false);
     Assert.assertEquals("v1", table.get("k1"));
     Assert.assertEquals("v2", table.getAsync("k2").get());
     Assert.assertNull(table.get("k3"));
@@ -106,7 +106,7 @@ public class TestLocalTableRead {
 
   @Test
   public void testGetAll() throws Exception {
-    ReadWriteTable table = createTable(false);
+    ReadWriteUpdateTable table = createTable(false);
     Assert.assertEquals(values, table.getAll(keys));
     Assert.assertEquals(values, table.getAllAsync(keys).get());
     verify(kvStore, times(2)).getAll(any());
@@ -121,7 +121,7 @@ public class TestLocalTableRead {
 
   @Test
   public void testTimerDisabled() throws Exception {
-    ReadWriteTable table = createTable(true);
+    ReadWriteUpdateTable table = createTable(true);
     table.get("");
     table.getAsync("").get();
     table.getAll(keys);

--- a/samza-kv/src/test/java/org/apache/samza/storage/kv/TestLocalTableWrite.java
+++ b/samza-kv/src/test/java/org/apache/samza/storage/kv/TestLocalTableWrite.java
@@ -32,7 +32,7 @@ import org.apache.samza.context.JobContext;
 import org.apache.samza.metrics.Counter;
 import org.apache.samza.metrics.MetricsRegistry;
 import org.apache.samza.metrics.Timer;
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -98,7 +98,7 @@ public class TestLocalTableWrite {
 
   @Test
   public void testPut() throws Exception {
-    ReadWriteTable table = createTable(false);
+    ReadWriteUpdateTable table = createTable(false);
     table.put("k1", "v1");
     table.putAsync("k2", "v2").get();
     table.putAsync("k3", null).get();
@@ -120,7 +120,7 @@ public class TestLocalTableWrite {
 
   @Test
   public void testPutAll() throws Exception {
-    ReadWriteTable table = createTable(false);
+    ReadWriteUpdateTable table = createTable(false);
     List<Entry> entries = Arrays.asList(new Entry("k1", "v1"), new Entry("k2", null));
     table.putAll(entries);
     table.putAllAsync(entries).get();
@@ -142,7 +142,7 @@ public class TestLocalTableWrite {
 
   @Test
   public void testDelete() throws Exception {
-    ReadWriteTable table = createTable(false);
+    ReadWriteUpdateTable table = createTable(false);
     table.delete("");
     table.deleteAsync("").get();
     verify(kvStore, times(2)).delete(any());
@@ -162,7 +162,7 @@ public class TestLocalTableWrite {
 
   @Test
   public void testDeleteAll() throws Exception {
-    ReadWriteTable table = createTable(false);
+    ReadWriteUpdateTable table = createTable(false);
     table.deleteAll(Collections.emptyList());
     table.deleteAllAsync(Collections.emptyList()).get();
     verify(kvStore, times(2)).deleteAll(any());
@@ -182,7 +182,7 @@ public class TestLocalTableWrite {
 
   @Test
   public void testFlush() {
-    ReadWriteTable table = createTable(false);
+    ReadWriteUpdateTable table = createTable(false);
     table.flush();
     table.flush();
     // Note: store.flush() is NOT called here
@@ -203,7 +203,7 @@ public class TestLocalTableWrite {
 
   @Test
   public void testTimerDisabled() throws Exception {
-    ReadWriteTable table = createTable(true);
+    ReadWriteUpdateTable table = createTable(true);
     table.put("", "");
     table.putAsync("", "").get();
     table.putAll(Collections.emptyList());

--- a/samza-sql/src/test/java/org/apache/samza/sql/util/RemoteStoreIOResolverTestFactory.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/util/RemoteStoreIOResolverTestFactory.java
@@ -64,7 +64,7 @@ public class RemoteStoreIOResolverTestFactory implements SqlIOResolverFactory {
     }
 
     @Override
-    public CompletableFuture<Void> updateAsync(Object key, Object update, @Nullable Object record) {
+    public CompletableFuture<Void> updateAsync(Object key, @Nullable Object record) {
       throw new SamzaException("Update unsupported");
     }
 

--- a/samza-sql/src/test/java/org/apache/samza/sql/util/RemoteStoreIOResolverTestFactory.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/util/RemoteStoreIOResolverTestFactory.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
+import org.apache.samza.SamzaException;
 import org.apache.samza.config.Config;
 import org.apache.samza.sql.serializers.SamzaSqlRelMessageSerdeFactory;
 import org.apache.samza.sql.serializers.SamzaSqlRelRecordSerdeFactory;
@@ -53,12 +55,17 @@ public class RemoteStoreIOResolverTestFactory implements SqlIOResolverFactory {
   }
 
   public static class InMemoryWriteFunction extends BaseTableFunction
-      implements TableWriteFunction<Object, Object> {
+      implements TableWriteFunction<Object, Object, Object> {
 
     @Override
     public CompletableFuture<Void> putAsync(Object key, Object record) {
       records.put(key.toString(), record);
       return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> updateAsync(Object key, Object update, @Nullable Object record) {
+      throw new SamzaException("Update unsupported");
     }
 
     @Override

--- a/samza-test/src/test/java/org/apache/samza/test/framework/StreamTaskIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/framework/StreamTaskIntegrationTest.java
@@ -45,7 +45,7 @@ import org.apache.samza.system.SystemStreamPartition;
 import org.apache.samza.system.kafka.descriptors.KafkaInputDescriptor;
 import org.apache.samza.system.kafka.descriptors.KafkaOutputDescriptor;
 import org.apache.samza.system.kafka.descriptors.KafkaSystemDescriptor;
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.apache.samza.task.InitableTask;
 import org.apache.samza.task.MessageCollector;
 import org.apache.samza.task.StreamTask;
@@ -258,11 +258,11 @@ public class StreamTaskIntegrationTest {
   }
 
   static public class StatefulStreamTask implements StreamTask, InitableTask {
-    private ReadWriteTable<Integer, Profile, ?> profileViewTable;
+    private ReadWriteUpdateTable<Integer, Profile, ?> profileViewTable;
 
     @Override
     public void init(Context context) throws Exception {
-      profileViewTable = context.getTaskContext().getTable("profile-view-store");
+      profileViewTable = context.getTaskContext().getUpdatableTable("profile-view-store");
     }
 
     @Override

--- a/samza-test/src/test/java/org/apache/samza/test/framework/StreamTaskIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/framework/StreamTaskIntegrationTest.java
@@ -258,7 +258,7 @@ public class StreamTaskIntegrationTest {
   }
 
   static public class StatefulStreamTask implements StreamTask, InitableTask {
-    private ReadWriteTable<Integer, Profile> profileViewTable;
+    private ReadWriteTable<Integer, Profile, ?> profileViewTable;
 
     @Override
     public void init(Context context) throws Exception {

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestCouchbaseRemoteTableEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestCouchbaseRemoteTableEndToEnd.java
@@ -135,12 +135,12 @@ public class TestCouchbaseRemoteTableEndToEnd {
           .withBootstrapCarrierDirectPort(couchbaseMock.getCarrierPort(outputBucketName))
           .withBootstrapHttpDirectPort(couchbaseMock.getHttpPort());
 
-      RemoteTableDescriptor inputTableDesc = new RemoteTableDescriptor<String, String>("input-table")
+      RemoteTableDescriptor inputTableDesc = new RemoteTableDescriptor<String, String, Void>("input-table")
           .withReadFunction(readFunction)
           .withRateLimiterDisabled();
       Table<KV<String, String>> inputTable = appDesc.getTable(inputTableDesc);
 
-      RemoteTableDescriptor outputTableDesc = new RemoteTableDescriptor<String, JsonObject>("output-table")
+      RemoteTableDescriptor outputTableDesc = new RemoteTableDescriptor<String, JsonObject, Object>("output-table")
           .withReadFunction(new NoOpTableReadFunction<>())
           .withWriteFunction(writeFunction)
           .withRateLimiterDisabled();
@@ -168,7 +168,7 @@ public class TestCouchbaseRemoteTableEndToEnd {
   }
 
   static class JoinFunction
-      implements StreamTableJoinFunction<String, KV<String, String>, KV<String, String>, KV<String, JsonObject>> {
+      implements StreamTableJoinFunction<String, KV<String, String>, KV<String, String>, Object> {
 
     @Override
     public KV<String, JsonObject> apply(KV<String, String> message, KV<String, String> record) {

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTableEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTableEndToEnd.java
@@ -43,7 +43,7 @@ import org.apache.samza.serializers.KVSerde;
 import org.apache.samza.serializers.NoOpSerde;
 import org.apache.samza.standalone.PassthroughJobCoordinatorFactory;
 import org.apache.samza.storage.kv.inmemory.descriptors.InMemoryTableDescriptor;
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.apache.samza.table.Table;
 import org.apache.samza.test.framework.TestRunner;
 import org.apache.samza.test.framework.system.descriptors.InMemoryInputDescriptor;
@@ -269,11 +269,11 @@ public class TestLocalTableEndToEnd {
     private static final Map<String, MyMapFunction> TASK_TO_MAP_FUNCTION_MAP = new HashMap<>();
 
     private transient List<Profile> received;
-    private transient ReadWriteTable table;
+    private transient ReadWriteUpdateTable table;
 
     @Override
     public void init(Context context) {
-      table = context.getTaskContext().getTable("t1");
+      table = context.getTaskContext().getUpdatableTable("t1");
       this.received = new ArrayList<>();
 
       TASK_TO_MAP_FUNCTION_MAP.put(context.getTaskContext().getTaskModel().getTaskName().getTaskName(), this);

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTableWithLowLevelApiEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTableWithLowLevelApiEndToEnd.java
@@ -30,7 +30,7 @@ import org.apache.samza.storage.kv.inmemory.descriptors.InMemoryTableDescriptor;
 import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.system.descriptors.DelegatingSystemDescriptor;
 import org.apache.samza.system.descriptors.GenericInputDescriptor;
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.apache.samza.task.InitableTask;
 import org.apache.samza.task.MessageCollector;
 import org.apache.samza.task.StreamTask;
@@ -69,10 +69,10 @@ public class TestLocalTableWithLowLevelApiEndToEnd {
   }
 
   static public class MyStreamTask implements StreamTask, InitableTask {
-    private ReadWriteTable<Integer, TestTableData.PageView, ?> pageViewTable;
+    private ReadWriteUpdateTable<Integer, TestTableData.PageView, ?> pageViewTable;
     @Override
     public void init(Context context) {
-      pageViewTable = context.getTaskContext().getTable("t1");
+      pageViewTable = context.getTaskContext().getUpdatableTable("t1");
     }
     @Override
     public void process(IncomingMessageEnvelope message, MessageCollector collector, TaskCoordinator coordinator) {

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTableWithLowLevelApiEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTableWithLowLevelApiEndToEnd.java
@@ -69,7 +69,7 @@ public class TestLocalTableWithLowLevelApiEndToEnd {
   }
 
   static public class MyStreamTask implements StreamTask, InitableTask {
-    private ReadWriteTable<Integer, TestTableData.PageView> pageViewTable;
+    private ReadWriteTable<Integer, TestTableData.PageView, ?> pageViewTable;
     @Override
     public void init(Context context) {
       pageViewTable = context.getTaskContext().getTable("t1");

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTableWithSideInputsEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTableWithSideInputsEndToEnd.java
@@ -170,7 +170,7 @@ public class TestLocalTableWithSideInputsEndToEnd {
   }
 
   static class PageViewProfileJoinStreamTask implements InitableTask, StreamTask {
-    private ReadWriteTable<Integer, Profile> profileTable;
+    private ReadWriteTable<Integer, Profile, ?> profileTable;
 
     @Override
     public void init(Context context) {

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTableWithSideInputsEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestLocalTableWithSideInputsEndToEnd.java
@@ -45,7 +45,7 @@ import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.system.OutgoingMessageEnvelope;
 import org.apache.samza.system.SystemStream;
 import org.apache.samza.system.descriptors.DelegatingSystemDescriptor;
-import org.apache.samza.table.ReadWriteTable;
+import org.apache.samza.table.ReadWriteUpdateTable;
 import org.apache.samza.table.Table;
 import org.apache.samza.table.descriptors.TableDescriptor;
 import org.apache.samza.task.InitableTask;
@@ -170,11 +170,11 @@ public class TestLocalTableWithSideInputsEndToEnd {
   }
 
   static class PageViewProfileJoinStreamTask implements InitableTask, StreamTask {
-    private ReadWriteTable<Integer, Profile, ?> profileTable;
+    private ReadWriteUpdateTable<Integer, Profile, ?> profileTable;
 
     @Override
     public void init(Context context) {
-      this.profileTable = context.getTaskContext().getTable(PROFILE_TABLE);
+      this.profileTable = context.getTaskContext().getUpdatableTable(PROFILE_TABLE);
     }
 
     @Override

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableEndToEnd.java
@@ -164,12 +164,6 @@ public class TestRemoteTableEndToEnd {
     }
 
     @Override
-    public CompletableFuture<Void> updateAsync(Integer key, EnrichedPageView update, Object ... args) {
-      records.add(update);
-      return CompletableFuture.completedFuture(null);
-    }
-
-    @Override
     public CompletableFuture<Void> deleteAsync(Integer key) {
       records.remove(key);
       return CompletableFuture.completedFuture(null);
@@ -217,29 +211,6 @@ public class TestRemoteTableEndToEnd {
 
     @Override
     public CompletableFuture<Void> updateAsync(Integer key, EnrichedPageView update) {
-      if (failUpdatesAlways) {
-        return CompletableFuture.supplyAsync(() -> {
-          throw new RuntimeException("Update failed");
-        });
-      }
-
-      if (!recordsMap.containsKey(key)) {
-        return CompletableFuture.supplyAsync(() -> {
-          throw new RecordNotFoundException("Record with key : " + key + " does not exist");
-        });
-      } else if (failAfterPutDefault) {
-        return CompletableFuture.supplyAsync(() -> {
-          throw new RuntimeException("Update failed");
-        });
-      } else {
-        COUNTERS.get(testName + "-update").incrementAndGet();
-        recordsMap.put(key, update);
-        return CompletableFuture.completedFuture(null);
-      }
-    }
-
-    @Override
-    public CompletableFuture<Void> updateAsync(Integer key, EnrichedPageView update, Object ... args) {
       if (failUpdatesAlways) {
         return CompletableFuture.supplyAsync(() -> {
           throw new RuntimeException("Update failed");
@@ -648,14 +619,14 @@ public class TestRemoteTableEndToEnd {
     TableWriteFunction<String, String, String> writer = mock(TableWriteFunction.class);
     CompletableFuture<String> future = new CompletableFuture<>();
     future.completeExceptionally(new RuntimeException("Expected test exception"));
-    doReturn(future).when(writer).updateAsync(anyString(), anyString(), anyString());
+    doReturn(future).when(writer).updateAsync(anyString(), anyString());
     TableRateLimiter rateLimitHelper = mock(TableRateLimiter.class);
     RemoteTable<String, String, String> table = new RemoteTable<>("table1", reader, writer,
         rateLimitHelper, rateLimitHelper, rateLimitHelper, Executors.newSingleThreadExecutor(),
         null, null, null,
         null, null, null);
     table.init(createMockContext());
-    table.update("abc", "xyz", "xyz");
+    table.update("abc", "xyz");
   }
 
   @Test

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableEndToEnd.java
@@ -435,13 +435,12 @@ public class TestRemoteTableEndToEnd {
       final RemoteTableDescriptor joinTableDesc =
               new RemoteTableDescriptor<Integer, TestTableData.Profile, Void>("profile-table-1")
           .withReadFunction(InMemoryProfileReadFunction.getInMemoryReadFunction(profiles))
-          .withRateLimiter(readRateLimiter, creditFunction, null, null);
+          .withRateLimiter(readRateLimiter, creditFunction, null);
 
       final RemoteTableDescriptor outputTableDesc =
               new RemoteTableDescriptor<Integer, EnrichedPageView, EnrichedPageView>("enriched-page-view-table-1")
           .withReadFunction(new NoOpTableReadFunction<>())
           .withReadRateLimiterDisabled()
-          .withUpdateRateLimiterDisabled()
           .withWriteFunction(new InMemoryEnrichedPageViewWriteFunction(testName))
           .withWriteRateLimit(1000);
 
@@ -533,12 +532,11 @@ public class TestRemoteTableEndToEnd {
       final RemoteTableDescriptor joinTableDesc =
           new RemoteTableDescriptor<Integer, TestTableData.Profile, Void>("profile-table-1").withReadFunction(
               InMemoryProfileReadFunction.getInMemoryReadFunction(profiles))
-              .withRateLimiter(readRateLimiter, creditFunction, null, null);
+              .withRateLimiter(readRateLimiter, creditFunction, null);
 
       final RemoteTableDescriptor outputTableDesc =
           new RemoteTableDescriptor<Integer, EnrichedPageView, EnrichedPageView>("enriched-page-view-table-1").withReadFunction(new NoOpTableReadFunction<>())
               .withReadRateLimiterDisabled()
-              .withUpdateRateLimiterDisabled()
               .withWriteFunction(new InMemoryEnrichedPageViewWriteFunction2(testName))
               .withWriteRateLimit(1000);
 

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableEndToEnd.java
@@ -360,12 +360,13 @@ public class TestRemoteTableEndToEnd {
       final RemoteTableDescriptor joinTableDesc =
               new RemoteTableDescriptor<Integer, TestTableData.Profile, Void>("profile-table-1")
           .withReadFunction(InMemoryProfileReadFunction.getInMemoryReadFunction(testName, profiles))
-          .withRateLimiter(readRateLimiter, creditFunction, null);
+          .withRateLimiter(readRateLimiter, creditFunction, null, null);
 
       final RemoteTableDescriptor outputTableDesc =
               new RemoteTableDescriptor<Integer, EnrichedPageView, EnrichedPageView>("enriched-page-view-table-1")
           .withReadFunction(new NoOpTableReadFunction<>())
           .withReadRateLimiterDisabled()
+          .withUpdateRateLimiterDisabled()
           .withWriteFunction(new InMemoryEnrichedPageViewWriteFunction(testName))
           .withWriteRateLimit(1000);
 

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableWithBatchEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableWithBatchEndToEnd.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import org.apache.samza.SamzaException;
 import org.apache.samza.application.StreamApplication;
 import org.apache.samza.operators.KV;
+import org.apache.samza.operators.UpdateOptions;
 import org.apache.samza.operators.UpdateMessage;
 import org.apache.samza.serializers.NoOpSerde;
 import org.apache.samza.storage.kv.Entry;
@@ -286,7 +287,7 @@ public class TestRemoteTableWithBatchEndToEnd {
           .map(pv -> new KV<>(pv.getMemberId(), pv))
           .join(inputTable, new PageViewToProfileJoinFunction())
           .map(m -> new KV<>(m.getMemberId(), UpdateMessage.of(m, m)))
-          .sendUpdateTo(table);
+          .sendTo(table, UpdateOptions.UPDATE_WITH_DEFAULTS);
     };
 
     InMemorySystemDescriptor isd = new InMemorySystemDescriptor("test");

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableWithBatchEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableWithBatchEndToEnd.java
@@ -189,7 +189,7 @@ public class TestRemoteTableWithBatchEndToEnd {
       RemoteTableDescriptor<Integer, Profile, Void> inputTableDesc = new RemoteTableDescriptor<>("profile-table-1");
       inputTableDesc
           .withReadFunction(InMemoryReadFunction.getInMemoryReadFunction(testName, profiles))
-          .withRateLimiter(readRateLimiter, creditFunction, null, null);
+          .withRateLimiter(readRateLimiter, creditFunction, null);
       if (batchRead) {
         inputTableDesc.withBatchProvider(new CompactBatchProvider().withMaxBatchSize(batchSize).withMaxBatchDelay(Duration.ofHours(1)));
       }
@@ -201,7 +201,7 @@ public class TestRemoteTableWithBatchEndToEnd {
       outputTableDesc
           .withReadFunction(readFn)
           .withWriteFunction(writer)
-          .withRateLimiter(writeRateLimiter, creditFunction, creditFunction, creditFunction);
+          .withRateLimiter(writeRateLimiter, creditFunction, creditFunction);
       if (batchWrite && partialUpdate) {
         outputTableDesc.withBatchProvider(new CompleteBatchProvider().withMaxBatchSize(batchSize).withMaxBatchDelay(Duration.ofHours(1)));
       } else if (batchWrite) {

--- a/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableWithBatchEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/table/TestRemoteTableWithBatchEndToEnd.java
@@ -191,7 +191,7 @@ public class TestRemoteTableWithBatchEndToEnd {
       RemoteTableDescriptor<Integer, Profile, Void> inputTableDesc = new RemoteTableDescriptor<>("profile-table-1");
       inputTableDesc
           .withReadFunction(InMemoryReadFunction.getInMemoryReadFunction(testName, profiles))
-          .withRateLimiter(readRateLimiter, creditFunction, null);
+          .withRateLimiter(readRateLimiter, creditFunction, null, null);
       if (batchRead) {
         inputTableDesc.withBatchProvider(new CompactBatchProvider().withMaxBatchSize(batchSize).withMaxBatchDelay(Duration.ofHours(1)));
       }
@@ -203,7 +203,7 @@ public class TestRemoteTableWithBatchEndToEnd {
       outputTableDesc
           .withReadFunction(readFn)
           .withWriteFunction(writer)
-          .withRateLimiter(writeRateLimiter, creditFunction, creditFunction);
+          .withRateLimiter(writeRateLimiter, creditFunction, creditFunction, creditFunction);
       if (batchWrite && partialUpdate) {
         outputTableDesc.withBatchProvider(new CompleteBatchProvider().withMaxBatchSize(batchSize).withMaxBatchDelay(Duration.ofHours(1)));
       } else if (batchWrite) {


### PR DESCRIPTION
**Feature**:
Samza Table API currently supports PUT, GET and DELETE. Puts typically write/overwrite the data for a key. Users have frequently requested for the ability to perform partial updates i.e update select fields or a part of the record. This PR intends to add `update` to Table API.

**Changes:**
- Added `updateAsync` and `updateAllAsync` methods to `TableWriteFunction` and to `AsyncReadWriteTable`
- All implementations of `AsyncReadWriteTable` have been changed to accommodate the API change
- Added `sendUpdateTo` method to `MessageStream`. Added corresponding operator spec and operator implementation as well

**Tests:**
- Added tests for changes to all table implementations

**API Changes**
- TableWriteFunction was earlier using K,V generic types to represent key and record type. With partial updates, U type has been added to represent partial updates which is a backward compatible change
- Similarly, U update generic type was added to AsyncReadWriteTable class generic signature. It affects all implementing classes as well.