### PR TITLE
SAMZA-2770: [Pipeline Drain] Enable drain monitor by default

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -165,9 +165,8 @@ public class JobConfig extends MapConfig {
   private static final String JOB_STARTPOINT_ENABLED = "job.startpoint.enabled";
 
   // Enable DrainMonitor in Samza Containers
-  // Default is false for now. Will be turned on after testing
   public static final String DRAIN_MONITOR_ENABLED = "job.drain-monitor.enabled";
-  public static final boolean DRAIN_MONITOR_ENABLED_DEFAULT = false;
+  public static final boolean DRAIN_MONITOR_ENABLED_DEFAULT = true;
 
   public static final String DRAIN_MONITOR_POLL_INTERVAL_MILLIS = "job.drain-monitor.poll.interval.ms";
   public static final long DRAIN_MONITOR_POLL_INTERVAL_MILLIS_DEFAULT = 60_000;

--- a/samza-test/src/test/java/org/apache/samza/test/drain/DrainHighLevelApiIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/drain/DrainHighLevelApiIntegrationTest.java
@@ -130,8 +130,7 @@ public class DrainHighLevelApiIntegrationTest {
 
     Map<String, String> customConfig = ImmutableMap.of(
         ApplicationConfig.APP_RUN_ID, runId,
-        JobConfig.DRAIN_MONITOR_POLL_INTERVAL_MILLIS, "100",
-        JobConfig.DRAIN_MONITOR_ENABLED, "true");
+        JobConfig.DRAIN_MONITOR_POLL_INTERVAL_MILLIS, "100");
 
     // Create a TestRunner
     // Set a InMemoryMetadataFactory.This factory is shared between TestRunner and DrainUtils's write drain method
@@ -180,8 +179,7 @@ public class DrainHighLevelApiIntegrationTest {
 
     Map<String, String> customConfig = ImmutableMap.of(
         ApplicationConfig.APP_RUN_ID, runId,
-        JobConfig.DRAIN_MONITOR_POLL_INTERVAL_MILLIS, "100",
-        JobConfig.DRAIN_MONITOR_ENABLED, "true");
+        JobConfig.DRAIN_MONITOR_POLL_INTERVAL_MILLIS, "100");
 
     // Create a TestRunner
     // Set a InMemoryMetadataFactory.This factory is shared between TestRunner and DrainUtils's write drain method
@@ -233,8 +231,7 @@ public class DrainHighLevelApiIntegrationTest {
 
     Map<String, String> customConfig = ImmutableMap.of(
         ApplicationConfig.APP_RUN_ID, runId,
-        JobConfig.DRAIN_MONITOR_POLL_INTERVAL_MILLIS, "100",
-        JobConfig.DRAIN_MONITOR_ENABLED, "true");
+        JobConfig.DRAIN_MONITOR_POLL_INTERVAL_MILLIS, "100");
 
     // Create a TestRunner
     // Set a InMemoryMetadataFactory.This factory is shared between TestRunner and DrainUtils's write drain method
@@ -276,8 +273,7 @@ public class DrainHighLevelApiIntegrationTest {
 
     Map<String, String> customConfig = ImmutableMap.of(
         ApplicationConfig.APP_RUN_ID, runId,
-        JobConfig.DRAIN_MONITOR_POLL_INTERVAL_MILLIS, "100",
-        JobConfig.DRAIN_MONITOR_ENABLED, "true");
+        JobConfig.DRAIN_MONITOR_POLL_INTERVAL_MILLIS, "100");
 
     // Create a TestRunner
     // Set a InMemoryMetadataFactory.This factory is shared between TestRunner and DrainUtils's write drain method

--- a/samza-test/src/test/java/org/apache/samza/test/drain/DrainLowLevelApiIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/test/drain/DrainLowLevelApiIntegrationTest.java
@@ -134,8 +134,7 @@ public class DrainLowLevelApiIntegrationTest {
 
     Map<String, String> customConfig = ImmutableMap.of(
         ApplicationConfig.APP_RUN_ID, runId,
-        JobConfig.DRAIN_MONITOR_POLL_INTERVAL_MILLIS, "100",
-        JobConfig.DRAIN_MONITOR_ENABLED, "true");
+        JobConfig.DRAIN_MONITOR_POLL_INTERVAL_MILLIS, "100");
 
     // Create a TestRunner
     // Set a InMemoryMetadataFactory.This factory is shared between TestRunner and DrainUtils's write drain method
@@ -184,8 +183,7 @@ public class DrainLowLevelApiIntegrationTest {
 
     Map<String, String> customConfig = ImmutableMap.of(
         ApplicationConfig.APP_RUN_ID, runId,
-        JobConfig.DRAIN_MONITOR_POLL_INTERVAL_MILLIS, "100",
-        JobConfig.DRAIN_MONITOR_ENABLED, "true");
+        JobConfig.DRAIN_MONITOR_POLL_INTERVAL_MILLIS, "100");
 
     // Create a TestRunner
     // Set a InMemoryMetadataFactory.This factory is shared between TestRunner and DrainUtils's write drain method


### PR DESCRIPTION
# Summary
Drain monitor had been turned off by default. The idea was to turn it on after testing the pipeline drain feature.

# Changes
- Set `DRAIN_MONITOR_ENABLED_DEFAULT` to true in `JobConfig`
- Alter Drain integration tests which had explicitly set the `job.drain-monitor.enabled` to true

# Tests
- No new tests. Re-run existing integration tests

# API Changes
None