### PR TITLE
SAMZA-2749: Startpoint bug fix

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/startpoint/StartpointManager.java
+++ b/samza-core/src/main/java/org/apache/samza/startpoint/StartpointManager.java
@@ -354,6 +354,7 @@ public class StartpointManager {
         fanOuts.entrySet().removeIf(e -> ssps.contains(e.getKey()));
         if (fanOuts.isEmpty()) {
           removeFanOutForTask(taskName);
+          LOG.debug("Deleted the fanned out startpoint for the task {}", taskName);
         } else {
           try {
             fanOutStore.put(toFanOutStoreKey(taskName), objectMapper.writeValueAsBytes(fanOutPerTask));

--- a/samza-core/src/main/java/org/apache/samza/startpoint/StartpointManager.java
+++ b/samza-core/src/main/java/org/apache/samza/startpoint/StartpointManager.java
@@ -317,15 +317,55 @@ public class StartpointManager {
    * @return fanned out Startpoints
    */
   public Map<SystemStreamPartition, Startpoint> getFanOutForTask(TaskName taskName) throws IOException {
+    return getStartpointFanOutPerTask(taskName)
+        .map(startpointFanOutPerTask -> ImmutableMap.copyOf(startpointFanOutPerTask.getFanOuts())).orElse(ImmutableMap.of());
+  }
+
+  private Optional<StartpointFanOutPerTask> getStartpointFanOutPerTask(TaskName taskName) throws IOException {
     Preconditions.checkState(!stopped, "Underlying metadata store not available");
     Preconditions.checkNotNull(taskName, "TaskName cannot be null");
 
     byte[] fanOutBytes = fanOutStore.get(toFanOutStoreKey(taskName));
     if (ArrayUtils.isEmpty(fanOutBytes)) {
-      return ImmutableMap.of();
+      return Optional.empty();
     }
-    StartpointFanOutPerTask startpointFanOutPerTask = objectMapper.readValue(fanOutBytes, StartpointFanOutPerTask.class);
-    return ImmutableMap.copyOf(startpointFanOutPerTask.getFanOuts());
+    return Optional.of(objectMapper.readValue(fanOutBytes, StartpointFanOutPerTask.class));
+  }
+
+  /**
+   * Remove the fanned out startpoints for the specified the system stream partitions of the given task. This method
+   * allows to partially remove the fanned out startpoints for the given task.
+   *
+   * Remove the whole task fan out from the store if the fan outs of all system stream partitions of the task are
+   * removed. No action takes if not any specify system stream partition
+   *
+   * @param taskName to (partially) remove the fanned out startpoints for
+   * @param ssps to remove the fanned out startpoints for
+   */
+  public void removeFanOutForTaskSSPs(TaskName taskName, Set<SystemStreamPartition> ssps) {
+    Preconditions.checkState(!stopped, "Underlying metadata store not available");
+    Preconditions.checkNotNull(taskName, "TaskName cannot be null");
+    if (ssps == null || ssps.isEmpty()) {
+      return;
+    }
+    try {
+      getStartpointFanOutPerTask(taskName).ifPresent(fanOutPerTask -> {
+        Map<SystemStreamPartition, Startpoint> fanOuts = fanOutPerTask.getFanOuts();
+        fanOuts.entrySet().removeIf(e -> ssps.contains(e.getKey()));
+        if (fanOuts.isEmpty()) {
+          removeFanOutForTask(taskName);
+        } else {
+          try {
+            fanOutStore.put(toFanOutStoreKey(taskName), objectMapper.writeValueAsBytes(fanOutPerTask));
+          } catch (IOException e) {
+            throw new SamzaException(e);
+          }
+          fanOutStore.flush();
+        }
+      });
+    } catch (IOException e) {
+      throw new SamzaException(e);
+    }
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/startpoint/StartpointManager.java
+++ b/samza-core/src/main/java/org/apache/samza/startpoint/StartpointManager.java
@@ -354,17 +354,19 @@ public class StartpointManager {
         fanOuts.entrySet().removeIf(e -> ssps.contains(e.getKey()));
         if (fanOuts.isEmpty()) {
           removeFanOutForTask(taskName);
-          LOG.debug("Deleted the fanned out startpoint for the task {}", taskName);
+          LOG.debug("Deleted the fanned out startpoints for the task {}", taskName);
         } else {
           try {
             fanOutStore.put(toFanOutStoreKey(taskName), objectMapper.writeValueAsBytes(fanOutPerTask));
           } catch (IOException e) {
+            LOG.error("Can't update the fanned out startpoints for task {}", taskName, e);
             throw new SamzaException(e);
           }
           fanOutStore.flush();
         }
       });
     } catch (IOException e) {
+      LOG.error("Can't get the fanned out startpoints for task {}", taskName, e);
       throw new SamzaException(e);
     }
   }

--- a/samza-core/src/test/scala/org/apache/samza/checkpoint/TestOffsetManager.scala
+++ b/samza-core/src/test/scala/org/apache/samza/checkpoint/TestOffsetManager.scala
@@ -233,17 +233,18 @@ class TestOffsetManager {
     // Should get offset 45 back from the checkpoint manager, which is last processed, and system admin should return 46 as starting offset.
     assertTrue(startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName).containsKey(systemStreamPartition))
     checkpoint(offsetManager, taskName)
+    assertTrue(startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName).containsKey(systemStreamPartition)) // Startpoint should not delete if the partition's processed offset is not updated
+    assertEquals("45", offsetManager.offsetManagerMetrics.checkpointedOffsets.get(systemStreamPartition).getValue)
+
+    offsetManager.update(taskName, systemStreamPartition, "46")
+    offsetManager.update(taskName, systemStreamPartition, "47")
+    checkpoint(offsetManager, taskName)
     intercept[IllegalStateException] {
       // StartpointManager should stop after last fan out is removed
       startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName)
     }
     startpointManagerUtil.getStartpointManager.start
-    assertFalse(startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName).containsKey(systemStreamPartition)) // Startpoint should delete after checkpoint commit
-    assertEquals("45", offsetManager.offsetManagerMetrics.checkpointedOffsets.get(systemStreamPartition).getValue)
-    offsetManager.update(taskName, systemStreamPartition, "46")
-
-    offsetManager.update(taskName, systemStreamPartition, "47")
-    checkpoint(offsetManager, taskName)
+    assertFalse(startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName).containsKey(systemStreamPartition)) // Startpoint should not delete after checkpoint commit
     assertEquals("47", offsetManager.offsetManagerMetrics.checkpointedOffsets.get(systemStreamPartition).getValue)
 
     offsetManager.update(taskName, systemStreamPartition, "48")
@@ -426,12 +427,7 @@ class TestOffsetManager {
     offsetsToCheckpoint.put(unregisteredSystemStreamPartition, "50")
     offsetManager.writeCheckpoint(taskName, new CheckpointV1(offsetsToCheckpoint))
 
-    intercept[IllegalStateException] {
-      // StartpointManager should stop after last fan out is removed
-      startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName)
-    }
-    startpointManagerUtil.getStartpointManager.start
-    assertFalse(startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName).containsKey(systemStreamPartition)) // Startpoint be deleted at first checkpoint
+    assertTrue(startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName).containsKey(systemStreamPartition)) // Startpoint should not delete if the partition's processed offset is not updated
 
     assertEquals("45", offsetManager.offsetManagerMetrics.checkpointedOffsets.get(systemStreamPartition).getValue)
     assertEquals("100", offsetManager.offsetManagerMetrics.checkpointedOffsets.get(systemStreamPartition2).getValue)
@@ -445,6 +441,13 @@ class TestOffsetManager {
     offsetManager.update(taskName, systemStreamPartition, "46")
     offsetManager.update(taskName, systemStreamPartition, "47")
     checkpoint(offsetManager, taskName)
+    intercept[IllegalStateException] {
+      // StartpointManager should stop after last fan out is removed
+      startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName)
+    }
+    startpointManagerUtil.getStartpointManager.start
+    assertFalse(startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName).containsKey(systemStreamPartition)) // Startpoint should delete if the partition's processed offset is updated
+
     assertEquals("47", offsetManager.offsetManagerMetrics.checkpointedOffsets.get(systemStreamPartition).getValue)
     assertEquals("100", offsetManager.offsetManagerMetrics.checkpointedOffsets.get(systemStreamPartition2).getValue)
     assertEquals("47", consumer.recentCheckpoint.get(systemStreamPartition))
@@ -488,12 +491,8 @@ class TestOffsetManager {
     // Should get offset 45 back from the checkpoint manager, which is last processed, and system admin should return 46 as starting offset.
     assertTrue(startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName).containsKey(systemStreamPartition))
     checkpoint(offsetManager, taskName)
-    intercept[IllegalStateException] {
-      // StartpointManager should stop after last fan out is removed
-      startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName)
-    }
-    startpointManagerUtil.getStartpointManager.start
-    assertFalse(startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName).containsKey(systemStreamPartition)) // Startpoint be deleted at first checkpoint
+
+    assertTrue(startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName).containsKey(systemStreamPartition)) // Startpoint should not delete if the partition's processed offset is not updated
     assertEquals("45", offsetManager.offsetManagerMetrics.checkpointedOffsets.get(systemStreamPartition).getValue)
 
     offsetManager.update(taskName, systemStreamPartition, "46")
@@ -501,6 +500,12 @@ class TestOffsetManager {
     val checkpoint46 = offsetManager.getLastProcessedOffsets(taskName)
     offsetManager.update(taskName, systemStreamPartition, "47") // Offset updated before checkpoint
     offsetManager.writeCheckpoint(taskName, new CheckpointV1(checkpoint46))
+    intercept[IllegalStateException] {
+      // StartpointManager should stop after last fan out is removed
+      startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName)
+    }
+    startpointManagerUtil.getStartpointManager.start
+    assertFalse(startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName).containsKey(systemStreamPartition)) // Startpoint should delete if the partition's processed offset is updated
     assertEquals(Some("47"), offsetManager.getLastProcessedOffset(taskName, systemStreamPartition))
     assertEquals("46", offsetManager.offsetManagerMetrics.checkpointedOffsets.get(systemStreamPartition).getValue)
 
@@ -618,6 +623,66 @@ class TestOffsetManager {
 
     assertEquals(Some("47"), offsetManager.getLastProcessedOffset(taskName, systemStreamPartitionWithKeyBucket))
     assertEquals("47", offsetManager.offsetManagerMetrics.checkpointedOffsets.get(systemStreamPartitionWithKeyBucket).getValue)
+  }
+
+  @Test
+  def testStartpointUpdate: Unit = {
+    val taskName = new TaskName("c")
+    val systemStream = new SystemStream("test-system", "test-stream")
+    val partition0 = new Partition(0)
+    val partition1 = new Partition(1)
+    val systemStreamPartition0 = new SystemStreamPartition(systemStream, partition0)
+    val systemStreamPartition1 = new SystemStreamPartition(systemStream, partition1)
+//    val unregisteredSystemStreamPartition = new SystemStreamPartition(systemStream3, partition)
+    val testStreamMetadata = new SystemStreamMetadata(systemStream.getStream, Map(
+      partition0 -> new SystemStreamPartitionMetadata("0", "1", "2"),
+      partition1 -> new SystemStreamPartitionMetadata("0", "1", "2")).asJava)
+    val systemStreamMetadata = Map(systemStream -> testStreamMetadata)
+    val config = new MapConfig
+    val checkpointManager = getCheckpointManager1(new CheckpointV1(Map(systemStreamPartition0 -> "45", systemStreamPartition1 -> "100").asJava),
+      taskName)
+    val startpointManagerUtil = getStartpointManagerUtil()
+    val systemAdmins = mock(classOf[SystemAdmins])
+    when(systemAdmins.getSystemAdmin(systemStream.getSystem)).thenReturn(getSystemAdmin)
+    val offsetManager = OffsetManager(systemStreamMetadata, config, checkpointManager, startpointManagerUtil.getStartpointManager, systemAdmins, Map(), new OffsetManagerMetrics)
+    offsetManager.register(taskName, Set(systemStreamPartition0, systemStreamPartition1))
+    val startpoint0 = new StartpointOldest
+    val startpoint1 = new StartpointUpcoming
+    startpointManagerUtil.getStartpointManager.writeStartpoint(systemStreamPartition0, taskName, startpoint0)
+    startpointManagerUtil.getStartpointManager.writeStartpoint(systemStreamPartition1, taskName, startpoint1)
+    assertTrue(startpointManagerUtil.getStartpointManager.fanOut(asTaskToSSPMap(taskName, systemStreamPartition0, systemStreamPartition1)).keySet().contains(taskName))
+    offsetManager.start
+    assertTrue(startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName).containsKey(systemStreamPartition0))
+    assertTrue(startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName).containsKey(systemStreamPartition1))
+
+    checkpoint(offsetManager, taskName)
+    // Startpoint should not delete if the partition's processed offset is not updated
+    assertTrue(startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName).containsKey(systemStreamPartition0))
+    assertEquals(Option(startpoint0), offsetManager.getStartpoint(taskName, systemStreamPartition0))
+    // Startpoint should not delete if the partition's processed offset is not updated
+    assertTrue(startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName).containsKey(systemStreamPartition1))
+    assertEquals(Option(startpoint1), offsetManager.getStartpoint(taskName, systemStreamPartition1))
+
+    offsetManager.update(taskName, systemStreamPartition0, "46")
+    checkpoint(offsetManager, taskName)
+    // Startpoint should delete if the partition's processed offset is updated
+    assertFalse(startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName).containsKey(systemStreamPartition0))
+    assertTrue(offsetManager.getStartpoint(taskName, systemStreamPartition0).isEmpty)
+    // Startpoint should not delete if the partition's processed offset is not updated
+    assertTrue(startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName).containsKey(systemStreamPartition1))
+    assertEquals(Option(startpoint1), offsetManager.getStartpoint(taskName, systemStreamPartition1))
+
+    offsetManager.update(taskName, systemStreamPartition1, "101")
+    checkpoint(offsetManager, taskName)
+    intercept[IllegalStateException] {
+      // StartpointManager should stop after last fan out is removed
+      startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName)
+    }
+    startpointManagerUtil.getStartpointManager.start
+    // Startpoint should delete if the partition's processed offset is updated
+    assertTrue(startpointManagerUtil.getStartpointManager.getFanOutForTask(taskName).isEmpty)
+    assertTrue(offsetManager.getStartpoint(taskName, systemStreamPartition1).isEmpty)
+    startpointManagerUtil.stop
   }
 
   // Utility method to create and write checkpoint in one statement


### PR DESCRIPTION
**Symptom**: 
Using startpoints to trigger full bootstrapping is not reliable in the current implementation, we observed that the bootstrapping only happened on the part of expected partitions. 

**Cause**:
Within Samza (the main class to pay attention to is OffsetManager.scala), there is a bug in which a startpoint can be deleted before the startpoint actually gets used for message consumption. If a container gets into this situation, then the result is that the startpoint is ignored and consumption will continue from the previous processed message from before the startpoint was applied.
- Load last processed offsets and startpoints
- Use startpoints to register starting offsets for consumers
- Message processing starts, but messages for only some of the partitions are received
- Write checkpoint using last processed offsets
   - If a partition did not get messages, then the last processed offset is still the offset from before the standpoint.
- Delete startpoints
- Container dies (e.g. due to running out of memory)
- On restart, load last processed offsets (startpoints have been deleted)
   - The partitions that did have messages in the previous deployment will have the correct checkpoint.
   - The partitions that did not have messages will have the checkpoint set to the offset from before the startpoint was applied. This is unexpected, and it means that bootstrapping is not happening for this partition.

**Changes**:
- Keep track of the partitions which have updated processed offsets, and only delete the startpoint for those partitions after checkpointing.

**Tests**:
- Added new unit tests and modified the existing unit tests for the new logic
- Tested with a local Samza job locally and verified the startpoints are deleted properly

**API Changes**:
- Added a new API `removeFanOutForTaskSSPs` in StartpointManager to allow clean up the fan outs on partition granularity

**Upgrade Instructions**: None
**Usage Instructions**: None