### PR TITLE
Set default RocksDB compaction threads to 4

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/BlobStoreUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/BlobStoreUtil.java
@@ -111,7 +111,8 @@ public class BlobStoreUtil {
     }
 
     if (checkpoint.getVersion() == 1) {
-      throw new SamzaException("Checkpoint version 1 is not supported for blob store backup and restore.");
+      LOG.warn("Checkpoint version 1 is not supported for blob store backup and restore.");
+      return ImmutableMap.of();
     }
 
     Map<String, CompletableFuture<Pair<String, SnapshotIndex>>>

--- a/samza-core/src/test/java/org/apache/samza/storage/blobstore/TestBlobStoreBackupManager.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/blobstore/TestBlobStoreBackupManager.java
@@ -155,7 +155,7 @@ public class TestBlobStoreBackupManager {
   }
 
   @Test
-  public void testInitWithInvalidCheckpointFails() {
+  public void testInitWithInvalidCheckpoint() {
     // init called with null checkpoint storeStorageEngineMap
     blobStoreBackupManager.init(null);
     // verify delete snapshot index blob called from init 0 times because prevSnapshotMap returned from init is empty
@@ -165,12 +165,10 @@ public class TestBlobStoreBackupManager {
 
     // init called with Checkpoint V1 -> unsupported
     Checkpoint checkpoint = new CheckpointV1(new HashMap<>());
-    String expectedException = "Checkpoint version 1 is not supported for blob store backup and restore.";
     try {
       blobStoreBackupManager.init(checkpoint);
-      Assert.fail("Checkpoint V1 is exepcted to fail.");
     } catch (SamzaException exception) {
-      Assert.assertEquals(exception.getMessage(), expectedException);
+      Assert.fail("Checkpoint V1 is expected to only log warning.");
     }
   }
 

--- a/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestBlobStoreUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestBlobStoreUtil.java
@@ -798,7 +798,6 @@ public class TestBlobStoreUtil {
     assertTrue(snapshotIndexes.isEmpty());
   }
 
-  @Test(expected = SamzaException.class)
   public void testGetSSIThrowsExceptionForCheckpointV1() {
     Checkpoint mockCheckpoint = mock(Checkpoint.class);
     when(mockCheckpoint.getVersion()).thenReturn((short) 1);

--- a/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestBlobStoreUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestBlobStoreUtil.java
@@ -804,7 +804,9 @@ public class TestBlobStoreUtil {
     when(mockCheckpoint.getVersion()).thenReturn((short) 1);
     BlobStoreUtil blobStoreUtil =
         new BlobStoreUtil(mock(BlobStoreManager.class), MoreExecutors.newDirectExecutorService(), null, null);
-    blobStoreUtil.getStoreSnapshotIndexes("testJobName", "testJobId", "taskName", mockCheckpoint);
+    Map<String, Pair<String, SnapshotIndex>> prevSnapshotIndexes =
+        blobStoreUtil.getStoreSnapshotIndexes("testJobName", "testJobId", "taskName", mockCheckpoint);
+    assertEquals(prevSnapshotIndexes.size(), 0);
   }
 
   @Test

--- a/samza-kv-rocksdb/src/main/java/org/apache/samza/storage/kv/RocksDbOptionsHelper.java
+++ b/samza-kv-rocksdb/src/main/java/org/apache/samza/storage/kv/RocksDbOptionsHelper.java
@@ -72,6 +72,12 @@ public class RocksDbOptionsHelper {
   private static final String ROCKSDB_MAX_OPEN_FILES = "rocksdb.max.open.files";
   private static final String ROCKSDB_MAX_FILE_OPENING_THREADS = "rocksdb.max.file.opening.threads";
 
+  /**
+   * RocksDB default for {@link RocksDbOptionsHelper#ROCKSDB_COMPACTION_MAX_BACKGROUND_COMPACTIONS} is 1.
+   */
+  private static final int DEFAULT_ROCKSDB_COMPACTION_MAX_BACKGROUND_COMPACTIONS = 4;
+
+
   public static Options options(Config storeConfig, int numTasksForContainer, File storeDir, StorageEngineFactory.StoreMode storeMode) {
     Options options = new Options();
 
@@ -155,7 +161,9 @@ public class RocksDbOptionsHelper {
     }
 
     if (storeConfig.containsKey(ROCKSDB_COMPACTION_MAX_BACKGROUND_COMPACTIONS)) {
-      options.setMaxBackgroundCompactions(storeConfig.getInt(ROCKSDB_COMPACTION_MAX_BACKGROUND_COMPACTIONS));
+      options.setMaxBackgroundCompactions(
+          storeConfig.getInt(ROCKSDB_COMPACTION_MAX_BACKGROUND_COMPACTIONS,
+              DEFAULT_ROCKSDB_COMPACTION_MAX_BACKGROUND_COMPACTIONS));
     }
 
     if (storeConfig.containsKey(ROCKSDB_COMPACTION_TARGET_FILE_SIZE_BASE)) {


### PR DESCRIPTION
Symptoms: Containers some times taking a longer than usual to restore checkpoint. 

Cause: RocksDB stalls write operations in order to perform compaction if there are large number of level 0 SST files. The default thread count of RocksDB compaction thread is 1. We saw that some jobs were blocked on container restore with RocksDb taking long time to complete compaction. Similar issue and some background [here](https://github.com/facebook/rocksdb/issues/3717).

Fix: We set the `rocksdb.compaction.max.background.compactions` config for Samza jobs to 4. 

Additional changes: Added a warning instead of an exception on first backup when Checkpoint v2 is enabled for a job.