### PR TITLE
LISAMZA-27395 removing the current recursive call prevention logic

### DIFF
--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppender.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
@@ -85,12 +84,6 @@ public class StreamAppender extends AbstractAppender {
   private String streamName = null;
   private final boolean usingAsyncLogger;
   private final LoggingContextHolder loggingContextHolder;
-
-  /**
-   * used to detect if this thread is called recursively
-   */
-  private final AtomicBoolean recursiveCall = new AtomicBoolean(false);
-
   protected static final int DEFAULT_QUEUE_SIZE = 100;
   protected volatile boolean systemInitialized = false;
   protected StreamAppenderMetrics metrics;
@@ -189,37 +182,30 @@ public class StreamAppender extends AbstractAppender {
 
   @Override
   public void append(LogEvent event) {
-    if (!recursiveCall.get()) {
-      try {
-        recursiveCall.set(true);
-        if (!systemInitialized) {
-          // configs are needed to set up producer system, so check that before actually initializing
-          if (this.loggingContextHolder.getConfig() != null) {
-            synchronized (this) {
-              if (!systemInitialized) {
-                setupSystem();
-                systemInitialized = true;
-              }
+    try {
+      if (!systemInitialized) {
+        // configs are needed to set up producer system, so check that before actually initializing
+        if (this.loggingContextHolder.getConfig() != null) {
+          synchronized (this) {
+            if (!systemInitialized) {
+              setupSystem();
+              systemInitialized = true;
             }
-            handleEvent(event);
-          } else {
-            // skip sending the log to the stream if initialization can't happen yet
-            System.out.println("Waiting for config to become available before log can be handled");
           }
-        } else {
           handleEvent(event);
+        } else {
+          // skip sending the log to the stream if initialization can't happen yet
+          System.out.println("Waiting for config to become available before log can be handled");
         }
-      } catch (Exception e) {
-        if (metrics != null) { // setupSystem() may not have been invoked yet so metrics can be null here.
-          metrics.logMessagesErrors.inc();
-        }
-        System.err.println(String.format("[%s] Error sending log message:", getName()));
-        e.printStackTrace();
-      } finally {
-        recursiveCall.set(false);
+      } else {
+        handleEvent(event);
       }
-    } else if (metrics != null) { // setupSystem() may not have been invoked yet so metrics can be null here.
-      metrics.recursiveCalls.inc();
+    } catch (Exception e) {
+      if (metrics != null) { // setupSystem() may not have been invoked yet so metrics can be null here.
+        metrics.logMessagesErrors.inc();
+      }
+      System.err.println(String.format("[%s] Error sending log message:", getName()));
+      e.printStackTrace();
     }
   }
 

--- a/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppenderMetrics.java
+++ b/samza-log4j2/src/main/java/org/apache/samza/logging/log4j2/StreamAppenderMetrics.java
@@ -28,9 +28,6 @@ public class StreamAppenderMetrics extends MetricsBase {
   /** The percentage of the log queue capacity that is currently filled with messages from 0 to 100. */
   public final Gauge<Integer> bufferFillPct;
 
-  /** The number of recursive calls to the StreamAppender. These events will not be logged. */
-  public final Counter recursiveCalls;
-
   /** The number of log messages dropped e.g. because of buffer overflow. Does not include recursive calls. */
   public final Counter logMessagesDropped;
 
@@ -46,7 +43,6 @@ public class StreamAppenderMetrics extends MetricsBase {
   public StreamAppenderMetrics(String prefix, MetricsRegistry registry) {
     super(prefix + "-", registry);
     bufferFillPct = newGauge("buffer-fill-percent", 0);
-    recursiveCalls = newCounter("recursive-calls");
     logMessagesDropped = newCounter("log-messages-dropped");
     logMessagesErrors = newCounter("log-messages-errors");
     logMessagesBytesSent = newCounter("log-messages-bytes-sent");


### PR DESCRIPTION
Issue: 
We observed logging data loss happens in StreamAppender
The RC is the current implementation of the “[append()](https://github.com/apache/samza/blob/master/samza-log4j/src/main/java/org/apache/samza/logging/log4j/StreamAppender.java#L146)” method uses one AtomicBoolean variable to detect if the thread is called recursively, which could lead to race conditions when "append()" is invoked by multiple threads and could cause log data loss.

we have reproduced the data loss issue locally in the multithread logging scenarios.

When the current implementation was introduced in samza, log4j1 framework didn't have recursive call prevention logic at the framework layer. More context can be found in [SAMZA-723](https://issues.apache.org/jira/browse/SAMZA-723)

However, the current implementation in samza has the side effect that data loss might occur in the parallel logging scenario. We believe it is a bug existing for a long time but never got noticed. 


Change:
Samza now is upgraded to [log4j2 framework](https://github.com/apache/logging-log4j2/blob/release-2.x/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AppenderControl.java#L122) which applies recursive call prevention at the framework layer

So we don't need recursive call prevention logic at Samza

API Changes:
Remove a metric recursiveCalls from StreamAppenderMetrics since it is no longer used

Test Done:
./gradlew build
