### PR TITLE
Upgrade to Kafka 2.4 and fix flaky tests

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -36,7 +36,7 @@
   jodaTimeVersion = "2.10.10"
   joptSimpleVersion = "5.0.4"
   junitVersion = "4.12"
-  kafkaVersion = "2.3.1"
+  kafkaVersion = "2.4.1"
   log4jVersion = "1.2.17"
   log4j2Version = "2.16.0"
   metricsVersion = "2.2.0"

--- a/samza-test/src/test/java/org/apache/samza/checkpoint/CheckpointVersionIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/checkpoint/CheckpointVersionIntegrationTest.java
@@ -128,7 +128,7 @@ public class CheckpointVersionIntegrationTest extends StreamApplicationIntegrati
     // verify that the input messages were produced successfully
     if (inputMessages.size() > 0) {
       List<ConsumerRecord<String, String>> inputRecords =
-          consumeMessages(Collections.singletonList(INPUT_TOPIC), inputMessages.size());
+          consumeMessages(INPUT_TOPIC, inputMessages.size());
       List<String> readInputMessages = inputRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
       Assert.assertEquals(expectedInputTopicMessages, readInputMessages);
     }
@@ -143,7 +143,7 @@ public class CheckpointVersionIntegrationTest extends StreamApplicationIntegrati
     // consume and verify the changelog messages
     if (expectedChangelogMessages.size() > 0) {
       List<ConsumerRecord<String, String>> changelogRecords =
-          consumeMessages(Collections.singletonList(CHANGELOG_TOPIC), expectedChangelogMessages.size());
+          consumeMessages(CHANGELOG_TOPIC, expectedChangelogMessages.size());
       List<String> changelogMessages = changelogRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
       Assert.assertEquals(expectedChangelogMessages, changelogMessages);
     }
@@ -172,7 +172,7 @@ public class CheckpointVersionIntegrationTest extends StreamApplicationIntegrati
 
     // consume and verify any additional changelog messages
     List<ConsumerRecord<String, String>> changelogRecords =
-        consumeMessages(Collections.singletonList(changelogTopic), expectedChangelogMessages.size());
+        consumeMessages(changelogTopic, expectedChangelogMessages.size());
     List<String> changelogMessages = changelogRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
     Assert.assertEquals(expectedChangelogMessages, changelogMessages);
   }

--- a/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateIntegrationTest.java
@@ -131,7 +131,7 @@ public class TransactionalStateIntegrationTest extends StreamApplicationIntegrat
     // verify that the input messages were produced successfully
     if (inputMessages.size() > 0) {
       List<ConsumerRecord<String, String>> inputRecords =
-          consumeMessages(Collections.singletonList(INPUT_TOPIC), inputMessages.size());
+          consumeMessages(INPUT_TOPIC, inputMessages.size());
       List<String> readInputMessages = inputRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
       Assert.assertEquals(inputMessages, readInputMessages);
     }
@@ -147,7 +147,7 @@ public class TransactionalStateIntegrationTest extends StreamApplicationIntegrat
     // consume and verify the changelog messages
     if (expectedChangelogMessages.size() > 0) {
       List<ConsumerRecord<String, String>> changelogRecords =
-          consumeMessages(Collections.singletonList(CHANGELOG_TOPIC), expectedChangelogMessages.size());
+          consumeMessages(CHANGELOG_TOPIC, expectedChangelogMessages.size());
       List<String> changelogMessages = changelogRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
       Assert.assertEquals(expectedChangelogMessages, changelogMessages);
     }
@@ -177,7 +177,7 @@ public class TransactionalStateIntegrationTest extends StreamApplicationIntegrat
 
     // consume and verify any additional changelog messages
     List<ConsumerRecord<String, String>> changelogRecords =
-        consumeMessages(Collections.singletonList(changelogTopic), expectedChangelogMessages.size());
+        consumeMessages(changelogTopic, expectedChangelogMessages.size());
     List<String> changelogMessages = changelogRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
     Assert.assertEquals(expectedChangelogMessages, changelogMessages);
 

--- a/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateMultiStoreIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateMultiStoreIntegrationTest.java
@@ -139,7 +139,7 @@ public class TransactionalStateMultiStoreIntegrationTest extends StreamApplicati
     // verify that the input messages were produced successfully
     if (inputMessages.size() > 0) {
       List<ConsumerRecord<String, String>> inputRecords =
-          consumeMessages(Collections.singletonList(INPUT_TOPIC), inputMessages.size());
+          consumeMessages(INPUT_TOPIC, inputMessages.size());
       List<String> readInputMessages = inputRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
       Assert.assertEquals(inputMessages, readInputMessages);
     }
@@ -156,7 +156,7 @@ public class TransactionalStateMultiStoreIntegrationTest extends StreamApplicati
     // consume and verify the changelog messages
     if (expectedChangelogMessages.size() > 0) {
       List<ConsumerRecord<String, String>> changelogRecords =
-          consumeMessages(Collections.singletonList(STORE_1_CHANGELOG), expectedChangelogMessages.size());
+          consumeMessages(STORE_1_CHANGELOG, expectedChangelogMessages.size());
       List<String> changelogMessages = changelogRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
       Assert.assertEquals(expectedChangelogMessages, changelogMessages);
     }
@@ -190,7 +190,7 @@ public class TransactionalStateMultiStoreIntegrationTest extends StreamApplicati
 
     // consume and verify any additional changelog messages
     List<ConsumerRecord<String, String>> changelogRecords =
-        consumeMessages(Collections.singletonList(changelogTopic), expectedChangelogMessages.size());
+        consumeMessages(changelogTopic, expectedChangelogMessages.size());
     List<String> changelogMessages = changelogRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
     Assert.assertEquals(expectedChangelogMessages, changelogMessages);
 

--- a/samza-test/src/test/java/org/apache/samza/test/framework/StreamApplicationIntegrationTestHarness.java
+++ b/samza-test/src/test/java/org/apache/samza/test/framework/StreamApplicationIntegrationTestHarness.java
@@ -20,15 +20,15 @@ package org.apache.samza.test.framework;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.samza.application.SamzaApplication;
 import org.apache.samza.config.ApplicationConfig;
@@ -75,7 +75,7 @@ import static org.apache.kafka.clients.producer.ProducerConfig.*;
  *
  * Execution model: {@link SamzaApplication}s are run as their own {@link org.apache.samza.job.local.ThreadJob}s.
  * Similarly, embedded Kafka servers and Zookeeper servers are run as their own threads.
- * {@link #produceMessage(String, int, String, String)} and {@link #consumeMessages(Collection, int)} are blocking calls.
+ * {@link #produceMessage(String, int, String, String)} and {@link #consumeMessages(String, int)} are blocking calls.
  *
  * <h3>Usage Example</h3>
  * Here is an actual test that publishes a message into Kafka, runs an application, and verifies consumption
@@ -100,6 +100,7 @@ public class StreamApplicationIntegrationTestHarness extends IntegrationTestHarn
   private static final Duration POLL_TIMEOUT_MS = Duration.ofSeconds(20);
   private static final int DEFAULT_REPLICATION_FACTOR = 1;
   private int numEmptyPolls = 3;
+  private Map<String, KafkaConsumer> topicConsumerMap = new HashMap<>();
 
   /**
    * Creates a kafka topic with the provided name and the number of partitions
@@ -128,7 +129,6 @@ public class StreamApplicationIntegrationTestHarness extends IntegrationTestHarn
     return Integer.parseInt(KafkaConfig.TOPIC_DEFAULT_REPLICATION_FACTOR());
   }
 
-
   /**
    * Read messages from the provided list of topics until {@param threshold} messages have been read or until
    * {@link #numEmptyPolls} polls return no messages.
@@ -136,24 +136,25 @@ public class StreamApplicationIntegrationTestHarness extends IntegrationTestHarn
    * The default poll time out is determined by {@link #POLL_TIMEOUT_MS} and the number of empty polls are
    * determined by {@link #numEmptyPolls}
    *
-   * @param topics the list of topics to consume from
+   * @param topic the topic to consume from
    * @param threshold the number of messages to consume
    * @return the list of {@link ConsumerRecord}s whose size can be atmost {@param threshold}
    */
-  public List<ConsumerRecord<String, String>> consumeMessages(Collection<String> topics, int threshold) {
+  public List<ConsumerRecord<String, String>> consumeMessages(String topic, int threshold) {
     int emptyPollCount = 0;
     List<ConsumerRecord<String, String>> recordList = new ArrayList<>();
-    consumer.subscribe(topics);
-
+    KafkaConsumer kafkaConsumer =
+        topicConsumerMap.computeIfAbsent(topic, t -> new KafkaConsumer<>(createConsumerConfigs()));
+    kafkaConsumer.subscribe(Collections.singletonList(topic));
     while (emptyPollCount < numEmptyPolls && recordList.size() < threshold) {
-      ConsumerRecords<String, String> records = consumer.poll(POLL_TIMEOUT_MS);
-      LOG.info("Read {} messages from topics: {}", records.count(), StringUtils.join(topics, ","));
+      ConsumerRecords<String, String> records = kafkaConsumer.poll(POLL_TIMEOUT_MS);
+      LOG.info("Read {} messages from topic: {}", records.count(), topic);
       if (!records.isEmpty()) {
         Iterator<ConsumerRecord<String, String>> iterator = records.iterator();
         while (iterator.hasNext() && recordList.size() < threshold) {
           ConsumerRecord record = iterator.next();
-          LOG.info("Read key: {} val: {} from topic: {} on partition: {}",
-              record.key(), record.value(), record.topic(), record.partition());
+          LOG.info("Read key: {} val: {} from topic: {} on partition: {}", record.key(), record.value(), record.topic(),
+              record.partition());
           recordList.add(record);
           emptyPollCount = 0;
         }
@@ -173,8 +174,7 @@ public class StreamApplicationIntegrationTestHarness extends IntegrationTestHarn
    * @return RunApplicationContext which contains objects created within runApplication, to be used for verification
    * if necessary
    */
-  protected RunApplicationContext runApplication(SamzaApplication streamApplication,
-      String appName,
+  protected RunApplicationContext runApplication(SamzaApplication streamApplication, String appName,
       Map<String, String> overriddenConfigs) {
     Map<String, String> configMap = new HashMap<>();
     configMap.put(ApplicationConfig.APP_RUNNER_CLASS, "org.apache.samza.runtime.LocalApplicationRunner");
@@ -263,6 +263,9 @@ public class StreamApplicationIntegrationTestHarness extends IntegrationTestHarn
      */
     consumerProps.setProperty(KEY_DESERIALIZER_CLASS_CONFIG, STRING_DESERIALIZER);
     consumerProps.setProperty(VALUE_DESERIALIZER_CLASS_CONFIG, STRING_DESERIALIZER);
+
+    // for every topic create a new consumer group to avoid group rebalance
+    consumerProps.setProperty(GROUP_ID_CONFIG, "group" + topicConsumerMap.size());
     return consumerProps;
   }
 }

--- a/samza-test/src/test/java/org/apache/samza/test/framework/TestStreamApplicationIntegrationTestHarness.java
+++ b/samza-test/src/test/java/org/apache/samza/test/framework/TestStreamApplicationIntegrationTestHarness.java
@@ -20,7 +20,6 @@
 package org.apache.samza.test.framework;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -45,7 +44,7 @@ public class TestStreamApplicationIntegrationTestHarness extends StreamApplicati
     // verify that the input messages were produced successfully
     if (inputMessages.size() > 0) {
       List<ConsumerRecord<String, String>> inputRecords =
-          consumeMessages(Collections.singletonList(INPUT_TOPIC), inputMessages.size());
+          consumeMessages(INPUT_TOPIC, inputMessages.size());
       List<String> readInputMessages = inputRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
       Assert.assertEquals(inputMessages, readInputMessages);
     }

--- a/samza-test/src/test/java/org/apache/samza/test/operator/TestRepartitionJoinWindowApp.java
+++ b/samza-test/src/test/java/org/apache/samza/test/operator/TestRepartitionJoinWindowApp.java
@@ -19,7 +19,6 @@
 package org.apache.samza.test.operator;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -92,7 +91,7 @@ public class TestRepartitionJoinWindowApp extends StreamApplicationIntegrationTe
     runApplication(app, appName, configs);
 
     // consume and validate result
-    List<ConsumerRecord<String, String>> messages = consumeMessages(Collections.singletonList(outputTopicName), 2);
+    List<ConsumerRecord<String, String>> messages = consumeMessages(outputTopicName, 2);
     assertEquals(2, messages.size());
 
     Assert.assertFalse(KafkaSystemAdmin.deleteMessageCalled);
@@ -121,7 +120,7 @@ public class TestRepartitionJoinWindowApp extends StreamApplicationIntegrationTe
     runApplication(app, appName, configs);
 
     // consume and validate result
-    List<ConsumerRecord<String, String>> messages = consumeMessages(Collections.singletonList(outputTopicName), 2);
+    List<ConsumerRecord<String, String>> messages = consumeMessages(outputTopicName, 2);
     assertEquals(2, messages.size());
 
     for (ConsumerRecord<String, String> message : messages) {


### PR DESCRIPTION

1. Upgrade Kafka version in dependency-versions.gradle

2. 
Issue:
StreamApplicationIntegrationTestHarness is flaky because in the test 
there is a Kafka consumer subscribes to input topic and consumes from it
then, the same consumer subscribes to the changelog topic. 
During this change, Kafka needs to revoke the previous assignments and do rebalancing which causes the changelog topic is not assigned to any member. 

Change:  create a separate consumer of a different consumer group to consume changelog topic, so it can avoid Kafka consumer group rebalance

3.
Issue:
Apache Kafka 2.4 introduces sticky partition strategy:https://www.confluent.io/blog/apache-kafka-producer-improvements-sticky-partitioner/
which causes TestZkLocalApplicationRunner tests flaky.

The reason is that in some of the tests,
Kafka events published to an input topic with 5 partitions with DefaultPartitioner. With the sticky partition strategy, some of the partitions could be empty. The tests bring up some stream processors to process them and wait for processors to consume messages.

However, a stream processor doesn't have any messages to process if it consumes from partitions that have no messages
In such a case, the test will be stuck and timeout. 

Change: publish Kafka events to all partitions in a round-robin way to make sure all partitions have messages


Tests:
/gradlew clean build

API Changes:
None

