### PR TITLE
SAMZA-2715: Bump up log4j2 version to fix CVE-2021-44228

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -38,7 +38,7 @@
   junitVersion = "4.12"
   kafkaVersion = "2.3.1"
   log4jVersion = "1.2.17"
-  log4j2Version = "2.15.0"
+  log4j2Version = "2.16.0"
   metricsVersion = "2.2.0"
   mockitoVersion = "1.10.19"
   powerMockVersion = "1.6.6"


### PR DESCRIPTION
The log4j2 2.15.0 is still vulnerable, we will need to bump up to 2.16.0: https://logging.apache.org/log4j/2.x/changes-report.html#a2.16.0