### PR TITLE
SAMZA-2782: Clean up container thread pool DI into StreamOperatorTask

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/context/ContainerContext.java
+++ b/samza-api/src/main/java/org/apache/samza/context/ContainerContext.java
@@ -18,6 +18,7 @@
  */
 package org.apache.samza.context;
 
+import java.util.concurrent.ExecutorService;
 import org.apache.samza.job.model.ContainerModel;
 import org.apache.samza.job.model.TaskModel;
 import org.apache.samza.metrics.MetricsRegistry;
@@ -44,4 +45,6 @@ public interface ContainerContext {
    * @return the {@link MetricsRegistry} for this container
    */
   MetricsRegistry getContainerMetricsRegistry();
+
+  ExecutorService getContainerThreadPool();
 }

--- a/samza-api/src/main/java/org/apache/samza/task/StreamOperatorTaskFactory.java
+++ b/samza-api/src/main/java/org/apache/samza/task/StreamOperatorTaskFactory.java
@@ -26,5 +26,6 @@ package org.apache.samza.task;
  * Note: It returns an {@link AsyncStreamTask} since <code>StreamOperatorTask</code> is not part of samza-api. It is
  * a temporary hack introduced for SAMZA-2172 and will eventually go away with SAMZA-2203
  */
+@Deprecated
 public interface StreamOperatorTaskFactory extends TaskFactory<AsyncStreamTask> {
 }

--- a/samza-core/src/main/java/org/apache/samza/context/ContainerContextImpl.java
+++ b/samza-core/src/main/java/org/apache/samza/context/ContainerContextImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.samza.context;
 
+import java.util.concurrent.ExecutorService;
 import org.apache.samza.job.model.ContainerModel;
 import org.apache.samza.metrics.MetricsRegistry;
 
@@ -26,9 +27,13 @@ public class ContainerContextImpl implements ContainerContext {
   private final ContainerModel containerModel;
   private final MetricsRegistry containerMetricsRegistry;
 
-  public ContainerContextImpl(ContainerModel containerModel, MetricsRegistry containerMetricsRegistry) {
+  private final ExecutorService containerThreadPool;
+
+  public ContainerContextImpl(ContainerModel containerModel, MetricsRegistry containerMetricsRegistry,
+      ExecutorService containerThreadPool) {
     this.containerModel = containerModel;
     this.containerMetricsRegistry = containerMetricsRegistry;
+    this.containerThreadPool = containerThreadPool;
   }
 
   @Override
@@ -39,5 +44,10 @@ public class ContainerContextImpl implements ContainerContext {
   @Override
   public MetricsRegistry getContainerMetricsRegistry() {
     return this.containerMetricsRegistry;
+  }
+
+  @Override
+  public ExecutorService getContainerThreadPool() {
+    return this.containerThreadPool;
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/storage/StorageRecovery.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/StorageRecovery.java
@@ -229,7 +229,7 @@ public class StorageRecovery {
         .getCheckpointManager(new MetricsRegistryMap()).orElse(null);
 
     for (ContainerModel containerModel : containers.values()) {
-      ContainerContext containerContext = new ContainerContextImpl(containerModel, new MetricsRegistryMap());
+      ContainerContext containerContext = new ContainerContextImpl(containerModel, new MetricsRegistryMap(), null);
 
       ContainerStorageManager containerStorageManager =
           new ContainerStorageManager(

--- a/samza-core/src/main/java/org/apache/samza/task/StreamOperatorTask.java
+++ b/samza-core/src/main/java/org/apache/samza/task/StreamOperatorTask.java
@@ -93,6 +93,11 @@ public class StreamOperatorTask implements AsyncStreamTask, InitableTask, Window
   public final void init(Context context) throws Exception {
     // create the operator impl DAG corresponding to the logical operator spec DAG
     this.operatorImplGraph = new OperatorImplGraph(specGraph, context, clock);
+    /*
+     * TODO: Consolidate the thread pool used by OperatorImpl and StreamOperatorTask. For now, we need to keep the
+     * existing behavior. The refactor however is to clean up the DI which is one step towards consolidation
+     */
+    this.taskThreadPool = context.getContainerContext().getContainerThreadPool();
   }
 
   /**

--- a/samza-core/src/main/java/org/apache/samza/task/TaskFactoryUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/task/TaskFactoryUtil.java
@@ -48,7 +48,7 @@ public class TaskFactoryUtil {
     if (appDesc instanceof TaskApplicationDescriptorImpl) {
       return ((TaskApplicationDescriptorImpl) appDesc).getTaskFactory();
     } else if (appDesc instanceof StreamApplicationDescriptorImpl) {
-      return (StreamOperatorTaskFactory) () -> new StreamOperatorTask(
+      return (AsyncStreamTaskFactory) () -> new StreamOperatorTask(
           ((StreamApplicationDescriptorImpl) appDesc).getOperatorSpecGraph());
     }
     throw new IllegalArgumentException(String.format("ApplicationDescriptorImpl has to be either TaskApplicationDescriptorImpl or "
@@ -112,24 +112,6 @@ public class TaskFactoryUtil {
       return factory;
     }
 
-    boolean isStreamOperatorTaskClass = factory instanceof StreamOperatorTaskFactory;
-
-    /*
-     * Note: Even though StreamOperatorTask is an instanceof AsyncStreamTask, we still need to
-     * adapt it in order to inject the container thread pool. Long term, this will go away once we have the
-     * InternalTaskContext refactor, which would then become the entry point for exposing any of the runtime objects
-     * created in the container.
-     * Refer to SAMZA-2203 for more details.
-     */
-    if (isStreamOperatorTaskClass) {
-      log.info("Adapting StreamOperatorTaskFactory to inject container thread pool");
-      return (AsyncStreamTaskFactory) () -> {
-        StreamOperatorTask operatorTask = (StreamOperatorTask) factory.createInstance();
-        operatorTask.setTaskThreadPool(taskThreadPool);
-        return operatorTask;
-      };
-    }
-
     log.info("Converting StreamTask to AsyncStreamTaskAdapter");
     return (AsyncStreamTaskFactory) () ->
         new AsyncStreamTaskAdapter(((StreamTaskFactory) factory).createInstance(), taskThreadPool);
@@ -141,11 +123,10 @@ public class TaskFactoryUtil {
     }
 
     boolean isValidFactory = factory instanceof StreamTaskFactory
-            || factory instanceof AsyncStreamTaskFactory
-            || factory instanceof StreamOperatorTaskFactory;
+            || factory instanceof AsyncStreamTaskFactory;
 
     if (!isValidFactory) {
-      throw new SamzaException(String.format("TaskFactory must be either StreamTaskFactory or AsyncStreamTaskFactory or StreamOperatorTaskFactory. %s is not supported",
+      throw new SamzaException(String.format("TaskFactory must be either StreamTaskFactory or AsyncStreamTaskFactory. %s is not supported",
           factory.getClass()));
     }
   }

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainer.scala
@@ -484,7 +484,7 @@ object SamzaContainer extends Logging {
       new ThreadFactoryBuilder().setNameFormat("Samza Task Commit Thread-%d").setDaemon(true).build())
 
     val taskModels = containerModel.getTasks.values.asScala
-    val containerContext = new ContainerContextImpl(containerModel, samzaContainerMetrics.registry)
+    val containerContext = new ContainerContextImpl(containerModel, samzaContainerMetrics.registry, taskThreadPool)
     val applicationContainerContextOption = applicationContainerContextFactoryOption
       .map(_.create(externalContextOption.orNull, jobContext, containerContext))
 

--- a/samza-core/src/test/java/org/apache/samza/storage/TestKafkaChangelogStateBackendFactory.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/TestKafkaChangelogStateBackendFactory.java
@@ -58,7 +58,7 @@ public class TestKafkaChangelogStateBackendFactory {
         new SystemStreamPartition("changelogSystem0", "store0-changelog", new Partition(11)),
         new SystemStreamPartition("changelogSystem1", "store1-changelog", new Partition(11)));
     Assert.assertEquals(expected, factory.getChangelogSSPForContainer(changeLogSystemStreams,
-        new ContainerContextImpl(containerModel, null)));
+        new ContainerContextImpl(containerModel, null, null)));
   }
 
   @Test
@@ -75,6 +75,6 @@ public class TestKafkaChangelogStateBackendFactory {
     ContainerModel containerModel = new ContainerModel("processorId",
         ImmutableMap.of(taskName0, taskModel0, taskName1, taskModel1));
     Assert.assertEquals(Collections.emptySet(), factory.getChangelogSSPForContainer(Collections.emptyMap(),
-        new ContainerContextImpl(containerModel, null)));
+        new ContainerContextImpl(containerModel, null, null)));
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/task/TestTaskFactoryUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/task/TestTaskFactoryUtil.java
@@ -93,19 +93,6 @@ public class TestTaskFactoryUtil {
     assertEquals(retFactory, mockAsyncStreamFactory);
   }
 
-  @Test
-  public void testFinalizeTaskFactoryForStreamOperatorTask() {
-    TaskFactory mockFactory = mock(StreamOperatorTaskFactory.class);
-    StreamOperatorTask mockStreamOperatorTask = mock(StreamOperatorTask.class);
-    when(mockFactory.createInstance())
-        .thenReturn(mockStreamOperatorTask);
-
-    ExecutorService mockThreadPool = mock(ExecutorService.class);
-    TaskFactory finalizedFactory = TaskFactoryUtil.finalizeTaskFactory(mockFactory, mockThreadPool);
-    finalizedFactory.createInstance();
-    verify(mockStreamOperatorTask, times(1)).setTaskThreadPool(eq(mockThreadPool));
-  }
-
   // test getTaskFactory with StreamApplicationDescriptor
   @Test
   public void testGetTaskFactoryWithStreamAppDescriptor() {
@@ -113,8 +100,8 @@ public class TestTaskFactoryUtil {
     OperatorSpecGraph mockSpecGraph = mock(OperatorSpecGraph.class);
     when(mockStreamApp.getOperatorSpecGraph()).thenReturn(mockSpecGraph);
     TaskFactory streamTaskFactory = TaskFactoryUtil.getTaskFactory(mockStreamApp);
-    assertTrue(streamTaskFactory instanceof StreamOperatorTaskFactory);
-    AsyncStreamTask streamTask = ((StreamOperatorTaskFactory) streamTaskFactory).createInstance();
+    assertTrue(streamTaskFactory instanceof AsyncStreamTaskFactory);
+    AsyncStreamTask streamTask = ((AsyncStreamTaskFactory) streamTaskFactory).createInstance();
     assertTrue(streamTask instanceof StreamOperatorTask);
     verify(mockSpecGraph).clone();
   }

--- a/samza-test/src/main/scala/org/apache/samza/test/performance/TestKeyValuePerformance.scala
+++ b/samza-test/src/main/scala/org/apache/samza/test/performance/TestKeyValuePerformance.scala
@@ -143,7 +143,7 @@ object TestKeyValuePerformance extends Logging {
           new MetricsRegistryMap,
           null,
           JobContextImpl.fromConfigWithDefaults(storageConfig, null),
-          new ContainerContextImpl(new ContainerModel("0", tasks.asJava), new MetricsRegistryMap), StoreMode.ReadWrite
+          new ContainerContextImpl(new ContainerModel("0", tasks.asJava), new MetricsRegistryMap, null), StoreMode.ReadWrite
         )
 
         val db = if(!engine.isInstanceOf[KeyValueStorageEngine[_,_]]) {


### PR DESCRIPTION
**Description**:
Prior to `TaskContext` and `ContainerContext`, the container thread pool was injected into `StreamOperatorTask` using `TaskFactoryUtil` and round about ways.
Now that we have these contexts, it is easier to inject and simplify the DI.

**Changes**:
- Add container thread pool to `ContainerContext`
- Clean up `TaskFactoryUtil` and other remnants of previous DI
- Deprecate `StreamOperatorTaskFactory`

**Tests**:
- Unit tests
- Updated existing tests

**API Changes**: 
Added `getContainerThreadPool` to `ContainerContext`

**Upgrade Instructions**: None

**Usage Instructions**: None