### PR TITLE
SAMZA-2685: fall back to ClusterBasedJobCoordinator when job.coordinator.factory is the empty string for cluster-based deployments

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/JobCoordinatorConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobCoordinatorConfig.java
@@ -74,13 +74,11 @@ public class JobCoordinatorConfig extends MapConfig {
   }
 
   public String getJobCoordinatorFactoryClassName() {
-    return getOptionalJobCoordinatorFactoryClassName()
-        .filter(className -> !Strings.isNullOrEmpty(className))
-        .orElse(ZkJobCoordinatorFactory.class.getName());
+    return getOptionalJobCoordinatorFactoryClassName().orElse(ZkJobCoordinatorFactory.class.getName());
   }
 
   public Optional<String> getOptionalJobCoordinatorFactoryClassName() {
-    return Optional.ofNullable(get(JOB_COORDINATOR_FACTORY));
+    return Optional.ofNullable(get(JOB_COORDINATOR_FACTORY)).filter(className -> !Strings.isNullOrEmpty(className));
   }
 
   public String getJobRestartSignalFactory() {

--- a/samza-core/src/test/java/org/apache/samza/config/TestJobCoordinatorConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestJobCoordinatorConfig.java
@@ -18,6 +18,7 @@
  */
 package org.apache.samza.config;
 
+import java.util.Optional;
 import com.google.common.collect.ImmutableMap;
 import org.apache.samza.coordinator.lifecycle.NoOpJobRestartSignalFactory;
 import org.apache.samza.zk.ZkJobCoordinatorFactory;
@@ -25,7 +26,6 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 
 public class TestJobCoordinatorConfig {
@@ -47,9 +47,14 @@ public class TestJobCoordinatorConfig {
   public void getOptionalJobCoordinatorFactoryClassName() {
     assertFalse(new JobCoordinatorConfig(new MapConfig()).getOptionalJobCoordinatorFactoryClassName().isPresent());
 
-    JobCoordinatorConfig jobCoordinatorConfig = new JobCoordinatorConfig(new MapConfig(
+    JobCoordinatorConfig jobCoordinatorConfig =
+        new JobCoordinatorConfig(new MapConfig(ImmutableMap.of(JobCoordinatorConfig.JOB_COORDINATOR_FACTORY, "")));
+    assertFalse(jobCoordinatorConfig.getOptionalJobCoordinatorFactoryClassName().isPresent());
+
+    jobCoordinatorConfig = new JobCoordinatorConfig(new MapConfig(
         ImmutableMap.of(JobCoordinatorConfig.JOB_COORDINATOR_FACTORY, "org.custom.MyJobCoordinatorFactory")));
-    assertTrue(jobCoordinatorConfig.getOptionalJobCoordinatorFactoryClassName().isPresent());
+    assertEquals(Optional.of("org.custom.MyJobCoordinatorFactory"),
+        jobCoordinatorConfig.getOptionalJobCoordinatorFactoryClassName());
   }
 
   @Test


### PR DESCRIPTION
Issues: The first PR for SAMZA-2685 (PR #1529) only used `ClusterBasedJobCoordinator` when `job.coordinator.factory` was not specified. Some apps may prefer to use the empty string instead to indicate using the default `ClusterBasedJobCoordinator`.

Changes: `getOptionalJobCoordinatorFactoryClassName` now returns "empty" when the value of `job.coordinator.factory` is the empty string. `getOptionalJobCoordinatorFactoryClassName` is used in `JobCoordinatorLaunchUtil`; the `ClusterBasedJobCoordinator` flow is used when `getOptionalJobCoordinatorFactoryClassName` returns "empty".

Tests: Added unit test

API/usage changes: Using the empty string as the value for `job.coordinator.factory` when running in a cluster-based system (e.g. YARN) results in using `ClusterBasedJobCoordinator` instead of trying to load a class with the name of an empty string (which would fail).