### PR TITLE
SAMZA-2711: Fix flaky TestZkLocalApplicationRunner

### DIFF
--- a/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
+++ b/samza-test/src/test/java/org/apache/samza/test/processor/TestZkLocalApplicationRunner.java
@@ -319,12 +319,12 @@ public class TestZkLocalApplicationRunner extends IntegrationTestHarness {
     assertEquals(previousJobModel[0], updatedJobModel);
     assertEquals(new MapConfig(), updatedJobModel.getConfig());
     assertEquals(NUM_KAFKA_EVENTS, processedMessagesLatch.getCount());
-    appRunner1.kill();
-    appRunner1.waitForFinish();
     appRunner2.kill();
     appRunner2.waitForFinish();
-    assertEquals(appRunner1.status(), ApplicationStatus.SuccessfulFinish);
     assertEquals(appRunner2.status(), ApplicationStatus.UnsuccessfulFinish);
+    appRunner1.kill();
+    appRunner1.waitForFinish();
+    assertEquals(appRunner1.status(), ApplicationStatus.SuccessfulFinish);
   }
 
   /**


### PR DESCRIPTION
Issues: 
TestZkLocalApplicationRunner.shouldStopNewProcessorsJoiningGroupWhenNumContainersIsGreaterThanNumTasks asserts
  A) JobModel generated before and after the addition of appRunner2 should be equal.
  B) Second stream application(appRunner2) should not join the group and process any message.


Assertion A is good, but the test can not guarantee Assertion B.
The reason is that the test kill appRunner1 then kill appRunner2, but after appRunner1 got killed and before appRunner2 gets killed, ZkJobCoordinator could generate a new JobModel with appRunner 2
That leads to appRunner2 status change from New->Running->SuccessfulFinish
instead of New->UnsuccessfulFinish, which result in the test failure

Changes: 
    kill appRunner2 and do assertion before kill appRunner1
    
Tests: ./gradlew build
API changes: N/A