### PR TITLE
Fixed check for files both present and removed in DirIndex. Added a check for blobs too.

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/diff/DirDiff.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/diff/DirDiff.java
@@ -91,6 +91,8 @@ public class DirDiff {
     Sets.SetView<String> retainedAndRemovedFilesSet = Sets.intersection(retainedFilesSet, removedFilesSet);
     Preconditions.checkState(retainedAndRemovedFilesSet.isEmpty(),
         String.format("Files present in both retained and removed sets: %s", retainedAndRemovedFilesSet.toString()));
+    // mutable files *names* like CURRENT may be present in both added and removed sets,
+    // which is fine since they need to be re-uploaded and the old blobs need to be deleted
 
     // validate that a subDir is not present in multiple lists
     Set<String> addedSubDirsSet = subDirsAdded.stream().map(DirDiff::getDirName).collect(Collectors.toSet());

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/index/DirIndex.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/index/DirIndex.java
@@ -106,6 +106,11 @@ public class DirIndex {
         .flatMap(fileIndex -> fileIndex.getBlobs().stream())
         .collect(Collectors.toCollection(HashSet::new));
 
+    // check within current subdir, since moving file to a different subDir should be OK.
+    Sets.SetView<FileIndex> presentAndRemovedFilesSet = Sets.intersection(filesPresentSet, filesRemovedSet);
+    Preconditions.checkState(presentAndRemovedFilesSet.isEmpty(),
+        String.format("File(s) present in both filesPresent and filesRemoved set: %s", presentAndRemovedFilesSet));
+
     for (DirIndex subDirPresent: subDirsPresent) {
       addFilesAndBlobsForSubDir(subDirPresent, filesPresentSet, filesRemovedSet, blobsPresentSet, blobsRemovedSet);
     }
@@ -113,10 +118,6 @@ public class DirIndex {
     for (DirIndex subDirRemoved: subDirsRemoved) {
       addFilesAndBlobsForSubDirRemoved(subDirRemoved, filesRemovedSet, blobsRemovedSet);
     }
-
-    Sets.SetView<FileIndex> presentAndRemovedFilesSet = Sets.intersection(filesPresentSet, filesRemovedSet);
-    Preconditions.checkState(presentAndRemovedFilesSet.isEmpty(),
-        String.format("File(s) present in both filesPresent and filesRemoved set: %s", presentAndRemovedFilesSet));
 
     Sets.SetView<FileBlob> presentAndRemovedBlobsSet = Sets.intersection(blobsPresentSet, blobsRemovedSet);
     Preconditions.checkState(presentAndRemovedBlobsSet.isEmpty(),

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/index/DirIndex.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/index/DirIndex.java
@@ -21,6 +21,8 @@ package org.apache.samza.storage.blobstore.index;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
+
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -51,12 +53,10 @@ public class DirIndex {
     Preconditions.checkNotNull(filesRemoved);
     Preconditions.checkNotNull(subDirsPresent);
     Preconditions.checkNotNull(subDirsRemoved);
-    // Check to validate that a file is not present in file removed and file present list
-    Set<String> filesPresentSet = filesPresent.stream().map(FileIndex::getFileName).collect(Collectors.toSet());
-    Set<String> filesRemovedSet = filesRemoved.stream().map(FileIndex::getFileName).collect(Collectors.toSet());
-    Sets.SetView<String> presentAndRemovedFilesSet = Sets.intersection(filesPresentSet, filesRemovedSet);
-    Preconditions.checkState(presentAndRemovedFilesSet.isEmpty(),
-        String.format("File present in both filesPresent and filesRemoved set: %s", presentAndRemovedFilesSet));
+
+    // validate that the same file/blob is not present in both present and removed lists
+    validatePresentAndRemovedOverlap(filesPresent, filesRemoved, subDirsPresent, subDirsRemoved);
+
     this.dirName = dirName;
     this.filesPresent = filesPresent;
     this.filesRemoved = filesRemoved;
@@ -92,6 +92,70 @@ public class DirIndex {
     Stats stats = new Stats();
     updateStats(dirIndex, stats);
     return stats;
+  }
+
+  private static void validatePresentAndRemovedOverlap(List<FileIndex> filesPresent, List<FileIndex> filesRemoved, List<DirIndex> subDirsPresent, List<DirIndex> subDirsRemoved) {
+    Set<FileIndex> filesPresentSet = new HashSet<>(filesPresent);
+    Set<FileIndex> filesRemovedSet = new HashSet<>(filesRemoved);
+
+    Set<FileBlob> blobsPresentSet = filesPresent.stream()
+        .flatMap(fileIndex -> fileIndex.getBlobs().stream())
+        .collect(Collectors.toCollection(HashSet::new));
+
+    Set<FileBlob> blobsRemovedSet = filesRemoved.stream()
+        .flatMap(fileIndex -> fileIndex.getBlobs().stream())
+        .collect(Collectors.toCollection(HashSet::new));
+
+    for (DirIndex subDirPresent: subDirsPresent) {
+      addFilesAndBlobsForSubDir(subDirPresent, filesPresentSet, filesRemovedSet, blobsPresentSet, blobsRemovedSet);
+    }
+
+    for (DirIndex subDirRemoved: subDirsRemoved) {
+      addFilesAndBlobsForSubDirRemoved(subDirRemoved, filesRemovedSet, blobsRemovedSet);
+    }
+
+    Sets.SetView<FileIndex> presentAndRemovedFilesSet = Sets.intersection(filesPresentSet, filesRemovedSet);
+    Preconditions.checkState(presentAndRemovedFilesSet.isEmpty(),
+        String.format("File(s) present in both filesPresent and filesRemoved set: %s", presentAndRemovedFilesSet));
+
+    Sets.SetView<FileBlob> presentAndRemovedBlobsSet = Sets.intersection(blobsPresentSet, blobsRemovedSet);
+    Preconditions.checkState(presentAndRemovedBlobsSet.isEmpty(),
+        String.format("Blob(s) present in both blobsPresentSet and blobsRemovedSet set: %s", presentAndRemovedBlobsSet));
+  }
+
+  private static void addFilesAndBlobsForSubDir(DirIndex dirIndex,
+      Set<FileIndex> filesAdded, Set<FileIndex> filesRemoved,
+      Set<FileBlob> blobsAdded, Set<FileBlob> blobsRemoved) {
+    for (FileIndex filePresent: dirIndex.getFilesPresent()) {
+      filesAdded.add(filePresent);
+      blobsAdded.addAll(filePresent.getBlobs());
+    }
+
+    for (DirIndex subDir: dirIndex.getSubDirsPresent()) {
+      addFilesAndBlobsForSubDir(subDir, filesAdded, filesRemoved, blobsAdded, blobsRemoved);
+    }
+
+    for (DirIndex subDir: dirIndex.getSubDirsRemoved()) {
+      addFilesAndBlobsForSubDirRemoved(subDir, filesRemoved, blobsRemoved);
+    }
+  }
+
+  private static void addFilesAndBlobsForSubDirRemoved(DirIndex dirIndex,
+      Set<FileIndex> filesRemoved,
+      Set<FileBlob> blobsRemoved) {
+    for (FileIndex filePresent: dirIndex.getFilesPresent()) {
+      filesRemoved.add(filePresent);
+      blobsRemoved.addAll(filePresent.getBlobs());
+    }
+
+    for (FileIndex fileRemoved: dirIndex.getFilesRemoved()) {
+      filesRemoved.add(fileRemoved);
+      blobsRemoved.addAll(fileRemoved.getBlobs());
+    }
+
+    for (DirIndex subDir: dirIndex.getSubDirsPresent()) {
+      addFilesAndBlobsForSubDirRemoved(subDir, filesRemoved, blobsRemoved);
+    }
   }
 
   private static void updateStats(DirIndex dirIndex, Stats stats) {

--- a/samza-core/src/test/java/org/apache/samza/storage/blobstore/index/TestDirIndex.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/blobstore/index/TestDirIndex.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.storage.blobstore.index;
+
+import java.util.Collections;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestDirIndex {
+
+  @Test
+  public void testDirIndexValidationForFileAddedAndRemovedChecksBlobsAndMetadataToo() {
+    FileBlob filePresentBlob = new FileBlob("filePresentBlobId", 0);
+    FileMetadata filePresentMetadata = new FileMetadata(1234L, 2345L, 12345, "owner", "group", "permission");
+    FileIndex filePresent = new FileIndex("mutableFile",
+        Collections.singletonList(filePresentBlob), filePresentMetadata, 789L);
+
+    // same name and metadata, different blobs
+    FileBlob fileRemovedBlob = new FileBlob("fileRemovedBlobId", 0);
+    FileIndex fileRemoved = new FileIndex("mutableFile",
+        Collections.singletonList(fileRemovedBlob), filePresentMetadata, 789L);
+
+    new DirIndex("dir", Collections.singletonList(filePresent), Collections.singletonList(fileRemoved),
+        Collections.emptyList(), Collections.emptyList());
+
+    // but if same name and blobs, different metadata, should fail due to blob duplication validation
+    try {
+      FileMetadata otherFileMetadata = new FileMetadata(541345L, 624L, 2125L, "owner", "group", "permission");
+      FileIndex otherFileRemoved = new FileIndex("mutableFile",
+          Collections.singletonList(filePresentBlob), otherFileMetadata, 789L);
+      new DirIndex("dir", Collections.singletonList(filePresent), Collections.singletonList(otherFileRemoved),
+          Collections.emptyList(), Collections.emptyList());
+      Assert.fail("Should have failed validation if same blob present in file added and removed, even if same name");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testDirIndexValidationFailsIfSameBlobAddedAndRemoved() {
+    FileBlob filePresentBlob = new FileBlob("filePresentBlobId", 0);
+    FileMetadata filePresentMetadata = new FileMetadata(1234L, 2345L, 12345, "owner", "group", "permission");
+    FileIndex filePresent = new FileIndex("filePresent",
+        Collections.singletonList(filePresentBlob), filePresentMetadata, 789L);
+
+    // different name and metadata, same blob id
+    FileBlob fileRemovedBlob = new FileBlob("filePresentBlobId", 0);
+    FileMetadata fileRemovedMetadata = new FileMetadata(324L, 625L, 4253L, "owner", "group", "permission");
+    FileIndex fileRemoved = new FileIndex("fileRemoved",
+        Collections.singletonList(fileRemovedBlob), fileRemovedMetadata, 1234L);
+
+    // should fail since same blob id is present in file present and removed
+    new DirIndex("dir", Collections.singletonList(filePresent), Collections.singletonList(fileRemoved),
+        Collections.emptyList(), Collections.emptyList());
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestBlobStoreUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestBlobStoreUtil.java
@@ -102,11 +102,11 @@ public class TestBlobStoreUtil {
     BlobStoreManager blobStoreManager = mock(BlobStoreManager.class);
 
     // File, dir and recursive dir added, retained and removed in local
-    String local = "[a, c, z/1, y/1, p/m/1, q/n/1]";
-    String remote = "[a, b, z/1, x/1, p/m/1, p/m/2, r/o/1]";
-    String expectedAdded = "[c, y/1, q/n/1]";
-    String expectedRetained = "[a, z/1, p/m/1]";
-    String expectedRemoved = "[b, x/1, r/o/1, p/m/2]";
+    String local = "[a, c, z/1, y/2, p/m/3, q/n/4]";
+    String remote = "[a, b, z/1, x/2, p/m/3, p/m/5, r/o/6]";
+    String expectedAdded = "[c, y/2, q/n/4]";
+    String expectedRetained = "[a, z/1, p/m/3]";
+    String expectedRemoved = "[b, x/2, r/o/6, p/m/5]";
     SortedSet<String> expectedAddedFiles = BlobStoreTestUtil.getExpected(expectedAdded);
     SortedSet<String> expectedRetainedFiles = BlobStoreTestUtil.getExpected(expectedRetained);
     SortedSet<String> expectedPresentFiles = new TreeSet<>(expectedAddedFiles);


### PR DESCRIPTION
Issue: Current validation for DirIndex checks if the same file _name_ is present in both filesAdded and filesRemoved. For mutable files like CURRENT this is valid since the metadata and blob ids are different.

Changes: Fixed the check for files to compare FileIndex instead of file name, which accounts for the blobs and metadata associated with the file too. Also added a similar check for all blobs added and removed in the DirIndex too. Made both checks recursive to account for subdirs.

API/usage changes: None

Tests: Added a couple of unit tests.