### PR TITLE
Update zookeeper and kazoo version

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -47,7 +47,7 @@
   slf4jVersion = "1.7.7"
   yarnVersion = "2.10.1"
   zkClientVersion = "0.11"
-  zookeeperVersion = "3.4.13"
+  zookeeperVersion = "3.6.3"
   failsafeVersion = "2.4.0"
   jlineVersion = "3.8.2"
   jnaVersion = "4.5.1"

--- a/samza-test/src/main/python/requirements.txt
+++ b/samza-test/src/main/python/requirements.txt
@@ -19,4 +19,4 @@ zopkio==0.2.5
 requests
 kafka-python==1.3.3
 Jinja2
-kazoo==2.5
+kazoo==2.8.0


### PR DESCRIPTION
Issues: We need to update the Zookeeper and Kazoo version to ensure the ZK client we are using is TLS compatible 

Changes:
Upgrade the dependency version

Tests: ./gradlew build 

API Changes: None

Upgrade Instructions: All current users of Samza should be able to continue using Samza as usual, there is nothing required for upgrading to this new version.

Usage Instructions: None