### PR TITLE
Make StreamAppender extensible for sending event to SystemProducer

### DIFF
--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
@@ -416,7 +416,7 @@ public class StreamAppender extends AbstractAppender {
    * Helper method to send a serialized log-event to the systemProducer, and increment respective methods.
    * @param logQueueEntry the serialized log-event to be sent to the systemProducer
    */
-  private void sendEventToSystemProducer(EncodedLogEvent logQueueEntry) {
+  protected void sendEventToSystemProducer(EncodedLogEvent logQueueEntry) {
     metrics.logMessagesBytesSent.inc(logQueueEntry.getEntryValueSize());
     metrics.logMessagesCountSent.inc();
     systemProducer.send(SOURCE, decorateLogEvent(logQueueEntry));

--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
@@ -73,7 +73,7 @@ public class StreamAppender extends AbstractAppender {
   private final BlockingQueue<EncodedLogEvent> logQueue = new LinkedBlockingQueue<>(DEFAULT_QUEUE_SIZE);
 
   private SystemStream systemStream = null;
-  private SystemProducer systemProducer = null;
+  protected SystemProducer systemProducer = null;
   private String key = null;
   private byte[] keyBytes; // Serialize the key once, since we will use it for every event.
   private String containerName = null;

--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppenderMetrics.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppenderMetrics.java
@@ -43,9 +43,6 @@ public class StreamAppenderMetrics extends MetricsBase {
   /** The number of log messages sent out to SystemProducer. */
   public final Counter logMessagesCountSent;
 
-  /** The number of log messages cannot be sent out due to record too large. */
-  public final Counter largeMessagesErrors;
-
   public StreamAppenderMetrics(String prefix, MetricsRegistry registry) {
     super(prefix + "-", registry);
     bufferFillPct = newGauge("buffer-fill-percent", 0);
@@ -54,6 +51,5 @@ public class StreamAppenderMetrics extends MetricsBase {
     logMessagesErrors = newCounter("log-messages-errors");
     logMessagesBytesSent = newCounter("log-messages-bytes-sent");
     logMessagesCountSent = newCounter("log-messages-count-sent");
-    largeMessagesErrors = newCounter("large-messages-errors");
   }
 }

--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppenderMetrics.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppenderMetrics.java
@@ -43,6 +43,9 @@ public class StreamAppenderMetrics extends MetricsBase {
   /** The number of log messages sent out to SystemProducer. */
   public final Counter logMessagesCountSent;
 
+  /** The number of log messages cannot be sent out due to record too large. */
+  public final Counter largeMessagesErrors;
+
   public StreamAppenderMetrics(String prefix, MetricsRegistry registry) {
     super(prefix + "-", registry);
     bufferFillPct = newGauge("buffer-fill-percent", 0);
@@ -51,5 +54,6 @@ public class StreamAppenderMetrics extends MetricsBase {
     logMessagesErrors = newCounter("log-messages-errors");
     logMessagesBytesSent = newCounter("log-messages-bytes-sent");
     logMessagesCountSent = newCounter("log-messages-count-sent");
+    largeMessagesErrors = newCounter("large-messages-errors");
   }
 }


### PR DESCRIPTION
Issues: 
Currently, StreamAppender is not extensible in terms of setting systemProducer and exposing sendEventToSystemProducer to child classes. It also makes it hard for child classes out of package to unit test any logic related to systemProducer
 
Changes: Make StreamAppender extensible
    1.  Change method sendEventToSystemProducer from private to protected
    2. Change member variable systemProducer from private to protected
 
Tests Done:
gradle build