### PR TITLE
SAMZA-2713: Add flag to disable container heartbeat monitor

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -172,6 +172,9 @@ public class JobConfig extends MapConfig {
   public static final String YARN_CONTAINER_HEARTBEAT_RETRY_SLEEP_DURATION_MS = "yarn.container.heartbeat.retry-sleep-duration.ms";
   public static final long YARN_CONTAINER_HEARTBEAT_RETRY_SLEEP_DURATION_MS_DEFAULT = 10000;
 
+  public static final String CONTAINER_HEARTBEAT_MONITOR_ENABLED = "job.container.heartbeat.monitor.enabled";
+  private static final boolean CONTAINER_HEARTBEAT_MONITOR_ENABLED_DEFAULT = true;
+
   public JobConfig(Config config) {
     super(config);
   }
@@ -458,5 +461,9 @@ public class JobConfig extends MapConfig {
 
   public boolean getStartpointEnabled() {
     return getBoolean(JOB_STARTPOINT_ENABLED, true);
+  }
+
+  public boolean getContainerHeartbeatMonitorEnabled() {
+    return getBoolean(CONTAINER_HEARTBEAT_MONITOR_ENABLED, CONTAINER_HEARTBEAT_MONITOR_ENABLED_DEFAULT);
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/config/TestJobConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestJobConfig.java
@@ -590,4 +590,13 @@ public class TestJobConfig {
     Assert.assertEquals(900, clusterManagerConfig.getContainerMemoryMb());
     Assert.assertEquals(2, clusterManagerConfig.getNumCores());
   }
+
+  @Test
+  public void testGetContainerHeartbeatMonitorEnabled() {
+    assertTrue(new JobConfig(new MapConfig()).getContainerHeartbeatMonitorEnabled());
+    assertTrue(new JobConfig(new MapConfig(
+        ImmutableMap.of(JobConfig.CONTAINER_HEARTBEAT_MONITOR_ENABLED, "true"))).getContainerHeartbeatMonitorEnabled());
+    assertFalse(new JobConfig(new MapConfig(ImmutableMap.of(JobConfig.CONTAINER_HEARTBEAT_MONITOR_ENABLED,
+        "false"))).getContainerHeartbeatMonitorEnabled());
+  }
 }


### PR DESCRIPTION
Issues: `ContainerHeartbeatMonitor` is used when the `EXECUTION_ENV_CONTAINER_ID` environment variable is set. However, the current implementation of `ContainerHeartbeatMonitor` is coupled with YARN while `EXECUTION_ENV_CONTAINER_ID` is not. For Kubernetes, we don't need `ContainerHeartbeatMonitor` since we don't need to deal with orphaned containers, but we would like to still fill in `EXECUTION_ENV_CONTAINER_ID`. Therefore, we need another way to disable the `ContainerHeartbeatMonitor`.

Changes: Add a config flag (`job.container.heartbeat.monitor.enabled`) for enabling `ContainerHeartbeatMonitor`.

Tests: Deployed application in minikube for following situations:
1. Monitor enabled, `EXECUTION_ENV_CONTAINER_ID` specified -> monitor runs and is expected to kill the container since there is no heartbeat endpoint in the Kubernetes job coordinator
2. Monitor enabled, `EXECUTION_ENV_CONTAINER_ID` not specified -> monitor does not run
3. Monitor disabled, `EXECUTION_ENV_CONTAINER_ID` specified -> monitor does not run

API changes (backwards compatible): Specify `job.container.heartbeat.monitor.enabled` as true/false to enable/disable the `ContainerHeartbeatMonitor`. This defaults to `true` for backwards compatibility. 