### PR TITLE
[SAMZA-2786] remove the docs gradle project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,47 +143,6 @@ subprojects {
   }
 }
 
-project(":docs") {
-  apply plugin: "com.github.jruby-gradle.base"
-  apply plugin: 'java'
-
-  repositories {
-    ruby.gems()
-  }
-
-  jruby {
-      jrubyVersion = '9.3.9.0'
-  }
-
-  dependencies {
-      gems "rubygems:jekyll-sass-converter:2.2.0"
-      gems "rubygems:jekyll:4.3.1"
-      gems "rubygems:http_parser.rb:0.6.0"
-      gems "rubygems:webrick:1.7.0"
-      gems "rubygems:json:2.6.3"
-      gems "rubygems:rouge:3.30.0"
-      gems "rubygems:kramdown:2.4.0"
-      gems "rubygems:kramdown-parser-gfm:1.1.0"
-  }
-
-  task jekyllBuild(type: com.github.jrubygradle.JRubyExec) {
-      script "jekyll"
-      scriptArgs "build", "$projectDir", "-d", "$projectDir/_site"
-  }
-
-  task jekyllServeLocal(type: com.github.jrubygradle.JRubyExec) {
-      def baseurl = ""
-      script "jekyll"
-      scriptArgs "serve", "--watch", "--source", "$projectDir" , "--destination", "$projectDir/_site", "--trace", "--baseurl", "$baseurl"
-  }
-
-  task jekyllServePublic(type: com.github.jrubygradle.JRubyExec) {
-      def baseurl = ""
-      script "jekyll"
-      scriptArgs "serve", "--watch", "--source", "$projectDir" , "--destination", "$projectDir/_site", "--trace", "--baseurl", "$baseurl", "--host", "0.0.0.0"
-  }
-
-}
 
 project(':samza-api') {
   apply plugin: 'java'

--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -28,5 +28,4 @@ repositories {
 dependencies {
   classpath 'de.obqo.gradle:gradle-lesscss-plugin:1.0-1.3.3'
   classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
-  classpath 'com.github.jruby-gradle:jruby-gradle-plugin:2.0.2'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -51,7 +51,6 @@ buildCache {
 }
 
 include \
-  'docs',
   'samza-api',
   'samza-sql',
   'samza-shell',


### PR DESCRIPTION
As explained in [SAMZA-2786](https://issues.apache.org/jira/browse/SAMZA-2786) a missing dependency used by the docs gradle project is blocking builds.  This PR will remove references to the docs gradle project until we figure out how to resolve the dependency problem.