### PR TITLE
SAMZA-2774: Resolve classpath symlinks

### DIFF
--- a/samza-shell/src/main/bash/run-class.sh
+++ b/samza-shell/src/main/bash/run-class.sh
@@ -57,7 +57,11 @@ CLASSPATH=""
 # all the jars need to be appended on newlines to ensure line argument length of 72 bytes is not violated
 for file in $BASE_LIB_DIR/*.[jw]ar;
 do
-  CLASSPATH=$CLASSPATH" $file \n"
+  # Symlinks need to be resolved here, otherwise, the jars listed in the
+  # manifest below will point at the first container launched instead of
+  # the jars at the application level.
+  resolved_file=$( cd $(dirname $(readlink `[[ $OSTYPE == linux* ]] && echo "-f"` "$file")) ; pwd -P)
+  CLASSPATH=$CLASSPATH" $resolved_file \n"
 done
 echo generated from BASE_LIB_DIR CLASSPATH=$CLASSPATH
 


### PR DESCRIPTION
Manifest generation (application-level) is pointing to container-level symlinks instead of application-level files.

This will cause issues when multiple containers for an application land on a single host and the container the manifest is pointing to gets cleaned up.

```
[yyy@zzz filecache]$ cat /data/appcache/application_1668550466222_0989/filecache/10/xxx-0.0.672.tgz/classpath_workspace/manifest.txt|tail -n 2
 /data/appcache/application_1668550466222_0989/container_e114_1668550466222_0989_01_000003/__package/lib/zstd-jni-1.5.2-3.jar

[yyy@zzz filecache]$
```

This patch is to resolve those symlinks to their application level paths.