### PR TITLE
SAMZA-2788: Add new metric to emit 1 when containers are processing

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
+++ b/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
@@ -627,6 +627,7 @@ public class RunLoop implements Runnable, Throttleable {
         public TaskCallback createCallback() {
           state.startProcess();
           containerMetrics.processes().inc();
+          // report 1 whenever the contaienr is running. Can be used to calculate the number of containers not running
           containerMetrics.containerRunning().set(1L);
           return isDraining && (envelope.isDrain() || envelope.isWatermark())
               ? callbackManager.createCallbackForDrain(task.taskName(), envelope, coordinator, drainCallbackTimeoutMs)

--- a/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
+++ b/samza-core/src/main/java/org/apache/samza/container/RunLoop.java
@@ -627,6 +627,7 @@ public class RunLoop implements Runnable, Throttleable {
         public TaskCallback createCallback() {
           state.startProcess();
           containerMetrics.processes().inc();
+          containerMetrics.containerRunning().set(1L);
           return isDraining && (envelope.isDrain() || envelope.isWatermark())
               ? callbackManager.createCallbackForDrain(task.taskName(), envelope, coordinator, drainCallbackTimeoutMs)
               : callbackManager.createCallback(task.taskName(), envelope, coordinator);

--- a/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/SamzaContainerMetrics.scala
@@ -52,6 +52,7 @@ class SamzaContainerMetrics(
   val totalProcessCpuUsage = newGauge("total-process-cpu-usage", 0.0)
   val containerThreadPoolSize = newGauge("container-thread-pool-size", 0L)
   val containerActiveThreads = newGauge("container-active-threads", 0L)
+  val containerRunning = newGauge("container-running", 0L)
 
   val taskStoreRestorationMetrics: util.Map[TaskName, Gauge[Long]] = new util.HashMap[TaskName, Gauge[Long]]()
 

--- a/samza-core/src/test/java/org/apache/samza/container/TestRunLoop.java
+++ b/samza-core/src/test/java/org/apache/samza/container/TestRunLoop.java
@@ -107,6 +107,7 @@ public class TestRunLoop {
     verify(task1).process(eq(envelopeA11), any(), any());
 
     assertEquals(4L, containerMetrics.envelopes().getCount());
+    assertEquals(1L, containerMetrics.containerRunning().getValue());
   }
 
   @Test

--- a/samza-core/src/test/java/org/apache/samza/container/TestRunLoop.java
+++ b/samza-core/src/test/java/org/apache/samza/container/TestRunLoop.java
@@ -107,7 +107,6 @@ public class TestRunLoop {
     verify(task1).process(eq(envelopeA11), any(), any());
 
     assertEquals(4L, containerMetrics.envelopes().getCount());
-    assertEquals(1L, containerMetrics.containerRunning().getValue());
   }
 
   @Test
@@ -178,6 +177,7 @@ public class TestRunLoop {
     verify(offsetManager).update(eq(taskName0), eq(sspA0), eq(envelopeA00.getOffset()));
 
     assertEquals(2L, containerMetrics.processes().getCount());
+    assertEquals(1L, containerMetrics.containerRunning().getValue());
   }
 
   @Test


### PR DESCRIPTION
LISAMZA-31001

Symptom: The "Container Not Running" metric is broken when container level metrics is enabled.

Fix: Adding a new gauge metric to report 1 whenever a container is processing. "Container Not Running" can be calculated by total_container_count - sum(container_running)