### PR TITLE
Wait for pending commits to finish during shutdown.

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -1077,18 +1077,6 @@ class SamzaContainer(
       }
     }
 
-    if (commitThreadPool != null) {
-      info("Shutting down task commit thread pool")
-      try {
-        commitThreadPool.shutdown()
-        if(!commitThreadPool.awaitTermination(shutdownMs, TimeUnit.MILLISECONDS)) {
-          commitThreadPool.shutdownNow()
-        }
-      } catch {
-        case e: Exception => error(e.getMessage, e)
-      }
-    }
-
     if (timerExecutor != null) {
       info("Shutting down timer executor")
       try {
@@ -1102,6 +1090,18 @@ class SamzaContainer(
     }
 
     taskInstances.values.foreach(_.shutdownTask)
+
+    if (commitThreadPool != null) {
+      info("Shutting down task commit thread pool")
+      try {
+        commitThreadPool.shutdown()
+        if(!commitThreadPool.awaitTermination(shutdownMs, TimeUnit.MILLISECONDS)) {
+          commitThreadPool.shutdownNow()
+        }
+      } catch {
+        case e: Exception => error(e.getMessage, e)
+      }
+    }
   }
 
   def shutdownStores {

--- a/samza-test/src/test/java/org/apache/samza/storage/kv/BlobStoreStateBackendIntegrationTest.java
+++ b/samza-test/src/test/java/org/apache/samza/storage/kv/BlobStoreStateBackendIntegrationTest.java
@@ -106,6 +106,7 @@ public class BlobStoreStateBackendIntegrationTest extends BaseStateBackendIntegr
 
       put(TaskConfig.COMMIT_MS, "-1"); // manual commit only
       put(TaskConfig.COMMIT_MAX_DELAY_MS, "0"); // Ensure no commits are skipped due to in progress commits
+      put(TaskConfig.TASK_SHUTDOWN_MS, "10000"); // wait for pending commits to complete.
 
       // override store level state backend for in memory stores to use Kafka changelogs
       put(String.format(StorageConfig.STORE_BACKUP_FACTORIES, IN_MEMORY_STORE_NAME),


### PR DESCRIPTION
Issue: BlobStoreStateBackendIntegrationTest.testStopAndRestart fails occassionally if SamzaContainer shuts down before pending commits for its tasks are complete. Note: This issue does not affect correctness of commits, but does affect test reliability.

Fix: 1) Wait for pending commits to complete before shutting the container down. 2) Shut down commitThreadPool after the pending commits are complete (otherwise queued tasks requried to complete commits will be cancelled and commits will be unsuccessful).

Test: BlobStoreStateBackendIntegrationTest.testStopAndRestart passes in a loop.