### PR TITLE
SAMZA-2727: Fix UTFDataFormatException for FileUtil

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/util/FileUtil.scala
+++ b/samza-core/src/main/scala/org/apache/samza/util/FileUtil.scala
@@ -48,8 +48,8 @@ class FileUtil extends Logging {
 
       var remainingDataSegment = data
       // Split data into writable segments
-      while (remainingDataSegment.length > MaxStringSegmentWriteSize) {
-        val splitData  = data.splitAt(MaxStringSegmentWriteSize)
+      while (remainingDataSegment.length >= MaxStringSegmentWriteSize) {
+        val splitData  = remainingDataSegment.splitAt(MaxStringSegmentWriteSize - 1)
         oos.writeUTF(splitData._1)
         remainingDataSegment = splitData._2
       }

--- a/samza-core/src/main/scala/org/apache/samza/util/FileUtil.scala
+++ b/samza-core/src/main/scala/org/apache/samza/util/FileUtil.scala
@@ -26,8 +26,7 @@ import java.nio.file._
 import java.util.zip.CRC32
 
 class FileUtil extends Logging {
-  val VERSION = 1
-  val MAX_WRITE_UTF_SEGMENT = 0xFFFF
+  val MaxStringSegmentWriteSize: Int = 64 * 1024
 
   /**
     * Writes checksum & data to a file
@@ -49,8 +48,8 @@ class FileUtil extends Logging {
 
       var remainingDataSegment = data
       // Split data into writable segments
-      while (remainingDataSegment.length > MAX_WRITE_UTF_SEGMENT) {
-        val splitData  = data.splitAt(MAX_WRITE_UTF_SEGMENT)
+      while (remainingDataSegment.length > MaxStringSegmentWriteSize) {
+        val splitData  = data.splitAt(MaxStringSegmentWriteSize)
         oos.writeUTF(splitData._1)
         remainingDataSegment = splitData._2
       }

--- a/samza-core/src/test/scala/org/apache/samza/util/TestFileUtil.scala
+++ b/samza-core/src/test/scala/org/apache/samza/util/TestFileUtil.scala
@@ -34,8 +34,8 @@ class TestFileUtil {
   val data = "100"
   val fileUtil = new FileUtil()
   val checksum: Long = fileUtil.getChecksum(data)
-  val TMP_DIR: String = System.getProperty("java.io.tmpdir")
-  val file = new File(TMP_DIR, "test")
+  val tmpDir: String = System.getProperty("java.io.tmpdir")
+  val file = new File(tmpDir, "test")
 
   @Test
   def testWriteDataToFile() {
@@ -56,7 +56,7 @@ class TestFileUtil {
 
   @Test
   def testWriteLargeDataToFile() {
-    val largeData = RandomStringUtils.randomAscii(fileUtil.MAX_WRITE_UTF_SEGMENT + 1)
+    val largeData = RandomStringUtils.randomAscii(fileUtil.MaxStringSegmentWriteSize + 1)
     val largeChecksum = fileUtil.getChecksum(largeData)
 
     // Invoke test
@@ -156,14 +156,14 @@ class TestFileUtil {
      * /tmp/samza-file-util-RANDOM-symlink (symlink to dir above)
      * /tmp/samza-file-util-RANDOM/subdir (created via the symlink above)
      */
-    val tmpDirPath = Paths.get(TMP_DIR)
+    val tmpDirPath = Paths.get(tmpDir)
     val tmpSubDirName = "samza-file-util-" + Random.nextInt()
     val tmpSubDirSymlinkName = tmpSubDirName + "-symlink"
 
-    val tmpSubDirPath = Paths.get(TMP_DIR, tmpSubDirName);
+    val tmpSubDirPath = Paths.get(tmpDir, tmpSubDirName);
     fileUtil.createDirectories(tmpSubDirPath)
 
-    val tmpSymlinkPath = Paths.get(TMP_DIR, tmpSubDirSymlinkName)
+    val tmpSymlinkPath = Paths.get(tmpDir, tmpSubDirSymlinkName)
     Files.createSymbolicLink(tmpSymlinkPath, tmpDirPath);
 
     try {
@@ -179,7 +179,7 @@ class TestFileUtil {
     fileUtil.createDirectories(tmpSymlinkPath)
 
     // verify that subdirs can be created via symlinks correctly.
-    val tmpSubSubDirPath = Paths.get(TMP_DIR, tmpSubDirName + "-symlink", "subdir")
+    val tmpSubSubDirPath = Paths.get(tmpDir, tmpSubDirName + "-symlink", "subdir")
     fileUtil.createDirectories(tmpSubSubDirPath)
   }
 }

--- a/samza-core/src/test/scala/org/apache/samza/util/TestFileUtil.scala
+++ b/samza-core/src/test/scala/org/apache/samza/util/TestFileUtil.scala
@@ -21,7 +21,7 @@
 
 package org.apache.samza.util
 
-import org.apache.samza.testUtils.FileUtil
+import org.apache.commons.lang3.RandomStringUtils
 
 import java.io.{File, FileInputStream, FileOutputStream, ObjectInputStream, ObjectOutputStream}
 import org.junit.Assert.{assertEquals, assertNull, assertTrue, fail}
@@ -33,8 +33,9 @@ import scala.util.Random
 class TestFileUtil {
   val data = "100"
   val fileUtil = new FileUtil()
-  val checksum = fileUtil.getChecksum(data)
-  val file = new File(System.getProperty("java.io.tmpdir"), "test")
+  val checksum: Long = fileUtil.getChecksum(data)
+  val TMP_DIR: String = System.getProperty("java.io.tmpdir")
+  val file = new File(TMP_DIR, "test")
 
   @Test
   def testWriteDataToFile() {
@@ -49,6 +50,26 @@ class TestFileUtil {
     // Check content of the file is as expected
     assertEquals(checksum, ois.readLong())
     assertEquals(data, ois.readUTF())
+    ois.close()
+    fis.close()
+  }
+
+  @Test
+  def testWriteLargeDataToFile() {
+    val largeData = RandomStringUtils.randomAscii(fileUtil.MAX_WRITE_UTF_SEGMENT + 1)
+    val largeChecksum = fileUtil.getChecksum(largeData)
+
+    // Invoke test
+    fileUtil.writeWithChecksum(file, largeData)
+
+    // Check that file exists
+    assertTrue("File was not created!", file.exists())
+    val fis = new FileInputStream(file)
+    val ois = new ObjectInputStream(fis)
+
+    // Check content of the file is as expected
+    assertEquals(largeChecksum, ois.readLong())
+    assertEquals(largeData, fileUtil.readWithChecksum(file))
     ois.close()
     fis.close()
   }
@@ -93,6 +114,18 @@ class TestFileUtil {
   }
 
   @Test
+  def testReadDataFromBackwardsCompatFile() {
+    // Write
+    fileUtil.writeWithChecksum(file, data)
+
+    // Invoke test
+    val result = fileUtil.readWithChecksum(file)
+
+    // Check data returned
+    assertEquals(data, result)
+  }
+
+  @Test
   def testReadInvalidDataFromFile() {
     // Write garbage to produce a null result when it's read
     val fos = new FileOutputStream(file)
@@ -123,14 +156,14 @@ class TestFileUtil {
      * /tmp/samza-file-util-RANDOM-symlink (symlink to dir above)
      * /tmp/samza-file-util-RANDOM/subdir (created via the symlink above)
      */
-    val tmpDirPath = Paths.get(FileUtil.TMP_DIR)
+    val tmpDirPath = Paths.get(TMP_DIR)
     val tmpSubDirName = "samza-file-util-" + Random.nextInt()
     val tmpSubDirSymlinkName = tmpSubDirName + "-symlink"
 
-    val tmpSubDirPath = Paths.get(FileUtil.TMP_DIR, tmpSubDirName);
+    val tmpSubDirPath = Paths.get(TMP_DIR, tmpSubDirName);
     fileUtil.createDirectories(tmpSubDirPath)
 
-    val tmpSymlinkPath = Paths.get(FileUtil.TMP_DIR, tmpSubDirSymlinkName)
+    val tmpSymlinkPath = Paths.get(TMP_DIR, tmpSubDirSymlinkName)
     Files.createSymbolicLink(tmpSymlinkPath, tmpDirPath);
 
     try {
@@ -146,7 +179,7 @@ class TestFileUtil {
     fileUtil.createDirectories(tmpSymlinkPath)
 
     // verify that subdirs can be created via symlinks correctly.
-    val tmpSubSubDirPath = Paths.get(FileUtil.TMP_DIR, tmpSubDirName + "-symlink", "subdir")
+    val tmpSubSubDirPath = Paths.get(TMP_DIR, tmpSubDirName + "-symlink", "subdir")
     fileUtil.createDirectories(tmpSubSubDirPath)
   }
 }

--- a/samza-core/src/test/scala/org/apache/samza/util/TestFileUtil.scala
+++ b/samza-core/src/test/scala/org/apache/samza/util/TestFileUtil.scala
@@ -56,7 +56,7 @@ class TestFileUtil {
 
   @Test
   def testWriteLargeDataToFile() {
-    val largeData = RandomStringUtils.randomAscii(fileUtil.MaxStringSegmentWriteSize + 1)
+    val largeData = RandomStringUtils.randomAscii(fileUtil.MaxStringSegmentWriteSize * 2)
     val largeChecksum = fileUtil.getChecksum(largeData)
 
     // Invoke test


### PR DESCRIPTION
**Symptom**: We see the following when writing a large checkpoint to disk
```
Caused by: java.io.UTFDataFormatException
	at java.io.ObjectOutputStream$BlockDataOutputStream.writeUTF(ObjectOutputStream.java:2164) ~[?:1.8.0_282]
	at java.io.ObjectOutputStream$BlockDataOutputStream.writeUTF(ObjectOutputStream.java:2007) ~[?:1.8.0_282]
	at java.io.ObjectOutputStream.writeUTF(ObjectOutputStream.java:869) ~[?:1.8.0_282]
	at org.apache.samza.util.FileUtil.writeWithChecksum(FileUtil.scala:45) ~[samza-core_2.11-317.1071.9.4.jar:317.1071.9.4]
	at org.apache.samza.storage.StorageManagerUtil.writeCheckpointV2File(StorageManagerUtil.java:245)
```
**Cause**: FileUtil uses `ObjectOutputStream$BlockDataOutputStream.writeUTF` which limits the size to 0xFFFF and throws `UTFDataFormatException` if the length is greater
 
**Changes**: Chunked data larger than 0xFFFF into individual writes allowing larger data size support, as well backwards compatibility
 
**Tests**: Added unit test for backward compatibility and large message testing