### PR TITLE
Capture build scans on ge.apache.org to benefit from deep build insights

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,39 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+plugins {
+  id 'com.gradle.enterprise' version '3.13.1'
+  id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.10'
+}
+
+def isGithubActions = System.getenv('GITHUB_ACTIONS') != null
+def isJenkins = System.getenv('JENKINS_URL') != null
+def isCI = isGithubActions || isJenkins
+
+gradleEnterprise {
+  server = "https://ge.apache.org"
+  buildScan {
+    capture { taskInputFiles = true }
+    uploadInBackground = !isCI
+    publishAlways()
+    publishIfAuthenticated()
+    obfuscation {
+      // This obfuscates the IP addresses of the build machine in the build scan.
+      // Alternatively, the build scan will provide the hostname for troubleshooting host-specific issues.
+      ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
+    }
+  }
+}
+
+buildCache {
+  local {
+    enabled = !isCI
+  }
+
+  remote(gradleEnterprise.buildCache) {
+    enabled = false
+  }
+}
 
 include \
   'docs',


### PR DESCRIPTION
This PR publishes a build scan for every CI build on Jenkins and GitHub Actions and for every local build from an authenticated Apache committer. The build will not fail if publishing fails.

The build scans of the Apache Samza project are published to the Gradle Enterprise instance at [ge.apache.org](https://ge.apache.org/), hosted by the Apache Software Foundation and run in partnership between the ASF and Gradle. This Gradle Enterprise instance has all features and extensions enabled and is freely available for use by the Apache Samza project and all other Apache projects.

This pull request enhances the functionality of publishing build scans to the publicly available [scans.gradle.com](https://scans.gradle.com/) by instead publishing build scans to [ge.apache.org](https://ge.apache.org/). On this Gradle Enterprise instance, Apache Samza will have access not only to all of the published build scans but other aggregate data features such as:

- Dashboards to view all historical build scans, along with performance trends over time
- Build failure analytics for enhanced investigation and diagnosis of build failures
- Test failure analytics to better understand trends and causes around slow, failing, and flaky tests

If interested in exploring a fully populated Gradle Enterprise instance, please explore the builds already connected to [ge.apache.org](https://ge.apache.org/), the [Spring project’s instance](https://ge.spring.io/scans?search.relativeStartTime=P28D&search.timeZoneId=Europe/Zurich), or any number of other [OSS projects](https://gradle.com/enterprise-customers/oss-projects/) for which we sponsor instances of Gradle Enterprise.

Please let me know if there are any questions about the value of Gradle Enterprise or the changes in this pull request and I’d be happy to address them.