### PR TITLE
Add metrics for BlobNotFound error

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/storage/blobstore/exceptions/BlobNotFoundException.java
+++ b/samza-api/src/main/java/org/apache/samza/storage/blobstore/exceptions/BlobNotFoundException.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.storage.blobstore.exceptions;
+
+/**
+ * Future should complete with this exception to indicate that the exception occurred due to the request for an
+ * a blob that is not present.
+ *
+ */
+public class BlobNotFoundException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  public BlobNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public BlobNotFoundException(String message) {
+    super(message);
+  }
+
+  public BlobNotFoundException(Throwable cause) {
+    super(cause);
+  }
+
+  public BlobNotFoundException() {
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/BlobStoreStateBackendFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/BlobStoreStateBackendFactory.java
@@ -40,6 +40,7 @@ import org.apache.samza.storage.StorageManagerUtil;
 import org.apache.samza.storage.TaskBackupManager;
 import org.apache.samza.storage.TaskRestoreManager;
 import org.apache.samza.storage.blobstore.metrics.BlobStoreBackupManagerMetrics;
+import org.apache.samza.storage.blobstore.metrics.BlobStoreManagerMetrics;
 import org.apache.samza.storage.blobstore.metrics.BlobStoreRestoreManagerMetrics;
 import org.apache.samza.util.Clock;
 import org.apache.samza.util.ReflectionUtil;
@@ -62,9 +63,10 @@ public class BlobStoreStateBackendFactory implements StateBackendFactory {
     Preconditions.checkState(StringUtils.isNotBlank(blobStoreManagerFactory));
     BlobStoreManagerFactory factory = ReflectionUtil.getObj(blobStoreManagerFactory, BlobStoreManagerFactory.class);
     BlobStoreManager blobStoreManager = factory.getBackupBlobStoreManager(config, backupExecutor);
-    BlobStoreBackupManagerMetrics metrics = new BlobStoreBackupManagerMetrics(metricsRegistry);
+    BlobStoreManagerMetrics blobStoreManagerMetrics = new BlobStoreManagerMetrics(metricsRegistry);
+    BlobStoreBackupManagerMetrics blobStoreBackupManagerMetrics = new BlobStoreBackupManagerMetrics(metricsRegistry);
     return new BlobStoreBackupManager(jobContext.getJobModel(), containerModel, taskModel, backupExecutor,
-        metrics, config, clock, loggedStoreBaseDir, new StorageManagerUtil(), blobStoreManager);
+        blobStoreManagerMetrics, blobStoreBackupManagerMetrics, config, clock, loggedStoreBaseDir, new StorageManagerUtil(), blobStoreManager);
   }
 
   @Override
@@ -85,9 +87,10 @@ public class BlobStoreStateBackendFactory implements StateBackendFactory {
     Preconditions.checkState(StringUtils.isNotBlank(blobStoreManagerFactory));
     BlobStoreManagerFactory factory = ReflectionUtil.getObj(blobStoreManagerFactory, BlobStoreManagerFactory.class);
     BlobStoreManager blobStoreManager = factory.getRestoreBlobStoreManager(config, restoreExecutor);
-    BlobStoreRestoreManagerMetrics metrics = new BlobStoreRestoreManagerMetrics(metricsRegistry);
-    return new BlobStoreRestoreManager(taskModel, restoreExecutor, storesToRestore, metrics, config, loggedStoreBaseDir,
-        nonLoggedStoreBaseDir, new StorageManagerUtil(), blobStoreManager);
+    BlobStoreManagerMetrics blobStoreManagerMetrics = new BlobStoreManagerMetrics(metricsRegistry);
+    BlobStoreRestoreManagerMetrics blobStoreRestoreManagerMetrics = new BlobStoreRestoreManagerMetrics(metricsRegistry);
+    return new BlobStoreRestoreManager(taskModel, restoreExecutor, storesToRestore, blobStoreManagerMetrics,
+        blobStoreRestoreManagerMetrics, config, loggedStoreBaseDir, nonLoggedStoreBaseDir, new StorageManagerUtil(), blobStoreManager);
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/metrics/BlobStoreManagerMetrics.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/metrics/BlobStoreManagerMetrics.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.storage.blobstore.metrics;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.samza.metrics.Gauge;
+import org.apache.samza.metrics.MetricsRegistry;
+
+
+public class BlobStoreManagerMetrics {
+  private static final String GROUP = BlobStoreManagerMetrics.class.getName();
+  private final MetricsRegistry metricsRegistry;
+
+  public final Map<String, Gauge<Long>> storeBlobNotFoundError;
+
+  public BlobStoreManagerMetrics(MetricsRegistry metricsRegistry) {
+    this.metricsRegistry = metricsRegistry;
+
+    storeBlobNotFoundError = new ConcurrentHashMap<>();
+  }
+
+  public void initStoreMetrics(Collection<String> storeNames) {
+    for (String storeName : storeNames) {
+      storeBlobNotFoundError.putIfAbsent(storeName,
+          metricsRegistry.newGauge(GROUP, String.format("%s-blob-not-found", storeName), 0L));
+    }
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/storage/blobstore/TestBlobStoreBackupManager.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/blobstore/TestBlobStoreBackupManager.java
@@ -64,6 +64,7 @@ import org.apache.samza.storage.blobstore.index.DirIndex;
 import org.apache.samza.storage.blobstore.index.SnapshotIndex;
 import org.apache.samza.storage.blobstore.index.SnapshotMetadata;
 import org.apache.samza.storage.blobstore.metrics.BlobStoreBackupManagerMetrics;
+import org.apache.samza.storage.blobstore.metrics.BlobStoreManagerMetrics;
 import org.apache.samza.storage.blobstore.util.BlobStoreTestUtil;
 import org.apache.samza.storage.blobstore.util.BlobStoreUtil;
 import org.apache.samza.storage.blobstore.util.DirDiffUtil;
@@ -108,6 +109,7 @@ public class TestBlobStoreBackupManager {
   private final Gauge<AtomicLong> atomicLongGauge = mock(Gauge.class);
 
   private BlobStoreBackupManager blobStoreBackupManager;
+  private BlobStoreManagerMetrics blobStoreTaskManagerMetrics;
   private BlobStoreBackupManagerMetrics blobStoreTaskBackupMetrics;
 
   // Remote and local snapshot definitions
@@ -147,10 +149,12 @@ public class TestBlobStoreBackupManager {
     when(atomicLongGauge.getValue()).thenReturn(new AtomicLong());
     when(metricsRegistry.newTimer(anyString(), anyString())).thenReturn(timer);
     blobStoreTaskBackupMetrics = new BlobStoreBackupManagerMetrics(metricsRegistry);
+    blobStoreTaskManagerMetrics = new BlobStoreManagerMetrics(metricsRegistry);
+
 
     blobStoreBackupManager =
         new MockBlobStoreBackupManager(jobModel, containerModel, taskModel, mockExecutor,
-            blobStoreTaskBackupMetrics, config,
+            blobStoreTaskManagerMetrics, blobStoreTaskBackupMetrics, config,
             Files.createTempDirectory("logged-store-").toFile(), storageManagerUtil, blobStoreManager);
   }
 
@@ -524,10 +528,11 @@ public class TestBlobStoreBackupManager {
   private class MockBlobStoreBackupManager extends BlobStoreBackupManager {
 
     public MockBlobStoreBackupManager(JobModel jobModel, ContainerModel containerModel, TaskModel taskModel,
-        ExecutorService backupExecutor, BlobStoreBackupManagerMetrics blobStoreTaskBackupMetrics, Config config,
+        ExecutorService backupExecutor, BlobStoreManagerMetrics blobStoreManagerMetrics,
+        BlobStoreBackupManagerMetrics blobStoreTaskBackupMetrics, Config config,
         File loggedStoreBaseDir, StorageManagerUtil storageManagerUtil,
         BlobStoreManager blobStoreManager) {
-      super(jobModel, containerModel, taskModel, backupExecutor, blobStoreTaskBackupMetrics, config, clock,
+      super(jobModel, containerModel, taskModel, backupExecutor, blobStoreManagerMetrics, blobStoreTaskBackupMetrics, config, clock,
           loggedStoreBaseDir, storageManagerUtil, blobStoreManager);
     }
 

--- a/samza-core/src/test/java/org/apache/samza/storage/blobstore/TestBlobStoreRestoreManager.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/blobstore/TestBlobStoreRestoreManager.java
@@ -44,6 +44,7 @@ import org.apache.samza.storage.StorageManagerUtil;
 import org.apache.samza.storage.blobstore.index.DirIndex;
 import org.apache.samza.storage.blobstore.index.SnapshotIndex;
 import org.apache.samza.storage.blobstore.index.SnapshotMetadata;
+import org.apache.samza.storage.blobstore.metrics.BlobStoreManagerMetrics;
 import org.apache.samza.storage.blobstore.metrics.BlobStoreRestoreManagerMetrics;
 import org.apache.samza.storage.blobstore.util.BlobStoreTestUtil;
 import org.apache.samza.storage.blobstore.util.BlobStoreUtil;
@@ -175,8 +176,9 @@ public class TestBlobStoreRestoreManager {
     String jobName = "testJobName";
     String jobId = "testJobId";
     TaskName taskName = mock(TaskName.class);
-    BlobStoreRestoreManagerMetrics metrics = new BlobStoreRestoreManagerMetrics(new MetricsRegistryMap());
-    metrics.initStoreMetrics(ImmutableList.of("storeName"));
+    BlobStoreManagerMetrics blobStoreManagerMetrics = new BlobStoreManagerMetrics(new MetricsRegistryMap());
+    BlobStoreRestoreManagerMetrics blobStoreRestoreManagerMetrics = new BlobStoreRestoreManagerMetrics(new MetricsRegistryMap());
+    blobStoreRestoreManagerMetrics.initStoreMetrics(ImmutableList.of("storeName"));
     Set<String> storesToRestore = ImmutableSet.of("storeName");
     SnapshotIndex snapshotIndex = mock(SnapshotIndex.class);
     Map<String, Pair<String, SnapshotIndex>> prevStoreSnapshotIndexes =
@@ -206,7 +208,7 @@ public class TestBlobStoreRestoreManager {
     when(dirDiffUtil.areSameDir(anySet(), anyBoolean())).thenReturn((arg1, arg2) -> true);
 
     BlobStoreRestoreManager.restoreStores(jobName, jobId, taskName, storesToRestore, prevStoreSnapshotIndexes,
-        loggedBaseDir.toFile(), storageConfig, metrics,
+        loggedBaseDir.toFile(), storageConfig, blobStoreManagerMetrics, blobStoreRestoreManagerMetrics,
         storageManagerUtil, blobStoreUtil, dirDiffUtil, EXECUTOR);
 
     // verify that the store directory restore was called and skipped (i.e. shouldRestore == true)
@@ -221,8 +223,9 @@ public class TestBlobStoreRestoreManager {
     String jobName = "testJobName";
     String jobId = "testJobId";
     TaskName taskName = mock(TaskName.class);
-    BlobStoreRestoreManagerMetrics metrics = new BlobStoreRestoreManagerMetrics(new MetricsRegistryMap());
-    metrics.initStoreMetrics(ImmutableList.of("storeName"));
+    BlobStoreManagerMetrics blobStoreManagerMetrics = new BlobStoreManagerMetrics(new MetricsRegistryMap());
+    BlobStoreRestoreManagerMetrics blobStoreRestoreManagerMetrics = new BlobStoreRestoreManagerMetrics(new MetricsRegistryMap());
+    blobStoreRestoreManagerMetrics.initStoreMetrics(ImmutableList.of("storeName"));
     Set<String> storesToRestore = ImmutableSet.of("storeName");
     SnapshotIndex snapshotIndex = mock(SnapshotIndex.class);
     Map<String, Pair<String, SnapshotIndex>> prevStoreSnapshotIndexes =
@@ -258,7 +261,7 @@ public class TestBlobStoreRestoreManager {
         .thenReturn(CompletableFuture.completedFuture(null));
 
     BlobStoreRestoreManager.restoreStores(jobName, jobId, taskName, storesToRestore, prevStoreSnapshotIndexes,
-        loggedBaseDir.toFile(), storageConfig, metrics,
+        loggedBaseDir.toFile(), storageConfig, blobStoreManagerMetrics, blobStoreRestoreManagerMetrics,
         storageManagerUtil, blobStoreUtil, dirDiffUtil, EXECUTOR);
 
     // verify that the store directory restore was called and skipped (i.e. shouldRestore == true)
@@ -273,8 +276,9 @@ public class TestBlobStoreRestoreManager {
     String jobName = "testJobName";
     String jobId = "testJobId";
     TaskName taskName = mock(TaskName.class);
-    BlobStoreRestoreManagerMetrics metrics = new BlobStoreRestoreManagerMetrics(new MetricsRegistryMap());
-    metrics.initStoreMetrics(ImmutableList.of("storeName"));
+    BlobStoreManagerMetrics blobStoreManagerMetrics = new BlobStoreManagerMetrics(new MetricsRegistryMap());
+    BlobStoreRestoreManagerMetrics blobStoreRestoreManagerMetrics = new BlobStoreRestoreManagerMetrics(new MetricsRegistryMap());
+    blobStoreRestoreManagerMetrics.initStoreMetrics(ImmutableList.of("storeName"));
     Set<String> storesToRestore = ImmutableSet.of("storeName");
     SnapshotIndex snapshotIndex = mock(SnapshotIndex.class);
     Map<String, Pair<String, SnapshotIndex>> prevStoreSnapshotIndexes =
@@ -314,7 +318,7 @@ public class TestBlobStoreRestoreManager {
         .thenReturn(CompletableFuture.completedFuture(null));
 
     BlobStoreRestoreManager.restoreStores(jobName, jobId, taskName, storesToRestore, prevStoreSnapshotIndexes,
-        loggedBaseDir.toFile(), storageConfig, metrics,
+        loggedBaseDir.toFile(), storageConfig, blobStoreManagerMetrics, blobStoreRestoreManagerMetrics,
         storageManagerUtil, blobStoreUtil, dirDiffUtil, EXECUTOR);
 
     // verify that the store directory restore was not called (should have restored from checkpoint dir)
@@ -331,8 +335,9 @@ public class TestBlobStoreRestoreManager {
     String jobName = "testJobName";
     String jobId = "testJobId";
     TaskName taskName = mock(TaskName.class);
-    BlobStoreRestoreManagerMetrics metrics = new BlobStoreRestoreManagerMetrics(new MetricsRegistryMap());
-    metrics.initStoreMetrics(ImmutableList.of("newStoreName"));
+    BlobStoreManagerMetrics blobStoreManagerMetrics = new BlobStoreManagerMetrics(new MetricsRegistryMap());
+    BlobStoreRestoreManagerMetrics blobStoreRestoreManagerMetrics = new BlobStoreRestoreManagerMetrics(new MetricsRegistryMap());
+    blobStoreRestoreManagerMetrics.initStoreMetrics(ImmutableList.of("newStoreName"));
     Set<String> storesToRestore = ImmutableSet.of("newStoreName"); // new store in config
     SnapshotIndex snapshotIndex = mock(SnapshotIndex.class);
     Map<String, Pair<String, SnapshotIndex>> prevStoreSnapshotIndexes = mock(Map.class);
@@ -351,7 +356,7 @@ public class TestBlobStoreRestoreManager {
     DirDiffUtil dirDiffUtil = mock(DirDiffUtil.class);
 
     BlobStoreRestoreManager.restoreStores(jobName, jobId, taskName, storesToRestore, prevStoreSnapshotIndexes,
-        loggedBaseDir.toFile(), storageConfig, metrics,
+        loggedBaseDir.toFile(), storageConfig, blobStoreManagerMetrics, blobStoreRestoreManagerMetrics,
         storageManagerUtil, blobStoreUtil, dirDiffUtil, EXECUTOR);
 
     // verify that we checked the previously checkpointed SCMs.

--- a/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestBlobStoreUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestBlobStoreUtil.java
@@ -132,7 +132,7 @@ public class TestBlobStoreUtil {
         });
 
     // Execute
-    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(blobStoreManager, EXECUTOR, null, null);
+    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(blobStoreManager, EXECUTOR, null, null, null);
     CompletionStage<DirIndex> dirIndexFuture = blobStoreUtil.putDir(dirDiff, snapshotMetadata);
     DirIndex dirIndex = null;
     try {
@@ -185,7 +185,7 @@ public class TestBlobStoreUtil {
         });
 
     // Execute
-    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(blobStoreManager, EXECUTOR, null, null);
+    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(blobStoreManager, EXECUTOR, null, null, null);
     CompletionStage<DirIndex> dirIndexFuture = blobStoreUtil.putDir(dirDiff, snapshotMetadata);
     try {
       // should be already complete. if not, future composition in putDir is broken.
@@ -232,7 +232,7 @@ public class TestBlobStoreUtil {
         });
 
     // Execute
-    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(blobStoreManager, EXECUTOR, null, null);
+    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(blobStoreManager, EXECUTOR, null, null, null);
     CompletionStage<DirIndex> dirIndexFuture = blobStoreUtil.putDir(dirDiff, snapshotMetadata);
     try {
       // should be already complete. if not, future composition in putDir is broken.
@@ -268,7 +268,7 @@ public class TestBlobStoreUtil {
     DirDiff dirDiff = DirDiffUtil.getDirDiff(localSnapshotDir.toFile(), remoteSnapshotDir,
       (localFile, remoteFile) -> localFile.getName().equals(remoteFile.getFileName()));
 
-    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(blobStoreManager, EXECUTOR, null, null);
+    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(blobStoreManager, EXECUTOR, null,null, null);
     when(blobStoreManager.put(any(InputStream.class), any(Metadata.class)))
         .thenReturn(CompletableFuture.completedFuture("blobId"));
     CompletionStage<DirIndex> dirIndexFuture = blobStoreUtil.putDir(dirDiff, snapshotMetadata);
@@ -321,7 +321,7 @@ public class TestBlobStoreUtil {
     DirDiff dirDiff = DirDiffUtil.getDirDiff(localSnapshotDir.toFile(), remoteSnapshotDir,
       (localFile, remoteFile) -> localFile.getName().equals(remoteFile.getFileName()));
 
-    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(blobStoreManager, EXECUTOR, null, null);
+    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(blobStoreManager, EXECUTOR, null,null, null);
     when(blobStoreManager.put(any(InputStream.class), any(Metadata.class)))
         .thenReturn(CompletableFuture.completedFuture("blobId"));
     CompletionStage<DirIndex> dirIndexFuture = blobStoreUtil.putDir(dirDiff, snapshotMetadata);
@@ -381,7 +381,7 @@ public class TestBlobStoreUtil {
     DirDiff dirDiff = DirDiffUtil.getDirDiff(localSnapshotDir.toFile(), remoteSnapshotDir,
       (localFile, remoteFile) -> localFile.getName().equals(remoteFile.getFileName()));
 
-    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(blobStoreManager, EXECUTOR, null, null);
+    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(blobStoreManager, EXECUTOR, null, null, null);
     when(blobStoreManager.put(any(InputStream.class), any(Metadata.class)))
         .thenReturn(CompletableFuture.completedFuture("blobId"));
     CompletionStage<DirIndex> dirIndexFuture = blobStoreUtil.putDir(dirDiff, snapshotMetadata);
@@ -453,7 +453,7 @@ public class TestBlobStoreUtil {
           return CompletableFuture.completedFuture(fileName);
         });
 
-    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(blobStoreManager, EXECUTOR, null, null);
+    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(blobStoreManager, EXECUTOR, null, null, null);
     CompletionStage<DirIndex> dirIndexFuture = blobStoreUtil.putDir(dirDiff, snapshotMetadata);
     DirIndex dirIndex = null;
     try {
@@ -506,7 +506,7 @@ public class TestBlobStoreUtil {
         return CompletableFuture.completedFuture("blobId");
       });
 
-    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(blobStoreManager, EXECUTOR, null, null);
+    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(blobStoreManager, EXECUTOR, null, null, null);
 
     CompletionStage<FileIndex> fileIndexFuture = blobStoreUtil.putFile(path.toFile(), snapshotMetadata);
     FileIndex fileIndex = null;
@@ -619,7 +619,7 @@ public class TestBlobStoreUtil {
         return CompletableFuture.completedFuture(null);
       });
 
-    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(mockBlobStoreManager, EXECUTOR, null, null);
+    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(mockBlobStoreManager, EXECUTOR, null,null, null);
     blobStoreUtil.restoreDir(restoreDirBasePath.toFile(), mockDirIndex, metadata).join();
 
     assertTrue(
@@ -677,7 +677,7 @@ public class TestBlobStoreUtil {
         return CompletableFuture.completedFuture(null); // success
       });
 
-    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(mockBlobStoreManager, EXECUTOR, null, null);
+    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(mockBlobStoreManager, EXECUTOR, null,null, null);
     blobStoreUtil.restoreDir(restoreDirBasePath.toFile(), mockDirIndex, metadata).join();
 
     assertTrue(
@@ -730,7 +730,7 @@ public class TestBlobStoreUtil {
           return CompletableFuture.completedFuture(null);
         });
 
-    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(mockBlobStoreManager, EXECUTOR, null, null);
+    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(mockBlobStoreManager, EXECUTOR, null, null, null);
     try {
       blobStoreUtil.restoreDir(restoreDirBasePath.toFile(), mockDirIndex, metadata).join();
       fail("Should have failed on non-retriable errors during file restore");
@@ -782,7 +782,7 @@ public class TestBlobStoreUtil {
       });
 
     Path restoreDirBasePath = Files.createTempDirectory(BlobStoreTestUtil.TEMP_DIR_PREFIX);
-    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(mockBlobStoreManager, EXECUTOR, null, null);
+    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(mockBlobStoreManager, EXECUTOR, null, null, null);
     blobStoreUtil.restoreDir(restoreDirBasePath.toFile(), dirIndex, metadata).join();
 
     assertTrue(new DirDiffUtil().areSameDir(Collections.emptySet(), false).test(restoreDirBasePath.toFile(), dirIndex));
@@ -795,7 +795,7 @@ public class TestBlobStoreUtil {
   @Test
   public void testGetSSIReturnsEmptyMapForNullCheckpoint() {
     BlobStoreUtil blobStoreUtil =
-        new BlobStoreUtil(mock(BlobStoreManager.class), MoreExecutors.newDirectExecutorService(), null, null);
+        new BlobStoreUtil(mock(BlobStoreManager.class), MoreExecutors.newDirectExecutorService(), null,null, null);
     Map<String, Pair<String, SnapshotIndex>> snapshotIndexes =
         blobStoreUtil.getStoreSnapshotIndexes("testJobName", "testJobId", "taskName", null, new HashSet<>());
     assertTrue(snapshotIndexes.isEmpty());
@@ -805,7 +805,7 @@ public class TestBlobStoreUtil {
     Checkpoint mockCheckpoint = mock(Checkpoint.class);
     when(mockCheckpoint.getVersion()).thenReturn((short) 1);
     BlobStoreUtil blobStoreUtil =
-        new BlobStoreUtil(mock(BlobStoreManager.class), MoreExecutors.newDirectExecutorService(), null, null);
+        new BlobStoreUtil(mock(BlobStoreManager.class), MoreExecutors.newDirectExecutorService(), null, null, null);
     Map<String, Pair<String, SnapshotIndex>> prevSnapshotIndexes =
         blobStoreUtil.getStoreSnapshotIndexes("testJobName", "testJobId", "taskName", mockCheckpoint, new HashSet<>());
     assertEquals(prevSnapshotIndexes.size(), 0);
@@ -819,7 +819,7 @@ public class TestBlobStoreUtil {
         ImmutableMap.of("com.OtherStateBackendFactory", ImmutableMap.of("storeName", "otherSCM")));
 
     BlobStoreUtil blobStoreUtil =
-        new BlobStoreUtil(mock(BlobStoreManager.class), MoreExecutors.newDirectExecutorService(), null, null);
+        new BlobStoreUtil(mock(BlobStoreManager.class), MoreExecutors.newDirectExecutorService(), null, null, null);
     Map<String, Pair<String, SnapshotIndex>> snapshotIndexes =
         blobStoreUtil.getStoreSnapshotIndexes("testJobName", "testJobId", "taskName", mockCheckpoint, new HashSet<>());
     assertTrue(snapshotIndexes.isEmpty());
@@ -833,7 +833,7 @@ public class TestBlobStoreUtil {
         ImmutableMap.of(BlobStoreStateBackendFactory.class.getName(), ImmutableMap.of()));
 
     BlobStoreUtil blobStoreUtil =
-        new BlobStoreUtil(mock(BlobStoreManager.class), MoreExecutors.newDirectExecutorService(), null, null);
+        new BlobStoreUtil(mock(BlobStoreManager.class), MoreExecutors.newDirectExecutorService(), null, null, null);
     Map<String, Pair<String, SnapshotIndex>> snapshotIndexes =
         blobStoreUtil.getStoreSnapshotIndexes("testJobName", "testJobId", "taskName", mockCheckpoint, new HashSet<>());
     assertTrue(snapshotIndexes.isEmpty());
@@ -981,7 +981,7 @@ public class TestBlobStoreUtil {
           return FutureUtil.failedFuture(new RetriableException()); // retriable error
         }).thenAnswer((Answer<CompletionStage<String>>) invocation -> CompletableFuture.completedFuture("blobId"));
 
-    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(blobStoreManager, EXECUTOR, null, null);
+    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(blobStoreManager, EXECUTOR, null,null, null);
 
     blobStoreUtil.putFile(path.toFile(), snapshotMetadata).join();
     // Verify put operation is retried 4 times


### PR DESCRIPTION
Changes:
- Added a new class of exception called BlobNotFoundException
- Added a new metric to track the count of of this exception during restore from blob stores.
