### PR TITLE
Side Inputs + Blob Store Backups - Part 2 - Allow bulk restore from blob store for side input stores

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -51,6 +51,7 @@ import org.apache.samza.job.model.TaskMode;
 import org.apache.samza.metrics.Gauge;
 import org.apache.samza.serializers.Serde;
 import org.apache.samza.serializers.SerdeManager;
+import org.apache.samza.storage.blobstore.BlobStoreStateBackendFactory;
 import org.apache.samza.system.StreamMetadataCache;
 import org.apache.samza.system.SystemAdmins;
 import org.apache.samza.system.SystemConsumer;
@@ -270,12 +271,30 @@ public class ContainerStorageManager {
         LOG.info("Obtained checkpoint: {} for state restore for taskName: {}", taskCheckpoint, taskName);
       }
       taskCheckpoints.put(taskName, taskCheckpoint);
-      Map<String, Set<String>> backendFactoryStoreNames =
+
+      Map<String, Set<String>> backendFactoryToStoreNames =
           ContainerStorageManagerUtil.getBackendFactoryStoreNames(
               nonSideInputStoreNames, taskCheckpoint, new StorageConfig(config));
+
+      Map<String, Set<String>> backendFactoryToSideInputStoreNames =
+          ContainerStorageManagerUtil.getBackendFactoryStoreNames(
+              sideInputStoreNames, taskCheckpoint, new StorageConfig(config));
+
+      // include side input stores for (initial bulk) restore if backed up using blob store state backend
+      String blobStoreStateBackendFactory = BlobStoreStateBackendFactory.class.getName();
+      if (backendFactoryToSideInputStoreNames.containsKey(blobStoreStateBackendFactory)) {
+        Set<String> sideInputStoreNames = backendFactoryToSideInputStoreNames.get(blobStoreStateBackendFactory);
+
+        if (backendFactoryToStoreNames.containsKey(blobStoreStateBackendFactory)) {
+          backendFactoryToStoreNames.get(blobStoreStateBackendFactory).addAll(sideInputStoreNames);
+        } else {
+          backendFactoryToStoreNames.put(blobStoreStateBackendFactory, sideInputStoreNames);
+        }
+      }
+
       Map<String, TaskRestoreManager> taskStoreRestoreManagers =
           ContainerStorageManagerUtil.createTaskRestoreManagers(
-              taskName, backendFactoryStoreNames, restoreStateBackendFactories,
+              taskName, backendFactoryToStoreNames, restoreStateBackendFactories,
               storageEngineFactories, storeConsumers,
               inMemoryStores, systemAdmins, restoreExecutor,
               taskModel, jobContext, containerContext,

--- a/samza-core/src/main/scala/org/apache/samza/storage/SideInputsManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/SideInputsManager.java
@@ -222,7 +222,8 @@ public class SideInputsManager {
           sideInputTaskMetrics.put(taskName, sideInputMetrics);
 
           RunLoopTask sideInputTask = new SideInputTask(taskName, taskSSPs,
-              taskSideInputHandlers.get(taskName), sideInputTaskMetrics.get(taskName));
+              taskSideInputHandlers.get(taskName), sideInputTaskMetrics.get(taskName),
+              new TaskConfig(config).getCommitMs());
           sideInputTasks.put(taskName, sideInputTask);
         }
       });

--- a/samza-test/src/test/java/org/apache/samza/checkpoint/CheckpointVersionIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/checkpoint/CheckpointVersionIntegrationTest.java
@@ -19,12 +19,15 @@
 
 package org.apache.samza.checkpoint;
 
+import com.google.common.collect.ImmutableSet;
+
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.samza.config.JobConfig;
@@ -135,7 +138,10 @@ public class CheckpointVersionIntegrationTest extends StreamApplicationIntegrati
 
     // run the application
     RunApplicationContext context = runApplication(
-        new MyStatefulApplication(INPUT_SYSTEM, INPUT_TOPIC, Collections.singletonMap(STORE_NAME, CHANGELOG_TOPIC)), "myApp", configs);
+        new MyStatefulApplication(INPUT_SYSTEM, INPUT_TOPIC,
+            ImmutableSet.of(STORE_NAME), Collections.singletonMap(STORE_NAME, CHANGELOG_TOPIC),
+            Optional.empty(), Optional.empty(), Optional.empty()),
+        "myApp", configs);
 
     // wait for the application to finish
     context.getRunner().waitForFinish();
@@ -162,7 +168,10 @@ public class CheckpointVersionIntegrationTest extends StreamApplicationIntegrati
 
     // run the application
     RunApplicationContext context = runApplication(
-        new MyStatefulApplication(INPUT_SYSTEM, INPUT_TOPIC, Collections.singletonMap(STORE_NAME, changelogTopic)), "myApp", overriddenConfigs);
+        new MyStatefulApplication(INPUT_SYSTEM, INPUT_TOPIC,
+            ImmutableSet.of(STORE_NAME), Collections.singletonMap(STORE_NAME, changelogTopic),
+            Optional.empty(), Optional.empty(), Optional.empty()),
+        "myApp", overriddenConfigs);
 
     // wait for the application to finish
     context.getRunner().waitForFinish();

--- a/samza-test/src/test/java/org/apache/samza/storage/kv/BlobStoreStateBackendIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/storage/kv/BlobStoreStateBackendIntegrationTest.java
@@ -1,0 +1,325 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.storage.kv;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.samza.config.BlobStoreConfig;
+import org.apache.samza.config.JobConfig;
+import org.apache.samza.config.JobCoordinatorConfig;
+import org.apache.samza.config.KafkaConfig;
+import org.apache.samza.config.StorageConfig;
+import org.apache.samza.config.TaskConfig;
+import org.apache.samza.storage.MyStatefulApplication;
+import org.apache.samza.storage.SideInputsProcessor;
+import org.apache.samza.storage.blobstore.Metadata;
+import org.apache.samza.storage.blobstore.index.SnapshotIndex;
+import org.apache.samza.storage.blobstore.index.serde.SnapshotIndexSerde;
+import org.apache.samza.system.IncomingMessageEnvelope;
+import org.apache.samza.test.framework.StreamApplicationIntegrationTestHarness;
+import org.apache.samza.test.util.TestBlobStoreManager;
+import org.apache.samza.util.FileUtil;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+@RunWith(value = Parameterized.class)
+public class BlobStoreStateBackendIntegrationTest extends StreamApplicationIntegrationTestHarness {
+  @Parameterized.Parameters(name = "hostAffinity={0}")
+  public static Collection<Boolean> data() {
+    return Arrays.asList(true, false);
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(BlobStoreStateBackendIntegrationTest.class);
+
+  private static final String INPUT_TOPIC = "inputTopic";
+  private static final String SIDE_INPUT_TOPIC = "sideInputTopic";
+  private static final String INPUT_SYSTEM = "kafka";
+  private static final String STORE_NAME = "regularStore";
+  private static final String SIDE_INPUT_STORE_NAME = "sideInputStore";
+
+  private static final String LOGGED_STORE_BASE_DIR = new File(System.getProperty("java.io.tmpdir"), "logged-store").getAbsolutePath();
+  private static final String BLOB_STORE_BASE_DIR = new File(System.getProperty("java.io.tmpdir"), "blob-store").getAbsolutePath();
+  private static final String BLOB_STORE_LEDGER_DIR = new File(BLOB_STORE_BASE_DIR, "ledger").getAbsolutePath();
+
+  private static final Map<String, String> CONFIGS = new HashMap<String, String>() { {
+      put(JobCoordinatorConfig.JOB_COORDINATOR_FACTORY, "org.apache.samza.standalone.PassthroughJobCoordinatorFactory");
+      put(JobConfig.PROCESSOR_ID, "0");
+      put(TaskConfig.GROUPER_FACTORY, "org.apache.samza.container.grouper.task.GroupByContainerIdsFactory");
+      put(TaskConfig.CHECKPOINT_READ_VERSIONS, "2, 1");
+      put(TaskConfig.CHECKPOINT_WRITE_VERSIONS, "1, 2");
+      put(TaskConfig.CHECKPOINT_MANAGER_FACTORY, "org.apache.samza.checkpoint.kafka.KafkaCheckpointManagerFactory");
+      put(TaskConfig.COMMIT_MS, "-1"); // manual commit only
+      put(StorageConfig.JOB_BACKUP_FACTORIES, "org.apache.samza.storage.blobstore.BlobStoreStateBackendFactory");
+      put(StorageConfig.JOB_RESTORE_FACTORIES, "org.apache.samza.storage.blobstore.BlobStoreStateBackendFactory");
+      put(BlobStoreConfig.BLOB_STORE_MANAGER_FACTORY, "org.apache.samza.test.util.TestBlobStoreManagerFactory");
+      put(JobConfig.JOB_LOGGED_STORE_BASE_DIR, LOGGED_STORE_BASE_DIR);
+      put(TestBlobStoreManager.BLOB_STORE_BASE_DIR, BLOB_STORE_BASE_DIR);
+      put(TestBlobStoreManager.BLOB_STORE_LEDGER_DIR, BLOB_STORE_LEDGER_DIR);
+      put(KafkaConfig.CHECKPOINT_REPLICATION_FACTOR(), "1");
+      put(TaskConfig.COMMIT_MAX_DELAY_MS, "0"); // Ensure no commits are skipped due to in progress commits
+    } };
+
+  private final boolean hostAffinity;
+
+  public BlobStoreStateBackendIntegrationTest(boolean hostAffinity) {
+    this.hostAffinity = hostAffinity;
+  }
+
+  @Before
+  @Override
+  public void setUp() {
+    super.setUp();
+    // reset static state shared with task between each parameterized iteration
+    MyStatefulApplication.resetTestState();
+    FileUtil fileUtil = new FileUtil();
+    fileUtil.rm(new File(LOGGED_STORE_BASE_DIR)); // always clear local store on startup
+    // no need to clear ledger dir since subdir of blob store base dir
+    fileUtil.rm(new File(BLOB_STORE_BASE_DIR)); // always clear local "blob store" on startup
+
+  }
+
+  @Test
+  public void testStopAndRestart() {
+    List<String> inputMessagesOnInitialRun = Arrays.asList("1", "2", "3", "2", "97", "-97", ":98", ":99", ":crash_once");
+    initialRun(inputMessagesOnInitialRun);
+    Pair<String, SnapshotIndex> lastSnapshot = verifyLedger(STORE_NAME, Optional.empty(), hostAffinity);
+
+    // verifies transactional state too
+    List<String> expectedInitialStoreContentsOnSecondRun = Arrays.asList("1", "2", "3");
+    secondRun(expectedInitialStoreContentsOnSecondRun, CONFIGS);
+    verifyLedger(STORE_NAME, Optional.of(lastSnapshot), hostAffinity);
+  }
+
+  @Test
+  public void testStopAndRestartWithSideInputStore() {
+    List<String> inputMessagesOnInitialRun = Arrays.asList("1", "2", "3", "2", "97", "-97", ":98", ":99", ":crash_once");
+    List<String> sideInputMessagesOnInitialRun = Arrays.asList("10", "20", "30", "40", "50", "60", "70", "80", "90");
+    initialRunWithSideInputs(inputMessagesOnInitialRun, sideInputMessagesOnInitialRun, CONFIGS);
+    Pair<String, SnapshotIndex> lastRegularSnapshot = verifyLedger(STORE_NAME, Optional.empty(), hostAffinity);
+    Pair<String, SnapshotIndex> lastSideInputSnapshot = verifyLedger(SIDE_INPUT_STORE_NAME, Optional.empty(), hostAffinity);
+
+    // verifies transactional state too
+    List<String> expectedInitialStoreContentsOnSecondRun = Arrays.asList("1", "2", "3");
+    secondRunWithSideInputs(expectedInitialStoreContentsOnSecondRun, CONFIGS);
+    verifyLedger(STORE_NAME, Optional.of(lastRegularSnapshot), hostAffinity);
+    verifyLedger(SIDE_INPUT_STORE_NAME, Optional.of(lastSideInputSnapshot), hostAffinity);
+  }
+
+  private void initialRun(List<String> inputMessages) {
+    // create input topic and produce the first batch of input messages
+    createTopic(INPUT_TOPIC, 1);
+    inputMessages.forEach(m -> produceMessage(INPUT_TOPIC, 0, m, m));
+
+    // verify that the input messages were produced successfully
+    if (inputMessages.size() > 0) {
+      List<ConsumerRecord<String, String>> inputRecords =
+          consumeMessages(INPUT_TOPIC, inputMessages.size());
+      List<String> readInputMessages = inputRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
+      Assert.assertEquals(inputMessages, readInputMessages);
+    }
+
+    // run the application
+    RunApplicationContext context = runApplication(
+        new MyStatefulApplication(INPUT_SYSTEM, INPUT_TOPIC,
+            ImmutableSet.of(STORE_NAME), Collections.emptyMap(),
+            Optional.empty(), Optional.empty(), Optional.empty()),
+        "myApp", CONFIGS);
+
+    // wait for the application to finish
+    context.getRunner().waitForFinish();
+
+    LOG.info("Finished initial run");
+  }
+
+  private void secondRun(List<String> expectedInitialStoreContents, Map<String, String> overriddenConfigs) {
+    // clear the local store directory
+    if (!hostAffinity) {
+      new FileUtil().rm(new File(LOGGED_STORE_BASE_DIR));
+    }
+
+    // produce the second batch of input messages
+
+    List<String> inputMessages = Arrays.asList("4", "5", "5", ":shutdown");
+    inputMessages.forEach(m -> produceMessage(INPUT_TOPIC, 0, m, m));
+
+    // run the application
+    RunApplicationContext context = runApplication(
+        new MyStatefulApplication(INPUT_SYSTEM, INPUT_TOPIC,
+            ImmutableSet.of(STORE_NAME), Collections.emptyMap(),
+            Optional.empty(), Optional.empty(), Optional.empty()),
+        "myApp", overriddenConfigs);
+
+    // wait for the application to finish
+    context.getRunner().waitForFinish();
+
+    // verify the store contents during startup (this is after changelog verification to ensure init has completed)
+    Assert.assertEquals(expectedInitialStoreContents, MyStatefulApplication.getInitialStoreContents().get(STORE_NAME));
+  }
+
+  private void initialRunWithSideInputs(List<String> inputMessages, List<String> sideInputMessages, Map<String, String> configs) {
+    // create input topic and produce the first batch of input messages
+    createTopic(INPUT_TOPIC, 1);
+    createTopic(SIDE_INPUT_TOPIC, 1);
+    inputMessages.forEach(m -> produceMessage(INPUT_TOPIC, 0, m, m));
+    sideInputMessages.forEach(m -> produceMessage(SIDE_INPUT_TOPIC, 0, m, m));
+
+    // verify that the input messages were produced successfully
+    if (inputMessages.size() > 0) {
+      List<ConsumerRecord<String, String>> inputRecords =
+          consumeMessages(INPUT_TOPIC, inputMessages.size());
+      List<String> readInputMessages = inputRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
+      Assert.assertEquals(inputMessages, readInputMessages);
+    }
+
+    if (sideInputMessages.size() > 0) {
+      List<ConsumerRecord<String, String>> sideInputRecords =
+          consumeMessages(SIDE_INPUT_TOPIC, sideInputMessages.size());
+      List<String> readSideInputMessages = sideInputRecords.stream().map(ConsumerRecord::value).collect(Collectors.toList());
+      Assert.assertEquals(sideInputMessages, readSideInputMessages);
+    }
+
+    // run the application
+    RunApplicationContext context = runApplication(
+        new MyStatefulApplication(INPUT_SYSTEM, INPUT_TOPIC,
+            ImmutableSet.of(STORE_NAME), Collections.emptyMap(),
+            Optional.of(SIDE_INPUT_STORE_NAME), Optional.of(SIDE_INPUT_TOPIC), Optional.of(new MySideInputProcessor())),
+        "myApp", configs);
+
+    // wait for the application to finish
+    context.getRunner().waitForFinish();
+
+    LOG.info("Finished initial run");
+  }
+
+  private void secondRunWithSideInputs(List<String> expectedInitialStoreContents, Map<String, String> configs) {
+    // clear the local store directory
+    if (!hostAffinity) {
+      new FileUtil().rm(new File(LOGGED_STORE_BASE_DIR));
+    }
+
+    // produce the second batch of input messages
+
+    List<String> inputMessages = Arrays.asList("4", "5", "5", ":shutdown");
+    inputMessages.forEach(m -> produceMessage(INPUT_TOPIC, 0, m, m));
+
+    // run the application
+    RunApplicationContext context = runApplication(
+        new MyStatefulApplication(INPUT_SYSTEM, INPUT_TOPIC,
+            ImmutableSet.of(STORE_NAME), Collections.emptyMap(),
+            Optional.of(SIDE_INPUT_STORE_NAME), Optional.of(SIDE_INPUT_TOPIC), Optional.of(new MySideInputProcessor())),
+        "myApp", configs);
+
+    // wait for the application to finish
+    context.getRunner().waitForFinish();
+
+    // verify the store contents during startup
+    Assert.assertEquals(expectedInitialStoreContents, MyStatefulApplication.getInitialStoreContents().get(STORE_NAME));
+  }
+
+  /**
+   * Verifies the ledger for TestBlobStoreManager.
+   * @param startingSnapshot snapshot file name and files present in snapshot at the beginning of verification (from previous run), if any.
+   * @return Pair file for latest snapshot at time of verification
+   */
+  private static Pair<String, SnapshotIndex> verifyLedger(String storeName,
+      Optional<Pair<String, SnapshotIndex>> startingSnapshot,
+      boolean hostAffinity) {
+    Path ledgerLocation = Paths.get(BLOB_STORE_LEDGER_DIR);
+    try {
+      File filesAddedLedger = Paths.get(ledgerLocation.toString(), TestBlobStoreManager.LEDGER_FILES_ADDED).toFile();
+      Set<String> filesAdded = Files.lines(filesAddedLedger.toPath()).filter(l -> l.contains(storeName)).collect(Collectors.toSet());
+      File filesReadLedger = Paths.get(ledgerLocation.toString(), TestBlobStoreManager.LEDGER_FILES_READ).toFile();
+      Set<String> filesRead = Files.lines(filesReadLedger.toPath()).filter(l -> l.contains(storeName)).collect(Collectors.toSet());
+      File filesDeletedLedger = Paths.get(ledgerLocation.toString(), TestBlobStoreManager.LEDGER_FILES_DELETED).toFile();
+      Set<String> filesDeleted = Files.lines(filesDeletedLedger.toPath()).filter(l -> l.contains(storeName)).collect(Collectors.toSet());
+      File filesTTLUpdatedLedger = Paths.get(ledgerLocation.toString(), TestBlobStoreManager.LEDGER_FILES_TTL_UPDATED).toFile();
+      Set<String> filesTTLUpdated = Files.lines(filesTTLUpdatedLedger.toPath()).filter(l -> l.contains(storeName)).collect(Collectors.toSet());
+
+      // 1. test that files read = files present in last snapshot *at run start* + snapshot file itself + previous snapshot files
+      if (startingSnapshot.isPresent() && !hostAffinity) { // no restore if host affinity (local state already present)
+        Set<String> filesPresentInStartingSnapshot = startingSnapshot.get().getRight()
+            .getDirIndex().getFilesPresent().stream()
+            .map(fi -> fi.getBlobs().get(0).getBlobId()).collect(Collectors.toSet());
+        Set<String> filesToRestore = new HashSet<>();
+        filesToRestore.add(startingSnapshot.get().getLeft());
+        filesToRestore.addAll(filesPresentInStartingSnapshot);
+        // assert that all files to restore in starting snapshot + starting snapshot itself are present in files read
+        assertTrue(Sets.difference(filesToRestore, filesRead).isEmpty());
+        // assert that the remaining read files are all snapshot indexes (for post commit cleanup)
+        assertTrue(Sets.difference(filesRead, filesToRestore).stream().allMatch(s -> s.contains(Metadata.SNAPSHOT_INDEX_PAYLOAD_PATH)));
+      }
+
+      // read files added again as ordered list, not set, to get last file added
+      List<String> filesAddedLines = Files.readAllLines(filesAddedLedger.toPath()).stream().filter(l -> l.contains(storeName)).collect(Collectors.toList());
+      String lastFileAdded = filesAddedLines.get(filesAddedLines.size() - 1); // get last line.
+      assertTrue(lastFileAdded.contains(Metadata.SNAPSHOT_INDEX_PAYLOAD_PATH)); // assert is a snapshot
+      SnapshotIndex lastSnapshotIndex = new SnapshotIndexSerde().fromBytes(Files.readAllBytes(Paths.get(lastFileAdded)));
+      Set<String> filesPresentInLastSnapshot = lastSnapshotIndex.getDirIndex().getFilesPresent().stream()
+          .map(fi -> fi.getBlobs().get(0).getBlobId()).collect(Collectors.toSet());
+
+      // 2. test that all added files were ttl reset
+      assertEquals(filesAdded, filesTTLUpdated);
+
+      // 3. test that files deleted = files added - files present in last snapshot + snapshot file itself
+      // i.e., net remaining files (files added - files deleted) = files present in last snapshot + snapshot file itself.
+      assertEquals(Sets.difference(filesAdded, filesDeleted),
+          Sets.union(filesPresentInLastSnapshot, Collections.singleton(lastFileAdded)));
+
+      return Pair.of(lastFileAdded, lastSnapshotIndex);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  static class MySideInputProcessor implements SideInputsProcessor, Serializable {
+    @Override
+    public Collection<Entry<?, ?>> process(IncomingMessageEnvelope message, KeyValueStore store) {
+      return ImmutableSet.of(new Entry<>(message.getKey(), message.getMessage()));
+    }
+  }
+}

--- a/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateIntegrationTest.java
@@ -20,6 +20,7 @@
 package org.apache.samza.storage.kv;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import java.io.File;
 import java.util.Arrays;
@@ -28,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.samza.config.JobConfig;
@@ -138,7 +140,9 @@ public class TransactionalStateIntegrationTest extends StreamApplicationIntegrat
 
     // run the application
     RunApplicationContext context = runApplication(
-        new MyStatefulApplication(INPUT_SYSTEM, INPUT_TOPIC, Collections.singletonMap(STORE_NAME, CHANGELOG_TOPIC)),
+        new MyStatefulApplication(INPUT_SYSTEM, INPUT_TOPIC,
+            ImmutableSet.of(STORE_NAME), Collections.singletonMap(STORE_NAME, CHANGELOG_TOPIC),
+            Optional.empty(), Optional.empty(), Optional.empty()),
         "myApp", CONFIGS);
 
     // wait for the application to finish
@@ -169,7 +173,9 @@ public class TransactionalStateIntegrationTest extends StreamApplicationIntegrat
 
     // run the application
     RunApplicationContext context = runApplication(
-        new MyStatefulApplication(INPUT_SYSTEM, INPUT_TOPIC, Collections.singletonMap(STORE_NAME, changelogTopic)),
+        new MyStatefulApplication(INPUT_SYSTEM, INPUT_TOPIC,
+            ImmutableSet.of(STORE_NAME), Collections.singletonMap(STORE_NAME, changelogTopic),
+            Optional.empty(), Optional.empty(), Optional.empty()),
         "myApp", overriddenConfigs);
 
     // wait for the application to finish

--- a/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateMultiStoreIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/storage/kv/TransactionalStateMultiStoreIntegrationTest.java
@@ -22,6 +22,8 @@ package org.apache.samza.storage.kv;
 import com.google.common.collect.ImmutableList;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
@@ -29,6 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.samza.application.SamzaApplication;
@@ -144,10 +147,10 @@ public class TransactionalStateMultiStoreIntegrationTest extends StreamApplicati
       Assert.assertEquals(inputMessages, readInputMessages);
     }
 
-    SamzaApplication app =  new MyStatefulApplication(INPUT_SYSTEM, INPUT_TOPIC, ImmutableMap.of(
-        STORE_1_NAME, STORE_1_CHANGELOG,
-        STORE_2_NAME, STORE_2_CHANGELOG
-    ));
+    SamzaApplication app =  new MyStatefulApplication(INPUT_SYSTEM, INPUT_TOPIC,
+        ImmutableSet.of(STORE_1_NAME, STORE_2_NAME),
+        ImmutableMap.of(STORE_1_NAME, STORE_2_CHANGELOG, STORE_2_NAME, STORE_2_CHANGELOG),
+        Optional.empty(), Optional.empty(), Optional.empty());
 
     // run the application
     RunApplicationContext context = runApplication(app, APP_NAME, CONFIGS);
@@ -178,10 +181,10 @@ public class TransactionalStateMultiStoreIntegrationTest extends StreamApplicati
     List<String> inputMessages = Arrays.asList("4", "5", "5", ":shutdown");
     inputMessages.forEach(m -> produceMessage(INPUT_TOPIC, 0, m, m));
 
-    SamzaApplication app =  new MyStatefulApplication(INPUT_SYSTEM, INPUT_TOPIC, ImmutableMap.of(
-        STORE_1_NAME, changelogTopic,
-        STORE_2_NAME, STORE_2_CHANGELOG
-    ));
+    SamzaApplication app =  new MyStatefulApplication(INPUT_SYSTEM, INPUT_TOPIC,
+        ImmutableSet.of(STORE_1_NAME, STORE_2_NAME),
+        ImmutableMap.of(STORE_1_NAME, changelogTopic, STORE_2_NAME, STORE_2_CHANGELOG),
+        Optional.empty(), Optional.empty(), Optional.empty());
     // run the application
     RunApplicationContext context = runApplication(app, APP_NAME, CONFIGS);
 

--- a/samza-test/src/test/java/org/apache/samza/test/util/TestBlobStoreManager.java
+++ b/samza-test/src/test/java/org/apache/samza/test/util/TestBlobStoreManager.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.test.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+import org.apache.commons.io.FileUtils;
+import org.apache.samza.checkpoint.CheckpointId;
+import org.apache.samza.config.Config;
+import org.apache.samza.storage.blobstore.BlobStoreManager;
+import org.apache.samza.storage.blobstore.Metadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestBlobStoreManager implements BlobStoreManager {
+  private static final Logger LOG = LoggerFactory.getLogger(TestBlobStoreManager.class);
+  public static final String BLOB_STORE_BASE_DIR = "blob.store.base.dir";
+  public static final String BLOB_STORE_LEDGER_DIR = "blob.store.ledger.dir";
+  public static final String LEDGER_FILES_ADDED = "filesAdded";
+  public static final String LEDGER_FILES_READ = "filesRead";
+  public static final String LEDGER_FILES_DELETED = "filesRemoved";
+  public static final String LEDGER_FILES_TTL_UPDATED = "filesTTLUpdated";
+
+  private final Path stateLocation;
+  private final File filesAddedLedger;
+  private final File filesReadLedger;
+  private final File filesDeletedLedger;
+  private final File filesTTLUpdatedLedger;
+
+  public TestBlobStoreManager(Config config, ExecutorService executorService) {
+    this.stateLocation = Paths.get(config.get(BLOB_STORE_BASE_DIR));
+    Path ledgerLocation = Paths.get(config.get(BLOB_STORE_LEDGER_DIR));
+    try {
+      if (Files.notExists(ledgerLocation)) {
+        Files.createDirectories(ledgerLocation);
+      }
+
+      filesAddedLedger = Paths.get(ledgerLocation.toString(), LEDGER_FILES_ADDED).toFile();
+      filesReadLedger = Paths.get(ledgerLocation.toString(), LEDGER_FILES_READ).toFile();
+      filesDeletedLedger = Paths.get(ledgerLocation.toString(), LEDGER_FILES_DELETED).toFile();
+      filesTTLUpdatedLedger = Paths.get(ledgerLocation.toString(), LEDGER_FILES_TTL_UPDATED).toFile();
+
+      FileUtils.touch(filesAddedLedger);
+      FileUtils.touch(filesReadLedger);
+      FileUtils.touch(filesDeletedLedger);
+      FileUtils.touch(filesTTLUpdatedLedger);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void init() {
+  }
+
+  @Override
+  public CompletionStage<String> put(InputStream inputStream, Metadata metadata) {
+    String payloadPath = metadata.getPayloadPath();
+    String suffix;
+    if (payloadPath.equals(Metadata.SNAPSHOT_INDEX_PAYLOAD_PATH)) {
+      // include (fake checkpoint ID as an) unique ID in path for snapshot index blobs to avoid overwriting
+      suffix = payloadPath + "-" + CheckpointId.create();
+    } else {
+      String[] parts = payloadPath.split("/");
+      String checkpointId = parts[parts.length - 2];
+      String fileName = parts[parts.length - 1];
+      suffix = checkpointId + "/" + fileName;
+    }
+
+    Path destination = Paths.get(stateLocation.toString(), metadata.getJobName(), metadata.getJobId(),
+        metadata.getTaskName(), metadata.getStoreName(), suffix);
+    LOG.info("Creating file at {}", destination);
+    try {
+      FileUtils.writeStringToFile(filesAddedLedger, destination + "\n", Charset.defaultCharset(), true);
+      FileUtils.copyInputStreamToFile(inputStream, destination.toFile());
+    } catch (IOException e) {
+      throw new RuntimeException("Error creating file " + destination, e);
+    }
+    return CompletableFuture.completedFuture(destination.toString());
+  }
+
+  @Override
+  public CompletionStage<Void> get(String id, OutputStream outputStream, Metadata metadata) {
+    LOG.info("Reading file at {}", id);
+    try {
+      FileUtils.writeStringToFile(filesReadLedger, id + "\n", Charset.defaultCharset(), true);
+      Path path = Paths.get(id);
+      Files.copy(path, outputStream);
+      outputStream.flush();
+    } catch (IOException e) {
+      throw new RuntimeException("Error reading file for id " + id, e);
+    }
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletionStage<Void> delete(String id, Metadata metadata) {
+    LOG.info("Deleting file at {}", id);
+    try {
+      FileUtils.writeStringToFile(filesDeletedLedger, id + "\n", Charset.defaultCharset(), true);
+      Files.delete(Paths.get(id));
+    } catch (IOException e) {
+      throw new RuntimeException("Error deleting file for id " + id, e);
+    }
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletionStage<Void> removeTTL(String blobId, Metadata metadata) {
+    LOG.info("Removing TTL (no-op) for file at {}", blobId);
+    try {
+      FileUtils.writeStringToFile(filesTTLUpdatedLedger, blobId + "\n", Charset.defaultCharset(), true);
+    } catch (IOException e) {
+      throw new RuntimeException("Error updating ttl for id " + blobId, e);
+    }
+
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/samza-test/src/test/java/org/apache/samza/test/util/TestBlobStoreManagerFactory.java
+++ b/samza-test/src/test/java/org/apache/samza/test/util/TestBlobStoreManagerFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.samza.test.util;
+
+import java.util.concurrent.ExecutorService;
+import org.apache.samza.config.Config;
+import org.apache.samza.storage.blobstore.BlobStoreManager;
+import org.apache.samza.storage.blobstore.BlobStoreManagerFactory;
+
+public class TestBlobStoreManagerFactory implements BlobStoreManagerFactory {
+  @Override
+  public BlobStoreManager getBackupBlobStoreManager(Config config, ExecutorService backupExecutor) {
+    return new TestBlobStoreManager(config, backupExecutor);
+  }
+
+  @Override
+  public BlobStoreManager getRestoreBlobStoreManager(Config config, ExecutorService restoreExecutor) {
+    return new TestBlobStoreManager(config, restoreExecutor);
+  }
+}


### PR DESCRIPTION
Feature: Allow bulk restore from blob store for side input stores.
If a blob store state backend is available, side input store restores can be sped up significantly by bulk-restoring initial state from the blob store, and only using the Kafka side input topic to catch up on the delta since last checkpoint. 

Additional Context for Reviewers:
Side inputs RunLoop and regular Task RunLoop are separate and commit independently. SideInputTask commit flushes the the side input store and writes the SIDE-INPUT-OFFSETS file in the store directory, but does not create a store checkpoint or upload it to the state backend. This SIDE-INPUT-OFFSETS file is used during restore to determine the starting offset in the side input topic. Regular Task commit creates store checkpoints, uploads them to the state backends, and saves the resulting store StateCheckpointMarker in the task checkpoint, but currently does not copy the SIDE-INPUT-OFFSETS file to the checkpoint directry.
 
Changes:
This is a follow up to #1654 and #1655 
1. Copy the SIDE-INPUT-OFFSETS file (if exists) to the side input store checkpoint directory created during regular Task commit, so that it can be backed up along with the side input store contents and used during restore for incremental catchup. This copying needs to be done under process-wide synchronization to avoid data corruption, since the two RunLoops are currently completely independent of each other and do not coordinate/synchronize their commits, and there are no atomic file copy APIs.
2. If a blob store state backend factory is configured for side input stores, use it to do an inital bulk restore in ContainerStorageManager before starting the incremental restore and consumption from side input topics.
 
 Tests: Added new integration tests to verify BlobStoreStateBackend functionality in general, and the new BlobStoreStateBackend + Side Inputs functionality in particular.