### PR TITLE
SAMZA-2734: [Elasticity] Update last processed offset after an envelopepe is finished processing when elasticity is enabled

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/checkpoint/OffsetManager.scala
+++ b/samza-core/src/main/scala/org/apache/samza/checkpoint/OffsetManager.scala
@@ -210,9 +210,19 @@ class OffsetManager(
    * Set the last processed offset for a given SystemStreamPartition.
    */
   def update(taskName: TaskName, systemStreamPartition: SystemStreamPartition, offset: String) {
+    // without elasticity enabled, there is exactly one entry of an ssp in the systemStreamPartitions map for a taskName
+    // with elasticity enabled, there is exactly one of the keyBuckets of an ssp that a task consumes
+    // and hence exactly one entry of an ssp with keyBucket in in the systemStreamPartitions map for a taskName
+    // hence from the given ssp, find its sspWithKeybucket for the task and use that for updating lastProcessedOffsets
+    val sspWithKeyBucket = systemStreamPartitions.getOrElse(taskName,
+      throw new SamzaException("No SSPs registered for task: " + taskName))
+      .filter(ssp => ssp.getSystemStream.equals(systemStreamPartition.getSystemStream)
+        && ssp.getPartition.equals(systemStreamPartition.getPartition))
+      .toIterator.next()
+
     lastProcessedOffsets.putIfAbsent(taskName, new ConcurrentHashMap[SystemStreamPartition, String]())
     if (offset != null && !offset.equals(IncomingMessageEnvelope.END_OF_STREAM_OFFSET)) {
-      lastProcessedOffsets.get(taskName).put(systemStreamPartition, offset)
+      lastProcessedOffsets.get(taskName).put(sspWithKeyBucket, offset)
     }
   }
 

--- a/samza-core/src/main/scala/org/apache/samza/system/SystemConsumers.scala
+++ b/samza-core/src/main/scala/org/apache/samza/system/SystemConsumers.scala
@@ -188,6 +188,8 @@ class SystemConsumers (
       // but the actual systemConsumer which consumes from the input does not know about KeyBucket.
       // hence, use an SSP without KeyBucket
       consumer.register(removeKeyBucket(systemStreamPartition), offset)
+      chooser.register(removeKeyBucket(systemStreamPartition), offset)
+      debug("consumer.register and chooser.register for ssp: %s with offset %s" format (systemStreamPartition, offset))
     }
 
     debug("Starting consumers.")
@@ -243,8 +245,6 @@ class SystemConsumers (
 
     metrics.registerSystemStreamPartition(systemStreamPartition)
     unprocessedMessagesBySSP.put(systemStreamPartition, new ArrayDeque[IncomingMessageEnvelope]())
-
-    chooser.register(systemStreamPartition, offset)
 
     try {
       val consumer = consumers(systemStreamPartition.getSystem)


### PR DESCRIPTION
**Feature:** Elasticity (SAMZA-2687) for a Samza job allows job to have more tasks than the number of input SystemStreamPartition(SSP). Thus, a job can scale up beyond its input partition count without needing the repartition the input stream.
This current PR is to update the last processed offsets maintained by the OffsetManager during processing stage of the container correctly when elasticity is enabled.

**Changes:**
1. Modify OffsetManager.udpate to correctly identify the ssp even with keyBucket info is not present in the given parameter ssp
2. Modify SystemConsumers to provide the ssp,offset to Chooser after all the registrations are done. This is because, chooser is given an ssp without keyBucket but a container could be processing multiple keyBuckets within the same ssp. So after registration for all is complete, the smallest offset is given to the chooser.

**Tests:** added unit test

**API changes:** no public api change

**Upgrade instructions:** none

**Usage instructions:** None.

**Backwards compatible:** yes. does not affect the existing flow