### PR TITLE
SAMZA-2731: Add readAllCheckpoints to CheckpointManager and implement for KafkaCheckpointManager

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/checkpoint/CheckpointManager.java
+++ b/samza-api/src/main/java/org/apache/samza/checkpoint/CheckpointManager.java
@@ -19,6 +19,8 @@
 
 package org.apache.samza.checkpoint;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.samza.container.TaskName;
 
 /**
@@ -66,4 +68,15 @@ public interface CheckpointManager {
    * Clear the checkpoints in the checkpoint stream.
    */
   default void clearCheckpoints() { }
+
+  /**
+   * Returns the last recorded checkpoint for all tasks present in the implementation-specific location.
+   * All tasks contains all the tasks within the current job model.
+   * All tasks also includes tasks which may have been part of the job model during a previous deploy.
+   * @return A Map of TaskName to Checkpoint object.
+   *         The Checkpoint object has the recorded offset data of the specified partition.
+   */
+  default Map<TaskName, Checkpoint> readAllCheckpoints() {
+    return new HashMap<>();
+  };
 }

--- a/samza-kafka/src/main/scala/org/apache/samza/checkpoint/kafka/KafkaCheckpointManager.scala
+++ b/samza-kafka/src/main/scala/org/apache/samza/checkpoint/kafka/KafkaCheckpointManager.scala
@@ -142,21 +142,20 @@ class KafkaCheckpointManager(checkpointSpec: KafkaStreamSpec,
 
     info(s"Reading checkpoint for taskName $taskName")
 
-    if (taskNamesToCheckpoints == null) {
-      info("Reading checkpoints for the first time")
-      taskNamesToCheckpoints = readCheckpoints()
-      if (stopConsumerAfterFirstRead) {
-        info("Stopping system consumer")
-        systemConsumer.stop()
-      }
-    } else if (!stopConsumerAfterFirstRead) {
-      taskNamesToCheckpoints ++= readCheckpoints()
-    }
+    populateTaskNamesToCheckpointsMap()
 
     val checkpoint: Checkpoint = taskNamesToCheckpoints.getOrElse(taskName, null)
 
     info(s"Got checkpoint state for taskName - $taskName: $checkpoint")
     checkpoint
+  }
+
+  /**
+   * @inheritdoc
+   */
+  override def readAllCheckpoints(): util.Map[TaskName, Checkpoint] = {
+    populateTaskNamesToCheckpointsMap()
+    scala.collection.JavaConverters.mapAsJavaMapConverter(taskNamesToCheckpoints).asJava
   }
 
   /**
@@ -408,6 +407,19 @@ class KafkaCheckpointManager(checkpointSpec: KafkaStreamSpec,
       checkpointV2MsgSerde.fromBytes(checkpointMsgBytes)
     } else {
       throw new IllegalArgumentException("Unknown checkpoint key type: " + checkpointKey.getType)
+    }
+  }
+
+  private def populateTaskNamesToCheckpointsMap() = {
+    if (taskNamesToCheckpoints == null) {
+      info("Reading checkpoints for the first time")
+      taskNamesToCheckpoints = readCheckpoints()
+      if (stopConsumerAfterFirstRead) {
+        info("Stopping system consumer")
+        systemConsumer.stop()
+      }
+    } else if (!stopConsumerAfterFirstRead) {
+      taskNamesToCheckpoints ++= readCheckpoints()
     }
   }
 }

--- a/samza-kafka/src/test/java/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.java
+++ b/samza-kafka/src/test/java/org/apache/samza/checkpoint/kafka/TestKafkaCheckpointManager.java
@@ -386,6 +386,25 @@ public class TestKafkaCheckpointManager {
   }
 
   @Test
+  public void testReadAllCheckpoints() throws InterruptedException {
+    Config config = config(ImmutableMap.of(TaskConfig.CHECKPOINT_READ_VERSIONS, "1,2"));
+    setupSystemFactory(config);
+    CheckpointV2 checkpointV2ForTask0 = buildCheckpointV2(INPUT_SSP0, "0");
+    CheckpointV2 checkpointV2ForTask1 = buildCheckpointV2(INPUT_SSP0, "1");
+    List<IncomingMessageEnvelope> checkpointEnvelopes =
+        ImmutableList.of(
+            newCheckpointV2Envelope(TASK0, checkpointV2ForTask0, "0"),
+            newCheckpointV2Envelope(TASK1, checkpointV2ForTask1, "1")
+            );
+    setupConsumer(checkpointEnvelopes);
+    Map<TaskName, Checkpoint> checkpointMap = ImmutableMap.of(TASK0, checkpointV2ForTask0, TASK1, checkpointV2ForTask1);
+    KafkaCheckpointManager kafkaCheckpointManager = buildKafkaCheckpointManager(true, config);
+    kafkaCheckpointManager.register(TASK0);
+    Map<TaskName, Checkpoint> readCheckpoints = kafkaCheckpointManager.readAllCheckpoints();
+    assertEquals(checkpointMap, readCheckpoints);
+  }
+
+  @Test
   public void testWriteCheckpointV1() {
     setupSystemFactory(config());
     KafkaCheckpointManager kafkaCheckpointManager = buildKafkaCheckpointManager(true, config());


### PR DESCRIPTION
**Improvement:** add functionality in CheckpointManager to return the last recorded checkpoint for all tasks present in the checkpoint stream.
Elasticity (SAMZA-2687) is a new feature which enables scaling up task count beyond the input partition count. When the task count changes, it is necessary to compute the starting offsets of the new tasks from the old tasks. Due to task name change (as count has changed), the earlier mechanism of fetching checkpoint by task name does not work. Hence computing the starting offsets for a new task requires looking at all the previous deploy's tasks' checkpoints. This PR exposes that functionality of fetching all checkpoints within the checkpoint stream and it will be leveraged in the later PRs for elasticity (PR #1598).


**Changes:**
1. Update CheckpointManager interface with new method “readAllCheckpoints” which returns an empty map
2. Implement “readAllCheckpoints” to return map of taskName to last recorded checkpoint for all task names present in the checkpoint kafka topic.

**Tests:** Added one test for readAllCheckpoints for KafkaCheckpointManager

**API changes:** Introduces new method in CheckpointManager public interface.

**Upgrade instructions:** None

**Usage instructions:** if implementing CheckpointManager then can either leave the readAllCheckpoints method untouched or override to read from the implementation-specific location to fetch all checkpoints and return last recorded for all tasks (incl those not in the current job model)

**Backwards compatible:** yes. Does not change any existing interface methods