### PR TITLE
Fix race condition in ContainerStorageManager

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -319,19 +319,6 @@ public class ContainerStorageManager {
       Map<TaskName, Checkpoint> newTaskCheckpoints = initRestoreAndNewCheckpointFuture.get();
       taskCheckpoints.putAll(newTaskCheckpoints);
       LOG.debug("Post init and restore checkpoints is: {}. NewTaskCheckpoints are: {}", taskCheckpoints, newTaskCheckpoints);
-      // Stop all persistent stores after restoring. Certain persistent stores opened in BulkLoad mode are compacted
-      // on stop, so paralleling stop() also parallelizes their compaction (a time-intensive operation).
-      taskRestoreManagers.forEach((taskName, factoryRestoreManager) -> {
-        factoryRestoreManager.values().forEach(taskRestoreManager -> {
-          try {
-            taskRestoreManager.close();
-          } catch (Exception e) {
-            LOG.error("Error closing restore manager for task: {} after {} restore", taskName, e);
-            // ignore exception from close. container may still be able to continue processing/backups
-            // if restore manager close fails.
-          }
-        });
-      });
     } catch (InterruptedException e) {
       LOG.warn("Received an interrupt during store restoration. Interrupting the restore executor to exit "
           + "prematurely without restoring full state.");

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -319,6 +319,19 @@ public class ContainerStorageManager {
       Map<TaskName, Checkpoint> newTaskCheckpoints = initRestoreAndNewCheckpointFuture.get();
       taskCheckpoints.putAll(newTaskCheckpoints);
       LOG.debug("Post init and restore checkpoints is: {}. NewTaskCheckpoints are: {}", taskCheckpoints, newTaskCheckpoints);
+      // Stop all persistent stores after restoring. Certain persistent stores opened in BulkLoad mode are compacted
+      // on stop, so paralleling stop() also parallelizes their compaction (a time-intensive operation).
+      taskRestoreManagers.forEach((taskName, factoryRestoreManager) -> {
+        factoryRestoreManager.values().forEach(taskRestoreManager -> {
+          try {
+            taskRestoreManager.close();
+          } catch (Exception e) {
+            LOG.error("Error closing restore manager for task: {} after {} restore", taskName, e);
+            // ignore exception from close. container may still be able to continue processing/backups
+            // if restore manager close fails.
+          }
+        });
+      });
     } catch (InterruptedException e) {
       LOG.warn("Received an interrupt during store restoration. Interrupting the restore executor to exit "
           + "prematurely without restoring full state.");

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManagerRestoreUtil.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManagerRestoreUtil.java
@@ -28,12 +28,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import org.apache.commons.io.FileUtils;
@@ -136,7 +134,7 @@ public class ContainerStorageManagerRestoreUtil {
       File loggedStoreDir, Set<String> forceRestoreTask) {
 
     Map<TaskName, Checkpoint> newTaskCheckpoints = new ConcurrentHashMap<>();
-    Queue<Future<Void>> restoreAndCleanupFutures = new ConcurrentLinkedQueue<>();
+    List<Future<Void>> restoreAndCleanupFutures = new ArrayList<>();
 
     // Submit restore callable for each taskInstance
     taskRestoreManagers.forEach((taskInstanceName, restoreManagersMap) -> {

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManagerRestoreUtil.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManagerRestoreUtil.java
@@ -412,20 +412,4 @@ public class ContainerStorageManagerRestoreUtil {
         FutureUtil.unwrapExceptions(SamzaException.class, ex));
     return unwrappedException instanceof DeletedException;
   }
-
-  /**
-   * Stop persistent stores.
-   * NOTE: Call this method concurrently for all {@link TaskRestoreManager}s so that stop() can be parallelized.
-   * Certain persistent stores opened in BulkLoad mode are compacted on stop, so paralleling stop()
-   * also parallelizes their compaction (a time-intensive operation).
-   */
-  private static void closeTaskRestoreManager(TaskRestoreManager taskRestoreManager, String taskName) {
-    try {
-      taskRestoreManager.close();
-    } catch (Exception exception) {
-      LOG.error("Error closing restore manager for task: {} after {} restore", taskName, exception);
-      // ignore exception from close. container may still be able to continue processing/backups
-      // if restore manager close fails.
-    }
-  }
 }


### PR DESCRIPTION
Bug:
taskRestoreManagers.close() which in return calls blobStoreManager.close(), is called before the future for restoreDeletedSnapshots completes. This should only be called when all the futures are returned and complete.

Fix:
Close taskRestoreManagers after the restore as well as recovery of deleted snapshots (which also involves restore) are returned and complete. 
Init the blobStoreManager returned by factory, to avoid any race condition of calling operations on a closed blobStoreManager.