### PR TITLE
SAMZA-2741: [Pipeline Drain] Fix processing of Drain messages for High-Level and Low-level API

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
+++ b/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -91,6 +90,8 @@ public class RunLoop implements Runnable, Throttleable {
   private volatile boolean runLoopResumedSinceLastChecked;
   private final int elasticityFactor;
   private final String runId;
+
+  private final boolean isHighLevelApiJob;
   private boolean isDraining = false;
 
   public RunLoop(Map<TaskName, RunLoopTask> runLoopTasks,
@@ -106,7 +107,7 @@ public class RunLoop implements Runnable, Throttleable {
       HighResolutionClock clock,
       boolean isAsyncCommitEnabled) {
     this(runLoopTasks, threadPool, consumerMultiplexer, maxConcurrency, windowMs, commitMs, callbackTimeoutMs,
-        maxThrottlingDelayMs, maxIdleMs, containerMetrics, clock, isAsyncCommitEnabled, 1, null);
+        maxThrottlingDelayMs, maxIdleMs, containerMetrics, clock, isAsyncCommitEnabled, 1, null, false);
   }
 
   public RunLoop(Map<TaskName, RunLoopTask> runLoopTasks,
@@ -122,7 +123,8 @@ public class RunLoop implements Runnable, Throttleable {
       HighResolutionClock clock,
       boolean isAsyncCommitEnabled,
       int elasticityFactor,
-      String runId) {
+      String runId,
+      boolean isHighLevelApiJob) {
 
     this.threadPool = threadPool;
     this.consumerMultiplexer = consumerMultiplexer;
@@ -141,23 +143,26 @@ public class RunLoop implements Runnable, Throttleable {
     // assign runId before creating workers. As the inner AsyncTaskWorker class is not static, it relies on
     // the outer class fields to be init first
     this.runId = runId;
+    this.isHighLevelApiJob = isHighLevelApiJob;
+    this.isAsyncCommitEnabled = isAsyncCommitEnabled;
+    this.elasticityFactor = elasticityFactor;
+
     Map<TaskName, AsyncTaskWorker>  workers = new HashMap<>();
     for (RunLoopTask task : runLoopTasks.values()) {
       workers.put(task.taskName(), new AsyncTaskWorker(task));
     }
     // Partions and tasks assigned to the container will not change during the run loop life time
     this.sspToTaskWorkerMapping = Collections.unmodifiableMap(getSspToAsyncTaskWorkerMap(runLoopTasks, workers));
-
     this.taskWorkers = Collections.unmodifiableList(new ArrayList<>(workers.values()));
-    this.isAsyncCommitEnabled = isAsyncCommitEnabled;
-    this.elasticityFactor = elasticityFactor;
   }
 
   /**
    * Sets the RunLoop to drain mode.
    * */
   private void drain() {
+    log.info("Setting the RunLoop to drain mode.");
     isDraining = true;
+    log.debug("Disabling async commit when the pipeline is draining.");
     isAsyncCommitEnabled = false;
   }
 
@@ -480,7 +485,7 @@ public class RunLoop implements Runnable, Throttleable {
       this.task = task;
       this.callbackManager = new TaskCallbackManager(this, callbackTimer, callbackTimeoutMs, maxConcurrency, clock);
       Set<SystemStreamPartition> sspSet = getWorkingSSPSet(task);
-      this.state = new AsyncTaskState(task.taskName(), task.metrics(), sspSet, !task.intermediateStreams().isEmpty(),
+      this.state = new AsyncTaskState(task.taskName(), task.metrics(), sspSet, !task.intermediateStreams().isEmpty(), isHighLevelApiJob,
           runId);
     }
 
@@ -841,16 +846,18 @@ public class RunLoop implements Runnable, Throttleable {
     private final TaskName taskName;
     private final TaskInstanceMetrics taskMetrics;
     private final boolean hasIntermediateStreams;
+    private final boolean isHighLevelApiJob;
     private final String runId;
 
     AsyncTaskState(TaskName taskName, TaskInstanceMetrics taskMetrics, Set<SystemStreamPartition> sspSet,
-        boolean hasIntermediateStreams, String runId) {
+        boolean hasIntermediateStreams, boolean isHighLevelApiJob, String runId) {
       this.taskName = taskName;
       this.taskMetrics = taskMetrics;
       this.pendingEnvelopeQueue = new ArrayDeque<>();
       this.processingSspSet = sspSet;
       this.processingSspSetToDrain = new HashSet<>(sspSet);
       this.hasIntermediateStreams = hasIntermediateStreams;
+      this.isHighLevelApiJob = isHighLevelApiJob;
       this.runId = runId;
     }
 
@@ -875,50 +882,39 @@ public class RunLoop implements Runnable, Throttleable {
         return false;
       }
 
-      if (!pendingEnvelopeQueue.isEmpty()) {
-        PendingEnvelope pendingEnvelope = pendingEnvelopeQueue.peek();
-        IncomingMessageEnvelope envelope = pendingEnvelope.envelope;
+      if (pendingEnvelopeQueue.size() > 0) {
+        final PendingEnvelope pendingEnvelope = pendingEnvelopeQueue.peek();
+        final IncomingMessageEnvelope envelope = pendingEnvelope.envelope;
 
         if (envelope.isDrain()) {
           final DrainMessage message = (DrainMessage) envelope.getMessage();
           if (!message.getRunId().equals(runId)) {
-            // Removing the drain message from the pending queue as it doesn't match with the current runId
-            // Removing it will ensure that it is not picked up by process()
-            pendingEnvelopeQueue.remove();
+            // Removing the drain message from the pending queue as it doesn't match with the current deployment
+            final PendingEnvelope discardedDrainMessage = pendingEnvelopeQueue.remove();
+            consumerMultiplexer.tryUpdate(discardedDrainMessage.envelope.getSystemStreamPartition());
           } else {
+            // Found drain message matching the current deployment
+
             // set the RunLoop to drain mode
             if (!isDraining) {
               drain();
             }
 
-            if (elasticityFactor <= 1) {
-              SystemStreamPartition ssp = envelope.getSystemStreamPartition();
-              processingSspSetToDrain.remove(ssp);
-            } else {
-              // SystemConsumers will write only one envelope (enclosing DrainMessage) per SSP in its buffer.
-              // This envelope doesn't have keybucket info it's SSP. With elasticity, the same SSP can be processed by
-              // multiple tasks. Therefore, if envelope contains drain message, the ssp of envelope should be removed
-              // from task's processing set irrespective of keyBucket.
-              SystemStreamPartition sspOfEnvelope = envelope.getSystemStreamPartition();
-              Optional<SystemStreamPartition> ssp = processingSspSetToDrain.stream()
-                  .filter(sspInSet -> sspInSet.getSystemStream().equals(sspOfEnvelope.getSystemStream())
-                      && sspInSet.getPartition().equals(sspOfEnvelope.getPartition()))
-                  .findFirst();
-              ssp.ifPresent(processingSspSetToDrain::remove);
-            }
+            if (!isHighLevelApiJob) {
+              // The flow below only applies to samza low-level API
 
-            if (!hasIntermediateStreams) {
-              // Don't remove from the pending queue as we want the DAG to pick up Drain message and propagate it to
-              // intermediate streams
+              // For high-level API, we do not remove the message from pending queue.
+              // It will be picked by the process flow instead of drain flow, as we want the drain control message
+              // to be processed by the High-level API Operator DAG.
+
+              processingSspSetToDrain.remove(envelope.getSystemStreamPartition());
               pendingEnvelopeQueue.remove();
             }
           }
         }
-        return processingSspSetToDrain.isEmpty();
       }
-      // if no messages are in the queue, the task has probably already drained or there are no messages from
-      // the chooser
-      return false;
+
+      return processingSspSetToDrain.isEmpty();
     }
 
     /**

--- a/samza-core/src/main/java/org/apache/samza/container/RunLoopFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/container/RunLoopFactory.java
@@ -42,7 +42,8 @@ public class RunLoopFactory {
       TaskConfig taskConfig,
       HighResolutionClock clock,
       int elasticityFactor,
-      String runId) {
+      String runId,
+      boolean isHighLevelApiJob) {
 
     long taskWindowMs = taskConfig.getWindowMs();
 
@@ -84,6 +85,7 @@ public class RunLoopFactory {
       clock,
       isAsyncCommitEnabled,
       elasticityFactor,
-      runId);
+      runId,
+      isHighLevelApiJob);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/ControlMessageSender.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/ControlMessageSender.java
@@ -67,6 +67,8 @@ class ControlMessageSender {
     int currentPartition = ssp.getPartition().getPartitionId();
     for (int i = 0; i < partitionCount; i++) {
       if (i != currentPartition) {
+        LOG.debug(String.format("Broadcast %s message from task %s to %s partition %d for aggregation",
+            MessageType.of(message).name(), message.getTaskName(), systemStream, i));
         OutgoingMessageEnvelope envelopeOut = new OutgoingMessageEnvelope(systemStream, i, null, message);
         collector.send(envelopeOut);
       }

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -29,6 +29,7 @@ import java.util.function.Consumer
 import java.util.{Base64, Optional}
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import org.apache.samza.SamzaException
+import org.apache.samza.application.ApplicationUtil
 import org.apache.samza.checkpoint.{CheckpointListener, OffsetManager, OffsetManagerMetrics}
 import org.apache.samza.clustermanager.StandbyTaskUtil
 import org.apache.samza.config.{StreamConfig, _}
@@ -624,6 +625,8 @@ object SamzaContainer extends Logging {
 
     val maxThrottlingDelayMs = config.getLong("container.disk.quota.delay.max.ms", TimeUnit.SECONDS.toMillis(1))
 
+    val isHighLevelApiJob = ApplicationUtil.isHighLevelApiJob(config)
+
     val runLoop: Runnable = RunLoopFactory.createRunLoop(
       taskInstances,
       consumerMultiplexer,
@@ -633,7 +636,8 @@ object SamzaContainer extends Logging {
       taskConfig,
       clock,
       jobConfig.getElasticityFactor,
-      appConfig.getRunId)
+      appConfig.getRunId,
+      isHighLevelApiJob)
 
     val containerMemoryMb : Int = new ClusterManagerConfig(config).getContainerMemoryMb
 

--- a/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
@@ -568,7 +568,8 @@ class TaskInstance(
     // within the keyBucket of the SSP assigned to the task.
     val incomingMessageSsp = envelope.getSystemStreamPartition(elasticityFactor)
 
-    if (IncomingMessageEnvelope.END_OF_STREAM_OFFSET.equals(envelope.getOffset)) {
+    if (IncomingMessageEnvelope.END_OF_STREAM_OFFSET.equals(envelope.getOffset)
+      || envelope.isDrain) {
       ssp2CaughtupMapping(incomingMessageSsp) = true
     } else {
       systemAdmins match {

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -42,6 +42,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.samza.SamzaException;
+import org.apache.samza.application.ApplicationUtil;
 import org.apache.samza.checkpoint.Checkpoint;
 import org.apache.samza.checkpoint.CheckpointManager;
 import org.apache.samza.checkpoint.CheckpointV2;
@@ -927,7 +928,7 @@ public class ContainerStorageManager {
         new SamzaContainerMetrics(SIDEINPUTS_METRICS_PREFIX + this.samzaContainerMetrics.source(),
             this.samzaContainerMetrics.registry(), SIDEINPUTS_METRICS_PREFIX);
 
-    ApplicationConfig applicationConfig = new ApplicationConfig(config);
+    final ApplicationConfig applicationConfig = new ApplicationConfig(config);
 
     this.sideInputRunLoop = new RunLoop(sideInputTasks,
         null, // all operations are executed in the main runloop thread
@@ -943,7 +944,9 @@ public class ContainerStorageManager {
         System::nanoTime,
         false,
         DEFAULT_SIDE_INPUT_ELASTICITY_FACTOR,
-        applicationConfig.getRunId()); // commit must be synchronous to ensure integrity of state flush
+        applicationConfig.getRunId(),
+        ApplicationUtil.isHighLevelApiJob(config)
+        ); // commit must be synchronous to ensure integrity of state flush
 
     try {
       sideInputsExecutor.submit(() -> {

--- a/samza-core/src/main/scala/org/apache/samza/system/SystemConsumers.scala
+++ b/samza-core/src/main/scala/org/apache/samza/system/SystemConsumers.scala
@@ -219,6 +219,10 @@ class SystemConsumers (
 
     chooser.start
 
+    // SystemConsumers could be set to drain mode prior to start if a drain message was encountered on container start
+    if (isDraining) {
+      writeDrainControlMessageToSspQueue()
+    }
 
     started = true
 
@@ -243,8 +247,9 @@ class SystemConsumers (
     if (!isDraining) {
       isDraining = true;
       info("SystemConsumers is set to drain mode.")
-      consumers.values.foreach(_.stop)
-      writeDrainControlMessageToSspQueue()
+      if (started) {
+        writeDrainControlMessageToSspQueue()
+      }
     }
   }
 

--- a/samza-test/src/test/java/org/apache/samza/test/drain/DrainHighLevelApiIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/drain/DrainHighLevelApiIntegrationTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import net.jcip.annotations.NotThreadSafe;
 import org.apache.samza.application.StreamApplication;
 import org.apache.samza.application.descriptors.StreamApplicationDescriptor;
 import org.apache.samza.config.ApplicationConfig;
@@ -50,7 +51,7 @@ import org.apache.samza.test.framework.system.descriptors.InMemorySystemDescript
 import org.apache.samza.test.table.TestTableData;
 import org.apache.samza.test.table.TestTableData.PageView;
 import org.apache.samza.util.CoordinatorStreamUtil;
-import org.junit.Ignore;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -59,38 +60,72 @@ import static org.junit.Assert.*;
 /**
  * End to end integration test to check drain functionality with samza high-level API.
  */
+@FixMethodOrder
+@NotThreadSafe
 public class DrainHighLevelApiIntegrationTest {
   private static final List<PageView> RECEIVED = new ArrayList<>();
-  private static final String SYSTEM_NAME = "test";
-  private static final String STREAM_ID = "PageView";
+  private static final String SYSTEM_NAME1 = "test1";
+  private static final String STREAM_ID1 = "PageView1";
 
-  private static class  PageViewEventCountHighLevelApplication implements StreamApplication {
+  private static final String SYSTEM_NAME2 = "test2";
+  private static final String STREAM_ID2 = "PageView2";
+
+  /**
+   * High-Level Job with multiple shuffle stages.
+   * */
+  private static class PageViewEventCountHighLevelApplication implements StreamApplication {
     @Override
     public void describe(StreamApplicationDescriptor appDescriptor) {
-      DelegatingSystemDescriptor sd = new DelegatingSystemDescriptor(SYSTEM_NAME);
+      DelegatingSystemDescriptor sd = new DelegatingSystemDescriptor(SYSTEM_NAME1);
       GenericInputDescriptor<KV<String, PageView>> isd =
-          sd.getInputDescriptor(STREAM_ID, KVSerde.of(new NoOpSerde<>(), new NoOpSerde<>()));
+          sd.getInputDescriptor(STREAM_ID1, KVSerde.of(new NoOpSerde<>(), new NoOpSerde<>()));
       appDescriptor.getInputStream(isd)
           .map(KV::getValue)
           .partitionBy(PageView::getMemberId, pv -> pv,
-              KVSerde.of(new IntegerSerde(), new TestTableData.PageViewJsonSerde()), "p1")
+              KVSerde.of(new IntegerSerde(), new TestTableData.PageViewJsonSerde()), "p11")
+          .map(kv -> KV.of(kv.getKey() * 31, kv.getValue()))
+          .partitionBy(KV::getKey, KV::getValue, KVSerde.of(new IntegerSerde(), new TestTableData.PageViewJsonSerde()), "p21")
           .sink((m, collector, coordinator) -> {
             RECEIVED.add(m.getValue());
           });
     }
   }
 
-  // The test can be occasionally flaky, so we set Ignore annotation
-  // Remove ignore annotation and run the test as follows:
-  // ./gradlew :samza-test:test --tests org.apache.samza.test.drain.DrainHighLevelApiIntegrationTest -PscalaSuffix=2.12
-  @Ignore
-  @Test
-  public void testPipeline() {
-    String runId = "DrainTestId";
-    int numPageViews = 40;
+  /**
+   * Simple high-level application without shuffle stages.
+   * */
+  private static class SimpleHighLevelApplication implements StreamApplication {
+    @Override
+    public void describe(StreamApplicationDescriptor appDescriptor) {
+      DelegatingSystemDescriptor sd = new DelegatingSystemDescriptor(SYSTEM_NAME2);
+      GenericInputDescriptor<KV<String, PageView>> isd =
+          sd.getInputDescriptor(STREAM_ID2, KVSerde.of(new NoOpSerde<>(), new NoOpSerde<>()));
+      appDescriptor.getInputStream(isd)
+          .sink((m, collector, coordinator) -> {
+            RECEIVED.add(m.getValue());
+          });
+    }
+  }
 
-    InMemorySystemDescriptor isd = new InMemorySystemDescriptor(SYSTEM_NAME);
-    InMemoryInputDescriptor<TestTableData.PageView> inputDescriptor = isd.getInputDescriptor(STREAM_ID, new NoOpSerde<>());
+
+  /**
+   * This test will test drain and consumption of some messages from the in-memory topic.
+   * In order to simulate the real-world behaviour of drain, the test adds messages to the in-memory topic buffer periodically
+   * in a delayed fashion instead of all at once. The test then writes the drain notification message to the in-memory
+   * metadata store to drain and stop the pipeline. This write is done shortly after the pipeline starts and before all
+   * the messages are written to the topic's buffer. As a result, the total count of the processed messages will be less
+   * than the expected count of messages.
+   * */
+  @Test
+  public void testDrain() {
+    int numPageViews = 200;
+    int numPartitions = 4;
+    long delayBetweenMessagesInMillis = 500L;
+    long drainTriggerDelay = 10_000L;
+    String runId = "DrainTestId";
+
+    InMemorySystemDescriptor isd = new InMemorySystemDescriptor(SYSTEM_NAME1);
+    InMemoryInputDescriptor<TestTableData.PageView> inputDescriptor = isd.getInputDescriptor(STREAM_ID1, new NoOpSerde<>());
     InMemoryMetadataStoreFactory metadataStoreFactory = new InMemoryMetadataStoreFactory();
 
     Map<String, String> customConfig = ImmutableMap.of(
@@ -99,14 +134,11 @@ public class DrainHighLevelApiIntegrationTest {
         JobConfig.DRAIN_MONITOR_ENABLED, "true");
 
     // Create a TestRunner
-    // Set a InMemoryMetadataFactory. We will use this factory in the test to create a metadata store and
-    // write drain message to it
-    // Mock data comprises of 40 messages across 4 partitions. TestRunner adds a 1 second delay between messages
-    // per partition when writing messages to the InputStream
+    // Set a InMemoryMetadataFactory.This factory is shared between TestRunner and DrainUtils's write drain method
     TestRunner testRunner = TestRunner.of(new PageViewEventCountHighLevelApplication())
         .setInMemoryMetadataFactory(metadataStoreFactory)
         .addConfig(customConfig)
-        .addInputStream(inputDescriptor, TestTableData.generatePartitionedPageViews(numPageViews, 4), 1000L);
+        .addInputStream(inputDescriptor, TestTableData.generatePartitionedPageViews(numPageViews, numPartitions), delayBetweenMessagesInMillis);
 
     Config configFromRunner = testRunner.getConfig();
     MetadataStore metadataStore = metadataStoreFactory.getMetadataStore("NoOp", configFromRunner, new MetricsRegistryMap());
@@ -125,10 +157,156 @@ public class DrainHighLevelApiIntegrationTest {
         UUID uuid = DrainUtils.writeDrainNotification(metadataStore);
         return uuid.toString();
       }
-    }, 2000L, TimeUnit.MILLISECONDS);
+    }, drainTriggerDelay, TimeUnit.MILLISECONDS);
+
+    testRunner.run(Duration.ofSeconds(40));
+
+    assertTrue(RECEIVED.size() < numPageViews && RECEIVED.size() > 0);
+    RECEIVED.clear();
+    clearMetadataStore(metadataStore);
+  }
+
+  @Test
+  public void testDrainWithoutReshuffleStages() {
+    int numPageViews = 200;
+    int numPartitions = 4;
+    long delayBetweenMessagesInMillis = 500L;
+    long drainTriggerDelay = 10_000L;
+    String runId = "DrainTestId";
+
+    InMemorySystemDescriptor isd = new InMemorySystemDescriptor(SYSTEM_NAME2);
+    InMemoryInputDescriptor<TestTableData.PageView> inputDescriptor = isd.getInputDescriptor(STREAM_ID2, new NoOpSerde<>());
+    InMemoryMetadataStoreFactory metadataStoreFactory = new InMemoryMetadataStoreFactory();
+
+    Map<String, String> customConfig = ImmutableMap.of(
+        ApplicationConfig.APP_RUN_ID, runId,
+        JobConfig.DRAIN_MONITOR_POLL_INTERVAL_MILLIS, "100",
+        JobConfig.DRAIN_MONITOR_ENABLED, "true");
+
+    // Create a TestRunner
+    // Set a InMemoryMetadataFactory.This factory is shared between TestRunner and DrainUtils's write drain method
+    TestRunner testRunner = TestRunner.of(new SimpleHighLevelApplication())
+        .setInMemoryMetadataFactory(metadataStoreFactory)
+        .addConfig(customConfig)
+        .addInputStream(inputDescriptor, TestTableData.generatePartitionedPageViews(numPageViews, numPartitions), delayBetweenMessagesInMillis);
+
+    Config configFromRunner = testRunner.getConfig();
+    MetadataStore metadataStore = metadataStoreFactory.getMetadataStore("NoOp", configFromRunner, new MetricsRegistryMap());
+
+    // Write configs to the coordinator stream here as neither the passthrough JC nor the StreamProcessor is writing
+    // configs to coordinator stream. RemoteApplicationRunner typically write the configs to the metadata store
+    // before starting the JC.
+    // We are doing this so that DrainUtils.writeDrainNotification can read app.run.id from the config
+    CoordinatorStreamUtil.writeConfigToCoordinatorStream(metadataStore, configFromRunner);
+
+    // write drain message after a delay
+    ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+    executorService.schedule(new Callable<String>() {
+      @Override
+      public String call() throws Exception {
+        UUID uuid = DrainUtils.writeDrainNotification(metadataStore);
+        return uuid.toString();
+      }
+    }, drainTriggerDelay, TimeUnit.MILLISECONDS);
+
+    testRunner.run(Duration.ofSeconds(40));
+
+    assertTrue(RECEIVED.size() < numPageViews && RECEIVED.size() > 0);
+    RECEIVED.clear();
+    clearMetadataStore(metadataStore);
+  }
+
+  /**
+   * This test will test drain and that no messages are processed as drain notification is written to the metadata store
+   * before start.
+   * */
+  @Test
+  public void testDrainOnContainerStart() {
+    int numPageViews = 200;
+    int numPartitions = 4;
+    long delayBetweenMessagesInMillis = 500L;
+    String runId = "DrainTestId";
+
+    InMemorySystemDescriptor isd = new InMemorySystemDescriptor(SYSTEM_NAME1);
+    InMemoryInputDescriptor<TestTableData.PageView> inputDescriptor = isd.getInputDescriptor(STREAM_ID1, new NoOpSerde<>());
+    InMemoryMetadataStoreFactory metadataStoreFactory = new InMemoryMetadataStoreFactory();
+
+    Map<String, String> customConfig = ImmutableMap.of(
+        ApplicationConfig.APP_RUN_ID, runId,
+        JobConfig.DRAIN_MONITOR_POLL_INTERVAL_MILLIS, "100",
+        JobConfig.DRAIN_MONITOR_ENABLED, "true");
+
+    // Create a TestRunner
+    // Set a InMemoryMetadataFactory.This factory is shared between TestRunner and DrainUtils's write drain method
+    TestRunner testRunner = TestRunner.of(new PageViewEventCountHighLevelApplication())
+        .setInMemoryMetadataFactory(metadataStoreFactory)
+        .addConfig(customConfig)
+        .addInputStream(inputDescriptor, TestTableData.generatePartitionedPageViews(numPageViews, numPartitions), delayBetweenMessagesInMillis);
+
+    Config configFromRunner = testRunner.getConfig();
+    MetadataStore
+        metadataStore = metadataStoreFactory.getMetadataStore("NoOp", configFromRunner, new MetricsRegistryMap());
+
+    // Write configs to the coordinator stream here as neither the passthrough JC nor the StreamProcessor is writing
+    // configs to coordinator stream. RemoteApplicationRunner typically write the configs to the metadata store
+    // before starting the JC.
+    // We are doing this so that DrainUtils.writeDrainNotification can read app.run.id from the config
+    CoordinatorStreamUtil.writeConfigToCoordinatorStream(metadataStore, configFromRunner);
+
+    // write on the test thread to ensure that drain notification is available on container start
+    DrainUtils.writeDrainNotification(metadataStore);
 
     testRunner.run(Duration.ofSeconds(20));
 
-    assertTrue(RECEIVED.size() < numPageViews && RECEIVED.size() > 0);
+    assertEquals(RECEIVED.size(), 0);
+    RECEIVED.clear();
+    clearMetadataStore(metadataStore);
+  }
+
+  @Test
+  public void testDrainOnContainerStartWithoutReshuffleStages() {
+    int numPageViews = 200;
+    int numPartitions = 4;
+    long delayBetweenMessagesInMillis = 500L;
+    String runId = "DrainTestId";
+
+    InMemorySystemDescriptor isd = new InMemorySystemDescriptor(SYSTEM_NAME2);
+    InMemoryInputDescriptor<TestTableData.PageView> inputDescriptor = isd.getInputDescriptor(STREAM_ID2, new NoOpSerde<>());
+    InMemoryMetadataStoreFactory metadataStoreFactory = new InMemoryMetadataStoreFactory();
+
+    Map<String, String> customConfig = ImmutableMap.of(
+        ApplicationConfig.APP_RUN_ID, runId,
+        JobConfig.DRAIN_MONITOR_POLL_INTERVAL_MILLIS, "100",
+        JobConfig.DRAIN_MONITOR_ENABLED, "true");
+
+    // Create a TestRunner
+    // Set a InMemoryMetadataFactory.This factory is shared between TestRunner and DrainUtils's write drain method
+    TestRunner testRunner = TestRunner.of(new SimpleHighLevelApplication())
+        .setInMemoryMetadataFactory(metadataStoreFactory)
+        .addConfig(customConfig)
+        .addInputStream(inputDescriptor, TestTableData.generatePartitionedPageViews(numPageViews, numPartitions), delayBetweenMessagesInMillis);
+
+    Config configFromRunner = testRunner.getConfig();
+    MetadataStore
+        metadataStore = metadataStoreFactory.getMetadataStore("NoOp", configFromRunner, new MetricsRegistryMap());
+
+    // Write configs to the coordinator stream here as neither the passthrough JC nor the StreamProcessor is writing
+    // configs to coordinator stream. RemoteApplicationRunner typically write the configs to the metadata store
+    // before starting the JC.
+    // We are doing this so that DrainUtils.writeDrainNotification can read app.run.id from the config
+    CoordinatorStreamUtil.writeConfigToCoordinatorStream(metadataStore, configFromRunner);
+
+    // write on the test thread to ensure that drain notification is available on container start
+    DrainUtils.writeDrainNotification(metadataStore);
+
+    testRunner.run(Duration.ofSeconds(20));
+
+    assertEquals(RECEIVED.size(), 0);
+    RECEIVED.clear();
+    clearMetadataStore(metadataStore);
+  }
+
+  private static void clearMetadataStore(MetadataStore store) {
+    store.all().keySet().forEach(store::delete);
   }
 }


### PR DESCRIPTION
# Symptoms and Cause:
There were a few issues with the processing of drain messages that this PR attempts to fix. The following issues were encountered during the end-to-end testing with test pipelines.

1. It was observed that the `RunLoop` was running into an exception when a task was trying to consume from intermediate streams.

This was happening as we stop all consumers in `SystemConsumers` when we encounter drain. This also stops the consumers which ingest data from the intermediate streams. 

_After 1 was resolved, some additional issues were observed-_
2. The pipeline was getting stuck after partial consumption of data after the last shuffle stage. 

This was happening as we were removing the SSPs from the processing set of SSPs for a task for high-level API processing. This was leading to unprocessed drain messages and thereby, the pipeline would remain stuck.

3. The pipeline would get stuck if a drain message was encountered prior to the start of the container. 

This is happening as we set the `SystemConsumers` to drain mode before it is even started by `SamzaContainer`. As a result, no messages are read by the container.

# Changes:
1. Changed the `SystemConsumers` code to remove the line which stopped registered `SystemConsumer`s on drain. 

2. Restrict the logic to remove the SSP from the processing SSP set only to low-level API. For high-level API, drain should be solely handled by Operator DAG. Additionally, ask the `TaskCoordinator` to commit the task once all streams for a task have drained.

3. To fix the issue of pipeline getting stuck if a drain control message was present prior to container start, drain and watermark control messages are written to the in-memory buffer on `SystemConsumers` start if it is already is in drain mode.

# Tests:
- End to end tests for both high-level and low-level API
- Unit tests for Drain in RunLoop
- Integ test for Drain for High-level and Low-Level API- DrainLowLevelApiIntegrationTest & DrainHighLevelApiIntegrationTest

# API changes:
None
