### PR TITLE
Fix deadlock in StreamAppender

### DIFF
--- a/samza-log4j2/src/test/java/org/apache/samza/logging/log4j2/MockSystemAdmin.java
+++ b/samza-log4j2/src/test/java/org/apache/samza/logging/log4j2/MockSystemAdmin.java
@@ -19,6 +19,8 @@
 
 package org.apache.samza.logging.log4j2;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.samza.system.StreamSpec;
@@ -30,6 +32,7 @@ import org.apache.samza.system.SystemStreamPartition;
 
 public class MockSystemAdmin implements SystemAdmin {
   public static StreamSpec createdStreamSpec = null;
+  public static List<MockSystemAdmin.MockSystemAdminListener> listeners = new ArrayList<>();
 
   @Override
   public void start() {
@@ -59,6 +62,7 @@ public class MockSystemAdmin implements SystemAdmin {
   @Override
   public boolean createStream(StreamSpec streamSpec) {
     createdStreamSpec = streamSpec;
+    listeners.forEach(listener -> listener.onCreate(streamSpec));
     return true;
   }
 
@@ -70,5 +74,9 @@ public class MockSystemAdmin implements SystemAdmin {
   @Override
   public boolean clearStream(StreamSpec streamSpec) {
     return false;
+  }
+
+  public interface MockSystemAdminListener {
+    void onCreate(StreamSpec streamSpec);
   }
 }


### PR DESCRIPTION
Issue:
In StreamAppender, there is a synchronized block around setupSystem(), which should be called the first time (after loggingContext config is set up) any logger logs something.
It could lead to a deadlock situation. Because if during the setupSystem(), any other threads try to do LOG.xxx(), they will be blocked, and if the system setup depends on those threads, it leads to deadlock

Change:
Replace the synchronized block with a [tryLock](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/locks/Lock.html#tryLock(long,%20java.util.concurrent.TimeUnit))(long time, [TimeUnit](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/TimeUnit.html) unit)
so that other threads won't be blocked forever if setupSystem() stuck or timeout

Usage Change:
If any thread try to log during the time that another thread is setting up the stream, it will wait for SET_UP_SYSTEM_TIMEOUT_MILLI_SECONDS. If timeout, StreamAppender will skip sending its log event

Note that before the change, the thread will block and wait until the stream setting up is done. This behavior opens the chance of deadlock and needs to be changed

Test Done:
Add new units for the change
./gradlew build