### PR TITLE
Side Inputs + Blob Store Backups - Part 1 - Fix duplicate uploads and broken metrics

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/StorageConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/StorageConfig.java
@@ -22,6 +22,7 @@ package org.apache.samza.config;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -99,7 +100,8 @@ public class StorageConfig extends MapConfig {
 
   public List<String> getStoreNames() {
     Config subConfig = subset(STORE_PREFIX, true);
-    List<String> storeNames = new ArrayList<>();
+    // side input store configs can contain both the store factory and side input processor factory configs. dedup.
+    Set<String> storeNames = new HashSet<>();
     for (String key : subConfig.keySet()) {
       if (key.endsWith(SIDE_INPUT_PROCESSOR_FACTORY_SUFFIX)) {
         storeNames.add(key.substring(0, key.length() - SIDE_INPUT_PROCESSOR_FACTORY_SUFFIX.length()));
@@ -107,7 +109,7 @@ public class StorageConfig extends MapConfig {
         storeNames.add(key.substring(0, key.length() - FACTORY_SUFFIX.length()));
       }
     }
-    return storeNames;
+    return new ArrayList<>(storeNames);
   }
 
   public Map<String, SystemStream> getStoreChangelogs() {

--- a/samza-core/src/main/java/org/apache/samza/storage/TaskStorageCommitManager.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/TaskStorageCommitManager.java
@@ -133,7 +133,7 @@ public class TaskStorageCommitManager {
     // state backend factory -> store Name -> state checkpoint marker
     Map<String, Map<String, String>> stateBackendToStoreSCMs = new HashMap<>();
 
-    // for each configured state backend factory, backup the state for all stores in this task.
+    // for each configured state backend factory, snapshot the state for all stores in this task.
     stateBackendToBackupManager.forEach((stateBackendFactoryName, backupManager) -> {
       Map<String, String> snapshotSCMs = backupManager.snapshot(checkpointId);
       LOG.debug("Created snapshot for taskName: {}, checkpoint id: {}, state backend: {}. Snapshot SCMs: {}",

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/BlobStoreBackupManager.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/BlobStoreBackupManager.java
@@ -21,6 +21,8 @@ package org.apache.samza.storage.blobstore;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -29,6 +31,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
@@ -73,7 +76,7 @@ public class BlobStoreBackupManager implements TaskBackupManager {
   private final BlobStoreConfig blobStoreConfig;
   private final Clock clock;
   private final StorageManagerUtil storageManagerUtil;
-  private final List<String> storesToBackup;
+  private final Set<String> storesToBackup;
   private final File loggedStoreBaseDir;
   private final BlobStoreManager blobStoreManager;
   private final BlobStoreUtil blobStoreUtil;
@@ -117,8 +120,8 @@ public class BlobStoreBackupManager implements TaskBackupManager {
     this.clock = clock;
     this.storageManagerUtil = storageManagerUtil;
     StorageConfig storageConfig = new StorageConfig(config);
-    this.storesToBackup =
-        storageConfig.getPersistentStoresWithBackupFactory(BlobStoreStateBackendFactory.class.getName());
+    this.storesToBackup = ImmutableSet.copyOf(
+        storageConfig.getPersistentStoresWithBackupFactory(BlobStoreStateBackendFactory.class.getName()));
     this.loggedStoreBaseDir = loggedStoreBaseDir;
     this.blobStoreManager = blobStoreManager;
     this.blobStoreUtil = createBlobStoreUtil(blobStoreManager, executor, blobStoreConfig, blobStoreTaskBackupMetrics);

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/metrics/BlobStoreBackupManagerMetrics.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/metrics/BlobStoreBackupManagerMetrics.java
@@ -107,30 +107,33 @@ public class BlobStoreBackupManagerMetrics {
   }
 
   public void initStoreMetrics(Collection<String> storeNames) {
+    // MetricRegistryMap#newGauge overwrites existing gauge, while newTimer retains and returns existing timer.
+    // For now, use computeIfAbsent instead of putIfAbsent to avoid overwriting old gauges and returning
+    // a new untracked one. Also to keep usage consistent b/w gauges and timers.
     for (String storeName: storeNames) {
-      storeDirDiffNs.putIfAbsent(storeName,
-          metricsRegistry.newTimer(GROUP, String.format("%s-dir-diff-ns", storeName)));
-      storeUploadNs.putIfAbsent(storeName,
-          metricsRegistry.newTimer(GROUP, String.format("%s-upload-ns", storeName)));
+      storeDirDiffNs.computeIfAbsent(storeName,
+        kStoreName -> metricsRegistry.newTimer(GROUP, String.format("%s-dir-diff-ns", kStoreName)));
+      storeUploadNs.computeIfAbsent(storeName,
+        kStoreName -> metricsRegistry.newTimer(GROUP, String.format("%s-upload-ns", kStoreName)));
 
-      storeFilesToUpload.putIfAbsent(storeName,
-          metricsRegistry.newGauge(GROUP, String.format("%s-files-to-upload", storeName), 0L));
-      storeFilesToRetain.putIfAbsent(storeName,
-          metricsRegistry.newGauge(GROUP, String.format("%s-files-to-retain", storeName), 0L));
-      storeFilesToRemove.putIfAbsent(storeName,
-          metricsRegistry.newGauge(GROUP, String.format("%s-files-to-remove", storeName), 0L));
-      storeSubDirsToUpload.putIfAbsent(storeName,
-          metricsRegistry.newGauge(GROUP, String.format("%s-sub-dirs-to-upload", storeName), 0L));
-      storeSubDirsToRetain.putIfAbsent(storeName,
-          metricsRegistry.newGauge(GROUP, String.format("%s-sub-dirs-to-retain", storeName), 0L));
-      storeSubDirsToRemove.putIfAbsent(storeName,
-          metricsRegistry.newGauge(GROUP, String.format("%s-sub-dirs-to-remove", storeName), 0L));
-      storeBytesToUpload.putIfAbsent(storeName,
-          metricsRegistry.newGauge(GROUP, String.format("%s-bytes-to-upload", storeName), 0L));
-      storeBytesToRetain.putIfAbsent(storeName,
-          metricsRegistry.newGauge(GROUP, String.format("%s-bytes-to-retain", storeName), 0L));
-      storeBytesToRemove.putIfAbsent(storeName,
-          metricsRegistry.newGauge(GROUP, String.format("%s-bytes-to-remove", storeName), 0L));
+      storeFilesToUpload.computeIfAbsent(storeName,
+        kStoreName -> metricsRegistry.newGauge(GROUP, String.format("%s-files-to-upload", kStoreName), 0L));
+      storeFilesToRetain.computeIfAbsent(storeName,
+        kStoreName -> metricsRegistry.newGauge(GROUP, String.format("%s-files-to-retain", kStoreName), 0L));
+      storeFilesToRemove.computeIfAbsent(storeName,
+        kStoreName -> metricsRegistry.newGauge(GROUP, String.format("%s-files-to-remove", kStoreName), 0L));
+      storeSubDirsToUpload.computeIfAbsent(storeName,
+        kStoreName -> metricsRegistry.newGauge(GROUP, String.format("%s-sub-dirs-to-upload", kStoreName), 0L));
+      storeSubDirsToRetain.computeIfAbsent(storeName,
+        kStoreName -> metricsRegistry.newGauge(GROUP, String.format("%s-sub-dirs-to-retain", kStoreName), 0L));
+      storeSubDirsToRemove.computeIfAbsent(storeName,
+        kStoreName -> metricsRegistry.newGauge(GROUP, String.format("%s-sub-dirs-to-remove", kStoreName), 0L));
+      storeBytesToUpload.computeIfAbsent(storeName,
+        kStoreName -> metricsRegistry.newGauge(GROUP, String.format("%s-bytes-to-upload", kStoreName), 0L));
+      storeBytesToRetain.computeIfAbsent(storeName,
+        kStoreName -> metricsRegistry.newGauge(GROUP, String.format("%s-bytes-to-retain", kStoreName), 0L));
+      storeBytesToRemove.computeIfAbsent(storeName,
+        kStoreName -> metricsRegistry.newGauge(GROUP, String.format("%s-bytes-to-remove", kStoreName), 0L));
     }
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/config/TestStorageConfig.java
+++ b/samza-core/src/test/java/org/apache/samza/config/TestStorageConfig.java
@@ -65,6 +65,34 @@ public class TestStorageConfig {
         ImmutableMap.of(String.format(FACTORY, STORE_NAME0), "store0.factory.class",
             String.format(StorageConfig.SIDE_INPUTS_PROCESSOR_FACTORY, STORE_NAME1), "store1.factory.class")));
 
+    actual = config.getStoreNames();
+
+    assertEquals(2, actual.size());
+    assertEquals(expectedStoreNames, ImmutableSet.copyOf(actual));
+  }
+
+  @Test
+  public void testGetStoreNamesDoesNotReturnDuplicatesForSideInputs() {
+    // empty config, so no stores
+    assertEquals(Collections.emptyList(), new StorageConfig(new MapConfig()).getStoreNames());
+
+    Set<String> expectedStoreNames = ImmutableSet.of(STORE_NAME0, STORE_NAME1);
+    // has stores
+    StorageConfig storageConfig = new StorageConfig(new MapConfig(
+        ImmutableMap.of(String.format(StorageConfig.FACTORY, STORE_NAME0), "store0.factory.class",
+            String.format(StorageConfig.FACTORY, STORE_NAME1), "store1.factory.class",
+            String.format(StorageConfig.SIDE_INPUTS_PROCESSOR_FACTORY, STORE_NAME1), "store1.side.inputs.processor")));
+
+    List<String> actual = storageConfig.getStoreNames();
+    // ordering shouldn't matter
+    assertEquals(2, actual.size());
+    assertEquals(expectedStoreNames, ImmutableSet.copyOf(actual));
+
+    //has side input stores
+    StorageConfig config = new StorageConfig(new MapConfig(
+        ImmutableMap.of(String.format(FACTORY, STORE_NAME0), "store0.factory.class",
+            String.format(StorageConfig.SIDE_INPUTS_PROCESSOR_FACTORY, STORE_NAME1), "store1.factory.class")));
+
     actual = storageConfig.getStoreNames();
 
     assertEquals(2, actual.size());
@@ -504,8 +532,8 @@ public class TestStorageConfig {
     assertEquals(ImmutableSet.of(KAFKA_STATE_BACKEND_FACTORY), new StorageConfig(new MapConfig(configMap)).getBackupFactories());
     assertEquals(DEFAULT_BACKUP_FACTORIES, new StorageConfig(new MapConfig(configMap)).getStoreBackupFactories(storeName));
     assertEquals(DEFAULT_BACKUP_FACTORIES, new StorageConfig(new MapConfig(configMap)).getStoreBackupFactories(storeName2));
-    assertEquals(ImmutableList.of(storeName2, storeName),
-        new StorageConfig(new MapConfig(configMap)).getStoresWithBackupFactory(KAFKA_STATE_BACKEND_FACTORY));
+    assertEquals(ImmutableSet.of(storeName2, storeName),
+        ImmutableSet.copyOf(new StorageConfig(new MapConfig(configMap)).getStoresWithBackupFactory(KAFKA_STATE_BACKEND_FACTORY)));
 
     // job restore manager config set should override to job backend factory
     String jobBackupFactory1 = "jobBackendBackupFactory1";
@@ -514,16 +542,16 @@ public class TestStorageConfig {
     configMap.put(JOB_BACKUP_FACTORIES, jobBackupFactoryOverride);
     assertEquals(ImmutableSet.of(jobBackupFactory1, jobBackupFactory2),
         new StorageConfig(new MapConfig(configMap)).getBackupFactories());
-    assertEquals(ImmutableList.of(jobBackupFactory1, jobBackupFactory2),
-        new StorageConfig(new MapConfig(configMap)).getStoreBackupFactories(storeName));
-    assertEquals(ImmutableList.of(jobBackupFactory1, jobBackupFactory2),
-        new StorageConfig(new MapConfig(configMap)).getStoreBackupFactories(storeName2));
+    assertEquals(ImmutableSet.of(jobBackupFactory1, jobBackupFactory2),
+        ImmutableSet.copyOf(new StorageConfig(new MapConfig(configMap)).getStoreBackupFactories(storeName)));
+    assertEquals(ImmutableSet.of(jobBackupFactory1, jobBackupFactory2),
+        ImmutableSet.copyOf(new StorageConfig(new MapConfig(configMap)).getStoreBackupFactories(storeName2)));
     assertEquals(Collections.emptyList(),
         new StorageConfig(new MapConfig(configMap)).getStoresWithBackupFactory(KAFKA_STATE_BACKEND_FACTORY));
-    assertEquals(ImmutableList.of(storeName2, storeName),
-        new StorageConfig(new MapConfig(configMap)).getStoresWithBackupFactory(jobBackupFactory1));
-    assertEquals(ImmutableList.of(storeName2, storeName),
-        new StorageConfig(new MapConfig(configMap)).getStoresWithBackupFactory(jobBackupFactory2));
+    assertEquals(ImmutableSet.of(storeName2, storeName),
+        ImmutableSet.copyOf(new StorageConfig(new MapConfig(configMap)).getStoresWithBackupFactory(jobBackupFactory1)));
+    assertEquals(ImmutableSet.of(storeName2, storeName),
+        ImmutableSet.copyOf(new StorageConfig(new MapConfig(configMap)).getStoresWithBackupFactory(jobBackupFactory2)));
 
     // store specific restore managers set
     String storeBackupFactory1 = "storeBackendBackupFactory1";


### PR DESCRIPTION
Part 1 of 2. Follow up PR to restore side input stores using Blob Store backups coming soon.

Symptoms: 
1. Side input stores are uploaded twice when using Blob Store State Backend.
2. Store-level Gauges (but not Timers) in BlobStoreBackupManagerMetrics are broken for side input stores.
3. Task level Gauges in BlobStoreBackupManagerMetrics have incorrect value (count twice for side input stores).

Cause: 
1. StorageConfig#getStoreNames() returns side input stores twice in the list. 
2. BlobStoreBackupManager does not dedup storesToBackup list.
3. PR #1223 makes the duplicate-registration behavior between Gauges and Timers inconsistent.
 
Changes: 
1. Fixed StorageConfig#getStoreNames() to dedup store names.
2. Added defensive dedup in BlobStoreBackupManager.
3. Changed store level metrics initialization in BlobStoreBackupManagerMetrics to computeIfAbsent instead of putIfAbsent to avoid overwriting-yet-returning-old-Gauges in case of duplicate store names.
 
Tests: 
Added unit tests for StorageConfig to verify deduping.