### PR TITLE
Fix performance bug in kafka/blobstore commit lifecycle.

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/storage/StateBackendFactory.java
+++ b/samza-api/src/main/java/org/apache/samza/storage/StateBackendFactory.java
@@ -20,6 +20,7 @@
 package org.apache.samza.storage;
 
 import java.io.File;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import org.apache.samza.config.Config;
@@ -29,6 +30,7 @@ import org.apache.samza.job.model.ContainerModel;
 import org.apache.samza.job.model.JobModel;
 import org.apache.samza.job.model.TaskModel;
 import org.apache.samza.metrics.MetricsRegistry;
+import org.apache.samza.system.SystemAdmin;
 import org.apache.samza.util.Clock;
 
 
@@ -40,6 +42,7 @@ public interface StateBackendFactory {
   TaskBackupManager getBackupManager(JobContext jobContext,
       ContainerModel containerModel,
       TaskModel taskModel,
+      Map<String, SystemAdmin> systemNameSystemAdminMap,
       ExecutorService backupExecutor,
       MetricsRegistry taskInstanceMetricsRegistry,
       Config config,

--- a/samza-core/src/main/java/org/apache/samza/storage/KafkaChangelogStateBackendFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/KafkaChangelogStateBackendFactory.java
@@ -40,6 +40,7 @@ import org.apache.samza.job.model.TaskModel;
 import org.apache.samza.metrics.MetricsRegistry;
 import org.apache.samza.system.SSPMetadataCache;
 import org.apache.samza.system.StreamMetadataCache;
+import org.apache.samza.system.SystemAdmin;
 import org.apache.samza.system.SystemAdmins;
 import org.apache.samza.system.SystemStream;
 import org.apache.samza.system.SystemStreamPartition;
@@ -66,13 +67,14 @@ public class KafkaChangelogStateBackendFactory implements StateBackendFactory {
   public TaskBackupManager getBackupManager(JobContext jobContext,
       ContainerModel containerModel,
       TaskModel taskModel,
+      Map<String, SystemAdmin> systemNameSystemAdminsMap,
       ExecutorService backupExecutor,
       MetricsRegistry metricsRegistry,
       Config config,
       Clock clock,
       File loggedStoreBaseDir,
       File nonLoggedStoreBaseDir) {
-    SystemAdmins systemAdmins = new SystemAdmins(config);
+    SystemAdmins systemAdmins = new SystemAdmins(systemNameSystemAdminsMap);
     StorageConfig storageConfig = new StorageConfig(config);
     Map<String, SystemStream> storeChangelogs = storageConfig.getStoreChangelogs();
 

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/BlobStoreStateBackendFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/BlobStoreStateBackendFactory.java
@@ -21,6 +21,7 @@ package org.apache.samza.storage.blobstore;
 
 import com.google.common.base.Preconditions;
 import java.io.File;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import org.apache.commons.lang3.StringUtils;
@@ -41,6 +42,7 @@ import org.apache.samza.storage.TaskBackupManager;
 import org.apache.samza.storage.TaskRestoreManager;
 import org.apache.samza.storage.blobstore.metrics.BlobStoreBackupManagerMetrics;
 import org.apache.samza.storage.blobstore.metrics.BlobStoreRestoreManagerMetrics;
+import org.apache.samza.system.SystemAdmin;
 import org.apache.samza.util.Clock;
 import org.apache.samza.util.ReflectionUtil;
 
@@ -51,6 +53,7 @@ public class BlobStoreStateBackendFactory implements StateBackendFactory {
       JobContext jobContext,
       ContainerModel containerModel,
       TaskModel taskModel,
+      Map<String, SystemAdmin> systemNameSystemAdminsMap,
       ExecutorService backupExecutor,
       MetricsRegistry metricsRegistry,
       Config config,

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -571,6 +571,7 @@ object SamzaContainer extends Logging {
       info ("Got task side input SSPs: %s" format taskSideInputSSPs)
 
       val taskBackupManagerMap = new util.HashMap[String, TaskBackupManager]()
+      val systemAdminsMap = systemAdmins.getSystemAdmins
       stateStorageBackendBackupFactories.asJava.forEach(new Consumer[StateBackendFactory] {
         override def accept(factory: StateBackendFactory): Unit = {
           val taskMetricsRegistry =
@@ -578,7 +579,7 @@ object SamzaContainer extends Logging {
               taskInstanceMetrics.get(taskName).isDefined) taskInstanceMetrics.get(taskName).get.registry
             else new MetricsRegistryMap
           val taskBackupManager = factory.getBackupManager(jobContext, containerModel,
-            taskModel, commitThreadPool, taskMetricsRegistry, config, SystemClock.instance(),
+            taskModel, systemAdminsMap, commitThreadPool, taskMetricsRegistry, config, SystemClock.instance,
             loggedStorageBaseDir, nonLoggedStorageBaseDir)
           taskBackupManagerMap.put(factory.getClass.getName, taskBackupManager)
         }


### PR DESCRIPTION
Bug
- We introduced blob store backed for state backup and restore in [this commit](https://github.com/apache/samza/commit/7cc4eaa96fff244f6dce9c18af804917db7c3b2b).
- `StateBackendFactory` implementations like for Kafka and BlobStore create systemAdmins every time `getBackupFactory` is called from `SamzaContainer`. This leads to creation of duplicate kafka admin threads. 
- This has impact on performance of large samza jobs as we have thousands of duplicate threads spawned.

Fix
- Pass `systemAdminsMap` to `getBackendFactory` method. This initializes the SystemAdmins with the system admin map rather than creating system admins every time the method is called. 

Test
- Tested with local jobs to verify the kafka admin threads are not duplicated. 