### PR TITLE
[Docs] Samza 1.8.0 release website updates

### DIFF
--- a/docs/_blog/2023-01-17-announcing-the-release-of-apache-samza--1.8.0.md
+++ b/docs/_blog/2023-01-17-announcing-the-release-of-apache-samza--1.8.0.md
@@ -1,0 +1,47 @@
+---
+layout: blog
+title: Announcing the release of Apache Samza 1.8.0
+icon: git-pull-request
+authors:
+    - name: Ajo Thomas
+      website:
+      image:
+excerpt_separator: <!--more-->
+---
+
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+# **Announcing the release of Apache Samza 1.8.0**
+
+<!--more-->
+
+We are thrilled to announce the release of Apache Samza 1.8.0
+
+### Key Features:
+Below is a list of key features that we intend to include in this release:
+- [SEP-31](https://cwiki.apache.org/confluence/display/SAMZA/SEP-31%3A+Pipeline+Drain-+Support+the+ability+to+drain+pipelines+to+allow+incompatible+intermediate+schema+changes): Pipeline Drain- Support the ability to drain pipelines to allow incompatible intermediate schema changes
+- [SAMZA-2757](https://issues.apache.org/jira/browse/SAMZA-2757): Make Samza Compatible with Java 11
+
+Full list of the Jira tickets addressed in this release can be found [here](https://issues.apache.org/jira/browse/SAMZA-2744?jql=project%20%3D%20SAMZA%20AND%20fixVersion%20%3D%201.8)
+
+#### Upgrade Instructions
+For applications that are on version 1.6 & below, please see instructions for 1.7.0 upgrade.
+For applications that are already on Samza 1.7.0, updating your dependencies to use Samza 1.8.0 should be sufficient to upgrade.
+
+### Sources downloads
+A source download of Samza 1.8.0 is available [here](https://dist.apache.org/repos/dist/release/samza/1.8.0/), and is also available in Apache’s Maven repository. See Samza’s download [page](https://samza.apache.org/startup/download/) for details and Samza’s feature preview for new features.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -25,7 +25,7 @@ exclude: [_docs]
 baseurl: http://samza.apache.org
 version: latest
 # this is the version you will go if you click 'switch version' in "latest" pages.
-latest-release: '1.6.0'
+latest-release: '1.8.0'
 collections:
   menu:
     output: false

--- a/docs/_menu/index.html
+++ b/docs/_menu/index.html
@@ -12,6 +12,10 @@ items:
     items_attributes: 'data-documentation="/learn/documentation/version/"'
   - menu_title: Releases
     items:
+      - menu_title: 1.8.0
+        url: '/releases/1.8.0'
+      - menu_title: 1.7.0
+        url: '/releases/1.7.0'
       - menu_title: 1.6.0
         url: '/releases/1.6.0'
       - menu_title: 1.5.1

--- a/docs/_releases/1.7.0.md
+++ b/docs/_releases/1.7.0.md
@@ -1,0 +1,40 @@
+---
+version: '1.7.0'
+order: 170
+layout: page
+menu_title: '1.7.0'
+title: Apache Samza 1.7.0 <a href="/learn/documentation/1.7.0/">      [Docs] </a>
+---
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+We are thrilled to announce the release of Apache Samza 1.7.0
+
+### Key Features:
+Below is a list of key features that we intend to include in this release:
+- [SEP-28](https://cwiki.apache.org/confluence/display/SAMZA/SEP-28%3A+Samza+State+Backend+Interface+and+Checkpointing+Improvements): Samza State Backend Interface and Checkpointing Improvements
+- [SEP-29](https://cwiki.apache.org/confluence/display/SAMZA/SEP-29%3A+Blob+Store+Based+State+Backup+And+Restore): Blob Store as backend for Samza State backup and restore
+- [SEP-30](https://cwiki.apache.org/confluence/display/SAMZA/SEP-30:+Support+Updates+in+Table+API): Adding partial update api to Table API
+
+Full list of the Jira tickets addressed in this release can be found [here](https://issues.apache.org/jira/issues/?jql=project%20%3D%20SAMZA%20AND%20fixVersion%20%3D%201.7)
+
+#### Upgrade Instructions
+For applications that are already on Samza 1.6.0, updating your dependencies to use Samza 1.7.0 should be sufficient to upgrade.
+For applications that are on version 1.5 & below, please see instructions for 1.6.0 upgrade.
+
+### Sources downloads
+A source download of Samza 1.7.0 is available [here](https://dist.apache.org/repos/dist/release/samza/1.7.0/), and is also available in Apache’s Maven repository. See Samza’s download [page](https://samza.apache.org/startup/download/) for details and Samza’s feature preview for new features.

--- a/docs/_releases/1.8.0.md
+++ b/docs/_releases/1.8.0.md
@@ -1,0 +1,39 @@
+---
+version: '1.8.0'
+order: 180
+layout: page
+menu_title: '1.8.0'
+title: Apache Samza 1.8.0 <a href="/learn/documentation/1.8.0/">      [Docs] </a>
+---
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+We are thrilled to announce the release of Apache Samza 1.8.0.
+
+### Key Features:
+Below is a list of key features that we intend to include in this release:
+- [SEP-31](https://cwiki.apache.org/confluence/display/SAMZA/SEP-31%3A+Pipeline+Drain-+Support+the+ability+to+drain+pipelines+to+allow+incompatible+intermediate+schema+changes): Pipeline Drain- Support the ability to drain pipelines to allow incompatible intermediate schema changes
+- [SAMZA-2757](https://issues.apache.org/jira/browse/SAMZA-2757): Make Samza Compatible with Java 11
+
+Full list of the jira tickets addressed in this release can be found [here](https://issues.apache.org/jira/browse/SAMZA-2744?jql=project%20%3D%20SAMZA%20AND%20fixVersion%20%3D%201.8)
+
+#### Upgrade Instructions
+For applications that are already on Samza 1.7.0, updating your dependencies to use Samza 1.8.0 should be sufficient to upgrade.
+For applications that are on version 1.6 & below, please see instructions for 1.7.0 upgrade.
+
+### Sources downloads
+A source download of Samza 1.8.0 is available [here](https://dist.apache.org/repos/dist/release/samza/1.8.0/), and is also available in Apache’s Maven repository. See Samza’s download [page](https://samza.apache.org/startup/download/) for details and Samza’s feature preview for new features.

--- a/docs/archive/index.html
+++ b/docs/archive/index.html
@@ -27,6 +27,22 @@ title: Documentation
   <li><a href="../startup/hello-samza/latest">Hello Samza</a></li>
 </ul>
 
+<h4 id="1.8.0">1.8.0 Release</h4>
+
+<ul class="documentation-list">
+  <li><a href="../learn/documentation/1.8.0">Documentation</a></li>
+  <li><a href="../learn/tutorials/1.8.0">Tutorials</a></li>
+  <li><a href="../startup/hello-samza/1.8.0">Hello Samza</a></li>
+</ul>
+
+<h4 id="1.7.0">1.7.0 Release</h4>
+
+<ul class="documentation-list">
+  <li><a href="../learn/documentation/1.7.0">Documentation</a></li>
+  <li><a href="../learn/tutorials/1.7.0">Tutorials</a></li>
+  <li><a href="../startup/hello-samza/1.7.0">Hello Samza</a></li>
+</ul>
+
 <h4 id="1.6.0">1.6.0 Release</h4>
 
 <ul class="documentation-list">

--- a/docs/learn/tutorials/versioned/hello-samza-high-level-yarn.md
+++ b/docs/learn/tutorials/versioned/hello-samza-high-level-yarn.md
@@ -63,7 +63,7 @@ Then, you can continue w/ the following command in hello-samza project:
 {% highlight bash %}
 mvn clean package
 mkdir -p deploy/samza
-tar -xvf ./target/hello-samza-1.7.0-SNAPSHOT-dist.tar.gz -C deploy/samza
+tar -xvf ./target/hello-samza-1.9.0-SNAPSHOT-dist.tar.gz -C deploy/samza
 {% endhighlight %}
 
 ### Run a Samza Application

--- a/docs/learn/tutorials/versioned/hello-samza-high-level-zk.md
+++ b/docs/learn/tutorials/versioned/hello-samza-high-level-zk.md
@@ -59,7 +59,7 @@ With the environment setup complete, let us move on to building the hello-samza 
 {% highlight bash %}
 mvn clean package
 mkdir -p deploy/samza
-tar -xvf ./target/hello-samza-1.7.0-SNAPSHOT-dist.tar.gz -C deploy/samza
+tar -xvf ./target/hello-samza-1.9.0-SNAPSHOT-dist.tar.gz -C deploy/samza
 {% endhighlight %}
 
 We are now all set to deploy the application locally.

--- a/docs/learn/tutorials/versioned/samza-rest-getting-started.md
+++ b/docs/learn/tutorials/versioned/samza-rest-getting-started.md
@@ -48,7 +48,7 @@ Run the following commands:
 {% highlight bash %}
 cd samza-rest/build/distributions/
 mkdir -p deploy/samza-rest
-tar -xvf ./samza-rest_2.11-1.7.0-SNAPSHOT.tgz -C deploy/samza-rest
+tar -xvf ./samza-rest_2.11-1.9.0-SNAPSHOT.tgz -C deploy/samza-rest
 {% endhighlight %}
 
 #### Configure the Installations Path

--- a/docs/startup/download/index.md
+++ b/docs/startup/download/index.md
@@ -31,6 +31,8 @@ Starting from 2016, Samza will begin requiring JDK8 or higher. Please see [this 
 
  Samza tools package contains command line tools that user can run to use Samza and it's input/output systems.
 
+ * [samza-tools_2.12-1.8.0.tgz](http://www-us.apache.org/dist/samza/1.8.0/samza-tools_2.12-1.8.0.tgz)
+ * [samza-tools_2.12-1.7.0.tgz](http://www-us.apache.org/dist/samza/1.7.0/samza-tools_2.12-1.7.0.tgz)
  * [samza-tools_2.11-1.6.0.tgz](http://www-us.apache.org/dist/samza/1.6.0/samza-tools_2.11-1.6.0.tgz)
  * [samza-tools_2.11-1.5.1.tgz](http://www-us.apache.org/dist/samza/1.5.1/samza-tools_2.11-1.5.1.tgz)
  * [samza-tools_2.11-1.5.0.tgz](http://www-us.apache.org/dist/samza/1.5.0/samza-tools_2.11-1.5.0.tgz)
@@ -44,6 +46,8 @@ Starting from 2016, Samza will begin requiring JDK8 or higher. Please see [this 
 
 ### Source Releases
 
+ * [samza-sources-1.8.0.tgz](http://www.apache.org/dyn/closer.lua/samza/1.8._0)
+ * [samza-sources-1.7.0.tgz](http://www.apache.org/dyn/closer.lua/samza/1.7.0)
  * [samza-sources-1.6.0.tgz](http://www.apache.org/dyn/closer.lua/samza/1.6.0)
  * [samza-sources-1.5.1.tgz](http://www.apache.org/dyn/closer.lua/samza/1.5.1)
  * [samza-sources-1.5.0.tgz](http://www.apache.org/dyn/closer.lua/samza/1.5.0)

--- a/docs/startup/hello-samza/versioned/index.md
+++ b/docs/startup/hello-samza/versioned/index.md
@@ -63,7 +63,7 @@ Then, you can continue w/ the following command in hello-samza project:
 {% highlight bash %}
 mvn clean package
 mkdir -p deploy/samza
-tar -xvf ./target/hello-samza-1.7.0-SNAPSHOT-dist.tar.gz -C deploy/samza
+tar -xvf ./target/hello-samza-1.9.0-SNAPSHOT-dist.tar.gz -C deploy/samza
 {% endhighlight %}
 
 ### Run a Samza Job

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 group=org.apache.samza
-version=1.7.0-SNAPSHOT
+version=1.9.0-SNAPSHOT
 scalaSuffix=2.12
 yarnVersion=2.10.1
 # This version of YARN supports Java11 and allows Samza to be run in a Java11 runtime environment


### PR DESCRIPTION
This PR has all website/doc related changes w.r.t to samza 1.8.0 release. Since we did not add anything for 1.7.0 release, this PR adds a release.md and download links for 1.7.0 release.