### PR TITLE
SAMZA-2755: Pin jdk to 8.0.232 (fix up rat / broken master build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java-version: [ 8.0.192, 8 ]
+        java-version: [ 8.0.232 ]
     steps:
       - name: Cache Gradle packages
         uses: actions/cache@v2


### PR DESCRIPTION
See: https://github.com/gradle/gradle/issues/9764 for additional details

For an example of how we might fix rat, see: https://github.com/apache/samza/pull/1619 (note that checkstyle, and maybe something else, also needs to be fixed)