### PR TITLE
SAMZA-2728: [Elasticity] improve distribution of messages across elastic tasks

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/system/IncomingMessageEnvelope.java
+++ b/samza-api/src/main/java/org/apache/samza/system/IncomingMessageEnvelope.java
@@ -132,7 +132,10 @@ public class IncomingMessageEnvelope {
     if (envelopeKeyorOffset == null) {
       return new SystemStreamPartition(systemStreamPartition, 0);
     }
-    int keyBucket = Math.abs(envelopeKeyorOffset.hashCode()) % elasticityFactor;
+
+    // modulo 31 first to best spread out the hashcode and then modulo elasticityFactor for actual keyBucket
+    // Note: elasticityFactor <= 16 so modulo 31 is safe to do.
+    int keyBucket = (Math.abs(envelopeKeyorOffset.hashCode()) % 31) % elasticityFactor;
     return new SystemStreamPartition(systemStreamPartition, keyBucket);
   }
 

--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -485,8 +485,8 @@ public class JobConfig extends MapConfig {
 
   public int getElasticityFactor() {
     int elasticityFactor = getInt(JOB_ELASTICITY_FACTOR, DEFAULT_JOB_ELASTICITY_FACTOR);
-    if (elasticityFactor < 1) {
-      throw new ConfigException("Elasticity factor can not be less than 1");
+    if (elasticityFactor < 1 || elasticityFactor > 16) {
+      throw new ConfigException("Elasticity factor can not be less than 1 or greater than 16");
     }
     return elasticityFactor;
   }

--- a/samza-core/src/test/java/org/apache/samza/config/TestJobConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestJobConfig.java
@@ -669,6 +669,16 @@ public class TestJobConfig {
     }
     assertTrue(exceptionCaught);
 
+    jobConfig =
+        new JobConfig(new MapConfig(ImmutableMap.of(JobConfig.JOB_ELASTICITY_FACTOR, Integer.toString(17))));
+    exceptionCaught = false;
+    try {
+      jobConfig.getElasticityFactor();
+    } catch (ConfigException e) {
+      exceptionCaught = true;
+    }
+    assertTrue(exceptionCaught);
+
     jobConfig = new JobConfig(new MapConfig());
     assertEquals(JobConfig.DEFAULT_JOB_ELASTICITY_FACTOR, jobConfig.getElasticityFactor());
   }


### PR DESCRIPTION
**Symptom:** When elasticity is enabled, for certain kind of input streams, some of the containers are not processing anything when container count = elastic task count = elasticity factor X original task count.

**Cause:** The input stream where this was observed had its message keys such that key.hashcode()%elasticiyFactor was always even for some partitions and odd for other partitions. lead to some of the elastic tasks no getting any messages. This is not a bug in the elasticity code but rather a skew in the input stream’s key distribution.

**Changes:** 
1. to distribute the messages to elastic tasks more evenly, the key bucket computation aka key.hashCode()%elasticityFactor is modified to (key.hashCode%31)%elasicityFactor and max value for elasticity factor is limited to 16 to be able to use %31 safely.
2. as a side effect, EOS message handling was found to be incorrect and rectified to remove from the task’s processing set, any keybucket of the eos messages’s ssp. This was discovered in tests which was not broken earlier due to EOS.hashCode%elasticityFactor coinciding with the task’s processing ssp in test setup.

**Tests:** added unit tests to check elasticity factor range.

**API changes:** None

**Usage/Upgrade instructions:** None