### PR TITLE
SAMZA-2747: Standby bug fixes

### DIFF
--- a/samza-core/src/test/scala/org/apache/samza/storage/TestContainerStorageManager.java
+++ b/samza-core/src/test/scala/org/apache/samza/storage/TestContainerStorageManager.java
@@ -614,10 +614,10 @@ public class TestContainerStorageManager {
     private static final TaskModel STANDBY_TASK_MODEL =
         new TaskModel(STANDBY_TASK_NAME, Collections.emptySet(), new Partition(0), TaskMode.Standby);
 
-    private static final String sideInputStore = "side-input-store";
-    private static final SystemStream sideInputSystemStream = new SystemStream("test", "side-input-stream");
-    private static final String testStore = "test-store";
-    private static final SystemStream testSystemStream = new SystemStream("test", "stream");
+    private static final String SIDE_INPUT_STORE = "side-input-store";
+    private static final SystemStream SIDE_INPUT_SYSTEM_STREAM = new SystemStream("test", "side-input-stream");
+    private static final String TEST_STORE = "test-store";
+    private static final SystemStream TEST_SYSTEM_STREAM = new SystemStream("test", "stream");
 
     private final ContainerModel activeContainerModel;
     private final ContainerModel activeAndStandbyContainerModel;
@@ -644,17 +644,17 @@ public class TestContainerStorageManager {
       standbyContainerModelWithSideInputs = new ContainerModel("standby-container-with-side-input",
           ImmutableMap.of(STANDBY_TASK_NAME_2, STANDBY_TASK_MODEL_WITH_SIDE_INPUT));
 
-      activeStores = ImmutableSet.of(sideInputStore);
-      standbyStores = ImmutableSet.of(sideInputStore, testStore);
+      activeStores = ImmutableSet.of(SIDE_INPUT_STORE);
+      standbyStores = ImmutableSet.of(SIDE_INPUT_STORE, TEST_STORE);
 
-      sideInputStoresToSystemStreams = ImmutableMap.of(sideInputStore, ImmutableSet.of(sideInputSystemStream));
-      storesToSystemStreams = ImmutableMap.of(testStore, testSystemStream);
+      sideInputStoresToSystemStreams = ImmutableMap.of(SIDE_INPUT_STORE, ImmutableSet.of(SIDE_INPUT_SYSTEM_STREAM));
+      storesToSystemStreams = ImmutableMap.of(TEST_STORE, TEST_SYSTEM_STREAM);
 
       activeSideInputSSPs = ImmutableMap.of(ACTIVE_TASK_NAME, Collections.emptyMap());
       standbyChangelogSSPs =
-          ImmutableMap.of(STANDBY_TASK_NAME, ImmutableMap.of(testStore, ImmutableSet.of(STANDBY_CHANGELOG_SSP)));
+          ImmutableMap.of(STANDBY_TASK_NAME, ImmutableMap.of(TEST_STORE, ImmutableSet.of(STANDBY_CHANGELOG_SSP)));
       standbyWithSideInputSSPs = ImmutableMap.of(STANDBY_TASK_NAME_2,
-          ImmutableMap.of(testStore, ImmutableSet.of(STANDBY_CHANGELOG_SSP), sideInputStore, STANDBY_TASK_INPUT_SSP));
+          ImmutableMap.of(TEST_STORE, ImmutableSet.of(STANDBY_CHANGELOG_SSP), SIDE_INPUT_STORE, STANDBY_TASK_INPUT_SSP));
     }
   }
 }


### PR DESCRIPTION
**Summary**:
Standby feature is broken for jobs that don't have explicit side inputs
Change logged stores are treated as non-change logged for standby containers

**Description**:
[PR 1367](https://github.com/apache/samza/pull/1367) - Introduced a bug where jobs with no side inputs caused jobs to not bootstrap data for logged stores. The root cause was related to mutation of `taskSideInputStoreSSPs` as `changelogSSPs` that were added to it during initialization were ignored since the initialization of `hasSideInputs` happened before.

[PR 1491](https://github.com/apache/samza/pull/1491) - Introduced a bug where the logged stores were incorrectly classified as non-logged stores for standby container resulting in discarding of state at the end of container lifecycle. The root cause was similar to above where `sideInputStoreNames` was initialized prior to updating `changelogSSPs` 

**Changes**:
- Compute the final value for `taskSideInputStoreSSPS` as part of initialization
- Compute the final value for `sideInputStoresNames` as part of initialization
- Remove mutating side input related fields after initialization for standby flows

**Tests**:
- Added unit tests for new code
- Validated standby failover and bootstrap characteristics of failed over container
- Validated standby failover across both version of checkpoints (V1 and V2)

**API Changes**: None
**Usage Instructions**: None
**Upgrade Instructions**: None
