### PR TITLE
SAMZA-2732: [Elasticity] Add elasticityFactor into the TaskName when elasticity is enabled

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/container/grouper/stream/GroupByPartition.java
+++ b/samza-core/src/main/java/org/apache/samza/container/grouper/stream/GroupByPartition.java
@@ -64,7 +64,7 @@ public class GroupByPartition implements SystemStreamPartitionGrouper {
         int keyBucket = elasticityFactor == 1 ? -1 : i;
         String taskNameStr = elasticityFactor == 1 ?
             String.format("Partition %d", ssp.getPartition().getPartitionId()) :
-            String.format("Partition %d %d", ssp.getPartition().getPartitionId(), keyBucket);
+            String.format("Partition %d_%d_%d", ssp.getPartition().getPartitionId(), keyBucket, elasticityFactor);
         TaskName taskName = new TaskName(taskNameStr);
         SystemStreamPartition sspWithKeyBucket = new SystemStreamPartition(ssp, keyBucket);
         groupedMap.putIfAbsent(taskName, new HashSet<>());

--- a/samza-core/src/main/java/org/apache/samza/container/grouper/stream/GroupBySystemStreamPartition.java
+++ b/samza-core/src/main/java/org/apache/samza/container/grouper/stream/GroupBySystemStreamPartition.java
@@ -63,7 +63,8 @@ public class GroupBySystemStreamPartition implements SystemStreamPartitionGroupe
         SystemStreamPartition sspWithKeyBucket = new SystemStreamPartition(ssp, keyBucket);
         HashSet<SystemStreamPartition> sspSet = new HashSet<SystemStreamPartition>();
         sspSet.add(sspWithKeyBucket);
-        groupedMap.put(new TaskName(sspWithKeyBucket.toString()), sspSet);
+        String elasticitySuffix = elasticityFactor == 1 ? "" : String.format("_%d", elasticityFactor);
+        groupedMap.put(new TaskName(sspWithKeyBucket.toString() + elasticitySuffix), sspSet);
       }
     }
 

--- a/samza-core/src/test/java/org/apache/samza/container/grouper/stream/TestGroupByPartition.java
+++ b/samza-core/src/test/java/org/apache/samza/container/grouper/stream/TestGroupByPartition.java
@@ -93,12 +93,12 @@ public class TestGroupByPartition {
     GroupByPartition grouper = new GroupByPartition(config);
     Map<TaskName, Set<SystemStreamPartition>> result = grouper.group(ImmutableSet.of(aa0, aa1, aa2, ab1, ab2, ac0));
     Map<TaskName, Set<SystemStreamPartition>> expectedResult = ImmutableMap.<TaskName, Set<SystemStreamPartition>>builder()
-        .put(new TaskName("Partition 0 0"), ImmutableSet.of(new SystemStreamPartition(aa0, 0), new SystemStreamPartition(ac0, 0)))
-        .put(new TaskName("Partition 0 1"), ImmutableSet.of(new SystemStreamPartition(aa0, 1), new SystemStreamPartition(ac0, 1)))
-        .put(new TaskName("Partition 1 0"), ImmutableSet.of(new SystemStreamPartition(aa1, 0), new SystemStreamPartition(ab1, 0)))
-        .put(new TaskName("Partition 1 1"), ImmutableSet.of(new SystemStreamPartition(aa1, 1), new SystemStreamPartition(ab1, 1)))
-        .put(new TaskName("Partition 2 0"), ImmutableSet.of(new SystemStreamPartition(aa2, 0), new SystemStreamPartition(ab2, 0)))
-        .put(new TaskName("Partition 2 1"), ImmutableSet.of(new SystemStreamPartition(aa2, 1), new SystemStreamPartition(ab2, 1)))
+        .put(new TaskName("Partition 0_0_2"), ImmutableSet.of(new SystemStreamPartition(aa0, 0), new SystemStreamPartition(ac0, 0)))
+        .put(new TaskName("Partition 0_1_2"), ImmutableSet.of(new SystemStreamPartition(aa0, 1), new SystemStreamPartition(ac0, 1)))
+        .put(new TaskName("Partition 1_0_2"), ImmutableSet.of(new SystemStreamPartition(aa1, 0), new SystemStreamPartition(ab1, 0)))
+        .put(new TaskName("Partition 1_1_2"), ImmutableSet.of(new SystemStreamPartition(aa1, 1), new SystemStreamPartition(ab1, 1)))
+        .put(new TaskName("Partition 2_0_2"), ImmutableSet.of(new SystemStreamPartition(aa2, 0), new SystemStreamPartition(ab2, 0)))
+        .put(new TaskName("Partition 2_1_2"), ImmutableSet.of(new SystemStreamPartition(aa2, 1), new SystemStreamPartition(ab2, 1)))
         .build();
 
     assertEquals(expectedResult, result);

--- a/samza-core/src/test/java/org/apache/samza/container/grouper/stream/TestGroupBySystemStreamPartition.java
+++ b/samza-core/src/test/java/org/apache/samza/container/grouper/stream/TestGroupBySystemStreamPartition.java
@@ -84,14 +84,22 @@ public class TestGroupBySystemStreamPartition {
 
     Map<TaskName, Set<SystemStreamPartition>> result = grouper.group(ImmutableSet.of(aa0, aa1, aa2, ac0));
     Map<TaskName, Set<SystemStreamPartition>> expectedResult = ImmutableMap.<TaskName, Set<SystemStreamPartition>>builder()
-        .put(new TaskName(new SystemStreamPartition(aa0, 0).toString()), ImmutableSet.of(new SystemStreamPartition(aa0, 0)))
-        .put(new TaskName(new SystemStreamPartition(aa0, 1).toString()), ImmutableSet.of(new SystemStreamPartition(aa0, 1)))
-        .put(new TaskName(new SystemStreamPartition(aa1, 0).toString()), ImmutableSet.of(new SystemStreamPartition(aa1, 0)))
-        .put(new TaskName(new SystemStreamPartition(aa1, 1).toString()), ImmutableSet.of(new SystemStreamPartition(aa1, 1)))
-        .put(new TaskName(new SystemStreamPartition(aa2, 0).toString()), ImmutableSet.of(new SystemStreamPartition(aa2, 0)))
-        .put(new TaskName(new SystemStreamPartition(aa2, 1).toString()), ImmutableSet.of(new SystemStreamPartition(aa2, 1)))
-        .put(new TaskName(new SystemStreamPartition(ac0, 0).toString()), ImmutableSet.of(new SystemStreamPartition(ac0, 0)))
-        .put(new TaskName(new SystemStreamPartition(ac0, 1).toString()), ImmutableSet.of(new SystemStreamPartition(ac0, 1)))
+        .put(new TaskName(new SystemStreamPartition(aa0, 0).toString() + "_2"),
+            ImmutableSet.of(new SystemStreamPartition(aa0, 0)))
+        .put(new TaskName(new SystemStreamPartition(aa0, 1).toString() + "_2"),
+            ImmutableSet.of(new SystemStreamPartition(aa0, 1)))
+        .put(new TaskName(new SystemStreamPartition(aa1, 0).toString() + "_2"),
+            ImmutableSet.of(new SystemStreamPartition(aa1, 0)))
+        .put(new TaskName(new SystemStreamPartition(aa1, 1).toString() + "_2"),
+            ImmutableSet.of(new SystemStreamPartition(aa1, 1)))
+        .put(new TaskName(new SystemStreamPartition(aa2, 0).toString() + "_2"),
+            ImmutableSet.of(new SystemStreamPartition(aa2, 0)))
+        .put(new TaskName(new SystemStreamPartition(aa2, 1).toString() + "_2"),
+            ImmutableSet.of(new SystemStreamPartition(aa2, 1)))
+        .put(new TaskName(new SystemStreamPartition(ac0, 0).toString() + "_2"),
+            ImmutableSet.of(new SystemStreamPartition(ac0, 0)))
+        .put(new TaskName(new SystemStreamPartition(ac0, 1).toString() + "_2"),
+            ImmutableSet.of(new SystemStreamPartition(ac0, 1)))
         .build();
 
     assertEquals(expectedResult, result);


### PR DESCRIPTION
Feature: Elasticity (SAMZA-2687) for a Samza job allows job to have more tasks than the number of input SystemStreamPartition(SSP). Thus, a job can scale up beyond its input partition count without needing the repartition the input stream. 

Changes: 
When elasticity is enabled, change the task name as follows
1. GroupByPartition SSP grouper: from "Partition 0 1" to "Partition 0_1_2" where 0 is the input partition, 1 is the keyBucket and 2 is the elasticity factor.
2. GroupBySystemStreamPartition SSP grouper: from "SystemStreamPartition [systemA, streamB, 0, 1]" to "SystemStreamPartition [systemA, streamB, 0, 1]_2" where 0 is the input partition, 1 is the keyBucket and 2 is the elasticity factor.

Tests: updated existing tests

API changes: none

Usage/ upgrade instructions: applicable when "job.elasticity.factor" is set to >1

Backwards compatible: yes. does not affect task name format when elasticity is disabled. 