### PR TITLE
SAMZA-2777: Add support for GenericFixed to AzureBlobAvroWriter

### DIFF
--- a/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriter.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/azureblob/avro/AzureBlobAvroWriter.java
@@ -38,7 +38,9 @@ import java.util.UUID;
 import java.util.concurrent.Executor;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DatumWriter;
@@ -60,11 +62,12 @@ import org.slf4j.LoggerFactory;
  * This byte[] is passed on to {@link org.apache.samza.system.azureblob.avro.AzureBlobOutputStream}.
  * AzureBlobOutputStream in turn uploads data to Storage as a blob.
  *
- * It also accepts encoded records as byte[] as long as the first OutgoingMessageEnvelope this writer receives
- * is a decoded record from which to get the schema and record type (GenericRecord vs SpecificRecord).
+ * It also accepts encoded records as avro fixed types or byte[] as long as the first OutgoingMessageEnvelope
+ * this writer receives is an avro type from which to get the schema and message. IndexedRecords of type SpecificRecord
+ * encode messages using SpecificDatumWriter, otherwise they are written using GenericDatumWriter.
  * The subsequent encoded records are written directly to AzureBlobOutputStream without checking if they conform
- * to the schema. It is the responsibility of the user to ensure this. Failing to do so may result in an
- * unreadable avro blob.
+ * to the schema or compatible with the writer. It is the responsibility of the user to ensure this. Failing to do so
+ * may result in an unreadable avro blob.
  *
  * It expects all OutgoingMessageEnvelopes to be of the same schema.
  * To handle schema evolution (sending envelopes of different schema), this writer has to be closed and a new writer
@@ -138,10 +141,12 @@ public class AzureBlobAvroWriter implements AzureBlobWriter {
 
   /**
    * This method expects the {@link org.apache.samza.system.OutgoingMessageEnvelope}
-   * to contain a message which is a {@link org.apache.avro.generic.IndexedRecord} or an encoded record aka byte[].
-   * If the record is already encoded, it will directly write the byte[] to the output stream without checking if it conforms to schema.
+   * to contain a message which is either a subtype of {@link org.apache.avro.generic.GenericContainer} or avro encoded data aka byte[].
+   * The subtypes are one of {@link org.apache.avro.generic.GenericFixed} or {@link org.apache.avro.generic.IndexedRecord}, both of
+   * which include the schema and data. If the record is already encoded, {@link org.apache.avro.generic.GenericFixed} or byte[],
+   * it will directly write the byte[] to the output stream without checking if it conforms to schema.
    * Else, it encodes the record and writes to output stream.
-   * However, the first envelope should always be a record and not a byte[].
+   * However, the first envelope should always be either a GenericFixed or an IndexedRecord and not a byte[] to set the schema.
    * If the blocksize threshold crosses, it will upload the output stream contents as a block.
    * If the number of records in current blob or size of current blob exceed limits then a new blob is created.
    * Multi-threading and thread-safety:
@@ -151,7 +156,7 @@ public class AzureBlobAvroWriter implements AzureBlobWriter {
    *  restricts access to the shared objects through the synchronized block.
    *  Concurrent access to shared objects is controlled through a common lock and synchronized block and hence ensures
    *  thread safety.
-   * @param ome - OutgoingMessageEnvelope that contains the IndexedRecord (GenericRecord or SpecificRecord) or an encoded record as byte[]
+   * @param ome - OutgoingMessageEnvelope that contains the GenericContainer (GenericFixed, GenericRecord or SpecificRecord) or an encoded record as byte[]
    * @throws IOException when
    *       - OutgoingMessageEnvelope's message is not an IndexedRecord or
    *       - underlying dataFileWriter.append fails
@@ -159,13 +164,17 @@ public class AzureBlobAvroWriter implements AzureBlobWriter {
    */
   @Override
   public void write(OutgoingMessageEnvelope ome) throws IOException {
-    Optional<IndexedRecord> optionalIndexedRecord;
+    Optional<GenericContainer> optionalGenericContainer;
     byte[] encodedRecord;
-    if (ome.getMessage() instanceof IndexedRecord) {
-      optionalIndexedRecord = Optional.of((IndexedRecord) ome.getMessage());
+    if (ome.getMessage() instanceof GenericFixed) {
+      GenericFixed fixed = (GenericFixed) ome.getMessage();
+      optionalGenericContainer = Optional.of(fixed);
+      encodedRecord = fixed.bytes();
+    } else if (ome.getMessage() instanceof IndexedRecord) {
+      optionalGenericContainer = Optional.of((IndexedRecord) ome.getMessage());
       encodedRecord = encodeRecord((IndexedRecord) ome.getMessage());
     } else if (ome.getMessage() instanceof byte[]) {
-      optionalIndexedRecord = Optional.empty();
+      optionalGenericContainer = Optional.empty();
       encodedRecord = (byte[]) ome.getMessage();
     } else {
       throw new IllegalArgumentException("AzureBlobAvroWriter only supports IndexedRecord and byte[].");
@@ -174,7 +183,7 @@ public class AzureBlobAvroWriter implements AzureBlobWriter {
     synchronized (currentDataFileWriterLock) {
       // if currentBlobWriterComponents is null, then it is the first blob of this AzureBlobAvroWriter object
       if (currentBlobWriterComponents == null || willCurrentBlobExceedSize(encodedRecord) || willCurrentBlobExceedRecordLimit()) {
-        startNextBlob(optionalIndexedRecord);
+        startNextBlob(optionalGenericContainer);
       }
       currentBlobWriterComponents.dataFileWriter.appendEncoded(ByteBuffer.wrap(encodedRecord));
       recordsInCurrentBlob++;
@@ -296,7 +305,7 @@ public class AzureBlobAvroWriter implements AzureBlobWriter {
     }
   }
 
-  private void startNextBlob(Optional<IndexedRecord> optionalIndexedRecord) throws IOException {
+  private void startNextBlob(Optional<GenericContainer> optionalGenericContainer) throws IOException {
     if (currentBlobWriterComponents != null) {
       LOG.info("Starting new blob as current blob size is "
           + currentBlobWriterComponents.azureBlobOutputStream.getSize()
@@ -310,10 +319,10 @@ public class AzureBlobAvroWriter implements AzureBlobWriter {
     // datumWriter is null when AzureBlobAvroWriter is created but has not yet received a message.
     // optionalIndexedRecord is the first message in this case.
     if (datumWriter == null) {
-      if (optionalIndexedRecord.isPresent()) {
-        IndexedRecord record = optionalIndexedRecord.get();
-        schema = record.getSchema();
-        if (record instanceof SpecificRecord) {
+      if (optionalGenericContainer.isPresent()) {
+        GenericContainer container = optionalGenericContainer.get();
+        schema = container.getSchema();
+        if (container instanceof SpecificRecord) {
           datumWriter = new SpecificDatumWriter<>(schema);
         } else {
           datumWriter = new GenericDatumWriter<>(schema);

--- a/samza-azure/src/test/java/org/apache/samza/system/azureblob/avro/TestAzureBlobAvroWriter.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/azureblob/avro/TestAzureBlobAvroWriter.java
@@ -128,21 +128,21 @@ public class TestAzureBlobAvroWriter {
 
   // GenericFixed type is schema and encoded message
   private class GenericFixedEvent implements org.apache.avro.generic.GenericFixed {
-    private final GenericRecordEvent _record = new GenericRecordEvent();
-    private final byte[] _bytes;
+    private final GenericRecordEvent record = new GenericRecordEvent();
+    private final byte[] bytes;
 
     GenericFixedEvent(byte[] encoded) {
-      _bytes = encoded;
+      bytes = encoded;
     }
 
     @Override
     public byte[] bytes() {
-      return _bytes;
+      return bytes;
     }
 
     @Override
     public Schema getSchema() {
-      return _record.getSchema();
+      return record.getSchema();
     }
   }
 

--- a/samza-azure/src/test/java/org/apache/samza/system/azureblob/avro/TestAzureBlobAvroWriter.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/azureblob/avro/TestAzureBlobAvroWriter.java
@@ -78,7 +78,7 @@ public class TestAzureBlobAvroWriter {
   private OutgoingMessageEnvelope ome;
   private byte[] encodedRecord;
   private AzureBlobAvroWriter azureBlobAvroWriter;
-  private DataFileWriter mockDataFileWriter;
+  private DataFileWriter<Object> mockDataFileWriter;
   private AzureBlobOutputStream mockAzureBlobOutputStream;
   private BlockBlobAsyncClient mockBlockBlobAsyncClient;
   private Compression mockCompression;
@@ -171,7 +171,7 @@ public class TestAzureBlobAvroWriter {
 
     encodedRecord = new byte[100];
     BlobContainerAsyncClient mockContainerAsyncClient = PowerMockito.mock(BlobContainerAsyncClient.class);
-    mockDataFileWriter = mock(DataFileWriter.class);
+    mockDataFileWriter = (DataFileWriter<Object>) mock(DataFileWriter.class);
     mockAzureBlobOutputStream = mock(AzureBlobOutputStream.class);
     mockBlockBlobAsyncClient = PowerMockito.mock(BlockBlobAsyncClient.class);
     when(mockBlockBlobAsyncClient.getBlobUrl()).thenReturn("https://samza.blob.core.windows.net/fake-blob-url");
@@ -306,7 +306,7 @@ public class TestAzureBlobAvroWriter {
         null, null, null, blobMetadataGeneratorFactory, blobMetadataGeneratorConfig, STREAM_NAME,
         maxBlobSize, 10, mockCompression, true));
 
-    DataFileWriter mockDataFileWriter1 = mock(DataFileWriter.class);
+    DataFileWriter<Object> mockDataFileWriter1 = (DataFileWriter<Object>) mock(DataFileWriter.class);
     PowerMockito.whenNew(DataFileWriter.class).withAnyArguments().thenReturn(mockDataFileWriter1);
 
     BlobAsyncClient mockBlobAsyncClient1 = mock(BlobAsyncClient.class);
@@ -324,7 +324,7 @@ public class TestAzureBlobAvroWriter {
     azureBlobAvroWriter.write(ome);
 
     OutgoingMessageEnvelope ome2 = createOME("Topic2");
-    DataFileWriter mockDataFileWriter2 = mock(DataFileWriter.class);
+    DataFileWriter<Object> mockDataFileWriter2 = (DataFileWriter<Object>) mock(DataFileWriter.class);
     PowerMockito.whenNew(DataFileWriter.class).withAnyArguments().thenReturn(mockDataFileWriter2);
 
     BlobAsyncClient mockBlobAsyncClient2 = mock(BlobAsyncClient.class);
@@ -369,7 +369,7 @@ public class TestAzureBlobAvroWriter {
         null, null, null, blobMetadataGeneratorFactory, blobMetadataGeneratorConfig, STREAM_NAME,
         maxBlobSize, maxRecordsPerBlob, mockCompression, true));
 
-    DataFileWriter mockDataFileWriter1 = mock(DataFileWriter.class);
+    DataFileWriter<Object> mockDataFileWriter1 = (DataFileWriter<Object>) mock(DataFileWriter.class);
     PowerMockito.whenNew(DataFileWriter.class).withAnyArguments().thenReturn(mockDataFileWriter1);
 
     BlobAsyncClient mockBlobAsyncClient1 = mock(BlobAsyncClient.class);
@@ -390,7 +390,7 @@ public class TestAzureBlobAvroWriter {
     }
 
     OutgoingMessageEnvelope ome2 = createOME("Topic2");
-    DataFileWriter mockDataFileWriter2 = mock(DataFileWriter.class);
+    DataFileWriter<Object> mockDataFileWriter2 = (DataFileWriter<Object>) mock(DataFileWriter.class);
     PowerMockito.whenNew(DataFileWriter.class).withAnyArguments().thenReturn(mockDataFileWriter2);
 
     BlobAsyncClient mockBlobAsyncClient2 = mock(BlobAsyncClient.class);
@@ -432,7 +432,7 @@ public class TestAzureBlobAvroWriter {
         mockDataFileWriter, mockAzureBlobOutputStream, mockBlockBlobAsyncClient, blobMetadataGeneratorFactory, blobMetadataGeneratorConfig, STREAM_NAME,
         maxBlobSize, maxRecordsPerBlob, mockCompression, false));
 
-    DataFileWriter<IndexedRecord> mockDataFileWriter2 = mock(DataFileWriter.class);
+    DataFileWriter<Object> mockDataFileWriter2 = mock(DataFileWriter.class);
     AzureBlobOutputStream mockAzureBlobOutputStream2 = mock(AzureBlobOutputStream.class);
 
     when(mockAzureBlobOutputStream.getSize()).thenReturn((long) 1);


### PR DESCRIPTION
### Feature
Add support for `GenericFixed` types to `AzureBlobAvroWriter`, the Samza provided implementation for `AzureBlobWriter`. This allows the caller to provide the `Schema` **and** deserialized object in the `OutgoingMessageEnvelope`. Using `GenericFixed`, the caller can avoid the CPU overhead of deserialization and guarantee that the `Schema` is set in the writer instance.

#### Discussion
The existing implementation requires that all messages are either of type `IndexedRecord` - a deserialized object with `Schema` - or an Avro-encoded `byte[]` - deserialized object without `Schema`. The writer aggregates these messages in an Avro file format which requires a `Schema`. Because the `Schema` is unset when the writer is initialized, it cannot aggregate the messages, until the caller sends an `IndexedRecord`.

Without `GenericFixed`, in order avoid deserialization (CPU cost), the caller **must** send an `IndexedRecord` as the first message to a new writer instance, then a `byte[]` for subsequent messages until `flush()`. This requires the caller track the state in the writer instances, but do so through the "SystemProducer". In the existing implementation, `AzureBlobSystemProducer`, the writer instances are private and are closed on [flush()](https://github.com/ehoner/samza/blob/03b187a6de0e123568f3ce3af94c946e6380fc8d/samza-azure/src/main/java/org/apache/samza/system/azureblob/producer/AzureBlobSystemProducer.java#L334).

### Changes
1. No public API change.
    These changes are to the Samza provided implementation and not to the original design in [SEP-26](https://cwiki.apache.org/confluence/display/SAMZA/SEP-26:+Azure+Blob+Storage+Producer). These changes extend item 3 under "[Implementation](https://cwiki.apache.org/confluence/display/SAMZA/SEP-26:+Azure+Blob+Storage+Producer#SEP26:AzureBlobStorageProducer-Implementation/TestPlan)", see AvroAzureBlobWriter is an AzureBlobWriter implementation to write messages which are Avro record....
1. Updated javadocs. 
1. Replaced type parameter for `DataFileWriter`, from `IndexedRecord` to `Object`. 
    The type parameter is specific to the data encoded by Avro, not necessarily the format/type received by the writer instance.

### Tests
New test: `testWriteGenericFixed()`.
Adds private class `GenericFixedEvent` and method `createOMEGenericFixed(...)`. These repeat the existing test patterns used by classes `GenericRecordEvent` and `SpecificRecordEvent` and their respective methods `createOMEGenericRecord(...)` and `createOME(...)`.

### Avro Background
AzureBlob storage expects an Avro encoded file format. The file format supports multiple records of a single `Schema`. In order to create the format, the writer instance **must** provide a `Schema` - see [DataFileWriter](https://avro.apache.org/docs/1.7.7/api/java/org/apache/avro/file/DataFileWriter.html). The existing implementation expects an [IndexedRecord](https://avro.apache.org/docs/1.7.7/api/java/org/apache/avro/generic/IndexedRecord.html) to access both `Schema` **and** data. The `IndexedRecord` is the sub type of [GenericContainer](https://avro.apache.org/docs/1.7.7/api/java/org/apache/avro/generic/GenericContainer.html), which is what provides `getSchema()`.  `GenericContainer` has only one other sub type, [GenericFixed](https://avro.apache.org/docs/1.7.7/api/java/org/apache/avro/generic/GenericFixed.html). The difference between "records" and "fixed" types is (de)serialization. `GenericFixed` objects are _serialized_ data and their `Schema`; while `IndexedRecord`s are _deserialized_ data and their `Schema`.