### PR TITLE
SAMZA-2730: Add process CPU usage metric using units of processor count instead of percentage

### DIFF
--- a/docs/learn/documentation/versioned/container/metrics-table.html
+++ b/docs/learn/documentation/versioned/container/metrics-table.html
@@ -356,6 +356,10 @@
         <td>Current CPU usage of the JVM process as a percentage from 0 to 100. The percentage represents the proportion of executed ticks by the JVM process to the total ticks across all CPUs. A negative number indicates the value was not available from the operating system. For more detail, see the JavaDoc for com.sun.management.OperatingSystemMXBean.</td>
     </tr>
     <tr>
+        <td>process-cpu-usage-processors</td>
+        <td>Number of processors currently in use by the JVM process, calculated by multiplying the usage percentage by the total number of processors. A negative number indicates that there was not enough information available to calculate this value. For more detail, see the JavaDoc for com.sun.management.OperatingSystemMXBean.</td>
+    </tr>
+    <tr>
         <td>system-cpu-usage</td>
         <td>Current CPU usage of the all processes in the whole system as a percentage from 0 to 100. The percentage represents the proportion of executed ticks by all processes to the total ticks across all CPUs. A negative number indicates the value was not available from the operating system. For more detail, see the JavaDoc for com.sun.management.OperatingSystemMXBean.</td>
     </tr>


### PR DESCRIPTION
Issues: Currently, "process-cpu-usage" is only reported as a percentage of the available CPU on the whole host. In some cases, it is useful to know the actual number of processors being used. For example, external systems (like an autosizer) or application owners can directly access the current processor count instead of needing to also query the total number of processors on a host in order to calculate the processor count.

Changes: Add a metric `process-cpu-usage-processors` which reports the number of processors being used.

Tests: Ran a container in minikube and used `LoggingMetricsReporter` to print out the values of `process-cpu-usage` and `process-cpu-usage-processors`. Verified that these values were consistent with the total processor count from running `lscpu` inside the container (i.e. (`process-cpu-usage`/100) * "total processor count from lscpu" = `process-cpu-usage-processors`).

API/usage changes: (backwards compatible) An extra metric `process-cpu-usage-processors` is now available which reports the number of processors being used.