### PR TITLE
SAMZA-2781: Use framework thread to execute hand-offs and sub-DAG execution

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/context/TaskContext.java
+++ b/samza-api/src/main/java/org/apache/samza/context/TaskContext.java
@@ -18,6 +18,7 @@
  */
 package org.apache.samza.context;
 
+import java.util.concurrent.ExecutorService;
 import org.apache.samza.annotation.InterfaceStability;
 import org.apache.samza.job.model.TaskModel;
 import org.apache.samza.metrics.MetricsRegistry;
@@ -108,4 +109,12 @@ public interface TaskContext {
    */
   @InterfaceStability.Evolving
   void setStartingOffset(SystemStreamPartition systemStreamPartition, String offset);
+
+  /**
+   * Gets the operator {@link ExecutorService} for this container.
+   * @return the {@link ExecutorService} used by the operator for this container
+   */
+  default ExecutorService getOperatorExecutor() {
+    throw new UnsupportedOperationException("Operator executor not available in the context");
+  }
 }

--- a/samza-api/src/main/java/org/apache/samza/context/TaskContext.java
+++ b/samza-api/src/main/java/org/apache/samza/context/TaskContext.java
@@ -112,7 +112,7 @@ public interface TaskContext {
 
   /**
    * Gets the operator {@link ExecutorService} for this container.
-   * @return the {@link ExecutorService} used by the operator for this container
+   * @return the {@link ExecutorService} used by the operator for this task
    */
   default ExecutorService getOperatorExecutor() {
     throw new UnsupportedOperationException("Operator executor not available in the context");

--- a/samza-api/src/main/java/org/apache/samza/task/TaskExecutorFactory.java
+++ b/samza-api/src/main/java/org/apache/samza/task/TaskExecutorFactory.java
@@ -41,7 +41,7 @@ public interface TaskExecutorFactory {
    * of synchronous operators in the application DAG. In case of asynchronous operators, typically the operator invocation
    * happens on one thread while completion of the callback happens on another thread. When the CompletionStage completes normally,
    * the subsequent DAG or hand-off code is executed on the operator thread pool.
-   * <b>Note:</b>It is upto the implementors of the factory to share the executor across tasks vs provide isolated executors
+   * <b>Note:</b>It is up to the implementors of the factory to share the executor across tasks vs provide isolated executors
    * per task. While the above determines fairness and contention between tasks, within a task
    * there are no fairness guarantees on how the chained futures of sub-DAG stages are executed nor any guarantees on
    * the order of tasks executed. The behavior is controlled by Java's implementation of CompletionStage and

--- a/samza-api/src/main/java/org/apache/samza/task/TaskExecutorFactory.java
+++ b/samza-api/src/main/java/org/apache/samza/task/TaskExecutorFactory.java
@@ -19,12 +19,15 @@
 package org.apache.samza.task;
 
 import java.util.concurrent.ExecutorService;
+import org.apache.samza.annotation.InterfaceStability;
 import org.apache.samza.config.Config;
+import org.apache.samza.container.TaskName;
 
 
 /**
  * Factory for creating the executor used when running tasks in multi-thread mode.
  */
+@InterfaceStability.Unstable
 public interface TaskExecutorFactory {
 
   /**
@@ -32,4 +35,23 @@ public interface TaskExecutorFactory {
    * @return task executor
    */
   ExecutorService getTaskExecutor(Config config);
+
+  /**
+   * Operator thread pool is asynchronous execution facility used to execute hand-off between operators and sub-DAG in case
+   * of synchronous operators in the application DAG. In case of asynchronous operators, typically the operator invocation
+   * happens on one thread while completion of the callback happens on another thread. When the CompletionStage completes normally,
+   * the subsequent DAG or hand-off code is executed on the operator thread pool.
+   * <b>Note:</b>It is upto the implementors of the factory to share the executor across tasks vs provide isolated executors
+   * per task. While the above determines fairness and contention between tasks, within a task
+   * there are no fairness guarantees on how the chained futures of sub-DAG stages are executed nor any guarantees on
+   * the order of tasks executed. The behavior is controlled by Java's implementation of CompletionStage and
+   * CompletableFuture which determines what thread and how tasks post completion of futures execute.
+   *
+   * @param taskName name of the task
+   * @param config application configuration
+   * @return an {@link ExecutorService} to run samza operator related tasks
+   */
+  default ExecutorService getOperatorExecutor(TaskName taskName, Config config) {
+    return getTaskExecutor(config);
+  }
 }

--- a/samza-core/src/main/java/org/apache/samza/context/TaskContextImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/context/TaskContextImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.samza.context;
 
+import java.util.concurrent.ExecutorService;
 import org.apache.samza.checkpoint.OffsetManager;
 import org.apache.samza.job.model.JobModel;
 import org.apache.samza.job.model.TaskModel;
@@ -55,6 +56,8 @@ public class TaskContextImpl implements TaskContext {
   private final StreamMetadataCache streamMetadataCache;
   private final Set<SystemStreamPartition> sspsExcludingSideInputs;
 
+  private final ExecutorService operatorExecutor;
+
   public TaskContextImpl(TaskModel taskModel,
       MetricsRegistry taskMetricsRegistry,
       Function<String, KeyValueStore> keyValueStoreProvider,
@@ -63,7 +66,8 @@ public class TaskContextImpl implements TaskContext {
       OffsetManager offsetManager,
       JobModel jobModel,
       StreamMetadataCache streamMetadataCache,
-      Set<SystemStreamPartition> sspsExcludingSideInputs) {
+      Set<SystemStreamPartition> sspsExcludingSideInputs,
+      ExecutorService operatorExecutor) {
     this.taskModel = taskModel;
     this.taskMetricsRegistry = taskMetricsRegistry;
     this.keyValueStoreProvider = keyValueStoreProvider;
@@ -73,6 +77,7 @@ public class TaskContextImpl implements TaskContext {
     this.jobModel = jobModel;
     this.streamMetadataCache = streamMetadataCache;
     this.sspsExcludingSideInputs = sspsExcludingSideInputs;
+    this.operatorExecutor = operatorExecutor;
   }
 
   @Override
@@ -113,6 +118,11 @@ public class TaskContextImpl implements TaskContext {
   @Override
   public void setStartingOffset(SystemStreamPartition systemStreamPartition, String offset) {
     this.offsetManager.setStartingOffset(this.taskModel.getTaskName(), systemStreamPartition, offset);
+  }
+
+  @Override
+  public ExecutorService getOperatorExecutor() {
+    return this.operatorExecutor;
   }
 
   public JobModel getJobModel() {

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImpl.java
@@ -21,6 +21,7 @@ package org.apache.samza.operators.impl;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
 import org.apache.samza.SamzaException;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.JobConfig;
@@ -65,7 +66,6 @@ import java.util.Set;
 public abstract class OperatorImpl<M, RM> {
   private static final Logger LOG = LoggerFactory.getLogger(OperatorImpl.class);
   private static final String METRICS_GROUP = OperatorImpl.class.getName();
-
   private boolean initialized;
   private boolean closed;
   private HighResolutionClock highResClock;
@@ -94,6 +94,7 @@ public abstract class OperatorImpl<M, RM> {
   private CallbackScheduler callbackScheduler;
   private ControlMessageSender controlMessageSender;
   private int elasticityFactor;
+  private ExecutorService operatorThreadPool;
 
   /**
    * Initialize this {@link OperatorImpl} and its user-defined functions.
@@ -102,6 +103,7 @@ public abstract class OperatorImpl<M, RM> {
    */
   public final void init(InternalTaskContext internalTaskContext) {
     final Context context = internalTaskContext.getContext();
+    final Config config = context.getJobContext().getConfig();
 
     String opId = getOpImplId();
 
@@ -113,7 +115,7 @@ public abstract class OperatorImpl<M, RM> {
       throw new IllegalStateException(String.format("Attempted to initialize Operator %s after it was closed.", opId));
     }
 
-    this.highResClock = createHighResClock(context.getJobContext().getConfig());
+    this.highResClock = createHighResClock(config);
     registeredOperators = new LinkedHashSet<>();
     prevOperators = new LinkedHashSet<>();
     inputStreams = new LinkedHashSet<>();
@@ -134,7 +136,8 @@ public abstract class OperatorImpl<M, RM> {
     this.taskModel = taskContext.getTaskModel();
     this.callbackScheduler = taskContext.getCallbackScheduler();
     handleInit(context);
-    this.elasticityFactor = new JobConfig(context.getJobContext().getConfig()).getElasticityFactor();
+    this.elasticityFactor = new JobConfig(config).getElasticityFactor();
+    this.operatorThreadPool = context.getTaskContext().getOperatorExecutor();
 
     initialized = true;
   }
@@ -189,7 +192,7 @@ public abstract class OperatorImpl<M, RM> {
               getOpImplId(), getOperatorSpec().getSourceLocation(), expectedType, actualType), e);
     }
 
-    CompletionStage<Void> result = completableResultsFuture.thenCompose(results -> {
+    CompletionStage<Void> result = completableResultsFuture.thenComposeAsync(results -> {
       long endNs = this.highResClock.nanoTime();
       this.handleMessageNs.update(endNs - startNs);
 
@@ -197,13 +200,13 @@ public abstract class OperatorImpl<M, RM> {
           .flatMap(r -> this.registeredOperators.stream()
             .map(op -> op.onMessageAsync(r, collector, coordinator)))
           .toArray(CompletableFuture[]::new));
-    });
+    }, operatorThreadPool);
 
     WatermarkFunction watermarkFn = getOperatorSpec().getWatermarkFn();
     if (watermarkFn != null) {
       // check whether there is new watermark emitted from the user function
       Long outputWm = watermarkFn.getOutputWatermark();
-      return result.thenCompose(ignored -> propagateWatermark(outputWm, collector, coordinator));
+      return result.thenComposeAsync(ignored -> propagateWatermark(outputWm, collector, coordinator), operatorThreadPool);
     }
 
     return result;
@@ -242,11 +245,11 @@ public abstract class OperatorImpl<M, RM> {
                 .map(op -> op.onMessageAsync(r, collector, coordinator)))
             .toArray(CompletableFuture[]::new));
 
-    return resultFuture.thenCompose(x ->
+    return resultFuture.thenComposeAsync(x ->
         CompletableFuture.allOf(this.registeredOperators
             .stream()
             .map(op -> op.onTimer(collector, coordinator))
-            .toArray(CompletableFuture[]::new)));
+            .toArray(CompletableFuture[]::new)), operatorThreadPool);
   }
 
   /**
@@ -313,14 +316,14 @@ public abstract class OperatorImpl<M, RM> {
 
       // populate the end-of-stream through the dag
       endOfStreamFuture = onEndOfStream(collector, coordinator)
-          .thenAccept(result -> {
+          .thenAcceptAsync(result -> {
             if (eosStates.allEndOfStream()) {
               // all inputs have been end-of-stream, shut down the task
               LOG.info("All input streams have reached the end for task {}", taskName.getTaskName());
               coordinator.commit(TaskCoordinator.RequestScope.CURRENT_TASK);
               coordinator.shutdown(TaskCoordinator.RequestScope.CURRENT_TASK);
             }
-          });
+          }, operatorThreadPool);
     }
 
     return endOfStreamFuture;
@@ -344,10 +347,10 @@ public abstract class OperatorImpl<M, RM> {
                   .map(op -> op.onMessageAsync(r, collector, coordinator)))
               .toArray(CompletableFuture[]::new));
 
-      endOfStreamFuture = resultFuture.thenCompose(x ->
+      endOfStreamFuture = resultFuture.thenComposeAsync(x ->
           CompletableFuture.allOf(this.registeredOperators.stream()
               .map(op -> op.onEndOfStream(collector, coordinator))
-              .toArray(CompletableFuture[]::new)));
+              .toArray(CompletableFuture[]::new)), operatorThreadPool);
     }
 
     return endOfStreamFuture;
@@ -404,14 +407,14 @@ public abstract class OperatorImpl<M, RM> {
       }
 
       drainFuture = onDrainOfStream(collector, coordinator)
-          .thenAccept(result -> {
+          .thenAcceptAsync(result -> {
             if (drainStates.areAllStreamsDrained()) {
               // All input streams have been drained, shut down the task
               LOG.info("All input streams have been drained for task {}. Requesting shutdown.", taskName.getTaskName());
               coordinator.commit(TaskCoordinator.RequestScope.CURRENT_TASK);
               coordinator.shutdown(TaskCoordinator.RequestScope.CURRENT_TASK);
             }
-          });
+          }, operatorThreadPool);
     }
 
     return drainFuture;
@@ -436,10 +439,10 @@ public abstract class OperatorImpl<M, RM> {
               .toArray(CompletableFuture[]::new));
 
       // propagate DrainMessage to downstream operators
-      drainFuture = resultFuture.thenCompose(x ->
+      drainFuture = resultFuture.thenComposeAsync(x ->
           CompletableFuture.allOf(this.registeredOperators.stream()
               .map(op -> op.onDrainOfStream(collector, coordinator))
-              .toArray(CompletableFuture[]::new)));
+              .toArray(CompletableFuture[]::new)), operatorThreadPool);
     }
 
     return drainFuture;
@@ -472,7 +475,7 @@ public abstract class OperatorImpl<M, RM> {
       }
       // populate the watermark through the dag
       watermarkFuture = onWatermark(watermark, collector, coordinator)
-          .thenAccept(ignored -> watermarkStates.updateAggregateMetric(ssp, watermark));
+          .thenAcceptAsync(ignored -> watermarkStates.updateAggregateMetric(ssp, watermark), operatorThreadPool);
     }
 
     return watermarkFuture;
@@ -527,7 +530,8 @@ public abstract class OperatorImpl<M, RM> {
                 .toArray(CompletableFuture[]::new));
       }
 
-      watermarkFuture = watermarkFuture.thenCompose(res -> propagateWatermark(outputWm, collector, coordinator));
+      watermarkFuture = watermarkFuture.thenComposeAsync(res -> propagateWatermark(outputWm, collector, coordinator),
+          operatorThreadPool);
     }
 
     return watermarkFuture;

--- a/samza-core/src/main/java/org/apache/samza/task/DefaultTaskExecutorFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/task/DefaultTaskExecutorFactory.java
@@ -61,18 +61,18 @@ public class DefaultTaskExecutorFactory implements TaskExecutorFactory {
   public ExecutorService getOperatorExecutor(TaskName taskName, Config config) {
     ExecutorService taskExecutor = TASK_EXECUTORS.computeIfAbsent(taskName, key -> {
       final int threadPoolSize = new JobConfig(config).getThreadPoolSize();
-      ExecutorService operatorThreadPool;
+      ExecutorService operatorExecutor;
 
       if (threadPoolSize > 1) {
         LOG.info("Using container thread pool as operator thread pool for task {}", key.getTaskName());
-        operatorThreadPool = getTaskExecutor(config);
+        operatorExecutor = getTaskExecutor(config);
       } else {
         LOG.info("Using single threaded thread pool as operator thread pool for task {}", key.getTaskName());
-        operatorThreadPool = Executors.newSingleThreadExecutor(
+        operatorExecutor = Executors.newSingleThreadExecutor(
             new ThreadFactoryBuilder().setNameFormat("Samza " + key.getTaskName() + " Thread-%d").build());
       }
 
-      return operatorThreadPool;
+      return operatorExecutor;
     });
 
     return taskExecutor;

--- a/samza-core/src/main/java/org/apache/samza/task/DefaultTaskExecutorFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/task/DefaultTaskExecutorFactory.java
@@ -19,16 +19,24 @@
 package org.apache.samza.task;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.samza.config.Config;
 import org.apache.samza.config.JobConfig;
+import org.apache.samza.container.TaskName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * Default factory for creating the executor used when running tasks in multi-thread mode.
  */
 public class DefaultTaskExecutorFactory implements TaskExecutorFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultTaskExecutorFactory.class);
+
+  private static final Map<TaskName, ExecutorService> TASK_EXECUTORS = new ConcurrentHashMap<>();
 
   @Override
   public ExecutorService getTaskExecutor(Config config) {
@@ -36,5 +44,37 @@ public class DefaultTaskExecutorFactory implements TaskExecutorFactory {
 
     return Executors.newFixedThreadPool(threadPoolSize,
         new ThreadFactoryBuilder().setNameFormat("Samza Container Thread-%d").build());
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * The choice of thread pool is determined based on the following logic
+   *    If job.operator.thread.pool.enabled,
+   *     a. Use {@link #getTaskExecutor(Config)} if job.container.thread.pool.size &gt; 1
+   *     b. Use default single threaded pool otherwise
+   * <b>Note:</b> The default single threaded pool used is a substitute for the scenario where container thread pool is null and
+   * the messages are dispatched on runloop thread. We can't have the stages schedule on the run loop thread and hence
+   * the fallback to use a single threaded executor across all tasks.
+   */
+  @Override
+  public ExecutorService getOperatorExecutor(TaskName taskName, Config config) {
+    ExecutorService taskExecutor = TASK_EXECUTORS.computeIfAbsent(taskName, key -> {
+      final int threadPoolSize = new JobConfig(config).getThreadPoolSize();
+      ExecutorService operatorThreadPool;
+
+      if (threadPoolSize > 1) {
+        LOG.info("Using container thread pool as operator thread pool for task {}", key.getTaskName());
+        operatorThreadPool = getTaskExecutor(config);
+      } else {
+        LOG.info("Using single threaded thread pool as operator thread pool for task {}", key.getTaskName());
+        operatorThreadPool = Executors.newSingleThreadExecutor(
+            new ThreadFactoryBuilder().setNameFormat("Samza " + key.getTaskName() + " Thread-%d").build());
+      }
+
+      return operatorThreadPool;
+    });
+
+    return taskExecutor;
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/context/TestTaskContextImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/context/TestTaskContextImpl.java
@@ -62,7 +62,7 @@ public class TestTaskContextImpl {
     MockitoAnnotations.initMocks(this);
     taskContext =
         new TaskContextImpl(taskModel, taskMetricsRegistry, keyValueStoreProvider, tableManager, callbackScheduler,
-            offsetManager, null, null, null);
+            offsetManager, null, null, null, null);
     when(this.taskModel.getTaskName()).thenReturn(TASK_NAME);
   }
 
@@ -95,6 +95,4 @@ public class TestTaskContextImpl {
     taskContext.setStartingOffset(ssp, "123");
     verify(offsetManager).setStartingOffset(TASK_NAME, ssp, "123");
   }
-
-
 }

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImpl.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executors;
 import org.apache.samza.context.Context;
 import org.apache.samza.context.InternalTaskContext;
 import org.apache.samza.context.MockContext;
@@ -66,6 +67,7 @@ public class TestOperatorImpl {
     when(this.internalTaskContext.fetchObject(WatermarkStates.class.getName())).thenReturn(mock(WatermarkStates.class));
     when(this.context.getTaskContext().getTaskMetricsRegistry()).thenReturn(new MetricsRegistryMap());
     when(this.context.getTaskContext().getTaskModel()).thenReturn(mock(TaskModel.class));
+    when(this.context.getTaskContext().getOperatorExecutor()).thenReturn(Executors.newSingleThreadExecutor());
     when(this.context.getContainerContext().getContainerMetricsRegistry()).thenReturn(new MetricsRegistryMap());
   }
 
@@ -185,7 +187,8 @@ public class TestOperatorImpl {
     // send a timer tick to this operator
     MessageCollector mockCollector = mock(MessageCollector.class);
     TaskCoordinator mockCoordinator = mock(TaskCoordinator.class);
-    opImpl.onTimer(mockCollector, mockCoordinator);
+    CompletionStage<?> future = opImpl.onTimer(mockCollector, mockCoordinator);
+    future.toCompletableFuture().join();
 
     // verify that it propagates its handleTimer results to next operators
     verify(mockNextOpImpl1, times(1)).handleMessageAsync(mockTestOpImplOutput, mockCollector, mockCoordinator);

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImplGraph.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImplGraph.java
@@ -21,6 +21,7 @@ package org.apache.samza.operators.impl;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import java.util.concurrent.Executors;
 import org.apache.samza.Partition;
 import org.apache.samza.application.descriptors.StreamApplicationDescriptorImpl;
 import org.apache.samza.config.Config;
@@ -97,6 +98,7 @@ public class TestOperatorImplGraph {
     when(taskModel.getTaskName()).thenReturn(new TaskName("task 0"));
     when(this.context.getTaskContext().getTaskModel()).thenReturn(taskModel);
     when(this.context.getTaskContext().getTaskMetricsRegistry()).thenReturn(new MetricsRegistryMap());
+    when(this.context.getTaskContext().getOperatorExecutor()).thenReturn(Executors.newSingleThreadExecutor());
     when(this.context.getContainerContext().getContainerMetricsRegistry()).thenReturn(new MetricsRegistryMap());
   }
 

--- a/samza-sql/src/test/java/org/apache/samza/sql/system/TestAvroSystemFactory.java
+++ b/samza-sql/src/test/java/org/apache/samza/sql/system/TestAvroSystemFactory.java
@@ -75,7 +75,7 @@ public class TestAvroSystemFactory implements SystemFactory {
   public static final int NULL_RECORD_FREQUENCY = 5;
 
 
-  public static List<OutgoingMessageEnvelope> messages = new ArrayList<>();
+  public static volatile List<OutgoingMessageEnvelope> messages = new ArrayList<>();
 
   public static List<String> getPageKeyProfileNameJoin(int numMessages) {
     return IntStream.range(0, numMessages)

--- a/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
+++ b/samza-test/src/test/java/org/apache/samza/test/samzasql/TestSamzaSqlEndToEnd.java
@@ -584,7 +584,7 @@ public class TestSamzaSqlEndToEnd extends SamzaSqlIntegrationTestHarness {
   }
 
   @Test
-  public void testEndToEndSubQuery() {
+  public void testEndToEndSubQuery() throws InterruptedException {
     int numMessages = 20;
     TestAvroSystemFactory.messages.clear();
     Map<String, String> staticConfigs = SamzaSqlTestConfig.fetchStaticConfigsWithFactories(numMessages);


### PR DESCRIPTION
**Description**:
Currently, the operator implementation chains the future using synchronous APIs (thenCompose, thenApply) which results in execution of these method calls on the future completion thread which happens to be the user thread in case of asynchronous operators in application DAG.

**Changes**:
- Use thread pool inject through `job.container.task.executor.factory`
- Extend the task executor factory to return operator executor 
- Wire in the task executor in `TaskContext`
- Default implementation which uses `#getTaskExecutor` if enabled and `job.container.thread.pool.size` > 1 or fallback to single threaded executor otherwise.

**Testing**:
- Unit tests for the factory
- Test updates for existing `OperatorImpl` tests.

**API Changes**:
- Add `getOperatorExecutor` to `TaskExecutorFactory`
- Provide a default implementation that reuses `getTaskExecutor`

**Usage Instructions**:
Refer to the config documentation to enable operator thread pool and about the task executor factory

**Upgrade Instructions**: 
None