### PR TITLE
Fix restore factory not configured log

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -441,6 +441,11 @@ public class ContainerStorageManager {
 
     backendFactoryStoreNames.forEach((factoryName, storeNames) -> {
       StateBackendFactory factory = factories.get(factoryName);
+      if (factory == null) {
+        throw new SamzaException(
+            String.format("Required restore state backend factory: %s not found in configured factories %s",
+                factoryName, String.join(", ", factories.keySet())));
+      }
       KafkaChangelogRestoreParams kafkaChangelogRestoreParams = new KafkaChangelogRestoreParams(storeConsumers,
           inMemoryStores.get(taskName), systemAdmins.getSystemAdmins(), storageEngineFactories, serdes,
           taskInstanceCollectors.get(taskName));


### PR DESCRIPTION
Currently if a restore factory is missing due to a misconfiguration we exit due to a NPE

```
2022-12-13 18:23:07.794 [main] SamzaContainer [ERROR] Caught exception/error while initializing container.
java.lang.NullPointerException: null
	at org.apache.samza.storage.ContainerStorageManager.lambda$createTaskRestoreManagers$15(ContainerStorageManager.java:485) ~[samza-core_2.12-320.1081.0.4.jar:?]
	at java.util.HashMap.forEach(HashMap.java:1289) ~[?:1.8.0_282]
	at org.apache.samza.storage.ContainerStorageManager.createTaskRestoreManagers(ContainerStorageManager.java:480) ~[samza-core_2.12-320.1081.0.4.jar:?]
	at org.apache.samza.storage.ContainerStorageManager.lambda$restoreStores$27(ContainerStorageManager.java:857) ~[samza-core_2.12-320.1081.0.4.jar:?]
	at java.util.LinkedHashMap.forEach(LinkedHashMap.java:684) ~[?:1.8.0_282]
```
Changed the behavior to output a more meaningful log