### PR TITLE
SAMZA-2740: Provide a way to specify a static file name for container metadata file

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -24,10 +24,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.samza.SamzaException;
 import org.apache.samza.container.grouper.stream.GroupByPartitionFactory;
 import org.apache.samza.container.grouper.stream.HashSystemStreamPartitionMapperFactory;
 import org.apache.samza.coordinator.metadatastore.CoordinatorStreamMetadataStoreFactory;
+import org.apache.samza.environment.EnvironmentVariables;
 import org.apache.samza.runtime.DefaultLocationIdProviderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -144,7 +146,7 @@ public class JobConfig extends MapConfig {
   static final int DEFAULT_STANDBY_TASKS_REPLICATION_FACTOR = 1;
 
   // Naming format and directory for container.metadata file
-  public static final String CONTAINER_METADATA_FILENAME_FORMAT = "%s.metadata"; // Filename: <containerID>.metadata
+  public static final String CONTAINER_METADATA_FILENAME_FORMAT = "%s.metadata";
   public static final String CONTAINER_METADATA_DIRECTORY_SYS_PROPERTY = "samza.log.dir";
 
   // Auto-sizing related configs that take precedence over respective sizing confings job.container.count, etc,
@@ -431,18 +433,30 @@ public class JobConfig extends MapConfig {
   }
 
   /**
-   * The metadata file is written in a {@code exec-env-container-id}.metadata file in the log-dir of the container.
-   * Here the {@code exec-env-container-id} refers to the ID assigned by the cluster manager (e.g., YARN) to the container,
-   * which uniquely identifies a container's lifecycle.
+   * Get the {@link File} in the "samza.log.dir" for writing container metadata.
+   * If {@link EnvironmentVariables#ENV_CONTAINER_METADATA_FILENAME} is specified, then use that as the file name.
+   * Otherwise, the file name is {@code exec-env-container-id}.metadata. Here the {@code exec-env-container-id} refers
+   * to the ID assigned by the cluster manager (e.g., YARN) to the container, which uniquely identifies a container's
+   * lifecycle.
    */
   public static Optional<File> getMetadataFile(String execEnvContainerId) {
     String dir = System.getProperty(CONTAINER_METADATA_DIRECTORY_SYS_PROPERTY);
-    if (dir == null || execEnvContainerId == null) {
-      return Optional.empty();
-    } else {
-      return Optional.of(
-          new File(dir, String.format(CONTAINER_METADATA_FILENAME_FORMAT, execEnvContainerId)));
+    if (dir != null) {
+      String fileName = System.getenv(EnvironmentVariables.ENV_CONTAINER_METADATA_FILENAME);
+      if (StringUtils.isNotBlank(fileName)) {
+        if (fileName.contains(File.separator)) {
+          throw new IllegalStateException(String.format("%s should not include directories, but it is %s",
+              EnvironmentVariables.ENV_CONTAINER_METADATA_FILENAME, fileName));
+        } else {
+          return Optional.of(new File(dir, fileName));
+        }
+      } else {
+        if (execEnvContainerId != null) {
+          return Optional.of(new File(dir, String.format(CONTAINER_METADATA_FILENAME_FORMAT, execEnvContainerId)));
+        }
+      }
     }
+    return Optional.empty();
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/environment/EnvironmentVariables.java
+++ b/samza-core/src/main/java/org/apache/samza/environment/EnvironmentVariables.java
@@ -36,4 +36,11 @@ public class EnvironmentVariables {
    * environment variable.
    */
   public static final String SAMZA_EPOCH_ID = "SAMZA_EPOCH_ID";
+
+  /**
+   * (Optional) File name to use for container metadata file. This should just be a file name, and it should not include
+   * any directory structure.
+   * If this is not specified, then the framework will choose a file name.
+   */
+  public static final String ENV_CONTAINER_METADATA_FILENAME = "CONTAINER_METADATA_FILENAME";
 }

--- a/samza-core/src/main/java/org/apache/samza/util/DiagnosticsUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/util/DiagnosticsUtil.java
@@ -80,6 +80,7 @@ public class DiagnosticsUtil {
       MetricsSnapshot metricsSnapshot = new MetricsSnapshot(metricsHeader, new Metrics());
       MetadataFileContents metadataFileContents =
           new MetadataFileContents("1", new String(new MetricsSnapshotSerdeV2().toBytes(metricsSnapshot)));
+      log.info("Writing metadata contents to {}", metadataFile.get().getPath());
       new FileUtil().writeToTextFile(metadataFile.get(), new String(new JsonSerde<>().toBytes(metadataFileContents)), false);
     } else {
       log.info("Skipping writing metadata file.");


### PR DESCRIPTION
Issue: For environments in which apps run in isolated containers (e.g. Kubernetes), there is no need to have unique file names for container metadata files. It is much easier to find these files when they have static names instead of depending on the exec-env-container-id. A concrete Kubernetes use case for this is to be able to set the `terminationMessagePath` to this container metadata file in order to pass some information through to controllers.

Changes: Add a new environment variable `CONTAINER_METADATA_FILENAME` which specifies the name of the container metadata file.

API/usage changes: (backwards compatible) If `CONTAINER_METADATA_FILENAME` is specified, then use that for generating the container metadata file name. Otherwise, fall back to using the exec-env-container-id to generate the file name.

Tests: Deployed in minikube and verified that the container metadata file matched the value set in the `CONTAINER_METADATA_FILENAME` environment variable.