### PR TITLE
SAMZA-2754: Set default scala suffix to 2.12

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 # under the License.
 group=org.apache.samza
 version=1.7.0-SNAPSHOT
-scalaSuffix=2.11
+scalaSuffix=2.12
 
 # after changing this value, run `$ ./gradlew wrapper` and commit the resulting changed files
 gradleVersion=5.2.1


### PR DESCRIPTION
We should set the default scala suffix to 2.12 since 2.11 is quite old at this point.