### PR TITLE
Re-factor DirDiffUtil.getDirDiff  to traverse and test files once.

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/index/FileMetadata.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/index/FileMetadata.java
@@ -58,11 +58,37 @@ public class FileMetadata {
     this.permissions = permissions;
   }
 
+  private static String lastGroupName = null;
+  private static String lastOwnerName = null;
+  private static Integer lastGroupId = null;
+  private static Integer lastOwnerId = null;
   public static FileMetadata fromFile(File file) throws IOException {
     PosixFileAttributes attributes = Files.readAttributes(file.toPath(), PosixFileAttributes.class);
 
+    String ownerName;
+    String groupName;
+
+    Integer groupId = (Integer)Files.getAttribute(file.toPath(), "unix:gid");
+    Integer ownerId = (Integer)Files.getAttribute(file.toPath(), "unix:uid");
+
+    if(lastGroupId != null && lastGroupId.equals(groupId)) {
+      groupName = lastGroupName;
+    } else {
+      groupName = attributes.group().getName();
+      lastGroupName = groupName;
+      lastGroupId = groupId;
+    }
+
+    if(lastOwnerId != null && lastGroupId.equals(ownerId)) {
+      ownerName = lastOwnerName;
+    } else {
+      ownerName = attributes.owner().getName();
+      lastOwnerName = ownerName;
+      lastOwnerId = ownerId;
+    }
+
     return new FileMetadata(attributes.creationTime().toMillis(), attributes.lastModifiedTime().toMillis(),
-        attributes.size(), attributes.owner().toString(), attributes.group().toString(),
+        attributes.size(), ownerName, groupName,
         PosixFilePermissions.toString(attributes.permissions()));
   }
 

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/index/FileMetadata.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/index/FileMetadata.java
@@ -58,37 +58,11 @@ public class FileMetadata {
     this.permissions = permissions;
   }
 
-  private static String lastGroupName = null;
-  private static String lastOwnerName = null;
-  private static Integer lastGroupId = null;
-  private static Integer lastOwnerId = null;
   public static FileMetadata fromFile(File file) throws IOException {
     PosixFileAttributes attributes = Files.readAttributes(file.toPath(), PosixFileAttributes.class);
 
-    String ownerName;
-    String groupName;
-
-    Integer groupId = (Integer)Files.getAttribute(file.toPath(), "unix:gid");
-    Integer ownerId = (Integer)Files.getAttribute(file.toPath(), "unix:uid");
-
-    if(lastGroupId != null && lastGroupId.equals(groupId)) {
-      groupName = lastGroupName;
-    } else {
-      groupName = attributes.group().getName();
-      lastGroupName = groupName;
-      lastGroupId = groupId;
-    }
-
-    if(lastOwnerId != null && lastGroupId.equals(ownerId)) {
-      ownerName = lastOwnerName;
-    } else {
-      ownerName = attributes.owner().getName();
-      lastOwnerName = ownerName;
-      lastOwnerId = ownerId;
-    }
-
     return new FileMetadata(attributes.creationTime().toMillis(), attributes.lastModifiedTime().toMillis(),
-        attributes.size(), ownerName, groupName,
+        attributes.size(), attributes.owner().toString(), attributes.group().toString(),
         PosixFilePermissions.toString(attributes.permissions()));
   }
 

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
@@ -213,16 +213,18 @@ public class DirDiffUtil {
                 remoteFilePermissions.contains(PosixFilePermission.OWNER_EXECUTE);
 
         if (!areSameFiles) {
-          LOG.warn("Local file: {} and remote file: {} are not same. " +
-                  "Local file attributes: {}. Remote file attributes: {}.",
-              localFile.getAbsolutePath(), remoteFile.getFileName(),
-              fileAttributesToString(localFileAttrs), remoteFile.getFileMetadata().toString());
+          if(LOG.isWarnEnabled()) {
+            LOG.warn("Local file: {} and remote file: {} are not same. "
+                    + "Local file attributes: {}. Remote file attributes: {}.", localFile.getAbsolutePath(), remoteFile.getFileName(),
+                fileAttributesToString(localFileAttrs), remoteFile.getFileMetadata().toString());
+          }
           return false;
         } else {
-          LOG.trace("Local file: {}. Remote file: {}. " +
-                  "Local file attributes: {}. Remote file attributes: {}.",
-              localFile.getAbsolutePath(), remoteFile.getFileName(),
-              fileAttributesToString(localFileAttrs), remoteFile.getFileMetadata().toString());
+          if(LOG.isTraceEnabled()) {
+            LOG.trace("Local file: {}. Remote file: {}. " + "Local file attributes: {}. Remote file attributes: {}.",
+                localFile.getAbsolutePath(), remoteFile.getFileName(), fileAttributesToString(localFileAttrs),
+                remoteFile.getFileMetadata().toString());
+          }
         }
 
         boolean isLargeFile = localFileAttrs.size() > 1024 * 1024;

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
@@ -161,15 +161,15 @@ public class DirDiffUtil {
    */
   public static BiPredicate<File, FileIndex> areSameFile(boolean compareLargeFileChecksums) {
     return areSameFile(compareLargeFileChecksums,
-        Suppliers.memoize(DirDiffUtil::_isSameGroup),
-        Suppliers.memoize(DirDiffUtil::_isSameOwner));
+        Suppliers.memoize(DirDiffUtil::_isSameGroup).get(),
+        Suppliers.memoize(DirDiffUtil::_isSameOwner).get());
   }
 
   /**
    * Internal overload of areSameFile to take memoized suppliers for group/owner to cache values.
    */
   private static BiPredicate<File, FileIndex> areSameFile(boolean compareLargeFileChecksums,
-      Supplier<BiPredicate<GroupPrincipal, String>> isSameGroup, Supplier<BiPredicate<UserPrincipal, String>> isSameOwner) {
+      BiPredicate<GroupPrincipal, String> isSameGroup, BiPredicate<UserPrincipal, String> isSameOwner) {
 
     return (localFile, remoteFile) -> {
       if (localFile.getName().equals(remoteFile.getFileName())) {
@@ -190,8 +190,8 @@ public class DirDiffUtil {
         // remote file, and will cause the file to be uploaded again during the first commit after restore.
         boolean areSameFiles =
             localFileAttrs.size() == remoteFileMetadata.getSize() &&
-                isSameGroup.get().test(localFileAttrs.group(), remoteFileMetadata.getGroup()) &&
-                isSameOwner.get().test(localFileAttrs.owner(), remoteFileMetadata.getOwner());
+                isSameGroup.test(localFileAttrs.group(), remoteFileMetadata.getGroup()) &&
+                isSameOwner.test(localFileAttrs.owner(), remoteFileMetadata.getOwner());
 
         // only verify permissions for file owner
         areSameFiles = areSameFiles &&

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
@@ -294,7 +294,7 @@ public class DirDiffUtil {
           filesToUpload.add(localFiles.get(file));
         }
       } else if (remoteFiles.containsKey(file)) {
-        // File exists remotely, but not locally.  Remove
+        // File exists remotely, but not locally,  Remove
         filesToRemove.add(remoteFiles.get(file));
       }
     }

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
@@ -18,8 +18,6 @@
  */
 
 package org.apache.samza.storage.blobstore.util;
-
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
@@ -20,15 +20,19 @@
 package org.apache.samza.storage.blobstore.util;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.nio.file.attribute.GroupPrincipal;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.attribute.UserPrincipal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -141,6 +145,13 @@ public class DirDiffUtil {
     };
   }
 
+
+  private static BiPredicate<GroupPrincipal, String> _isSameGroup() {
+    return (a,b) -> a.getName().equals(b);
+  }
+  private static BiPredicate<UserPrincipal, String> _isSameOwner() {
+    return (a,b) -> a.getName().equals(b);
+  }
   /**
    * Bipredicate to test a local file in the filesystem and a remote file {@link FileIndex} and find out if they represent
    * the same file. Files with same attributes as well as content are same file. A SST file in a special case. They are
@@ -149,6 +160,17 @@ public class DirDiffUtil {
    * @return BiPredicate to test similarity of local and remote files
    */
   public static BiPredicate<File, FileIndex> areSameFile(boolean compareLargeFileChecksums) {
+    return areSameFile(compareLargeFileChecksums,
+        Suppliers.memoize(DirDiffUtil::_isSameGroup),
+        Suppliers.memoize(DirDiffUtil::_isSameOwner));
+  }
+
+  /**
+   * Internal overload of areSameFile to take memoized suppliers for group/owner to cache values.
+   */
+  private static BiPredicate<File, FileIndex> areSameFile(boolean compareLargeFileChecksums,
+      Supplier<BiPredicate<GroupPrincipal, String>> isSameGroup, Supplier<BiPredicate<UserPrincipal, String>> isSameOwner) {
+
     return (localFile, remoteFile) -> {
       if (localFile.getName().equals(remoteFile.getFileName())) {
         FileMetadata remoteFileMetadata = remoteFile.getFileMetadata();
@@ -168,8 +190,8 @@ public class DirDiffUtil {
         // remote file, and will cause the file to be uploaded again during the first commit after restore.
         boolean areSameFiles =
             localFileAttrs.size() == remoteFileMetadata.getSize() &&
-                localFileAttrs.group().getName().equals(remoteFileMetadata.getGroup()) &&
-                localFileAttrs.owner().getName().equals(remoteFileMetadata.getOwner());
+                isSameGroup.get().test(localFileAttrs.group(), remoteFileMetadata.getGroup()) &&
+                isSameOwner.get().test(localFileAttrs.owner(), remoteFileMetadata.getOwner());
 
         // only verify permissions for file owner
         areSameFiles = areSameFiles &&
@@ -181,25 +203,28 @@ public class DirDiffUtil {
                 remoteFilePermissions.contains(PosixFilePermission.OWNER_EXECUTE);
 
         if (!areSameFiles) {
-          LOG.warn("Local file: {} and remote file: {} are not same. " +
-                  "Local file attributes: {}. Remote file attributes: {}.",
-              localFile.getAbsolutePath(), remoteFile.getFileName(),
-              fileAttributesToString(localFileAttrs), remoteFile.getFileMetadata().toString());
+          if(LOG.isWarnEnabled()) {
+            LOG.warn("Local file: {} and remote file: {} are not same. "
+                    + "Local file attributes: {}. Remote file attributes: {}.", localFile.getAbsolutePath(), remoteFile.getFileName(),
+                fileAttributesToString(localFileAttrs), remoteFile.getFileMetadata().toString());
+          }
           return false;
         } else {
-          LOG.trace("Local file: {}. Remote file: {}. " +
-                  "Local file attributes: {}. Remote file attributes: {}.",
-              localFile.getAbsolutePath(), remoteFile.getFileName(),
-              fileAttributesToString(localFileAttrs), remoteFile.getFileMetadata().toString());
+          if(LOG.isTraceEnabled()) {
+            LOG.trace("Local file: {}. Remote file: {}. " + "Local file attributes: {}. Remote file attributes: {}.",
+                localFile.getAbsolutePath(), remoteFile.getFileName(), fileAttributesToString(localFileAttrs),
+                remoteFile.getFileMetadata().toString());
+          }
         }
 
         boolean isLargeFile = localFileAttrs.size() > 1024 * 1024;
         if (!compareLargeFileChecksums && isLargeFile) {
           // Since RocksDB SST files are immutable after creation, we can skip the expensive checksum computations
           // which requires reading the entire file.
-          LOG.debug("Local file: {} and remote file: {} are same. " +
-                  "Skipping checksum calculation for large file of size: {}.",
-              localFile.getAbsolutePath(), remoteFile.getFileName(), localFileAttrs.size());
+          if(LOG.isDebugEnabled()) {
+            LOG.debug("Local file: {} and remote file: {} are same. "
+                + "Skipping checksum calculation for large file of size: {}.", localFile.getAbsolutePath(), remoteFile.getFileName(), localFileAttrs.size());
+          }
           return true;
         } else {
           try {
@@ -212,12 +237,15 @@ public class DirDiffUtil {
 
             boolean areSameChecksum = localFileChecksum == remoteFile.getChecksum();
             if (!areSameChecksum) {
-              LOG.warn("Local file: {} and remote file: {} are not same. " +
-                      "Local checksum: {}. Remote checksum: {}",
-                  localFile.getAbsolutePath(), remoteFile.getFileName(), localFileChecksum, remoteFile.getChecksum());
+              if(LOG.isWarnEnabled()) {
+                LOG.warn("Local file: {} and remote file: {} are not same. " + "Local checksum: {}. Remote checksum: {}",
+                    localFile.getAbsolutePath(), remoteFile.getFileName(), localFileChecksum, remoteFile.getChecksum());
+              }
             } else {
-              LOG.debug("Local file: {} and remote file: {} are same. Local checksum: {}. Remote checksum: {}",
-                  localFile.getAbsolutePath(), remoteFile.getFileName(), localFileChecksum, remoteFile.getChecksum());
+              if(LOG.isDebugEnabled()) {
+                LOG.debug("Local file: {} and remote file: {} are same. Local checksum: {}. Remote checksum: {}",
+                    localFile.getAbsolutePath(), remoteFile.getFileName(), localFileChecksum, remoteFile.getChecksum());
+              }
             }
             return areSameChecksum;
           } catch (IOException e) {
@@ -279,6 +307,7 @@ public class DirDiffUtil {
     Map<String, File> localFiles = localSnapshotFiles.stream()
         .collect(Collectors.toMap(File::getName, Function.identity()));
 
+    Map<Integer, String> uidMap = new HashMap<Integer, String>();
     for(String file : Sets.union(remoteFiles.keySet(), localFiles.keySet())) {
       if(localFiles.containsKey(file)) {
         if(remoteFiles.containsKey(file)) {

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
@@ -162,7 +162,7 @@ public class DirDiffUtil {
       if (localFile.getName().equals(remoteFile.getFileName())) {
         FileMetadata remoteFileMetadata = remoteFile.getFileMetadata();
 
-        boolean areSameFiles = false;
+        boolean areSameFiles;
         PosixFileAttributes localFileAttrs;
         try {
           localFileAttrs = Files.readAttributes(localFile.toPath(), PosixFileAttributes.class);
@@ -293,7 +293,6 @@ public class DirDiffUtil {
     Map<String, File> localFiles = localSnapshotFiles.stream()
         .collect(Collectors.toMap(File::getName, Function.identity()));
 
-    Map<Integer, String> uidMap = new HashMap<Integer, String>();
     for(String file : Sets.union(remoteFiles.keySet(), localFiles.keySet())) {
       if(localFiles.containsKey(file)) {
         if(remoteFiles.containsKey(file)) {

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
@@ -155,7 +155,9 @@ public class DirDiffUtil {
       if (localFile.getName().equals(remoteFile.getFileName())) {
         FileMetadata remoteFileMetadata = remoteFile.getFileMetadata();
 
+        // Cache owner/group names to reduce calls to sun.nio.fs.UnixFileAttributes.group
         Cache<String, String> groupCache = CacheBuilder.newBuilder().maximumSize(CACHE_SIZE).build();
+        // Cache owner/group names to reduce calls to sun.nio.fs.UnixFileAttributes.owner
         Cache<String, String> ownerCache = CacheBuilder.newBuilder().maximumSize(CACHE_SIZE).build();
 
         boolean areSameFiles;

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
@@ -20,8 +20,6 @@
 package org.apache.samza.storage.blobstore.util;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.FileInputStream;

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
@@ -169,9 +169,9 @@ public class DirDiffUtil {
           // remote file, and will cause the file to be uploaded again during the first commit after restore.
           areSameFiles = localFileAttrs.size() == remoteFileMetadata.getSize() &&
               groupCache.get(String.valueOf(Files.getAttribute(localFile.toPath(), "unix:gid")),
-                  () -> localFileAttrs.group().getName()).equals(remoteFileMetadata.getGroup()) &&
+                () -> localFileAttrs.group().getName()).equals(remoteFileMetadata.getGroup()) &&
               ownerCache.get(String.valueOf(Files.getAttribute(localFile.toPath(), "unix:uid")),
-                  () -> localFileAttrs.owner().getName()).equals(remoteFileMetadata.getOwner());
+                () -> localFileAttrs.owner().getName()).equals(remoteFileMetadata.getOwner());
 
         } catch (IOException | ExecutionException e) {
           LOG.error("Error reading attributes for file: {}", localFile.getAbsolutePath());
@@ -191,14 +191,14 @@ public class DirDiffUtil {
                 remoteFilePermissions.contains(PosixFilePermission.OWNER_EXECUTE);
 
         if (!areSameFiles) {
-          if(LOG.isWarnEnabled()) {
+          if (LOG.isWarnEnabled()) {
             LOG.warn("Local file: {} and remote file: {} are not same. "
                     + "Local file attributes: {}. Remote file attributes: {}.", localFile.getAbsolutePath(), remoteFile.getFileName(),
                 fileAttributesToString(localFileAttrs), remoteFile.getFileMetadata().toString());
           }
           return false;
         } else {
-          if(LOG.isTraceEnabled()) {
+          if (LOG.isTraceEnabled()) {
             LOG.trace("Local file: {}. Remote file: {}. " + "Local file attributes: {}. Remote file attributes: {}.",
                 localFile.getAbsolutePath(), remoteFile.getFileName(), fileAttributesToString(localFileAttrs),
                 remoteFile.getFileMetadata().toString());
@@ -290,10 +290,10 @@ public class DirDiffUtil {
     Map<String, File> localFiles = localSnapshotFiles.stream()
         .collect(Collectors.toMap(File::getName, Function.identity()));
 
-    for(String file : Sets.union(remoteFiles.keySet(), localFiles.keySet())) {
-      if(localFiles.containsKey(file)) {
-        if(remoteFiles.containsKey(file)) {
-          if(areSameFile.test(localFiles.get(file), remoteFiles.get(file))) {
+    for (String file : Sets.union(remoteFiles.keySet(), localFiles.keySet())) {
+      if (localFiles.containsKey(file)) {
+        if (remoteFiles.containsKey(file)) {
+          if (areSameFile.test(localFiles.get(file), remoteFiles.get(file))) {
             // Files are the same locally and remotely, Retain
             filesToRetain.add(remoteFiles.get(file));
           } else {

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/DirDiffUtil.java
@@ -321,7 +321,8 @@ public class DirDiffUtil {
             // Files are the same locally and remotely, Retain
             filesToRetain.add(remoteFiles.get(file));
           } else {
-            // Files are not the same, Upload
+            // Files are not the same, remove and upload
+            filesToRemove.add(remoteFiles.get(file));
             filesToUpload.add(localFiles.get(file));
           }
         } else {

--- a/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestDirDiffUtilAreSameFile.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestDirDiffUtilAreSameFile.java
@@ -1,4 +1,4 @@
-/*
+/* 
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,8 +19,6 @@
 
 package org.apache.samza.storage.blobstore.util;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -39,9 +37,7 @@ import org.apache.samza.storage.blobstore.index.FileMetadata;
 import org.junit.Before;
 import org.junit.Test;
 
-public class TestDirDiffUtilAreSameFile
-
-{
+public class TestDirDiffUtilAreSameFile {
   public static final int SMALL_FILE = 100;
   public static final int LARGE_FILE = 1024 * 1024 + 1;
   private BiPredicate<File, FileIndex> areSameFile = null;
@@ -64,9 +60,9 @@ public class TestDirDiffUtilAreSameFile
     localFile = File.createTempFile("temp", null);
     final String data = "a";
     CRC32 crc32 = new CRC32();
-    try(FileWriter writer = new FileWriter(localFile);
+    try (FileWriter writer = new FileWriter(localFile);
         BufferedWriter bw = new BufferedWriter(writer)) {
-      for(int i =0; i < fileSize; i++) {
+      for (int i = 0; i < fileSize; i++) {
         crc32.update(data.getBytes(StandardCharsets.UTF_8));
         bw.write(data);
       }
@@ -76,7 +72,7 @@ public class TestDirDiffUtilAreSameFile
 
     localFileAttrs = Files.readAttributes(localFile.toPath(), PosixFileAttributes.class);
 
-    remoteFileMetadata = new FileMetadata(0,0,
+    remoteFileMetadata = new FileMetadata(0, 0,
         localContentLength,
         localFileAttrs.owner().getName(),
         localFileAttrs.group().getName(),
@@ -105,7 +101,7 @@ public class TestDirDiffUtilAreSameFile
 
   @Test
   public void testAreSameFile_DifferentSize() {
-    remoteFileMetadata = new FileMetadata(0,0,
+    remoteFileMetadata = new FileMetadata(0, 0,
         localContentLength + 1,
         localFileAttrs.owner().getName(),
         localFileAttrs.group().getName(),
@@ -116,7 +112,7 @@ public class TestDirDiffUtilAreSameFile
 
   @Test
   public void testAreSameFile_DifferentOwner() {
-    remoteFileMetadata = new FileMetadata(0,0,
+    remoteFileMetadata = new FileMetadata(0, 0,
         localContentLength,
         localFileAttrs.owner().getName() + "_different",
         localFileAttrs.group().getName(),
@@ -127,7 +123,7 @@ public class TestDirDiffUtilAreSameFile
 
   @Test
   public void testAreSameFile_DifferentGroup() {
-    remoteFileMetadata = new FileMetadata(0,0,
+    remoteFileMetadata = new FileMetadata(0, 0,
         localContentLength,
         localFileAttrs.owner().getName(),
         localFileAttrs.group().getName() + "_different",
@@ -140,7 +136,7 @@ public class TestDirDiffUtilAreSameFile
   public void testAreSameFile_DifferentOwnerRead() {
     Set<PosixFilePermission> remoteFilePermissions = localFileAttrs.permissions();
     remoteFilePermissions.remove(PosixFilePermission.OWNER_READ);
-    remoteFileMetadata = new FileMetadata(0,0,
+    remoteFileMetadata = new FileMetadata(0, 0,
         localContentLength,
         localFileAttrs.owner().getName(),
         localFileAttrs.group().getName(),
@@ -153,7 +149,7 @@ public class TestDirDiffUtilAreSameFile
   public void testAreSameFile_DifferentOwnerWrite() {
     Set<PosixFilePermission> remoteFilePermissions = localFileAttrs.permissions();
     remoteFilePermissions.remove(PosixFilePermission.OWNER_WRITE);
-    remoteFileMetadata = new FileMetadata(0,0,
+    remoteFileMetadata = new FileMetadata(0, 0,
         localContentLength,
         localFileAttrs.owner().getName(),
         localFileAttrs.group().getName(),
@@ -166,7 +162,7 @@ public class TestDirDiffUtilAreSameFile
   public void testAreSameFile_DifferentOwnerExecute() {
     Set<PosixFilePermission> remoteFilePermissions = localFileAttrs.permissions();
     remoteFilePermissions.add(PosixFilePermission.OWNER_EXECUTE);
-    remoteFileMetadata = new FileMetadata(0,0,
+    remoteFileMetadata = new FileMetadata(0, 0,
         localContentLength,
         localFileAttrs.owner().getName(),
         localFileAttrs.group().getName(),

--- a/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestDirDiffUtilAreSameFile.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestDirDiffUtilAreSameFile.java
@@ -1,0 +1,223 @@
+package org.apache.samza.storage.blobstore.util;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.attribute.GroupPrincipal;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.attribute.UserPrincipal;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiPredicate;
+import java.util.zip.CRC32;
+import junit.framework.Assert;
+import org.apache.samza.storage.blobstore.index.FileIndex;
+import org.apache.samza.storage.blobstore.index.FileMetadata;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+
+public class TestDirDiffUtilAreSameFile
+
+{
+  public static final int SMALL_FILE = 100;
+  public static final int LARGE_FILE = 1024 * 1024 + 1;
+  private BiPredicate<File, FileIndex> areSameFile = null;
+
+  File localFile = null;
+
+  FileIndex remoteFile = null;
+  private long localChecksum = 0;
+  private PosixFileAttributes localFileAttrs = null;
+  private FileMetadata remoteFileMetadata = null;
+  private long localContentLength = 0;
+  private Map<String, String> cacheGroup;
+  private Map<String, String> cacheOwner;
+
+  @Before
+  public void testSetup() throws Exception {
+    cacheGroup = new HashMap<>();
+    cacheOwner = new HashMap<>();
+    areSameFile = DirDiffUtil.areSameFile(false, cacheGroup, cacheOwner);
+    createFile(SMALL_FILE);
+  }
+
+  void createFile(int fileSize) throws Exception {
+    localFile = File.createTempFile("temp", null);
+    final String data = "a";
+    CRC32 crc32 = new CRC32();
+    try(FileWriter writer = new FileWriter(localFile);
+        BufferedWriter bw = new BufferedWriter(writer)) {
+      for(int i =0; i < fileSize; i++) {
+        crc32.update(data.getBytes(StandardCharsets.UTF_8));
+        bw.write(data);
+      }
+    }
+    localContentLength = localFile.length();
+    localChecksum = crc32.getValue();
+
+    localFileAttrs = Files.readAttributes(localFile.toPath(), PosixFileAttributes.class);
+
+    remoteFileMetadata = new FileMetadata(0,0,
+        localContentLength,
+        localFileAttrs.owner().getName(),
+        localFileAttrs.group().getName(),
+        PosixFilePermissions.toString(localFileAttrs.permissions()));
+
+    remoteFile = new FileIndex(localFile.getName(), new ArrayList<>(), remoteFileMetadata, localChecksum);
+    localFile.deleteOnExit();
+  }
+
+  @Test
+  public void testAreSameFile_SameFile() {
+    Assert.assertTrue(areSameFile.test(localFile, remoteFile));
+  }
+
+  @Test
+  public void testAreSameFile_DifferentFile() {
+    remoteFile = new FileIndex(localFile.getName() + "_other", new ArrayList<>(), remoteFileMetadata, localChecksum + 1);
+    Assert.assertFalse(areSameFile.test(localFile, remoteFile));
+  }
+
+  @Test
+  public void testAreSameFile_DifferentCrc() {
+    remoteFile = new FileIndex(localFile.getName(), new ArrayList<>(), remoteFileMetadata, localChecksum + 1);
+    Assert.assertFalse(areSameFile.test(localFile, remoteFile));
+  }
+
+  @Test
+  public void testAreSameFile_DifferentSize() {
+    remoteFileMetadata = new FileMetadata(0,0,
+        localContentLength + 1,
+        localFileAttrs.owner().getName(),
+        localFileAttrs.group().getName(),
+        PosixFilePermissions.toString(localFileAttrs.permissions()));
+    remoteFile = new FileIndex(localFile.getName(), new ArrayList<>(), remoteFileMetadata, localChecksum);
+    Assert.assertFalse(areSameFile.test(localFile, remoteFile));
+  }
+
+  @Test
+  public void testAreSameFile_DifferentOwner() {
+    remoteFileMetadata = new FileMetadata(0,0,
+        localContentLength,
+        localFileAttrs.owner().getName() + "_different",
+        localFileAttrs.group().getName(),
+        PosixFilePermissions.toString(localFileAttrs.permissions()));
+    remoteFile = new FileIndex(localFile.getName(), new ArrayList<>(), remoteFileMetadata, localChecksum);
+    Assert.assertFalse(areSameFile.test(localFile, remoteFile));
+  }
+
+  @Test
+  public void testAreSameFile_DifferentGroup() {
+    remoteFileMetadata = new FileMetadata(0,0,
+        localContentLength,
+        localFileAttrs.owner().getName(),
+        localFileAttrs.group().getName() + "_different",
+        PosixFilePermissions.toString(localFileAttrs.permissions()));
+    remoteFile = new FileIndex(localFile.getName(), new ArrayList<>(), remoteFileMetadata, localChecksum);
+    Assert.assertFalse(areSameFile.test(localFile, remoteFile));
+  }
+
+  @Test
+  public void testAreSameFile_DifferentOwnerRead() {
+    Set<PosixFilePermission> remoteFilePermissions = localFileAttrs.permissions();
+    remoteFilePermissions.remove(PosixFilePermission.OWNER_READ);
+    remoteFileMetadata = new FileMetadata(0,0,
+        localContentLength,
+        localFileAttrs.owner().getName(),
+        localFileAttrs.group().getName(),
+        PosixFilePermissions.toString(remoteFilePermissions));
+    remoteFile = new FileIndex(localFile.getName(), new ArrayList<>(), remoteFileMetadata, localChecksum);
+    Assert.assertFalse(areSameFile.test(localFile, remoteFile));
+  }
+
+  @Test
+  public void testAreSameFile_DifferentOwnerWrite() {
+    Set<PosixFilePermission> remoteFilePermissions = localFileAttrs.permissions();
+    remoteFilePermissions.remove(PosixFilePermission.OWNER_WRITE);
+    remoteFileMetadata = new FileMetadata(0,0,
+        localContentLength,
+        localFileAttrs.owner().getName(),
+        localFileAttrs.group().getName(),
+        PosixFilePermissions.toString(remoteFilePermissions));
+    remoteFile = new FileIndex(localFile.getName(), new ArrayList<>(), remoteFileMetadata, localChecksum);
+    Assert.assertFalse(areSameFile.test(localFile, remoteFile));
+  }
+
+  @Test
+  public void testAreSameFile_DifferentOwnerExecute() {
+    Set<PosixFilePermission> remoteFilePermissions = localFileAttrs.permissions();
+    remoteFilePermissions.add(PosixFilePermission.OWNER_EXECUTE);
+    remoteFileMetadata = new FileMetadata(0,0,
+        localContentLength,
+        localFileAttrs.owner().getName(),
+        localFileAttrs.group().getName(),
+        PosixFilePermissions.toString(remoteFilePermissions));
+    remoteFile = new FileIndex(localFile.getName(), new ArrayList<>(), remoteFileMetadata, localChecksum);
+    Assert.assertFalse(areSameFile.test(localFile, remoteFile));
+  }
+
+  @Test
+  public void testAreSameFile_SmallFile_DifferentCrc() {
+    remoteFile = new FileIndex(localFile.getName(), new ArrayList<>(), remoteFileMetadata, localChecksum + 1);
+    Assert.assertFalse(areSameFile.test(localFile, remoteFile));
+  }
+
+  @Test
+  public void testAreSameFile_LargeFile_DifferentCrc() throws Exception {
+    createFile(LARGE_FILE);
+    remoteFile = new FileIndex(localFile.getName(), new ArrayList<>(), remoteFileMetadata, localChecksum + 1);
+    Assert.assertTrue(areSameFile.test(localFile, remoteFile));
+  }
+
+  @Test
+  public void testAreSameFile_cacheSingleGroupOwner() {
+    for(int i=0; i < 20; i++) {
+      for (int j = 0; j < 2; j++) {
+        Assert.assertTrue(areSameFile.test(localFile, remoteFile));
+      }
+    }
+    Assert.assertEquals(1, cacheGroup.size());
+    Assert.assertEquals(1, cacheOwner.size());
+  }
+
+  @Test
+  public void testAreSameFile_cacheMultipleGroup() throws Exception {
+
+    PosixFileAttributes attributes = Mockito.mock(PosixFileAttributes.class);
+    GroupPrincipal groupPrincipal = Mockito.mock(GroupPrincipal.class);
+    Mockito.when(attributes.group()).thenReturn(groupPrincipal);
+    for(int i = 0; i < 20; i++) {
+      Mockito.when(groupPrincipal.getName()).thenReturn("v" + i);
+      for (int j = 0; j < 2; j++) {
+        Assert.assertEquals("v" + i, DirDiffUtil.getCachedGroupName(cacheGroup, String.valueOf(i), attributes));
+      }
+    }
+    Assert.assertEquals(DirDiffUtil.CACHE_SIZE, cacheGroup.size());
+    Assert.assertEquals(0, cacheOwner.size());
+  }
+
+  @Test
+  public void testAreSameFile_cacheMultipleOwner() throws Exception {
+
+    PosixFileAttributes attributes = Mockito.mock(PosixFileAttributes.class);
+    UserPrincipal ownerPrincipal = Mockito.mock(UserPrincipal.class);
+    Mockito.when(attributes.owner()).thenReturn(ownerPrincipal);
+    for(int i = 0; i < 20; i++) {
+      Mockito.when(ownerPrincipal.getName()).thenReturn("v" + i);
+      for (int j = 0; j < 2; j++) {
+        Assert.assertEquals("v" + i, DirDiffUtil.getCachedOwnerName(cacheOwner, String.valueOf(i), attributes));
+      }
+    }
+    Assert.assertEquals(0, cacheGroup.size());
+    Assert.assertEquals(DirDiffUtil.CACHE_SIZE, cacheOwner.size());
+  }
+}

--- a/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestDirDiffUtilAreSameFile.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestDirDiffUtilAreSameFile.java
@@ -34,14 +34,10 @@ public class TestDirDiffUtilAreSameFile
   private PosixFileAttributes localFileAttrs = null;
   private FileMetadata remoteFileMetadata = null;
   private long localContentLength = 0;
-  private Cache<String, String> cacheGroup;
-  private Cache<String, String> cacheOwner;
 
   @Before
   public void testSetup() throws Exception {
-    cacheGroup = CacheBuilder.newBuilder().maximumSize(DirDiffUtil.CACHE_SIZE).build();
-    cacheOwner = CacheBuilder.newBuilder().maximumSize(DirDiffUtil.CACHE_SIZE).build();
-    areSameFile = DirDiffUtil.areSameFile(false, cacheGroup, cacheOwner);
+    areSameFile = DirDiffUtil.areSameFile(false);
     createFile(SMALL_FILE);
   }
 
@@ -171,16 +167,5 @@ public class TestDirDiffUtilAreSameFile
     createFile(LARGE_FILE);
     remoteFile = new FileIndex(localFile.getName(), new ArrayList<>(), remoteFileMetadata, localChecksum + 1);
     Assert.assertTrue(areSameFile.test(localFile, remoteFile));
-  }
-
-  @Test
-  public void testAreSameFile_cacheSingleGroupOwner() {
-    for(int i=0; i < 20; i++) {
-      for (int j = 0; j < 2; j++) {
-        Assert.assertTrue(areSameFile.test(localFile, remoteFile));
-      }
-    }
-    Assert.assertEquals(1, cacheGroup.size());
-    Assert.assertEquals(1, cacheOwner.size());
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestDirDiffUtilAreSameFile.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestDirDiffUtilAreSameFile.java
@@ -1,20 +1,17 @@
 package org.apache.samza.storage.blobstore.util;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.attribute.GroupPrincipal;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.nio.file.attribute.UserPrincipal;
-import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Set;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.function.BiPredicate;
 import java.util.zip.CRC32;
 import junit.framework.Assert;
@@ -22,8 +19,6 @@ import org.apache.samza.storage.blobstore.index.FileIndex;
 import org.apache.samza.storage.blobstore.index.FileMetadata;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
-
 
 public class TestDirDiffUtilAreSameFile
 
@@ -39,13 +34,13 @@ public class TestDirDiffUtilAreSameFile
   private PosixFileAttributes localFileAttrs = null;
   private FileMetadata remoteFileMetadata = null;
   private long localContentLength = 0;
-  private Map<String, String> cacheGroup;
-  private Map<String, String> cacheOwner;
+  private Cache<String, String> cacheGroup;
+  private Cache<String, String> cacheOwner;
 
   @Before
   public void testSetup() throws Exception {
-    cacheGroup = new HashMap<>();
-    cacheOwner = new HashMap<>();
+    cacheGroup = CacheBuilder.newBuilder().maximumSize(DirDiffUtil.CACHE_SIZE).build();
+    cacheOwner = CacheBuilder.newBuilder().maximumSize(DirDiffUtil.CACHE_SIZE).build();
     areSameFile = DirDiffUtil.areSameFile(false, cacheGroup, cacheOwner);
     createFile(SMALL_FILE);
   }
@@ -187,37 +182,5 @@ public class TestDirDiffUtilAreSameFile
     }
     Assert.assertEquals(1, cacheGroup.size());
     Assert.assertEquals(1, cacheOwner.size());
-  }
-
-  @Test
-  public void testAreSameFile_cacheMultipleGroup() throws Exception {
-
-    PosixFileAttributes attributes = Mockito.mock(PosixFileAttributes.class);
-    GroupPrincipal groupPrincipal = Mockito.mock(GroupPrincipal.class);
-    Mockito.when(attributes.group()).thenReturn(groupPrincipal);
-    for(int i = 0; i < 20; i++) {
-      Mockito.when(groupPrincipal.getName()).thenReturn("v" + i);
-      for (int j = 0; j < 2; j++) {
-        Assert.assertEquals("v" + i, DirDiffUtil.getCachedGroupName(cacheGroup, String.valueOf(i), attributes));
-      }
-    }
-    Assert.assertEquals(DirDiffUtil.CACHE_SIZE, cacheGroup.size());
-    Assert.assertEquals(0, cacheOwner.size());
-  }
-
-  @Test
-  public void testAreSameFile_cacheMultipleOwner() throws Exception {
-
-    PosixFileAttributes attributes = Mockito.mock(PosixFileAttributes.class);
-    UserPrincipal ownerPrincipal = Mockito.mock(UserPrincipal.class);
-    Mockito.when(attributes.owner()).thenReturn(ownerPrincipal);
-    for(int i = 0; i < 20; i++) {
-      Mockito.when(ownerPrincipal.getName()).thenReturn("v" + i);
-      for (int j = 0; j < 2; j++) {
-        Assert.assertEquals("v" + i, DirDiffUtil.getCachedOwnerName(cacheOwner, String.valueOf(i), attributes));
-      }
-    }
-    Assert.assertEquals(0, cacheGroup.size());
-    Assert.assertEquals(DirDiffUtil.CACHE_SIZE, cacheOwner.size());
   }
 }

--- a/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestDirDiffUtilAreSameFile.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestDirDiffUtilAreSameFile.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.samza.storage.blobstore.util;
 
 import com.google.common.cache.Cache;


### PR DESCRIPTION
## Summary

Re-factor `DirDiffUtil.getDirDiff` to minimize calls to sun.nio.fs.*

## Details
Profiling a real-world job showed ~38% of the time being spent in `DirDiffUtil.getDirDiff` for a given profile snapshot.  Investigating it seems that the call to `DirDiffUtil.areSameFile` is the primary cause of `DirDiffUtil.getDirDiff` showing up high on this particular profile.  Looking at the code there is the following comment:

```
  // TODO MED shesharm: this compares each file in directory 3 times. Categorize files in one traversal instead.
```

Re-factored creation of the lists `filesToUpload`, `filesToRetain`, and `filesToRemove` to iterate on the files once which reduces the number of times `DirDiffUtil.areSameFile` is called.  

The re-factor should reduce the number of calls by reducing the number of calls to `areSameFile`.  it is also noticed that inside of `areSameFile` there are calls to getting owner and user.  The expected number of users/groups is very small and the repeated calls to get the name from the id can be cached effectively.  Overload creation of `areSameFile` to cache calls to get user and owner.

JIRA=[SAMZA-2783](https://issues.apache.org/jira/browse/SAMZA-2783)

## Testing
`./gradlew clean && ./gradlew test`