### PR TITLE
SAMZA-2776: Fix unused parameter - EventHubSystemConsumer

### DIFF
--- a/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
+++ b/samza-azure/src/main/java/org/apache/samza/system/eventhub/consumer/EventHubSystemConsumer.java
@@ -283,9 +283,10 @@ public class EventHubSystemConsumer extends BlockingEnvelopeMap {
           // If no such offset exists Eventhub will return an error.
           ReceiverOptions receiverOptions = new ReceiverOptions();
           receiverOptions.setPrefetchCount(prefetchCount);
+          EventPosition position = EventPosition.fromOffset(offset, /* inclusiveFlag */false);
           receiver = eventHubClientManager.getEventHubClient()
-              .createReceiver(consumerGroup, partitionId.toString(),
-                  EventPosition.fromOffset(offset, /* inclusiveFlag */false)).get(DEFAULT_EVENTHUB_CREATE_RECEIVER_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+              .createReceiver(consumerGroup, partitionId.toString(), position, receiverOptions)
+              .get(DEFAULT_EVENTHUB_CREATE_RECEIVER_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         }
 
         PartitionReceiveHandler handler =
@@ -378,9 +379,9 @@ public class EventHubSystemConsumer extends BlockingEnvelopeMap {
       // Recreate receiver
       ReceiverOptions receiverOptions = new ReceiverOptions();
       receiverOptions.setPrefetchCount(prefetchCount);
+      EventPosition position = EventPosition.fromOffset(offset, !offset.equals(EventHubSystemConsumer.START_OF_STREAM));
       PartitionReceiver receiver = eventHubClientManager.getEventHubClient()
-          .createReceiverSync(consumerGroup, partitionId.toString(),
-              EventPosition.fromOffset(offset, !offset.equals(EventHubSystemConsumer.START_OF_STREAM)), receiverOptions);
+          .createReceiverSync(consumerGroup, partitionId.toString(), position, receiverOptions);
 
       // Timeout for EventHubClient receive
       receiver.setReceiveTimeout(DEFAULT_EVENTHUB_RECEIVER_TIMEOUT);

--- a/samza-azure/src/test/java/org/apache/samza/system/eventhub/MockEventHubClientManagerFactory.java
+++ b/samza-azure/src/test/java/org/apache/samza/system/eventhub/MockEventHubClientManagerFactory.java
@@ -138,7 +138,7 @@ public class MockEventHubClientManagerFactory extends EventHubClientManagerFacto
                 return CompletableFuture.completedFuture(mockPartitionReceiver);
               });
 
-        PowerMockito.when(mockEventHubClient.createReceiver(anyString(), anyString(), anyObject()))
+        PowerMockito.when(mockEventHubClient.createReceiver(anyString(), anyString(), anyObject(), anyObject()))
               .then((Answer<CompletableFuture<PartitionReceiver>>) invocationOnMock -> {
                 String partitionId = invocationOnMock.getArgumentAt(1, String.class);
                 EventPosition offset = invocationOnMock.getArgumentAt(2, EventPosition.class);


### PR DESCRIPTION
Symptom: self-reported bug.
 
Cause: A variable added in #1660 is unused. The parameter sets the offset in the `PartitionReceiver`. The change was required because of API changes in the previous PR.
 
Changes: This change was required in two places in the original PR, however, only [one](https://github.com/apache/samza/pull/1660#discussion_r1228789636) was unused. This PR corrects that and updates both sites to a similar code structure.
 
Tests: No new tests were added. Existing tests did not identify the mistake because the change did not affect  the mock used for testing. After the change, the tests failed until the mock was updated.

