### PR TITLE
Fix rollback stale checkpoints

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
@@ -127,6 +127,8 @@ public class TaskConfig extends MapConfig {
   // checkpoint version to read during container startup
   public static final String CHECKPOINT_READ_VERSIONS = "task.checkpoint.read.versions";
   public static final List<String> DEFAULT_CHECKPOINT_READ_VERSIONS = ImmutableList.of("1");
+  public static final String LIVE_CHECKPOINT_MAX_AGE_MS = "task.live.checkpoint.max.age";
+  public static final long DEFAULT_LIVE_CHECKPOINT_MAX_AGE_MS = 600000L; // 10 mins
 
   public static final String TRANSACTIONAL_STATE_CHECKPOINT_ENABLED = "task.transactional.state.checkpoint.enabled";
   private static final boolean DEFAULT_TRANSACTIONAL_STATE_CHECKPOINT_ENABLED = true;
@@ -358,6 +360,10 @@ public class TaskConfig extends MapConfig {
     } else {
       return checkpointReadPriorityList;
     }
+  }
+
+  public long getLiveCheckpointMaxAgeMillis() {
+    return getLong(LIVE_CHECKPOINT_MAX_AGE_MS, DEFAULT_LIVE_CHECKPOINT_MAX_AGE_MS);
   }
 
   public boolean getTransactionalStateCheckpointEnabled() {

--- a/samza-kafka/src/main/scala/org/apache/samza/checkpoint/kafka/KafkaCheckpointManager.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/checkpoint/kafka/KafkaCheckpointManager.scala
@@ -82,7 +82,7 @@ class KafkaCheckpointManager(checkpointSpec: KafkaStreamSpec,
   val stopConsumerAfterFirstRead: Boolean = new TaskConfig(config).getCheckpointManagerConsumerStopAfterFirstRead
 
   val checkpointReadVersions: util.List[lang.Short] = new TaskConfig(config).getCheckpointReadVersions
-  val LiveCheckpointMaxAgeMillis: Long = new TaskConfig(config).getLiveCheckpointMaxAgeMillis
+  val liveCheckpointMaxAgeMillis: Long = new TaskConfig(config).getLiveCheckpointMaxAgeMillis
 
 
   /**
@@ -398,7 +398,7 @@ class KafkaCheckpointManager(checkpointSpec: KafkaStreamSpec,
     currentCheckpoint.isEmpty ||
       checkpointReadVersions.indexOf(newCheckpointVersion) <=
         checkpointReadVersions.indexOf(currentCheckpoint.get.getVersion) ||
-      (newCheckpointAppendTime - currentCheckpointAppendTime.get > LiveCheckpointMaxAgeMillis)
+      (newCheckpointAppendTime - currentCheckpointAppendTime.get > liveCheckpointMaxAgeMillis)
   }
 
   private def deserializeCheckpoint(checkpointKey: KafkaCheckpointLogKey, checkpointMsgBytes: Array[Byte]): Checkpoint = {

--- a/samza-kafka/src/main/scala/org/apache/samza/checkpoint/kafka/KafkaCheckpointManager.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/checkpoint/kafka/KafkaCheckpointManager.scala
@@ -82,6 +82,8 @@ class KafkaCheckpointManager(checkpointSpec: KafkaStreamSpec,
   val stopConsumerAfterFirstRead: Boolean = new TaskConfig(config).getCheckpointManagerConsumerStopAfterFirstRead
 
   val checkpointReadVersions: util.List[lang.Short] = new TaskConfig(config).getCheckpointReadVersions
+  val LiveCheckpointMaxAgeMillis: Long = new TaskConfig(config).getLiveCheckpointMaxAgeMillis
+
 
   /**
     * Create checkpoint stream prior to start.
@@ -243,12 +245,15 @@ class KafkaCheckpointManager(checkpointSpec: KafkaStreamSpec,
     */
   private def readCheckpoints(): Map[TaskName, Checkpoint] = {
     val checkpoints = mutable.Map[TaskName, Checkpoint]()
+    val checkpointAppendTime = mutable.Map[TaskName, Long]()
 
     val iterator = new SystemStreamPartitionIterator(systemConsumer, checkpointSsp)
     var numMessagesRead = 0
 
     while (iterator.hasNext) {
       val checkpointEnvelope: IncomingMessageEnvelope = iterator.next
+      // Kafka log append time for the checkpoint message
+      val checkpointEnvelopeTs = checkpointEnvelope.getEventTime;
       val offset = checkpointEnvelope.getOffset
 
       numMessagesRead += 1
@@ -290,9 +295,12 @@ class KafkaCheckpointManager(checkpointSpec: KafkaStreamSpec,
           // if checkpoint key version does not match configured checkpoint version to read, skip the message.
           if (checkpointReadVersions.contains(
             KafkaCheckpointLogKey.CHECKPOINT_KEY_VERSIONS.get(checkpointKey.getType))) {
-            if (!checkpoints.contains(checkpointKey.getTaskName) ||
-              shouldOverrideCheckpoint(checkpoints.get(checkpointKey.getTaskName), checkpointKey)) {
-              checkpoints.put(checkpointKey.getTaskName, deserializeCheckpoint(checkpointKey, msgBytes))
+            val taskName = checkpointKey.getTaskName
+            if (!checkpoints.contains(taskName) ||
+              shouldOverrideCheckpoint(checkpoints.get(taskName), checkpointKey, checkpointAppendTime.get(taskName),
+                checkpointEnvelopeTs)) {
+              checkpoints.put(taskName, deserializeCheckpoint(checkpointKey, msgBytes))
+              checkpointAppendTime.put(taskName, checkpointEnvelopeTs)
             } // else ignore the de-prioritized checkpoint
           } else {
             // Ignore and skip the unknown checkpoint key type. We do not want to throw any exceptions for this case
@@ -375,19 +383,22 @@ class KafkaCheckpointManager(checkpointSpec: KafkaStreamSpec,
     }
   }
 
-  private def shouldOverrideCheckpoint(currentCheckpoint: Option[Checkpoint],
-    newCheckpointKey: KafkaCheckpointLogKey): Boolean = {
+  private def shouldOverrideCheckpoint(currentCheckpoint: Option[Checkpoint], newCheckpointKey: KafkaCheckpointLogKey,
+    currentCheckpointAppendTime: Option[Long], newCheckpointAppendTime: Long): Boolean = {
     val newCheckpointVersion = KafkaCheckpointLogKey.CHECKPOINT_KEY_VERSIONS.get(newCheckpointKey.getType)
     if (newCheckpointVersion == null) {
       // Unknown checkpoint version
       throw new IllegalArgumentException("Unknown checkpoint key type: " + newCheckpointKey.getType +
         " for checkpoint key: " + newCheckpointKey)
     }
-    // Override checkpoint if the current checkpoint does not exist or if new checkpoint has a higher restore
-    // priority than the currently written checkpoint
+    // Override checkpoint if:
+    // 1. The current checkpoint does not exist or
+    // 2. The new checkpoint has a higher restore priority than the currently written checkpoint
+    // 3. The current checkpoint is determined to be stale compared to the new checkpoint timestamp
     currentCheckpoint.isEmpty ||
       checkpointReadVersions.indexOf(newCheckpointVersion) <=
-        checkpointReadVersions.indexOf(currentCheckpoint.get.getVersion)
+        checkpointReadVersions.indexOf(currentCheckpoint.get.getVersion) ||
+      (newCheckpointAppendTime - currentCheckpointAppendTime.get > LiveCheckpointMaxAgeMillis)
   }
 
   private def deserializeCheckpoint(checkpointKey: KafkaCheckpointLogKey, checkpointMsgBytes: Array[Byte]): Checkpoint = {

--- a/samza-test/src/test/java/org/apache/samza/checkpoint/CheckpointVersionIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/checkpoint/CheckpointVersionIntegrationTest.java
@@ -77,7 +77,7 @@ public class CheckpointVersionIntegrationTest extends StreamApplicationIntegrati
     List<String> inputMessagesOnInitialRun = Arrays.asList("1", "2", "3", "2", "97", "-97", ":98", ":99", ":crash_once");
     // double check collectors.flush
     List<String> expectedChangelogMessagesOnInitialRun = Arrays.asList("1", "2", "3", "2", "97", null, "98", "99");
-    initialRun(inputMessagesOnInitialRun, expectedChangelogMessagesOnInitialRun);
+    runStatefulApp(inputMessagesOnInitialRun, inputMessagesOnInitialRun, expectedChangelogMessagesOnInitialRun, CONFIGS);
 
     // first two are reverts for uncommitted messages from last run for keys 98 and 99
     List<String> expectedChangelogMessagesAfterSecondRun =
@@ -85,11 +85,42 @@ public class CheckpointVersionIntegrationTest extends StreamApplicationIntegrati
     List<String> expectedInitialStoreContentsOnSecondRun = Arrays.asList("1", "2", "3");
     Map<String, String> configOverrides = new HashMap<>(CONFIGS);
     configOverrides.put(TaskConfig.CHECKPOINT_READ_VERSIONS, "2");
-    secondRun(CHANGELOG_TOPIC,
-        expectedChangelogMessagesAfterSecondRun, expectedInitialStoreContentsOnSecondRun, configOverrides);
+    finalRun(CHANGELOG_TOPIC,
+        expectedChangelogMessagesAfterSecondRun, expectedInitialStoreContentsOnSecondRun,
+        Arrays.asList("4", "5", "5", ":shutdown"),configOverrides);
   }
 
-  private void initialRun(List<String> inputMessages, List<String> expectedChangelogMessages) {
+  @Test
+  public void testStopCheckpointV1V2AndRestartStaleCheckpointV2() {
+    List<String> inputMessagesOnInitialRun = Arrays.asList("1", "2", "3", "2", "97", "-97", ":98", ":99", ":crash_once");
+    // double check collectors.flush
+    List<String> expectedChangelogMessagesOnInitialRun = Arrays.asList("1", "2", "3", "2", "97", null, "98", "99");
+    runStatefulApp(inputMessagesOnInitialRun, inputMessagesOnInitialRun, expectedChangelogMessagesOnInitialRun, CONFIGS);
+
+
+    Map<String, String> secondConfigRunOverrides = new HashMap<>(CONFIGS);
+    // only write checkpoint v1, making checkpoint v2 stale
+    secondConfigRunOverrides.put(TaskConfig.CHECKPOINT_WRITE_VERSIONS, "1");
+    secondConfigRunOverrides.put(TaskConfig.CHECKPOINT_READ_VERSIONS, "2, 1");
+    List<String> inputMessagesOnSecondRun = Arrays.asList("77", "78", "79", ":shutdown");
+    // first two are reverts for uncommitted messages from last run for keys 98 and 99
+    expectedChangelogMessagesOnInitialRun = Arrays.asList(null, null, "98", "99", "77", "78", "79");
+    runStatefulApp(inputMessagesOnSecondRun, inputMessagesOnSecondRun, expectedChangelogMessagesOnInitialRun,
+        secondConfigRunOverrides);
+
+    // takes the latest written checkpoint v1 from run 2 since v2 checkpoints are stale
+    List<String> expectedInitialStoreContentsOnSecondRun = Arrays.asList("1", "2", "3", "77", "78", "79", "98", "99");
+
+    Map<String, String> configOverrides = new HashMap<>(CONFIGS);
+    configOverrides.put(TaskConfig.CHECKPOINT_READ_VERSIONS, "2, 1");
+    // Does not have to rewind to the last written v2 checkpoints (1, 2, 3) despite the v2 priority
+    configOverrides.put(TaskConfig.LIVE_CHECKPOINT_MAX_AGE_MS, "0"); // use the latest checkpoint
+    finalRun(CHANGELOG_TOPIC,
+        Collections.emptyList(), expectedInitialStoreContentsOnSecondRun, Collections.emptyList(), configOverrides);
+  }
+
+  private void runStatefulApp(List<String> inputMessages, List<String> expectedInputTopicMessages,
+      List<String> expectedChangelogMessages, Map<String, String> configs) {
     // create input topic and produce the first batch of input messages
     createTopic(INPUT_TOPIC, 1);
     inputMessages.forEach(m -> produceMessage(INPUT_TOPIC, 0, m, m));
@@ -99,12 +130,12 @@ public class CheckpointVersionIntegrationTest extends StreamApplicationIntegrati
       List<ConsumerRecord<String, String>> inputRecords =
           consumeMessages(Collections.singletonList(INPUT_TOPIC), inputMessages.size());
       List<String> readInputMessages = inputRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
-      Assert.assertEquals(inputMessages, readInputMessages);
+     Assert.assertEquals(expectedInputTopicMessages, readInputMessages);
     }
 
     // run the application
     RunApplicationContext context = runApplication(
-        new MyStatefulApplication(INPUT_SYSTEM, INPUT_TOPIC, Collections.singletonMap(STORE_NAME, CHANGELOG_TOPIC)), "myApp", CONFIGS);
+        new MyStatefulApplication(INPUT_SYSTEM, INPUT_TOPIC, Collections.singletonMap(STORE_NAME, CHANGELOG_TOPIC)), "myApp", configs);
 
     // wait for the application to finish
     context.getRunner().waitForFinish();
@@ -120,14 +151,13 @@ public class CheckpointVersionIntegrationTest extends StreamApplicationIntegrati
     LOG.info("Finished initial run");
   }
 
-  private void secondRun(String changelogTopic, List<String> expectedChangelogMessages,
-      List<String> expectedInitialStoreContents, Map<String, String> overriddenConfigs) {
+  private void finalRun(String changelogTopic, List<String> expectedChangelogMessages,
+      List<String> expectedInitialStoreContents,  List<String> inputMessages, Map<String, String> overriddenConfigs) {
     // remove previous files so restore is from the checkpointV2
     new FileUtil().rm(new File(LOGGED_STORE_BASE_DIR));
 
     // produce the second batch of input messages
 
-    List<String> inputMessages = Arrays.asList("4", "5", "5", ":shutdown");
     inputMessages.forEach(m -> produceMessage(INPUT_TOPIC, 0, m, m));
 
     // run the application

--- a/samza-test/src/test/java/org/apache/samza/checkpoint/CheckpointVersionIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/checkpoint/CheckpointVersionIntegrationTest.java
@@ -87,7 +87,7 @@ public class CheckpointVersionIntegrationTest extends StreamApplicationIntegrati
     configOverrides.put(TaskConfig.CHECKPOINT_READ_VERSIONS, "2");
     finalRun(CHANGELOG_TOPIC,
         expectedChangelogMessagesAfterSecondRun, expectedInitialStoreContentsOnSecondRun,
-        Arrays.asList("4", "5", "5", ":shutdown"),configOverrides);
+        Arrays.asList("4", "5", "5", ":shutdown"), configOverrides);
   }
 
   @Test
@@ -130,7 +130,7 @@ public class CheckpointVersionIntegrationTest extends StreamApplicationIntegrati
       List<ConsumerRecord<String, String>> inputRecords =
           consumeMessages(Collections.singletonList(INPUT_TOPIC), inputMessages.size());
       List<String> readInputMessages = inputRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
-     Assert.assertEquals(expectedInputTopicMessages, readInputMessages);
+      Assert.assertEquals(expectedInputTopicMessages, readInputMessages);
     }
 
     // run the application


### PR DESCRIPTION
Symptom: Checkpoint v2 preference could cause stale checkpoints to get picked up when newer v1 checkpoints are available

Cause: Kafka checkpoint manager selects the checkpoints based on the `task.checkpoint.read.versions` priority list. This does not account for the fact that the prioritized checkpoint may be stale and a new checkpoint lower on the priority list is present in the checkpoint topic. This will cause the job to silently use the stale checkpoint and cause more reprocessing than the most recent commit. 

An example case where this could happen is when the users upgrades to a v2 checkpoint commits a v2 checkpoint and rollbacks to a previous version using only v1 checkpoint version then upgrading to the newest version again, using that stale v2 checkpoint from the initial upgrade.

Changes:
Added a `task.live.checkpoint.max.age` default 10 mins (must be > task.commit.ms interval; internal config) which would indicate if a checkpoint has gone stale if:
a) There exists a checkpoint of another type more recent than it
b) The diff between new checkpoint's kafka log append time and the prioritized version's log append time > `task.live.checkpoint.max.age'

Tests: Integration tests writing to the checkpoint topic with stale checkpoint v2 and consuming it with a job that prioritize v2 over v1 checkpoints with `task.live.checkpoint.max.age' = 0 asserting it prioritizes v1 checkpoints instead.