### PR TITLE
SAMZA-2714: Bump log4j2 to mitigate CVE-2021-44228

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -38,7 +38,7 @@
   junitVersion = "4.12"
   kafkaVersion = "2.3.1"
   log4jVersion = "1.2.17"
-  log4j2Version = "2.12.0"
+  log4j2Version = "2.15.0"
   metricsVersion = "2.2.0"
   mockitoVersion = "1.10.19"
   powerMockVersion = "1.6.6"


### PR DESCRIPTION
See https://blog.cloudflare.com/cve-2021-44228-log4j-rce-0-day-mitigation/