### PR TITLE
SAMZA-2688 [Elasticity] introduce elasticity factor config and key bucket within SSP

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/system/IncomingMessageEnvelope.java
+++ b/samza-api/src/main/java/org/apache/samza/system/IncomingMessageEnvelope.java
@@ -111,6 +111,13 @@ public class IncomingMessageEnvelope {
     return systemStreamPartition;
   }
 
+  // used for elasticity to determine which elastic task should handle this envelope
+  public SystemStreamPartition getSystemStreamPartition(int elasticityFactor) {
+    Object envelopeKeyorOffset = key != null ? key : offset;
+    int keyBucket = Math.abs(envelopeKeyorOffset.hashCode() % elasticityFactor);
+    return new SystemStreamPartition(systemStreamPartition, keyBucket);
+  }
+
   /**
    * Offset associated with this message, provided by the system consumer that consumed the message.
    */

--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -175,6 +175,12 @@ public class JobConfig extends MapConfig {
   public static final String CONTAINER_HEARTBEAT_MONITOR_ENABLED = "job.container.heartbeat.monitor.enabled";
   private static final boolean CONTAINER_HEARTBEAT_MONITOR_ENABLED_DEFAULT = true;
 
+
+  // Enabled elasticity for the job
+  // number of (elastic) tasks in the job will be old task count X elasticity factor
+  public static final String JOB_ELASTICITY_FACTOR = "job.elasticity.factor";
+  public static final int DEFAULT_JOB_ELASTICITY_FACTOR = 1;
+
   public JobConfig(Config config) {
     super(config);
   }
@@ -465,5 +471,13 @@ public class JobConfig extends MapConfig {
 
   public boolean getContainerHeartbeatMonitorEnabled() {
     return getBoolean(CONTAINER_HEARTBEAT_MONITOR_ENABLED, CONTAINER_HEARTBEAT_MONITOR_ENABLED_DEFAULT);
+  }
+
+  public boolean getElasticityEnabled() {
+    return getElasticityFactor() > 1;
+  }
+
+  public int getElasticityFactor() {
+    return getInt(JOB_ELASTICITY_FACTOR, DEFAULT_JOB_ELASTICITY_FACTOR);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/serializers/model/SamzaObjectMapper.java
+++ b/samza-core/src/main/java/org/apache/samza/serializers/model/SamzaObjectMapper.java
@@ -246,6 +246,7 @@ public class SamzaObjectMapper {
       systemStreamPartitionMap.put("system", systemStreamPartition.getSystem());
       systemStreamPartitionMap.put("stream", systemStreamPartition.getStream());
       systemStreamPartitionMap.put("partition", systemStreamPartition.getPartition());
+      systemStreamPartitionMap.put("keyBucket", systemStreamPartition.getKeyBucket());
       jsonGenerator.writeObject(systemStreamPartitionMap);
     }
   }
@@ -258,7 +259,11 @@ public class SamzaObjectMapper {
       String system = node.get("system").textValue();
       String stream = node.get("stream").textValue();
       Partition partition = new Partition(node.get("partition").intValue());
-      return new SystemStreamPartition(system, stream, partition);
+      int keyBucket = -1;
+      if (node.get("keyBucket") != null) {
+        keyBucket = node.get("keyBucket").intValue();
+      }
+      return new SystemStreamPartition(system, stream, partition, keyBucket);
     }
   }
 

--- a/samza-core/src/test/java/org/apache/samza/config/TestJobConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestJobConfig.java
@@ -599,4 +599,53 @@ public class TestJobConfig {
     assertFalse(new JobConfig(new MapConfig(ImmutableMap.of(JobConfig.CONTAINER_HEARTBEAT_MONITOR_ENABLED,
         "false"))).getContainerHeartbeatMonitorEnabled());
   }
+
+  @Test
+  public void testGetElastictyEnabled() {
+    // greater than 1 means enabled
+    JobConfig jobConfig = new JobConfig(
+        new MapConfig(ImmutableMap.of(JobConfig.JOB_ELASTICITY_FACTOR, Integer.toString(2))));
+    assertTrue(jobConfig.getElasticityEnabled());
+
+    // one means disabled
+    jobConfig =
+        new JobConfig(new MapConfig(ImmutableMap.of(JobConfig.JOB_ELASTICITY_FACTOR, Integer.toString(1))));
+    assertFalse(jobConfig.getElasticityEnabled());
+
+    // zero means disabled
+    jobConfig =
+        new JobConfig(new MapConfig(ImmutableMap.of(JobConfig.JOB_ELASTICITY_FACTOR, Integer.toString(0))));
+    assertFalse(jobConfig.getElasticityEnabled());
+
+    // negative means disabled
+    jobConfig =
+        new JobConfig(new MapConfig(ImmutableMap.of(JobConfig.JOB_ELASTICITY_FACTOR, Integer.toString(-1))));
+    assertFalse(jobConfig.getElasticityEnabled());
+
+    // not specified uses the default standby count, which means disabled
+    jobConfig = new JobConfig(new MapConfig());
+    assertFalse(jobConfig.getElasticityEnabled());
+  }
+
+  @Test
+  public void testGetElasticityFactor() {
+    JobConfig jobConfig = new JobConfig(
+        new MapConfig(ImmutableMap.of(JobConfig.JOB_ELASTICITY_FACTOR, Integer.toString(2))));
+    assertEquals(2, jobConfig.getElasticityFactor());
+
+    jobConfig = new JobConfig(
+        new MapConfig(ImmutableMap.of(JobConfig.JOB_ELASTICITY_FACTOR, Integer.toString(1))));
+    assertEquals(1, jobConfig.getElasticityFactor());
+
+    jobConfig =
+        new JobConfig(new MapConfig(ImmutableMap.of(JobConfig.JOB_ELASTICITY_FACTOR, Integer.toString(0))));
+    assertEquals(0, jobConfig.getElasticityFactor());
+
+    jobConfig =
+        new JobConfig(new MapConfig(ImmutableMap.of(JobConfig.JOB_ELASTICITY_FACTOR, Integer.toString(-1))));
+    assertEquals(-1, jobConfig.getElasticityFactor());
+
+    jobConfig = new JobConfig(new MapConfig());
+    assertEquals(JobConfig.DEFAULT_JOB_ELASTICITY_FACTOR, jobConfig.getElasticityFactor());
+  }
 }

--- a/samza-core/src/test/java/org/apache/samza/serializers/model/TestSamzaObjectMapper.java
+++ b/samza-core/src/test/java/org/apache/samza/serializers/model/TestSamzaObjectMapper.java
@@ -187,6 +187,77 @@ public class TestSamzaObjectMapper {
     deserializeFromObjectNode(jobModelJson);
   }
 
+  @Test
+  public void testSerializeSystemStreamPartition() throws IOException {
+    // case 1: keyBucket not explicitly mentioned
+    SystemStreamPartition ssp = new SystemStreamPartition("foo", "bar", new Partition(1));
+    String serializedString = this.samzaObjectMapper.writeValueAsString(ssp);
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    ObjectNode sspJson = objectMapper.createObjectNode();
+    sspJson.put("system", "foo");
+    sspJson.put("stream", "bar");
+    sspJson.put("partition", 1);
+
+    // use a plain ObjectMapper to read JSON to make comparison easier
+    ObjectNode serializedAsJson = (ObjectNode) new ObjectMapper().readTree(serializedString);
+    ObjectNode expectedJson = sspJson;
+
+    assertEquals(expectedJson.get("system"), serializedAsJson.get("system"));
+    assertEquals(expectedJson.get("stream"), serializedAsJson.get("stream"));
+    assertEquals(expectedJson.get("partition"), serializedAsJson.get("partition"));
+
+    //Case 2: with non-null keyBucket
+    ssp = new SystemStreamPartition("foo", "bar", new Partition(1), 1);
+    serializedString = this.samzaObjectMapper.writeValueAsString(ssp);
+
+    sspJson = objectMapper.createObjectNode();
+    sspJson.put("system", "foo");
+    sspJson.put("stream", "bar");
+    sspJson.put("partition", 1);
+    sspJson.put("keyBucket", 1);
+
+    // use a plain ObjectMapper to read JSON to make comparison easier
+    serializedAsJson = (ObjectNode) new ObjectMapper().readTree(serializedString);
+    expectedJson = sspJson;
+
+    assertEquals(expectedJson.get("system"), serializedAsJson.get("system"));
+    assertEquals(expectedJson.get("stream"), serializedAsJson.get("stream"));
+    assertEquals(expectedJson.get("partition"), serializedAsJson.get("partition"));
+    assertEquals(expectedJson.get("keyBucket"), serializedAsJson.get("keyBucket"));
+  }
+
+  @Test
+  public void testDeserializeSystemStreamPartition() throws IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    // case 1: keyBucket not explicitly mentioned
+    ObjectNode sspJson = objectMapper.createObjectNode();
+    sspJson.put("system", "foo");
+    sspJson.put("stream", "bar");
+    sspJson.put("partition", 1);
+
+    SystemStreamPartition ssp = new SystemStreamPartition("foo", "bar", new Partition(1));
+    String jsonString = new ObjectMapper().writeValueAsString(sspJson);
+    SystemStreamPartition deserSSP = this.samzaObjectMapper.readValue(jsonString, SystemStreamPartition.class);
+
+    assertEquals(ssp, deserSSP);
+
+    // case 2: explicitly set key bucket
+    sspJson = objectMapper.createObjectNode();
+    sspJson.put("system", "foo");
+    sspJson.put("stream", "bar");
+    sspJson.put("partition", 1);
+    sspJson.put("keyBucket", 1);
+
+    ssp = new SystemStreamPartition("foo", "bar", new Partition(1), 1);
+    jsonString = new ObjectMapper().writeValueAsString(sspJson);
+    deserSSP = this.samzaObjectMapper.readValue(jsonString, SystemStreamPartition.class);
+
+    assertEquals(ssp, deserSSP);
+  }
+
   private JobModel deserializeFromObjectNode(ObjectNode jobModelJson) throws IOException {
     // use plain ObjectMapper to get JSON string
     String jsonString = new ObjectMapper().writeValueAsString(jobModelJson);
@@ -206,6 +277,7 @@ public class TestSamzaObjectMapper {
     containerModel1TaskTestSSPJson.put("system", "foo");
     containerModel1TaskTestSSPJson.put("stream", "bar");
     containerModel1TaskTestSSPJson.put("partition", 1);
+    containerModel1TaskTestSSPJson.put("keyBucket", -1);
 
     ArrayNode containerModel1TaskTestSSPsJson = objectMapper.createArrayNode();
     containerModel1TaskTestSSPsJson.add(containerModel1TaskTestSSPJson);


### PR DESCRIPTION
**Feature:** Elasticity (SAMZA-2687) for a Samza job allows job to have more tasks than the number of input SystemStreamPartition(SSP). Thus, a job can scale up beyond its input partition count without needing the repartition the input stream.
- This is achieved by having elastic tasks which is the same as a task for all practical purposes. But an elastic task consumes only a subset of the messages of an SSP. 
- With an elasticity factor F (integer), the number of elastic tasks will be F times N with N = original task count. 
- The F elastic tasks per original task all consume subsets of same SSP as the original task. There will be F subsets (aka key bucket) per SSP and a message falls into an SSP bucket 'i' if its message.key.hash()%F == i. 
 
**Changes:**
1. introduce the config for enabling elasticity as job.elasticity.factor. If the job without elasticity has N tasks then with factor = F > 1, there will be F times N (elastic) tasks
2. Add "key bucket" (an integer ranging 0-F) to SSP which will identify the messages within the SSP
3. Compute the key bucket the IncomingMessageEnvelope falls into given elasticity factor F. 
4. SamzaObjectMapper changes to serde keyBucket component of SSP. 
 
 **Tests:** updated unit tests and added new ones.
 
 **API Changes:** no public API changes
 
**Upgrade Instructions:** N/A
 
**Usage Instructions:** set the config job.elasticity.factor > 1 to enable elasticity for the job. 