### PR TITLE
[Minor] Change log level to debug in PosixCommandBasedStatisticsGetter

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -43,7 +43,7 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
    * @throws IOException
    */
   private List<String> getAllCommandOutput(String[] cmdArray) throws IOException {
-    log.info("Executing commands {}", Arrays.toString(cmdArray));
+    log.debug("Executing commands {}", Arrays.toString(cmdArray));
     Process executable = Runtime.getRuntime().exec(cmdArray);
     BufferedReader processReader;
     List<String> psOutput = new ArrayList<>();


### PR DESCRIPTION
Problem: User log is flooded by logging in `PosixCommandBasedStatisticsGetter`

Changes: change the log from info to debug