### PR TITLE
SAMZA-2719: [Elasticity] fix container level metrics when elasticity is enabled

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
+++ b/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
@@ -270,15 +270,18 @@ public class RunLoop implements Runnable, Throttleable {
           }
         } else if (elasticityFactor > 1) {
           // is listOfWorkersForEnvelope is null and elascity factor > 1 (aka enabled), then
-          // this condition happens when a keyBucket of the SSP is being consumed but other keyBuckets are not consumed
+          // this condition happens when only a subset of keyBuckets of an SSP are being consumed at this container
+          // but not all keyBuckets of an SSP are consumed, therefore, we fake the consumption of the envelope,
+          // and decrement the metric, since this envelope's processing is skipped.
           // if this update is not done for the SSP then the unprocessed envelopes from other keyBuckets
-          // will make the consumerMultiplexer not poll as it sees envelopes available for consumption.
+          // will prevent the consumerMultiplexer from polling as it sees envelopes available for consumption.
           consumerMultiplexer.tryUpdate(envelope.getSystemStreamPartition(elasticityFactor));
           log.trace("updating the system consumers for ssp keyBucket {} not processed by this runloop",
               envelope.getSystemStreamPartition(elasticityFactor));
           // since this envelope is not processed by the container, need to decrement the # envelopes metric
           // # envelopes metric was incremented when the envelope was returned by the SystemConsumers
           containerMetrics.envelopes().dec();
+          containerMetrics.skippedEnvelopes().inc();
         }
       }
 

--- a/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
+++ b/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
@@ -276,6 +276,9 @@ public class RunLoop implements Runnable, Throttleable {
           consumerMultiplexer.tryUpdate(envelope.getSystemStreamPartition(elasticityFactor));
           log.trace("updating the system consumers for ssp keyBucket {} not processed by this runloop",
               envelope.getSystemStreamPartition(elasticityFactor));
+          // since this envelope is not processed by the container, need to decrement the # envelopes metric
+          // # envelopes metric was incremented when the envelope was returned by the SystemConsumers
+          containerMetrics.envelopes().dec();
         }
       }
 

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -431,7 +431,8 @@ object SamzaContainer extends Logging {
       metrics = systemConsumersMetrics,
       dropDeserializationError = dropDeserializationError,
       pollIntervalMs = pollIntervalMs,
-      clock = () => clock.nanoTime())
+      clock = () => clock.nanoTime(),
+      elasticityFactor = jobConfig.getElasticityFactor)
 
     val producerMultiplexer = new SystemProducers(
       producers = producers,

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
@@ -35,6 +35,7 @@ class SamzaContainerMetrics(
   val processes = newCounter("process-calls")
   val envelopes = newCounter("process-envelopes")
   val nullEnvelopes = newCounter("process-null-envelopes")
+  val skippedEnvelopes = newCounter("skipped-envelopes")
   val chooseNs = newTimer("choose-ns")
   val windowNs = newTimer("window-ns")
   val timerNs = newTimer("timer-ns")

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -300,7 +300,8 @@ public class ContainerStorageManager {
       sideInputSystemConsumers =
           new SystemConsumers(chooser, ScalaJavaUtil.toScalaMap(sideInputConsumers), systemAdmins, serdeManager,
               sideInputSystemConsumersMetrics, SystemConsumers.DEFAULT_NO_NEW_MESSAGES_TIMEOUT(), SystemConsumers.DEFAULT_DROP_SERIALIZATION_ERROR(),
-              TaskConfig.DEFAULT_POLL_INTERVAL_MS, ScalaJavaUtil.toScalaFunction(() -> System.nanoTime()));
+              TaskConfig.DEFAULT_POLL_INTERVAL_MS, ScalaJavaUtil.toScalaFunction(() -> System.nanoTime()),
+              JobConfig.DEFAULT_JOB_ELASTICITY_FACTOR);
     }
 
   }

--- a/samza-core/src/main/scala/org/apache/samza/system/SystemConsumers.scala
+++ b/samza-core/src/main/scala/org/apache/samza/system/SystemConsumers.scala
@@ -353,19 +353,7 @@ class SystemConsumers (
       while (sspAndEnvelopeIterator.hasNext) {
         val sspAndEnvelope = sspAndEnvelopeIterator.next
         val systemStreamPartition = sspAndEnvelope.getKey
-        val filtered_envelopes = new util.ArrayList[IncomingMessageEnvelope](sspAndEnvelope.getValue)
-        // filter out all the envelopes with SSP not registered with this SystemConsumers
-        // with elasticity enabled, SSP of the envelope will be the SSP with KeyBucket
-        // and hence will filter out envelopes if their key bucket is not registered
-        // without elasticity, there are no key buckets
-        // and hence full SSP is registered and all envelopes of the SSP will be retained
-        filtered_envelopes.removeIf {
-          new Predicate[IncomingMessageEnvelope] {
-            def test(envelope: IncomingMessageEnvelope): Boolean =
-              !sspKeyBucketsRegistered.contains(envelope.getSystemStreamPartition(elasticityFactor))
-          }
-        }
-        val envelopes = new ArrayDeque[IncomingMessageEnvelope](filtered_envelopes)
+        val envelopes = new ArrayDeque(sspAndEnvelope.getValue)
         val numEnvelopes = envelopes.size
         totalUnprocessedMessages += numEnvelopes
 

--- a/samza-core/src/test/scala/org/apache/samza/system/TestSystemConsumers.scala
+++ b/samza-core/src/test/scala/org/apache/samza/system/TestSystemConsumers.scala
@@ -426,11 +426,9 @@ class TestSystemConsumers {
     consumer.setNextResponse(nextResponse01)
 
     // envelope01 does not belong to ssp_keybucket processed by the container
-    // and hence systemConsumers should not return it during choose no matter how many times choose is called
     // and hence the metric for choseObject should not be updated
-    assertNull(systemConsumers.choose())
-    assertNull(systemConsumers.choose())
-    assertNull(systemConsumers.choose())
+    assertNull(systemConsumers.choose()) //refresh
+    assertEquals(envelope01, systemConsumers.choose())
     assertEquals(1, systemConsumersMetrics.choseObject.getCount)
   }
 

--- a/samza-core/src/test/scala/org/apache/samza/system/TestSystemConsumers.scala
+++ b/samza-core/src/test/scala/org/apache/samza/system/TestSystemConsumers.scala
@@ -32,6 +32,7 @@ import org.apache.samza.system.chooser.DefaultChooser
 import org.apache.samza.system.chooser.MockMessageChooser
 import org.apache.samza.util.BlockingEnvelopeMap
 import org.mockito.Mockito
+import org.mockito.Mockito.{spy, when}
 
 import scala.collection.JavaConverters._
 
@@ -372,6 +373,65 @@ class TestSystemConsumers {
       TaskConfig.DEFAULT_POLL_INTERVAL_MS, clock = () => 0)
 
     consumers.register(systemStreamPartition1, "0")
+  }
+
+  @Test
+  def testSystemConsumersElasticityEnabled: Unit = {
+    val system = "test-system"
+    // create two key bucekts "ssp0" and "ssp1" within one SSP "ssp"
+    // and two IME such that one of their ssp keybucket maps to ssp0 and the other one maps to ssp1
+    // registed only "ssp0" with the SystemConsumers
+    val ssp = new SystemStreamPartition(system, "some-stream", new Partition(0))
+    val ssp0 = new SystemStreamPartition(system, "some-stream", new Partition(0), 0)
+    val ssp1 = new SystemStreamPartition(system, "some-stream", new Partition(0), 1)
+    val envelope = spy(new IncomingMessageEnvelope(ssp, "100", "key", "value"))
+    val envelope00 = spy(new IncomingMessageEnvelope(ssp, "0", "key0", "value0"))
+    val envelope01 = spy(new IncomingMessageEnvelope(ssp, "1", "key1", "value0"))
+    when(envelope00.getSystemStreamPartition(2)).thenReturn(ssp0)
+    when(envelope01.getSystemStreamPartition(2)).thenReturn(ssp1)
+
+    val consumer = new CustomPollResponseSystemConsumer(envelope)
+    var now = 0
+    val systemAdmins = Mockito.mock(classOf[SystemAdmins])
+    when(systemAdmins.getSystemAdmin(system)).thenReturn(Mockito.mock(classOf[SystemAdmin]))
+
+    val systemConsumersMetrics = new SystemConsumersMetrics
+
+    val systemConsumers = new SystemConsumers(new MockMessageChooser, Map(system -> consumer), systemAdmins,
+      new SerdeManager, systemConsumersMetrics,
+      SystemConsumers.DEFAULT_NO_NEW_MESSAGES_TIMEOUT,
+      SystemConsumers.DEFAULT_DROP_SERIALIZATION_ERROR,
+      TaskConfig.DEFAULT_POLL_INTERVAL_MS, clock = () => now, 2)
+
+    systemConsumers.register(ssp0, "0")
+    systemConsumers.start
+
+    // Tell the consumer to return envelope00
+    val nextResponse00 = Map[SystemStreamPartition, java.util.List[IncomingMessageEnvelope]](
+      ssp -> Collections.singletonList(envelope00)
+    )
+    consumer.setNextResponse(nextResponse00)
+
+    // Choose to trigger a refresh with data.
+    assertNull(systemConsumers.choose())
+
+    assertEquals(envelope00, systemConsumers.choose())
+    assertEquals(1, systemConsumersMetrics.choseObject.getCount)
+
+
+    // Tell the consumer to return envelop01
+    val nextResponse01 = Map[SystemStreamPartition, java.util.List[IncomingMessageEnvelope]](
+      ssp -> Collections.singletonList(envelope01)
+    )
+    consumer.setNextResponse(nextResponse01)
+
+    // envelope01 does not belong to ssp_keybucket processed by the container
+    // and hence systemConsumers should not return it during choose no matter how many times choose is called
+    // and hence the metric for choseObject should not be updated
+    assertNull(systemConsumers.choose())
+    assertNull(systemConsumers.choose())
+    assertNull(systemConsumers.choose())
+    assertEquals(1, systemConsumersMetrics.choseObject.getCount)
   }
 
   /**


### PR DESCRIPTION
Symptom: Certain container level metrics have incorrect values when elasticity is enabled. Metrics affected: chose-object, process-calls, messages-chosen.

Cause: With elasticity enabled, a container may process only some of the messages of an SSP and not all of the messages in the SSP. the messages processed belong to the key buckets within the container's model. However, pre-elasticity container level metrics counted the messages per ssp. 

Changes: Adapt SystemConsumers and RunLoop to account for key buckets. SystemConsumers keeps track of all the SSP(with key buckets) registered with it by the RunLoop and increments only the metrics only if the message belongs to this SSP set. new metric skipped-envelopes added for those messages in an ssp but not processed by runloop

Tests: added unit tests to verify correct values for metrics

API changes: None

Usage/Upgrade instructions: None