### PR TITLE
GetDeleted API and Recover from DeletedException

### DIFF
--- a/samza-api/src/main/java/org/apache/samza/storage/blobstore/BlobStoreManager.java
+++ b/samza-api/src/main/java/org/apache/samza/storage/blobstore/BlobStoreManager.java
@@ -56,6 +56,18 @@ public interface BlobStoreManager {
   CompletionStage<Void> get(String id, OutputStream outputStream, Metadata metadata);
 
   /**
+   * Non-blocking GET call to remote blob store
+   * @param id Blob ID of the blob to get
+   * @param outputStream OutputStream to write the downloaded blob
+   * @param metadata User supplied {@link Metadata} of the request
+   * @param getDeletedBlob Flag to indicate if get should try to get a blob marked for deletion but not yet compacted
+   * @return A future that completes when all the chunks are downloaded and written successfully to the OutputStream
+   * @throws org.apache.samza.storage.blobstore.exceptions.DeletedException returned future should complete
+   *         exceptionally with DeletedException on failure with the blob already deleted error.
+   */
+  CompletionStage<Void> get(String id, OutputStream outputStream, Metadata metadata, Boolean getDeletedBlob);
+
+  /**
    * Non-blocking call to mark a blob for deletion in the remote blob store
    * @param id Blob ID of the blob to delete
    * @param metadata User supplied {@link Metadata} of the request


### PR DESCRIPTION
[WIP - Do not merge yet]
Problem Statement:
- Yarn can sometimes create orphaned containers. In our production systems, we noticed that there were overlapping Samza containers running/committing at the same time. 
- If the stores are backed up to a blob store, this orphaned and overlapping container may delete a blob (which is common during delta state calculation in commit lifecycle with blob store backend). The other non-orphaned container may expect this blob to be present. 
- This causes the container and subsequently the job to fail. During this, the container fails with DeletedException - which is Blob store's response that the blob was present but is gone now. 

Fix:
- During commit, if a container fails with DeletedException, let it fail/restart.
- During the recovery phase of the restart, get the deleted blob with get() call with getDeleted flag that indicates that if the blob is tombstoned but not compacted, blob store will return it. 
- Recreate the new blob by uploading it to blob store afresh. Use the new blob id received to create a new checkpoint. 
- After this, and as long as orphaned container is not cleaned up by Yarn, the container should be able to commit regulary. 

Tests:
TBD