### PR TITLE
SAMZA-2741: [Pipeline Drain] Simplifying DrainUtils writeDrainNotification method and change tests

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
+++ b/samza-core/src/main/java/org/apache/samza/runtime/LocalApplicationRunner.java
@@ -220,7 +220,6 @@ public class LocalApplicationRunner implements ApplicationRunner {
 
     try {
       List<JobConfig> jobConfigs = planner.prepareJobs();
-
       // create the StreamProcessors
       if (jobConfigs.isEmpty()) {
         throw new SamzaException("No jobs to run.");


### PR DESCRIPTION
**Improvement:**

This PR is a part of the Pipeline Drain work and aims to improve `DrainUtils.writeDrainNotification` method which writes drain notifications to the metadata store. Currently, an external controller needs to supply the deployment id (runId).  The controller needs to have the knowledge of the current runId. For draining the current job, we should be able to retrieve the runId from the metadata store so it is not necessary for the caller of `DrainUtils.writeDrainNotification` to supply a runId for the current deployment.

**Changes:**

- Add a new method `DrainUtils.writeDrainNotification` which just takes the metadata store as the parameter. In cluster based deployments, configs (including the runId of a job) are written to the metadata store prior to starting the Job Coordinator. The method will read the configs from the metadata store, get the runId and use that to write a DrainNotification to the metadata store  corresponding to the runId.

**Tests:**

- Changes in Unit tests for `DrainMonitor`
- Changes in Integ test for Drain for High-level and Low-Level API- `DrainLowLevelApiIntegrationTest` & `DrainHighLevelApiIntegrationTest` 
