### PR TITLE
SAMZA-2762: new cpu usage metric which counts child processes usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -192,6 +192,9 @@ project(":samza-core_$scalaSuffix") {
     compile "org.scala-lang:scala-library:$scalaVersion"
     compile "org.slf4j:slf4j-api:$slf4jVersion"
     compile "net.jodah:failsafe:$failsafeVersion"
+    compile "com.github.oshi:oshi-core:$oshiVersion"
+    compile "net.java.dev.jna:jna:$jnaVersion"
+    compile "net.java.dev.jna:jna-platform:$jnaVersion"
     testCompile project(":samza-api").sourceSets.test.output
     testCompile "junit:junit:$junitVersion"
     testCompile "org.mockito:mockito-core:$mockitoVersion"

--- a/docs/learn/documentation/versioned/container/metrics-table.html
+++ b/docs/learn/documentation/versioned/container/metrics-table.html
@@ -216,6 +216,10 @@
         <td>Current work factor in use</td>
     </tr>
     <tr>
+        <td>total-process-cpu-usage</td>
+        <td>The process cpu usage percentage (in the [0, 100] interval) used by the Samza container process and all its child processes</td>
+    </tr>
+    <tr>
         <td>physical-memory-mb</td>
         <td>The physical memory used by the Samza container process (native + on heap) (in megabytes)</td>
     </tr>

--- a/docs/learn/documentation/versioned/operations/monitoring.md
+++ b/docs/learn/documentation/versioned/operations/monitoring.md
@@ -392,6 +392,7 @@ All \<system\>, \<stream\>, \<partition\>, \<store-name\>, \<topic\>, are popula
 | | disk-usage-bytes | Total disk space size used by key-value stores (in bytes). |
 | | disk-quota-bytes | Disk memory usage quota for key-value stores (in bytes). |
 | | executor-work-factor | The work factor of the run loop. A work factor of 1 indicates full throughput, while a work factor of less than 1 will introduce delays into the execution to approximate the requested work factor. The work factor is set by the disk space monitor in accordance with the disk quota policy. Given the latest percentage of available disk quota, this policy returns the work factor that should be applied. |
+| | total-process-cpu-usage | The process cpu usage percentage (in the [0, 100] interval) used by the Samza container process and all its child processes. |
 | | physical-memory-mb | The physical memory used by the Samza container process (native + on heap) (in MBs). |
 | | physical-memory-utilization | The ratio between the physical memory used by the Samza container process (native + on heap) and the total physical memory of the Samza container. |
 | | container-thread-pool-size | The current size of a Samza container's thread pool. It may or may not be the same as job.container.thread.pool.size, depending on the implementation. |

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -50,8 +50,9 @@
   zookeeperVersion = "3.6.3"
   failsafeVersion = "2.4.0"
   jlineVersion = "3.8.2"
-  jnaVersion = "4.5.1"
+  jnaVersion = "5.12.1"
   couchbaseClientVersion = "2.7.2"
   couchbaseMockVersion = "1.5.22"
   yarn3Version = "3.3.4"
+  oshiVersion = "6.3.0"
 }

--- a/samza-core/src/main/java/org/apache/samza/container/host/DefaultSystemStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/DefaultSystemStatisticsGetter.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.container.host;
+
+import com.google.common.annotations.VisibleForTesting;
+
+
+/**
+ * An default implementation of {@link SystemStatisticsGetter} that relies on {@link PosixCommandBasedStatisticsGetter}
+ * and {@link OshiBasedStatisticsGetter} implementations
+ */
+public class DefaultSystemStatisticsGetter implements SystemStatisticsGetter {
+
+  private final OshiBasedStatisticsGetter oshiBasedStatisticsGetter;
+  private final PosixCommandBasedStatisticsGetter posixCommandBasedStatisticsGetter;
+
+  public DefaultSystemStatisticsGetter() {
+    this(new OshiBasedStatisticsGetter(), new PosixCommandBasedStatisticsGetter());
+  }
+
+  @VisibleForTesting
+  DefaultSystemStatisticsGetter(OshiBasedStatisticsGetter oshiBasedStatisticsGetter,
+      PosixCommandBasedStatisticsGetter posixCommandBasedStatisticsGetter) {
+    this.oshiBasedStatisticsGetter = oshiBasedStatisticsGetter;
+    this.posixCommandBasedStatisticsGetter = posixCommandBasedStatisticsGetter;
+  }
+
+  @Override
+  public SystemMemoryStatistics getSystemMemoryStatistics() {
+    return posixCommandBasedStatisticsGetter.getSystemMemoryStatistics();
+  }
+
+  @Override
+  public ProcessCPUStatistics getProcessCPUStatistics() {
+    return oshiBasedStatisticsGetter.getProcessCPUStatistics();
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/container/host/DefaultSystemStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/DefaultSystemStatisticsGetter.java
@@ -26,7 +26,6 @@ import com.google.common.annotations.VisibleForTesting;
  * and {@link OshiBasedStatisticsGetter} implementations
  */
 public class DefaultSystemStatisticsGetter implements SystemStatisticsGetter {
-
   private final OshiBasedStatisticsGetter oshiBasedStatisticsGetter;
   private final PosixCommandBasedStatisticsGetter posixCommandBasedStatisticsGetter;
 

--- a/samza-core/src/main/java/org/apache/samza/container/host/OshiBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/OshiBasedStatisticsGetter.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.container.host;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.NotImplementedException;
+import oshi.SystemInfo;
+import oshi.software.os.OSProcess;
+import oshi.software.os.OperatingSystem;
+
+
+/**
+ * An implementation of {@link SystemStatisticsGetter} that relies on using oshi framework(https://www.oshi.ooo/)
+ */
+public class OshiBasedStatisticsGetter implements SystemStatisticsGetter {
+  // the snapshots of current JVM process and its child processes
+  private final Map<Integer, OSProcess> previousProcessSnapshots = new HashMap<>();
+
+  private final OperatingSystem os;
+  private final int cpuCount;
+
+  public OshiBasedStatisticsGetter() {
+    this(new SystemInfo());
+  }
+
+  @VisibleForTesting
+  OshiBasedStatisticsGetter(SystemInfo si) {
+    this(si.getOperatingSystem(), si.getHardware().getProcessor().getPhysicalProcessorCount());
+  }
+
+  @VisibleForTesting
+  OshiBasedStatisticsGetter(OperatingSystem os, int cpuCount) {
+    this.os = os;
+    this.cpuCount = cpuCount;
+  }
+
+  @Override
+  public SystemMemoryStatistics getSystemMemoryStatistics() {
+    throw new NotImplementedException("Not implemented");
+  }
+
+  @Override
+  public ProcessCPUStatistics getProcessCPUStatistics() {
+    final List<OSProcess> currentProcessAndChildProcesses = getCurrentProcessAndChildProcesses();
+    final double totalCPUUsage = getTotalCPUUsage(currentProcessAndChildProcesses);
+    refreshProcessSnapshots(currentProcessAndChildProcesses);
+    return new ProcessCPUStatistics(100d * totalCPUUsage / cpuCount);
+  }
+
+  private List<OSProcess> getCurrentProcessAndChildProcesses() {
+    final List<OSProcess> processes = new ArrayList<>();
+    // get current process
+    processes.add(os.getProcess(os.getProcessId()));
+    // get all child processes of current process
+    processes.addAll(os.getChildProcesses(os.getProcessId(), OperatingSystem.ProcessFiltering.ALL_PROCESSES,
+        OperatingSystem.ProcessSorting.NO_SORTING, 0));
+    return processes;
+  }
+
+  private double getTotalCPUUsage(List<OSProcess> processes) {
+    return processes.stream()
+        .mapToDouble(p -> p.getProcessCpuLoadBetweenTicks(previousProcessSnapshots.get(p.getProcessID())))
+        .sum();
+  }
+
+  private void refreshProcessSnapshots(List<OSProcess> processes) {
+    previousProcessSnapshots.clear();
+    processes.forEach(p -> previousProcessSnapshots.put(p.getProcessID(), p));
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/container/host/OshiBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/OshiBasedStatisticsGetter.java
@@ -50,7 +50,7 @@ public class OshiBasedStatisticsGetter implements SystemStatisticsGetter {
 
   @VisibleForTesting
   OshiBasedStatisticsGetter(SystemInfo si) {
-    this(si.getOperatingSystem(), si.getHardware().getProcessor().getPhysicalProcessorCount());
+    this(si.getOperatingSystem(), si.getHardware().getProcessor().getLogicalProcessorCount());
   }
 
   @VisibleForTesting

--- a/samza-core/src/main/java/org/apache/samza/container/host/OshiBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/OshiBasedStatisticsGetter.java
@@ -40,7 +40,7 @@ import oshi.software.os.OperatingSystem;
  */
 @NotThreadSafe
 public class OshiBasedStatisticsGetter implements SystemStatisticsGetter {
-  private static final Logger logger = LoggerFactory.getLogger(OshiBasedStatisticsGetter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(OshiBasedStatisticsGetter.class);
   // the snapshots of current JVM process and its child processes
   private final Map<Integer, OSProcess> previousProcessSnapshots = new HashMap<>();
 
@@ -75,7 +75,7 @@ public class OshiBasedStatisticsGetter implements SystemStatisticsGetter {
       refreshProcessSnapshots(currentProcessAndChildProcesses);
       return new ProcessCPUStatistics(100d * totalCPUUsage / cpuCount);
     } catch (Exception e) {
-      logger.warn("Error when running oshi: ", e);
+      LOGGER.warn("Error when running oshi: ", e);
       return null;
     }
   }

--- a/samza-core/src/main/java/org/apache/samza/container/host/OshiBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/OshiBasedStatisticsGetter.java
@@ -23,15 +23,20 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang3.NotImplementedException;
 import oshi.SystemInfo;
+import oshi.annotation.concurrent.NotThreadSafe;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OperatingSystem;
 
 
 /**
  * An implementation of {@link SystemStatisticsGetter} that relies on using oshi framework(https://www.oshi.ooo/)
+ *
+ * This class captures the recent cpu usage percentage(in the [0, 100] interval) used by the Samza container process and
+ * its child processes. It gets CPU usage of this process since a previous snapshot of the same process, the snapshot is
+ * triggered by last poll, have polling interval of at least a few seconds is recommended.
  */
+@NotThreadSafe
 public class OshiBasedStatisticsGetter implements SystemStatisticsGetter {
   // the snapshots of current JVM process and its child processes
   private final Map<Integer, OSProcess> previousProcessSnapshots = new HashMap<>();
@@ -56,7 +61,7 @@ public class OshiBasedStatisticsGetter implements SystemStatisticsGetter {
 
   @Override
   public SystemMemoryStatistics getSystemMemoryStatistics() {
-    throw new NotImplementedException("Not implemented");
+    throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override

--- a/samza-core/src/main/java/org/apache/samza/container/host/OshiBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/OshiBasedStatisticsGetter.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import oshi.SystemInfo;
 import oshi.annotation.concurrent.NotThreadSafe;
 import oshi.software.os.OSProcess;
@@ -38,6 +40,7 @@ import oshi.software.os.OperatingSystem;
  */
 @NotThreadSafe
 public class OshiBasedStatisticsGetter implements SystemStatisticsGetter {
+  private static final Logger logger = LoggerFactory.getLogger(OshiBasedStatisticsGetter.class);
   // the snapshots of current JVM process and its child processes
   private final Map<Integer, OSProcess> previousProcessSnapshots = new HashMap<>();
 
@@ -66,10 +69,15 @@ public class OshiBasedStatisticsGetter implements SystemStatisticsGetter {
 
   @Override
   public ProcessCPUStatistics getProcessCPUStatistics() {
-    final List<OSProcess> currentProcessAndChildProcesses = getCurrentProcessAndChildProcesses();
-    final double totalCPUUsage = getTotalCPUUsage(currentProcessAndChildProcesses);
-    refreshProcessSnapshots(currentProcessAndChildProcesses);
-    return new ProcessCPUStatistics(100d * totalCPUUsage / cpuCount);
+    try {
+      final List<OSProcess> currentProcessAndChildProcesses = getCurrentProcessAndChildProcesses();
+      final double totalCPUUsage = getTotalCPUUsage(currentProcessAndChildProcesses);
+      refreshProcessSnapshots(currentProcessAndChildProcesses);
+      return new ProcessCPUStatistics(100d * totalCPUUsage / cpuCount);
+    } catch (Exception e) {
+      logger.warn("Error when running oshi: ", e);
+      return null;
+    }
   }
 
   private List<OSProcess> getCurrentProcessAndChildProcesses() {

--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -18,16 +18,14 @@
  */
 package org.apache.samza.container.host;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import org.apache.commons.lang3.NotImplementedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An implementation of {@link SystemStatisticsGetter} that relies on using Posix commands like ps.
@@ -89,7 +87,7 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
 
   @Override
   public ProcessCPUStatistics getProcessCPUStatistics() {
-    throw new NotImplementedException(
+    throw new UnsupportedOperationException(
         "No appropriate Posix command available for getting recent CPU usage information. For example, the CPU information exposed by ps command 'ps -o %cpu= -p <PID>' represents the percentage of time spent running during the entire lifetime of a process not for the recent CPU usage");
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/PosixCommandBasedStatisticsGetter.java
@@ -21,6 +21,7 @@ package org.apache.samza.container.host;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,5 +85,11 @@ public class PosixCommandBasedStatisticsGetter implements SystemStatisticsGetter
       log.warn("Error when running ps: ", e);
       return null;
     }
+  }
+
+  @Override
+  public ProcessCPUStatistics getProcessCPUStatistics() {
+    throw new NotImplementedException(
+        "No appropriate Posix command available for getting recent CPU usage information. For example, the CPU information exposed by ps command 'ps -o %cpu= -p <PID>' represents the percentage of time spent running during the entire lifetime of a process not for the recent CPU usage");
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/container/host/ProcessCPUStatistics.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/ProcessCPUStatistics.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.container.host;
+
+import java.util.Objects;
+
+
+/**
+ * A {@link ProcessCPUStatistics} object represents recent CPU usage percentage about the container process(including its child processes)
+ */
+public class ProcessCPUStatistics {
+
+  /**
+   * The CPU used by the Samza container process(including its child processes) in percentage.
+   */
+  private final double processCPUUsagePercentage;
+
+  ProcessCPUStatistics(double processCpuUsagePercentage) {
+    this.processCPUUsagePercentage = processCpuUsagePercentage;
+  }
+
+  public double getProcessCPUUsagePercentage() {
+    return processCPUUsagePercentage;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ProcessCPUStatistics that = (ProcessCPUStatistics) o;
+    return Double.compare(that.processCPUUsagePercentage, processCPUUsagePercentage) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(processCPUUsagePercentage);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessCPUStatistics{" + "processCPUUsagePercentage=" + processCPUUsagePercentage + '}';
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/container/host/SystemStatistics.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/SystemStatistics.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.container.host;
+
+import java.util.Objects;
+
+/**
+ * A {@link SystemStatistics} object represents system related information about the physical process that runs the
+ * {@link org.apache.samza.container.SamzaContainer}.
+ */
+public class SystemStatistics {
+
+  private final ProcessCPUStatistics cpuStatistics;
+  private final SystemMemoryStatistics memoryStatistics;
+
+  public SystemStatistics(ProcessCPUStatistics cpuStatistics, SystemMemoryStatistics memoryStatistics) {
+    this.cpuStatistics = cpuStatistics;
+    this.memoryStatistics = memoryStatistics;
+  }
+
+  public ProcessCPUStatistics getCpuStatistics() {
+    return cpuStatistics;
+  }
+
+  public SystemMemoryStatistics getMemoryStatistics() {
+    return memoryStatistics;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SystemStatistics that = (SystemStatistics) o;
+    return Objects.equals(cpuStatistics, that.cpuStatistics) && Objects.equals(memoryStatistics, that.memoryStatistics);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(cpuStatistics, memoryStatistics);
+  }
+
+  @Override
+  public String toString() {
+    return "SystemStatistics{" + "cpuStatistics=" + cpuStatistics + ", memoryStatistics=" + memoryStatistics + '}';
+  }
+}

--- a/samza-core/src/main/java/org/apache/samza/container/host/SystemStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/SystemStatisticsGetter.java
@@ -32,7 +32,8 @@ public interface SystemStatisticsGetter {
   SystemMemoryStatistics getSystemMemoryStatistics();
 
   /**
-   * Returns the {@link ProcessCPUStatistics} for the current Samza container process(includes its child processes)
+   * Returns the {@link ProcessCPUStatistics} for the current Samza container process(includes its child processes). A
+   * 'null' value is returned if no statistics are available.
    *
    * @return {@link ProcessCPUStatistics} for the Samza container process
    */

--- a/samza-core/src/main/java/org/apache/samza/container/host/SystemStatisticsGetter.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/SystemStatisticsGetter.java
@@ -30,4 +30,11 @@ public interface SystemStatisticsGetter {
    * @return {@link SystemMemoryStatistics} for the Samza container
    */
   SystemMemoryStatistics getSystemMemoryStatistics();
+
+  /**
+   * Returns the {@link ProcessCPUStatistics} for the current Samza container process(includes its child processes)
+   *
+   * @return {@link ProcessCPUStatistics} for the Samza container process
+   */
+  ProcessCPUStatistics getProcessCPUStatistics();
 }

--- a/samza-core/src/main/java/org/apache/samza/container/host/SystemStatisticsMonitor.java
+++ b/samza-core/src/main/java/org/apache/samza/container/host/SystemStatisticsMonitor.java
@@ -54,7 +54,7 @@ public interface SystemStatisticsMonitor {
      *
      * @param sample the currently sampled statistic.
      */
-    void onUpdate(SystemMemoryStatistics sample);
+    void onUpdate(SystemStatistics sample);
   }
 
 }

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -35,7 +35,7 @@ import org.apache.samza.clustermanager.StandbyTaskUtil
 import org.apache.samza.config.{StreamConfig, _}
 import org.apache.samza.container.disk.DiskSpaceMonitor.Listener
 import org.apache.samza.container.disk.{DiskQuotaPolicyFactory, DiskSpaceMonitor, NoThrottlingDiskQuotaPolicyFactory, PollingScanDiskSpaceMonitor}
-import org.apache.samza.container.host.{StatisticsMonitorImpl, SystemMemoryStatistics, SystemStatisticsMonitor}
+import org.apache.samza.container.host.{StatisticsMonitorImpl, SystemMemoryStatistics, SystemStatistics, SystemStatisticsMonitor}
 import org.apache.samza.context._
 import org.apache.samza.diagnostics.DiagnosticsManager
 import org.apache.samza.drain.DrainMonitor.DrainCallback

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
@@ -49,6 +49,7 @@ class SamzaContainerMetrics(
   val executorWorkFactor = newGauge("executor-work-factor", 1.0)
   val physicalMemoryMb = newGauge("physical-memory-mb", 0.0F)
   val physicalMemoryUtilization = newGauge("physical-memory-utilization", 0.0F)
+  val totalProcessCpuUsage = newGauge("total-process-cpu-usage", 0.0)
   val containerThreadPoolSize = newGauge("container-thread-pool-size", 0L)
   val containerActiveThreads = newGauge("container-active-threads", 0L)
 

--- a/samza-core/src/test/java/org/apache/samza/container/host/TestDefaultSystemStatisticsGetter.java
+++ b/samza-core/src/test/java/org/apache/samza/container/host/TestDefaultSystemStatisticsGetter.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.container.host;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.*;
+
+
+public class TestDefaultSystemStatisticsGetter {
+
+  @Mock
+  private OshiBasedStatisticsGetter oshiBasedStatisticsGetter;
+  @Mock
+  private PosixCommandBasedStatisticsGetter posixCommandBasedStatisticsGetter;
+
+  private DefaultSystemStatisticsGetter defaultSystemStatisticsGetter;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+    this.defaultSystemStatisticsGetter =
+        new DefaultSystemStatisticsGetter(oshiBasedStatisticsGetter, posixCommandBasedStatisticsGetter);
+  }
+
+  @Test
+  public void testGetSystemMemoryStatistics() {
+    defaultSystemStatisticsGetter.getSystemMemoryStatistics();
+    verify(posixCommandBasedStatisticsGetter).getSystemMemoryStatistics();
+  }
+
+  @Test
+  public void testGetProcessCPUStatistics() {
+    defaultSystemStatisticsGetter.getProcessCPUStatistics();
+    verify(oshiBasedStatisticsGetter).getProcessCPUStatistics();
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/container/host/TestOshiBasedStatisticsGetter.java
+++ b/samza-core/src/test/java/org/apache/samza/container/host/TestOshiBasedStatisticsGetter.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.container.host;
+
+import com.google.common.collect.Lists;
+import org.apache.commons.lang3.NotImplementedException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import oshi.software.os.OSProcess;
+import oshi.software.os.OperatingSystem;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+
+public class TestOshiBasedStatisticsGetter {
+
+  @Mock
+  private OperatingSystem os;
+  @Mock
+  private OSProcess process;
+  @Mock
+  private OSProcess childProcess;
+  @Mock
+  private OSProcess processSnapshot;
+  @Mock
+  private OSProcess childProcessSnapshot;
+
+  private final int pid = 10001;
+  private final int childPid = 10002;
+  private final int cpuCount = 2;
+
+  private OshiBasedStatisticsGetter oshiBasedStatisticsGetter;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+
+    when(process.getProcessID()).thenReturn(pid);
+    when(processSnapshot.getProcessID()).thenReturn(pid);
+    when(childProcess.getProcessID()).thenReturn(childPid);
+    when(childProcessSnapshot.getProcessID()).thenReturn(childPid);
+
+    when(os.getProcessId()).thenReturn(pid);
+
+    oshiBasedStatisticsGetter = new OshiBasedStatisticsGetter(os, cpuCount);
+  }
+
+  @Test
+  public void testGetProcessCPUStatistics() {
+    // first time to get cpu usage info
+    double processCpuUsage1 = 0.5;
+    double childProcessCPUUsage1 = 0.3;
+    when(os.getProcess(pid)).thenReturn(processSnapshot);
+    when(os.getProcess(childPid)).thenReturn(childProcessSnapshot);
+    when(os.getChildProcesses(pid, OperatingSystem.ProcessFiltering.ALL_PROCESSES,
+        OperatingSystem.ProcessSorting.NO_SORTING, 0)).thenReturn(Lists.newArrayList(childProcessSnapshot));
+    when(processSnapshot.getProcessCpuLoadBetweenTicks(null)).thenReturn(processCpuUsage1);
+    when(childProcessSnapshot.getProcessCpuLoadBetweenTicks(null)).thenReturn(childProcessCPUUsage1);
+    assertEquals(new ProcessCPUStatistics(100d * (processCpuUsage1 + childProcessCPUUsage1) / cpuCount),
+        oshiBasedStatisticsGetter.getProcessCPUStatistics());
+
+    // second time to get cpu usage info
+    double processCpuUsage2 = 0.2;
+    double childProcessCPUUsage2 = 2;
+    when(os.getProcess(pid)).thenReturn(process);
+    when(os.getProcess(childPid)).thenReturn(childProcess);
+    when(os.getChildProcesses(pid, OperatingSystem.ProcessFiltering.ALL_PROCESSES,
+        OperatingSystem.ProcessSorting.NO_SORTING, 0)).thenReturn(Lists.newArrayList(childProcess));
+    when(process.getProcessCpuLoadBetweenTicks(processSnapshot)).thenReturn(processCpuUsage2);
+    when(childProcess.getProcessCpuLoadBetweenTicks(childProcessSnapshot)).thenReturn(childProcessCPUUsage2);
+    assertEquals(new ProcessCPUStatistics(100d * (processCpuUsage2 + childProcessCPUUsage2) / cpuCount),
+        oshiBasedStatisticsGetter.getProcessCPUStatistics());
+  }
+
+  @Test(expected = NotImplementedException.class)
+  public void testGetSystemMemoryStatistics() {
+    oshiBasedStatisticsGetter.getSystemMemoryStatistics();
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/container/host/TestOshiBasedStatisticsGetter.java
+++ b/samza-core/src/test/java/org/apache/samza/container/host/TestOshiBasedStatisticsGetter.java
@@ -19,7 +19,6 @@
 package org.apache.samza.container.host;
 
 import com.google.common.collect.Lists;
-import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -32,7 +31,6 @@ import static org.mockito.Mockito.*;
 
 
 public class TestOshiBasedStatisticsGetter {
-
   @Mock
   private OperatingSystem os;
   @Mock
@@ -91,7 +89,7 @@ public class TestOshiBasedStatisticsGetter {
         oshiBasedStatisticsGetter.getProcessCPUStatistics());
   }
 
-  @Test(expected = NotImplementedException.class)
+  @Test(expected = UnsupportedOperationException.class)
   public void testGetSystemMemoryStatistics() {
     oshiBasedStatisticsGetter.getSystemMemoryStatistics();
   }


### PR DESCRIPTION
# Symptom

We have observed that some use cases used quasar(TensorFlow framework) to do model inference and this framework spawn child processes(non-JVM) to run TensorFlow serving. These child processes were using high CPU usage(200%) however their CPU usage can't be captured by the existing CPU usage metric `process-cpu-usage`

# Cause

The existing metric `process-cpu-usage` metric was designed for capturing the [CPU usage for the JVM process](https://samza.apache.org/learn/documentation/1.6.0/operations/monitoring.html) only, it can't count the child processes(especially for non-JVM processes) usage.

# Changes

- Reply on [oshi framwork](https://www.oshi.ooo/) to capture the CPU usage for the JVM process and all its child processes, and create a new metric to display the total CPU usage.
- The CPU usage percentage is calculated based on top of the logical CPU count on the system

# API Changes

- Added a new metric `total-process-cpu-usage` in `SamzaContainerMetrics` which is similar with [how we provided `physical-memory-mb` metric](https://github.com/apache/samza/pull/1530)

# Tests

- Unit tests
- Tested with `samza-hello-samza` and verify the metric data points
![Screen Shot 2022-10-25 at 10 23 58 PM](https://user-images.githubusercontent.com/59407935/197942249-21dae598-7e18-4bb0-88e5-6a752ca49765.png)
