### PR TITLE
SAMZA-2743: [Elasticity] Add keybucket into SSP serde for checkpoint

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/serializers/model/SamzaObjectMapper.java
+++ b/samza-core/src/main/java/org/apache/samza/serializers/model/SamzaObjectMapper.java
@@ -221,7 +221,9 @@ public class SamzaObjectMapper {
   public static class SystemStreamPartitionKeySerializer extends JsonSerializer<SystemStreamPartition> {
     @Override
     public void serialize(SystemStreamPartition ssp, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-      String sspString = ssp.getSystem() + "." + ssp.getStream() + "." + String.valueOf(ssp.getPartition().getPartitionId());
+      String sspString = ssp.getSystem() + "." + ssp.getStream() + "."
+          + String.valueOf(ssp.getPartition().getPartitionId()) + "."
+          + String.valueOf(ssp.getKeyBucket());
       jgen.writeFieldName(sspString);
     }
   }
@@ -230,11 +232,16 @@ public class SamzaObjectMapper {
     @Override
     public Object deserializeKey(String sspString, DeserializationContext ctxt) throws IOException {
       String[] parts = sspString.split("\\.");
-      if (parts.length < 3) {
-        throw new IllegalArgumentException("System stream partition expected in format 'system.stream.partition");
+      if (parts.length < 3 || parts.length > 4) {
+        throw new IllegalArgumentException("System stream partition expected in format 'system.stream.partition' "
+            + "or 'system.stream.partition.keyBucket");
       }
-      return new SystemStreamPartition(
-          new SystemStream(parts[0], parts[1]), new Partition(Integer.parseInt(parts[2])));
+      if (parts.length == 3) {
+        return new SystemStreamPartition(
+            new SystemStream(parts[0], parts[1]), new Partition(Integer.parseInt(parts[2])));
+      }
+      // else parts.length == 4 and the 4th part is the keyBucket
+      return new SystemStreamPartition(parts[0], parts[1], new Partition(Integer.parseInt(parts[2])), Integer.parseInt(parts[3]));
     }
   }
 

--- a/samza-core/src/main/scala/org/apache/samza/serializers/CheckpointV1Serde.scala
+++ b/samza-core/src/main/scala/org/apache/samza/serializers/CheckpointV1Serde.scala
@@ -40,13 +40,13 @@ class CheckpointV1Serde extends Serde[CheckpointV1] with Logging {
   // Serialize checkpoint as maps keyed by the SSP.toString() to the another map of the constituent SSP components
   // and offset. Jackson can't automatically serialize the SSP since it's not a POJO and this avoids
   // having to wrap it another class while maintaining readability.
-  // { "SSP.toString()" -> {"system": system, "stream": stream, "partition": partition, "offset": offset)}
+  // { "SSP.toString()" -> {"system": system, "stream": stream, "partition": partition, "keyBucket": keyBucket, "offset": offset)}
   def fromBytes(bytes: Array[Byte]): CheckpointV1 = {
     try {
       val jMap = jsonMapper.readValue(bytes, classOf[util.HashMap[String, util.HashMap[String, String]]])
 
       def deserializeJSONMap(sspInfo:util.HashMap[String, String]) = {
-        require(sspInfo.size() == 4, "All JSON-encoded SystemStreamPartitions must have four keys")
+        require(sspInfo.size() >= 4, "All JSON-encoded SystemStreamPartitions must have atleast four keys")
         val system = sspInfo.get("system")
         require(system != null, "System must be present in JSON-encoded SystemStreamPartition")
         val stream = sspInfo.get("stream")
@@ -55,8 +55,12 @@ class CheckpointV1Serde extends Serde[CheckpointV1] with Logging {
         require(partition != null, "Partition must be present in JSON-encoded SystemStreamPartition")
         val offset = sspInfo.get("offset")
         // allow null offsets, e.g. for changelog ssps
+        var keyBucket = sspInfo.get("keyBucket")
+        if (keyBucket == null) {
+          keyBucket = "-1"
+        }
 
-        new SystemStreamPartition(system, stream, new Partition(partition.toInt)) -> offset
+        new SystemStreamPartition(system, stream, new Partition(partition.toInt), keyBucket.toInt) -> offset
       }
 
       val cpMap = jMap.values.asScala.map(deserializeJSONMap).toMap
@@ -79,6 +83,7 @@ class CheckpointV1Serde extends Serde[CheckpointV1] with Logging {
         jMap.put("system", ssp.getSystemStream.getSystem)
         jMap.put("stream", ssp.getSystemStream.getStream)
         jMap.put("partition", ssp.getPartition.getPartitionId.toString)
+        jMap.put("keyBucket", ssp.getKeyBucket.toString)
         jMap.put("offset", offset)
 
         asMap.put(ssp.toString, jMap)

--- a/samza-core/src/test/scala/org/apache/samza/serializers/TestCheckpointV1Serde.scala
+++ b/samza-core/src/test/scala/org/apache/samza/serializers/TestCheckpointV1Serde.scala
@@ -19,10 +19,11 @@
 
 package org.apache.samza.serializers
 
-import java.util
+import com.fasterxml.jackson.databind.ObjectMapper
 
+import java.util
 import org.apache.samza.Partition
-import org.apache.samza.checkpoint.{CheckpointV1}
+import org.apache.samza.checkpoint.CheckpointV1
 import org.apache.samza.container.TaskName
 import org.apache.samza.system.SystemStreamPartition
 import org.junit.Assert._
@@ -48,5 +49,82 @@ class TestCheckpointV1Serde {
     val checkpointSerde = new CheckpointV1Serde
     val checkpoint = checkpointSerde.fromBytes(checkpointBytes)
     assertNull(checkpoint)
+  }
+
+  @Test
+  def testSSPWithKeyBucket {
+    // case 1: write and read with serde that is aware of KeyBucket within SSP
+    val serde = new CheckpointV1Serde
+    var offsets = Map[SystemStreamPartition, String]()
+    val ssp = new SystemStreamPartition("test-system", "test-stream",
+      new Partition(777), -1)
+    offsets += ssp -> "1"
+    val deserializedOffsets = serde.fromBytes(serde.toBytes(new CheckpointV1(offsets.asJava)))
+    assertEquals("1", deserializedOffsets.getOffsets.get(ssp))
+    assertEquals(1, deserializedOffsets.getOffsets.size)
+
+    // case 2: SSP was serialized by serde not aware of KeyBucket - aka did not put keyBucket into serialized form
+    val deserializedOffsets2 = serde.fromBytes(toBytesWithoutKeyBucket(new CheckpointV1(offsets.asJava)))
+    assertEquals("1", deserializedOffsets2.getOffsets.get(ssp))
+    assertEquals(1, deserializedOffsets2.getOffsets.size)
+
+    // case 3: SSP was serialized by serde aware of KeyBucket but deserialized by serde not aware of KeyBucket
+    val deserializedOffsets3 = fromBytesWithoutKeyBucket(serde.toBytes(new CheckpointV1(offsets.asJava)))
+    assertEquals("1", deserializedOffsets3.getOffsets.get(ssp))
+    assertEquals(1, deserializedOffsets3.getOffsets.size)
+
+    // case 4: SSP has keyBucket = 0 (aka not default -1) - serialize by serde NOT aware of keyBucket
+    // when serialized with serde not aware of keyBucket, the info about keyBucket is lost,
+    // we can only recover the system, stream and partition parts out during deserialization.
+    // hence after deser, we need to look for SSP without key bucket
+    val sspWithKeyBucket = new SystemStreamPartition("test-system", "test-stream",
+      new Partition(777), 0)
+    val sspWithoutKeyBucket = new SystemStreamPartition("test-system", "test-stream",
+      new Partition(777))
+    var offsets1 = Map[SystemStreamPartition, String]()
+    offsets1 += sspWithKeyBucket -> "1"
+
+    val deserializedOffsets4 = serde.fromBytes(toBytesWithoutKeyBucket(new CheckpointV1(offsets1.asJava)))
+    assertEquals("1", deserializedOffsets4.getOffsets.get(sspWithoutKeyBucket))
+    assertEquals(1, deserializedOffsets4.getOffsets.size)
+
+    // case 5: SSP has KeyBucket = 0, serialized by serde aware of keyBucket
+    val deserializedOffsets5 = fromBytesWithoutKeyBucket(serde.toBytes(new CheckpointV1(offsets1.asJava)))
+    assertEquals("1", deserializedOffsets5.getOffsets.get(sspWithoutKeyBucket))
+    assertEquals(1, deserializedOffsets5.getOffsets.size)
+  }
+
+  private  def fromBytesWithoutKeyBucket(bytes: Array[Byte]): CheckpointV1 = {
+    val jsonMapper = new ObjectMapper()
+    val jMap = jsonMapper.readValue(bytes, classOf[util.HashMap[String, util.HashMap[String, String]]])
+
+    def deserializeJSONMap(sspInfo:util.HashMap[String, String]) = {
+      val system = sspInfo.get("system")
+      val stream = sspInfo.get("stream")
+      val partition = sspInfo.get("partition")
+      val offset = sspInfo.get("offset")
+      new SystemStreamPartition(system, stream, new Partition(partition.toInt)) -> offset
+    }
+    val cpMap = jMap.values.asScala.map(deserializeJSONMap).toMap
+    new CheckpointV1(cpMap.asJava)
+  }
+
+  private   def toBytesWithoutKeyBucket(checkpoint: CheckpointV1): Array[Byte] = {
+    val jsonMapper = new ObjectMapper()
+    val offsets = checkpoint.getOffsets
+    val asMap = new util.HashMap[String, util.HashMap[String, String]](offsets.size())
+
+    offsets.asScala.foreach {
+      case (ssp, offset) =>
+        val jMap = new util.HashMap[String, String](4)
+        jMap.put("system", ssp.getSystemStream.getSystem)
+        jMap.put("stream", ssp.getSystemStream.getStream)
+        jMap.put("partition", ssp.getPartition.getPartitionId.toString)
+        jMap.put("offset", offset)
+
+        asMap.put(ssp.toString, jMap)
+    }
+
+    jsonMapper.writeValueAsBytes(asMap)
   }
 }


### PR DESCRIPTION
**Feature:** Add KeyBucket into SSP serde for checkpoint. Elasticity (SAMZA-2687) allows consumption of part of SSP denoted by KeyBucket (introduced in #1576). This PR is to add the keybucket into SSP serde for checkpointv1 and when SSP is key in checkpointv2

**changes:**
1. add keybucket into CheckpointV1Serde
2. add keybucket for serde of SSP as Key in SamzaObjectMapper
 
**Tests:** updated and added new tests
**API Changes:** no public API changes
**Upgrade/usage instructions:** None
**Backwards compatible:** yes, new test added uses old serde and new serde together