### PR TITLE
SAMZA-2723: Fix yarn version and scala version for scalate

### DIFF
--- a/bin/check-all.sh
+++ b/bin/check-all.sh
@@ -23,7 +23,7 @@ set -e
 
 SCALAs=( "2.11" "2.12" )
 JDKs=( "JAVA8_HOME" )
-YARNs=( "2.6.1" "2.7.1" )
+YARNs=( "2.10.1" )
 
 # get base directory
 home_dir=`pwd`

--- a/gradle/dependency-versions-scala-2.12.gradle
+++ b/gradle/dependency-versions-scala-2.12.gradle
@@ -18,7 +18,7 @@
  */
 ext {
   scalaSuffix = "2.12"
-  scalaVersion = "2.12.1"
+  scalaVersion = "2.12.11"
   // Extra options for the compiler:
   // -feature: Give detailed warnings about language feature use (rather than just 'there were 4 warnings')
   // -language:implicitConversions: Allow the use of implicit conversions without warning or library import

--- a/samza-test/src/main/python/tests/standalone_failure_tests.py
+++ b/samza-test/src/main/python/tests/standalone_failure_tests.py
@@ -104,9 +104,9 @@ def job_model_watcher(event, expected_processors):
 
 def __validate_job_model(job_model, killed_processors=[]):
     ## Validate the TaskModel. Check if all the partitions are assigned to the containers.
-    expected_ssps = [{u'partition': 0, u'system': u'testSystemName', u'stream': u'standalone_integration_test_kafka_input_topic'},
-                        {u'partition': 1, u'system': u'testSystemName', u'stream': u'standalone_integration_test_kafka_input_topic'},
-                        {u'partition': 2, u'system': u'testSystemName', u'stream': u'standalone_integration_test_kafka_input_topic'}]
+    expected_ssps = [{u'keyBucket': -1, u'partition': 0, u'system': u'testSystemName', u'stream': u'standalone_integration_test_kafka_input_topic'},
+                        {u'keyBucket': -1, u'partition': 1, u'system': u'testSystemName', u'stream': u'standalone_integration_test_kafka_input_topic'},
+                        {u'keyBucket': -1, u'partition': 2, u'system': u'testSystemName', u'stream': u'standalone_integration_test_kafka_input_topic'}]
     actual_ssps = []
     for container_id, tasks in job_model['containers'].iteritems():
         for partition, ssps in tasks['tasks'].iteritems():


### PR DESCRIPTION
Fix for observed failures in release testing

1. Symptom: 
```
> Task :samza-yarn_2.11:compileTestScala FAILED
Pruning sources from previous analysis, due to incompatible CompileSetup.

/Users/dchen1/code/samza212/samza/samza-yarn/src/test/scala/org/apache/samza/job/yarn/TestSamzaYarnAppMasterLifecycle.scala:57: type ResourceTypeInfo is not a member of package org.apache.hadoop.yarn.api.records

        override def setResourceTypes(types: java.util.List[org.apache.hadoop.yarn.api.records.ResourceTypeInfo]): Unit = ()
```
Cause: we have updated (https://github.com/apache/samza/pull/1557) the yarn version but did not change it in release tests
Fix: Update ./bin/check-all.sh yarn verison

2. Fix scalate and scala 2.12 version compatibility
We need to update the scala version from 2.12.1 -> 2.12.11 for scalate compatibility
Symptom:
```
Caused by: java.lang.NoSuchMethodError: scala.tools.nsc.symtab.classfile.ClassfileParser$unpickler$.unpickle([BILscala/reflect/internal/Symbols$ClassSymbol;Lscala/reflect/internal/Symbols$ModuleSymbol;Ljava/lang/String;)V
at scala.tools.nsc.symtab.classfile.ClassfileParser.parseAttribute$1(ClassfileParser.scala:847)

at scala.tools.nsc.symtab.classfile.ClassfileParser.$anonfun$parseAttributes$17(ClassfileParser.scala:1039)

at scala.tools.nsc.symtab.classfile.ClassfileParser.parseAttributes(ClassfileParser.scala:1039)

at scala.tools.nsc.symtab.classfile.ClassfileParser.parseClass(ClassfileParser.scala:489)

at scala.tools.nsc.symtab.classfile.ClassfileParser.$anonfun$parse$1(ClassfileParser.scala:156)

at scala.tools.nsc.symtab.classfile.ClassfileParser.parse(ClassfileParser.scala:127)

at scala.tools.nsc.symtab.SymbolLoaders$ClassfileLoader.doComplete(SymbolLoaders.scala:311)

at scala.tools.nsc.symtab.SymbolLoaders$SymbolLoader.complete(SymbolLoaders.scala:213)
```
Cause: we bumped Scalate version
Fix: find the respective matching scala version
3. Symptom fix integration tests for standalone
```
2022-02-28 11:27:08,056 zopkio.test_runner [INFO] test_kill_multiple_followers----failed
2022-02-28 11:27:08,056 zopkio.test_runner [INFO] ["AssertionError: Expected ssp: [{u'partition': 0, u'system': u'testSystemName', u'st
ream': u'standalone_integration_test_kafka_input_topic'}, {u'partition': 1, u'system': u'testSystemName', u'stream': u'standalone_integ
ration_test_kafka_input_topic'}, {u'partition': 2, u'system': u'testSystemName', u'stream': u'standalone_integration_test_kafka_input_t
opic'}], Actual ssp: [{u'keyBucket': -1, u'partition': 0, u'system': u'testSystemName', u'stream': u'standalone_integration_test_kafka_
input_topic'}, {u'keyBucket': -1, u'partition': 1, u'system': u'testSystemName', u'stream': u'standalone_integration_test_kafka_input_t
opic'}, {u'keyBucket': -1, u'partition': 2, u'system': u'testSystemName', u'stream': u'standalone_integration_test_kafka_input_topic'}]
.\n"]
``` 
Cause: We are using hard coded validation in py integration tests scripts and have changed the SSP class field to add keyBucket (https://github.com/apache/samza/pull/1576)
Fix: Update tests to use newer field