### PR TITLE
SAMZA-2720: Allow custom task executor to be injected and used.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,3 @@
-#Mon Jun 01 15:50:38 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip

--- a/samza-api/src/main/java/org/apache/samza/task/TaskExecutorFactory.java
+++ b/samza-api/src/main/java/org/apache/samza/task/TaskExecutorFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.task;
+
+import java.util.concurrent.ExecutorService;
+import org.apache.samza.config.Config;
+
+
+/**
+ * Factory for creating the executor used when running tasks in multi-thread mode.
+ */
+public interface TaskExecutorFactory {
+
+  /**
+   * @param config contains configs for the executor
+   * @return task executor
+   */
+  ExecutorService getTaskExecutor(Config config);
+}

--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -63,6 +63,8 @@ public class JobConfig extends MapConfig {
   public static final String JOB_CONTAINER_COUNT = "job.container.count";
   static final int DEFAULT_JOB_CONTAINER_COUNT = 1;
   public static final String JOB_CONTAINER_THREAD_POOL_SIZE = "job.container.thread.pool.size";
+  public static final String JOB_CONTAINER_TASK_EXECUTOR_TYPE = "job.container.task.executor.type";
+  public static final String DEFAULT_JOB_CONTAINER_TASK_EXECUTOR_TYPE = "org.apache.samza.task.DefaultTaskExecutorFactory";
   // num commit threads == min(max(2 * num tasks in container, thread pool size), max thread pool size)
   public static final String COMMIT_THREAD_POOL_SIZE = "job.container.commit.thread.pool.size";
   static final int DEFAULT_COMMIT_THREAD_POOL_SIZE = 2;
@@ -353,6 +355,10 @@ public class JobConfig extends MapConfig {
     } else {
       return getInt(JOB_CONTAINER_THREAD_POOL_SIZE, 0);
     }
+  }
+
+  public String getTaskExecutorFactory() {
+    return get(JOB_CONTAINER_TASK_EXECUTOR_TYPE, DEFAULT_JOB_CONTAINER_TASK_EXECUTOR_TYPE);
   }
 
   public int getCommitThreadPoolSize() {

--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -63,8 +63,8 @@ public class JobConfig extends MapConfig {
   public static final String JOB_CONTAINER_COUNT = "job.container.count";
   static final int DEFAULT_JOB_CONTAINER_COUNT = 1;
   public static final String JOB_CONTAINER_THREAD_POOL_SIZE = "job.container.thread.pool.size";
-  public static final String JOB_CONTAINER_TASK_EXECUTOR_TYPE = "job.container.task.executor.type";
-  public static final String DEFAULT_JOB_CONTAINER_TASK_EXECUTOR_TYPE = "org.apache.samza.task.DefaultTaskExecutorFactory";
+  public static final String JOB_CONTAINER_TASK_EXECUTOR_FACTORY_TYPE = "job.container.task.executor.factory.type";
+  public static final String DEFAULT_JOB_CONTAINER_TASK_EXECUTOR_FACTORY_TYPE = "org.apache.samza.task.DefaultTaskExecutorFactory";
   // num commit threads == min(max(2 * num tasks in container, thread pool size), max thread pool size)
   public static final String COMMIT_THREAD_POOL_SIZE = "job.container.commit.thread.pool.size";
   static final int DEFAULT_COMMIT_THREAD_POOL_SIZE = 2;
@@ -358,7 +358,7 @@ public class JobConfig extends MapConfig {
   }
 
   public String getTaskExecutorFactory() {
-    return get(JOB_CONTAINER_TASK_EXECUTOR_TYPE, DEFAULT_JOB_CONTAINER_TASK_EXECUTOR_TYPE);
+    return get(JOB_CONTAINER_TASK_EXECUTOR_FACTORY_TYPE, DEFAULT_JOB_CONTAINER_TASK_EXECUTOR_FACTORY_TYPE);
   }
 
   public int getCommitThreadPoolSize() {

--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -63,8 +63,8 @@ public class JobConfig extends MapConfig {
   public static final String JOB_CONTAINER_COUNT = "job.container.count";
   static final int DEFAULT_JOB_CONTAINER_COUNT = 1;
   public static final String JOB_CONTAINER_THREAD_POOL_SIZE = "job.container.thread.pool.size";
-  public static final String JOB_CONTAINER_TASK_EXECUTOR_FACTORY_TYPE = "job.container.task.executor.factory.type";
-  public static final String DEFAULT_JOB_CONTAINER_TASK_EXECUTOR_FACTORY_TYPE = "org.apache.samza.task.DefaultTaskExecutorFactory";
+  public static final String JOB_CONTAINER_TASK_EXECUTOR_FACTORY = "job.container.task.executor.factory";
+  public static final String DEFAULT_JOB_CONTAINER_TASK_EXECUTOR_FACTORY = "org.apache.samza.task.DefaultTaskExecutorFactory";
   // num commit threads == min(max(2 * num tasks in container, thread pool size), max thread pool size)
   public static final String COMMIT_THREAD_POOL_SIZE = "job.container.commit.thread.pool.size";
   static final int DEFAULT_COMMIT_THREAD_POOL_SIZE = 2;
@@ -358,7 +358,7 @@ public class JobConfig extends MapConfig {
   }
 
   public String getTaskExecutorFactory() {
-    return get(JOB_CONTAINER_TASK_EXECUTOR_FACTORY_TYPE, DEFAULT_JOB_CONTAINER_TASK_EXECUTOR_FACTORY_TYPE);
+    return get(JOB_CONTAINER_TASK_EXECUTOR_FACTORY, DEFAULT_JOB_CONTAINER_TASK_EXECUTOR_FACTORY);
   }
 
   public int getCommitThreadPoolSize() {

--- a/samza-core/src/main/java/org/apache/samza/task/DefaultTaskExecutorFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/task/DefaultTaskExecutorFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.task;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.JobConfig;
+
+
+/**
+ * Default factory for creating the executor used when running tasks in multi-thread mode.
+ */
+public class DefaultTaskExecutorFactory implements TaskExecutorFactory {
+
+  @Override
+  public ExecutorService getTaskExecutor(Config config) {
+    int threadPoolSize = new JobConfig(config).getThreadPoolSize();
+
+    return Executors.newFixedThreadPool(threadPoolSize,
+        new ThreadFactoryBuilder().setNameFormat("Samza Container Thread-%d").build());
+  }
+}

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -458,11 +458,7 @@ object SamzaContainer extends Logging {
     val taskThreadPool = if (threadPoolSize > 0) {
       val taskExecutorFactoryClassName = jobConfig.getTaskExecutorFactory
       val taskExecutorFactory = ReflectionUtil.getObj(taskExecutorFactoryClassName, classOf[TaskExecutorFactory])
-      if (taskExecutorFactory != null) {
-        taskExecutorFactory.getTaskExecutor(config)
-      } else {
-        null
-      }
+      taskExecutorFactory.getTaskExecutor(config)
     } else {
       null
     }

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -456,8 +456,13 @@ object SamzaContainer extends Logging {
     samzaContainerMetrics.containerThreadPoolSize.set(threadPoolSize)
 
     val taskThreadPool = if (threadPoolSize > 0) {
-      Executors.newFixedThreadPool(threadPoolSize,
-        new ThreadFactoryBuilder().setNameFormat("Samza Container Thread-%d").build())
+      val taskExecutorFactoryClassName = jobConfig.getTaskExecutorFactory
+      val taskExecutorFactory = ReflectionUtil.getObj(taskExecutorFactoryClassName, classOf[TaskExecutorFactory])
+      if (taskExecutorFactory != null) {
+        taskExecutorFactory.getTaskExecutor(config)
+      } else {
+        null
+      }
     } else {
       null
     }

--- a/samza-core/src/test/java/org/apache/samza/task/TestDefaultTaskExecutorFactory.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestDefaultTaskExecutorFactory.java
@@ -29,7 +29,8 @@ import org.apache.samza.util.ReflectionUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.apache.samza.config.JobConfig.*;
+import static org.apache.samza.config.JobConfig.JOB_CONTAINER_THREAD_POOL_SIZE;
+import static org.apache.samza.config.JobConfig.JOB_CONTAINER_TASK_EXECUTOR_FACTORY;
 
 
 /**
@@ -54,7 +55,7 @@ public class TestDefaultTaskExecutorFactory {
   @Test
   public void testGetTaskExecutorFactory() {
     Map<String, String> mapConfig = new HashMap<>();
-    mapConfig.put(JOB_CONTAINER_TASK_EXECUTOR_FACTORY_TYPE, MockTaskExecutorFactory.class.getName());
+    mapConfig.put(JOB_CONTAINER_TASK_EXECUTOR_FACTORY, MockTaskExecutorFactory.class.getName());
     JobConfig config = new JobConfig(new MapConfig(mapConfig));
 
     String taskExecutorFactoryClassName = config.getTaskExecutorFactory();

--- a/samza-core/src/test/java/org/apache/samza/task/TestDefaultTaskExecutorFactory.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestDefaultTaskExecutorFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.task;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.MapConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.samza.config.JobConfig.JOB_CONTAINER_THREAD_POOL_SIZE;
+
+
+/**
+ * Tests {@link DefaultTaskExecutorFactory}.
+ */
+public class TestDefaultTaskExecutorFactory {
+
+  @Test
+  public void testGetTaskExecutor() {
+    DefaultTaskExecutorFactory factory = new DefaultTaskExecutorFactory();
+
+    Map<String, String> mapConfig = new HashMap<>();
+    int poolSize = 12;
+    mapConfig.put(JOB_CONTAINER_THREAD_POOL_SIZE, String.valueOf(poolSize));
+    Config config = new MapConfig(mapConfig);
+
+    ExecutorService executor = factory.getTaskExecutor(config);
+
+    Assert.assertEquals(poolSize, ((ThreadPoolExecutor) executor).getCorePoolSize());
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/task/TestDefaultTaskExecutorFactory.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestDefaultTaskExecutorFactory.java
@@ -23,11 +23,13 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import org.apache.samza.config.Config;
+import org.apache.samza.config.JobConfig;
 import org.apache.samza.config.MapConfig;
+import org.apache.samza.util.ReflectionUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.apache.samza.config.JobConfig.JOB_CONTAINER_THREAD_POOL_SIZE;
+import static org.apache.samza.config.JobConfig.*;
 
 
 /**
@@ -47,5 +49,25 @@ public class TestDefaultTaskExecutorFactory {
     ExecutorService executor = factory.getTaskExecutor(config);
 
     Assert.assertEquals(poolSize, ((ThreadPoolExecutor) executor).getCorePoolSize());
+  }
+
+  @Test
+  public void testGetTaskExecutorFactory() {
+    Map<String, String> mapConfig = new HashMap<>();
+    mapConfig.put(JOB_CONTAINER_TASK_EXECUTOR_FACTORY_TYPE, MockTaskExecutorFactory.class.getName());
+    JobConfig config = new JobConfig(new MapConfig(mapConfig));
+
+    String taskExecutorFactoryClassName = config.getTaskExecutorFactory();
+    TaskExecutorFactory taskExecutorFactory = ReflectionUtil.getObj(taskExecutorFactoryClassName, TaskExecutorFactory.class);
+
+    Assert.assertTrue(taskExecutorFactory instanceof MockTaskExecutorFactory);
+  }
+
+  public static class MockTaskExecutorFactory implements TaskExecutorFactory {
+
+    @Override
+    public ExecutorService getTaskExecutor(Config config) {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
Feature: [SAMZA-2720](https://issues.apache.org/jira/browse/SAMZA-2720)
 
Changes: Allow custom task executor to be injected and used.
 
 Tests: Added unit testing and verified working on local deployment.

API Changes: This backwards compatible change introduces a way to inject custom task executor. The default behavior is unchanged - use plain java executor.
 
Upgrade Instructions: None
 
Usage:
1. Implement TaskExecutorFactory interface.
2. Configure config key “job.container.task.executor.type” with implementation class name (eg "org.apache.samza.task.DefaultTaskExecutorFactory")


