### PR TITLE
SAMZA-2741: [Pipeline Drain] Fix ApplicationUtil.isHighLevelApiJob to work for anonymous and lambda `SamzaApplication` classes

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/application/ApplicationApiType.java
+++ b/samza-api/src/main/java/org/apache/samza/application/ApplicationApiType.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.samza.application;
+
+/**
+ * Enum to denote the possible API types for a samza application.
+ * */
+public enum ApplicationApiType {
+  /**
+   * Defined using {@link StreamApplication}
+   * */
+  HIGH_LEVEL,
+  /**
+   * Defined using {@link TaskApplication}
+   * */
+  LOW_LEVEL,
+  /**
+   * Defined using defined using task.class config.
+   * */
+  LEGACY
+}

--- a/samza-core/src/main/java/org/apache/samza/application/ApplicationUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/application/ApplicationUtil.java
@@ -18,7 +18,6 @@
  */
 package org.apache.samza.application;
 
-import com.google.common.base.Strings;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.samza.config.ApplicationConfig;
@@ -68,22 +67,10 @@ public class ApplicationUtil {
 
   /**
    * Determines if the job is a Samza high-level job.
-   * High-level job implements StreamApplication.
    * @param config config
    * */
   public static boolean isHighLevelApiJob(Config config) {
     final ApplicationConfig applicationConfig = new ApplicationConfig(config);
-    final String appClass = applicationConfig.getAppClass();
-    if (!Strings.isNullOrEmpty(appClass)) {
-      try {
-        return StreamApplication.class.isAssignableFrom(Class.forName(appClass));
-      } catch (ClassNotFoundException e) {
-        LOG.debug("Error while determining if the job is a high level API job", e);
-        return false;
-      }
-    } else {
-      LOG.warn("Config {} is empty or null. Cannot determine if the job is a high-level API job", ApplicationConfig.APP_CLASS);
-      return false;
-    }
+    return applicationConfig.getAppApiType() == ApplicationApiType.HIGH_LEVEL;
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/config/ApplicationConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/ApplicationConfig.java
@@ -18,9 +18,9 @@
  */
 package org.apache.samza.config;
 
+import org.apache.samza.application.ApplicationApiType;
 import org.apache.samza.clustermanager.DefaultApplicationMain;
 import org.apache.samza.runtime.UUIDGenerator;
-
 
 /**
  * Accessors for configs associated with Application scope
@@ -60,7 +60,7 @@ public class ApplicationConfig extends MapConfig {
   public static final String APP_MAIN_CLASS = "app.main.class";
   public static final String APP_MAIN_ARGS = "app.main.args";
   public static final String APP_RUNNER_CLASS = "app.runner.class";
-
+  public static final String APP_API_TYPE = "app.api.type";
   private static final String DEFAULT_APP_RUNNER = "org.apache.samza.runtime.RemoteApplicationRunner";
 
   public ApplicationConfig(Config config) {
@@ -109,5 +109,9 @@ public class ApplicationConfig extends MapConfig {
 
   public String getAppRunnerClass() {
     return get(APP_RUNNER_CLASS, DEFAULT_APP_RUNNER);
+  }
+
+  public ApplicationApiType getAppApiType() {
+    return ApplicationApiType.valueOf(get(APP_API_TYPE, ApplicationApiType.HIGH_LEVEL.name()).toUpperCase());
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/container/RunLoopFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/container/RunLoopFactory.java
@@ -69,6 +69,12 @@ public class RunLoopFactory {
 
     log.info("Got current run Id: {}.", runId);
 
+    if (isHighLevelApiJob) {
+      log.info("The application uses high-level API.");
+    } else {
+      log.info("The application doesn't use high-level API.");
+    }
+
     log.info("Run loop in asynchronous mode.");
 
     return new RunLoop(

--- a/samza-core/src/test/java/org/apache/samza/application/TestApplicationUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/application/TestApplicationUtil.java
@@ -30,7 +30,7 @@ import org.apache.samza.config.TaskConfig;
 import org.apache.samza.task.MockStreamTask;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 
 /**
@@ -84,6 +84,19 @@ public class TestApplicationUtil {
   public void testNoAppClassNoTaskClass() {
     Map<String, String> configMap = new HashMap<>();
     ApplicationUtil.fromConfig(new MapConfig(configMap));
+  }
+
+  @Test
+  public void testIsHighLevelJob() {
+    final Map<String, String> configMap = new HashMap<>();
+    configMap.put(ApplicationConfig.APP_API_TYPE, ApplicationApiType.HIGH_LEVEL.name());
+    assertTrue(ApplicationUtil.isHighLevelApiJob(new MapConfig(configMap)));
+
+    configMap.put(ApplicationConfig.APP_API_TYPE, ApplicationApiType.LOW_LEVEL.name());
+    assertFalse(ApplicationUtil.isHighLevelApiJob(new MapConfig(configMap)));
+
+    configMap.put(ApplicationConfig.APP_API_TYPE, ApplicationApiType.LEGACY.name());
+    assertFalse(ApplicationUtil.isHighLevelApiJob(new MapConfig(configMap)));
   }
 
   /**


### PR DESCRIPTION
# Summary
`ApplicationUtil.isHighLevelApiJob` doesn't work for cases where `SamzaApplication` were created as an anonymous class or lambda

# Cause
Anonymous class names and lambdas classes cannot be created using `Class forName()`. As a result, the current logic currently assumes that the class name was incorrect. 

# Fix 
Introduce an internal config `app.api.type` and we set the config using `AppDescriptor` in `JobPlanner`.

# Test
- Unit test for `ApplicationUtil.isHighLevelApiJob`
- Tested with a sample application