### PR TITLE
Add new SamzaApplicationMaster metric to track allocated containers buffered in AM

### DIFF
--- a/docs/learn/documentation/versioned/container/metrics-table.html
+++ b/docs/learn/documentation/versioned/container/metrics-table.html
@@ -523,6 +523,10 @@
         <td>container-from-previous-attempt</td>
         <td>Number of containers carried from previous attempt in YARN. The metrics is applicable only when Application Master High Availability is enabled</td>
     </tr>
+    <tr>
+        <td>allocated-containers-in-buffer</td>
+        <td>Number of containers allocated by the RM and buffered in the AM</td>
+    </tr>
 
     <tr>
         <th colspan="2" class="section" id="kafka-system-consumer-metrics">org.apache.samza.system.kafka.KafkaSystemConsumerMetrics</th>

--- a/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnClusterResourceManager.java
+++ b/samza-yarn/src/main/java/org/apache/samza/job/yarn/YarnClusterResourceManager.java
@@ -298,6 +298,7 @@ public class YarnClusterResourceManager extends ClusterResourceManager implement
       }
       amClient.releaseAssignedContainer(container.getId());
       allocatedResources.remove(resource);
+      metrics.decrementAllocatedContainersInBuffer();
     }
   }
 
@@ -508,6 +509,7 @@ public class YarnClusterResourceManager extends ClusterResourceManager implement
       SamzaResource resource = new SamzaResource(numCores, memory, host, containerId);
       allocatedResources.put(resource, container);
       resources.add(resource);
+      metrics.incrementAllocatedContainersInBuffer();
     }
     clusterManagerCallback.onResourcesAvailable(resources);
   }

--- a/samza-yarn/src/main/scala/org/apache/samza/job/yarn/SamzaAppMasterMetrics.scala
+++ b/samza-yarn/src/main/scala/org/apache/samza/job/yarn/SamzaAppMasterMetrics.scala
@@ -42,11 +42,20 @@ class SamzaAppMasterMetrics(val config: Config,
 
   private val metricsConfig = new MetricsConfig(config)
   val containersFromPreviousAttempts = newGauge("container-from-previous-attempt", 0L)
+  val allocatedContainersInBuffer = newGauge("allocated-containers-in-buffer", 0L)
   val reporters = MetricsReporterLoader.getMetricsReporters(metricsConfig, SamzaAppMasterMetrics.sourceName).asScala
   reporters.values.foreach(_.register(SamzaAppMasterMetrics.sourceName, registry))
 
   def setContainersFromPreviousAttempts(containerCount: Int) {
     containersFromPreviousAttempts.set(containerCount)
+  }
+
+  def incrementAllocatedContainersInBuffer(): Unit = {
+    allocatedContainersInBuffer.set(allocatedContainersInBuffer.getValue + 1)
+  }
+
+  def decrementAllocatedContainersInBuffer(): Unit = {
+    allocatedContainersInBuffer.set(allocatedContainersInBuffer.getValue - 1)
   }
 
   def start() {

--- a/samza-yarn/src/test/java/org/apache/samza/webapp/TestApplicationMasterRestClient.java
+++ b/samza-yarn/src/test/java/org/apache/samza/webapp/TestApplicationMasterRestClient.java
@@ -108,7 +108,7 @@ public class TestApplicationMasterRestClient {
     assertTrue(metricsResult.containsKey(group));
 
     Map<String, Object> amMetricsGroup = metricsResult.get(group);
-    assertEquals(8, amMetricsGroup.size());
+    assertEquals(9, amMetricsGroup.size());
     assertEquals(samzaAppState.runningProcessors.size(),  amMetricsGroup.get("running-containers"));
     assertEquals(samzaAppState.neededProcessors.get(),    amMetricsGroup.get("needed-containers"));
     assertEquals(samzaAppState.completedProcessors.get(), amMetricsGroup.get("completed-containers"));
@@ -117,6 +117,7 @@ public class TestApplicationMasterRestClient {
     assertEquals(samzaAppState.processorCount.get(),      amMetricsGroup.get("container-count"));
     assertEquals(samzaAppState.jobHealthy.get() ? 1 : 0,  amMetricsGroup.get("job-healthy"));
     assertEquals(0, amMetricsGroup.get("container-from-previous-attempt"));
+    assertEquals(0, amMetricsGroup.get("allocated-containers-in-buffer"));
   }
 
   @Test


### PR DESCRIPTION
[LISAMZA-28234](https://jira01.corp.linkedin.com:8443/browse/LISAMZA-28234)

Symptom:
We have observed that Samza YARN AM requests 2-3x more containers than needed during job startup. Can cause temporary resource exhaustion in cluster when large jobs are launched, causing unrelated deployments to timeout/fail.

Change:
This PR added a Samza AM metric to monitor how many containers are allocated by RM and buffered in AM 
The metric increments when AM got an allocated container from RM and add it to the buffer. The metric decrements when AM released the overallocated containers (after all processors started). 

By observing this metric, we can know how many containers were allocated to a job during its startup and how long before the overallocated ones got released.

