### PR TITLE
Authenticate GitHub Actions builds to ge.apache.org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
     strategy:
       matrix:
         java-version: [ 8.0.232 ]
+    env:
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - name: Cache Gradle packages
         uses: actions/cache@v2


### PR DESCRIPTION
This change allows GitHub Actions builds to submit build scans to ge.apache.org by authenticating those builds. The access key has been stored as an organizational secret by the ASF Infrastructure team in the Apache GitHub organization. The access key is not available to workflows triggered from forks.

This builds on the changes in https://github.com/apache/samza/pull/1665