### PR TITLE
Ignore file owners comparison on restore when config is set

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/BlobStoreConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/BlobStoreConfig.java
@@ -47,6 +47,10 @@ public class BlobStoreConfig extends MapConfig {
   public static final String RETRY_POLICY_JITTER_FACTOR =  RETRY_POLICY_PREFIX + "jitter.factor";
   // random retry delay between -0.1*retry-delay to 0.1*retry-delay
   public static final double DEFAULT_RETRY_POLICY_JITTER_FACTOR = 0.1;
+  // Set wether to compare file owners after restoring blobs from remote store. Useful when the job is started on a new
+  // machine with new gid/uid or if gid/uid changes for some reason
+  public static final String COMPARE_FILE_OWNERS_ON_RESTORE = PREFIX + "compare.file.owners.on.restore";
+  public static final boolean DEFAULT_COMPARE_FILE_OWNERS_ON_RESTORE = true;
 
   public BlobStoreConfig(Config config) {
     super(config);
@@ -69,5 +73,9 @@ public class BlobStoreConfig extends MapConfig {
             getLong(RETRY_POLICY_BACKOFF_MAX_DELAY_MILLIS, DEFAULT_RETRY_POLICY_BACKOFF_MAX_DELAY_MILLIS),
             getInt(RETRY_POLICY_BACKOFF_DELAY_FACTOR, DEFAULT_RETRY_POLICY_BACKOFF_DELAY_FACTOR), ChronoUnit.MILLIS);
     return retryPolicyConfig;
+  }
+
+  public boolean shouldCompareFileOwnersOnRestore() {
+    return getBoolean(COMPARE_FILE_OWNERS_ON_RESTORE, DEFAULT_COMPARE_FILE_OWNERS_ON_RESTORE);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/config/BlobStoreConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/BlobStoreConfig.java
@@ -47,8 +47,8 @@ public class BlobStoreConfig extends MapConfig {
   public static final String RETRY_POLICY_JITTER_FACTOR =  RETRY_POLICY_PREFIX + "jitter.factor";
   // random retry delay between -0.1*retry-delay to 0.1*retry-delay
   public static final double DEFAULT_RETRY_POLICY_JITTER_FACTOR = 0.1;
-  // Set wether to compare file owners after restoring blobs from remote store. Useful when the job is started on a new
-  // machine with new gid/uid or if gid/uid changes for some reason
+  // Set whether to compare file owners after restoring blobs from remote store. Useful when the job is started on a new
+  // machine with new gid/uid or if gid/uid changes due to host migration
   public static final String COMPARE_FILE_OWNERS_ON_RESTORE = PREFIX + "compare.file.owners.on.restore";
   public static final boolean DEFAULT_COMPARE_FILE_OWNERS_ON_RESTORE = true;
 

--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/BlobStoreBackupManager.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/BlobStoreBackupManager.java
@@ -207,7 +207,7 @@ public class BlobStoreBackupManager implements TaskBackupManager {
 
         long dirDiffStartTime = System.nanoTime();
         // get the diff between previous and current store directories
-        DirDiff dirDiff = DirDiffUtil.getDirDiff(checkpointDir, prevDirIndex, DirDiffUtil.areSameFile(false));
+        DirDiff dirDiff = DirDiffUtil.getDirDiff(checkpointDir, prevDirIndex, DirDiffUtil.areSameFile(false, true));
         metrics.storeDirDiffNs.get(storeName).update(System.nanoTime() - dirDiffStartTime);
 
         DirDiff.Stats stats = DirDiff.getStats(dirDiff);

--- a/samza-core/src/test/java/org/apache/samza/storage/blobstore/TestBlobStoreBackupManager.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/blobstore/TestBlobStoreBackupManager.java
@@ -261,7 +261,7 @@ public class TestBlobStoreBackupManager {
           File localCheckpointDir = new File(localRemoteSnapshotPair.getLeft() + "-" + checkpointId.serialize());
           DirIndex dirIndex = new DirIndex(localCheckpointDir.getName(), Collections.emptyList(), Collections.emptyList(),
               Collections.emptyList(), Collections.emptyList());
-          return DirDiffUtil.getDirDiff(localCheckpointDir, dirIndex, DirDiffUtil.areSameFile(false));
+          return DirDiffUtil.getDirDiff(localCheckpointDir, dirIndex, DirDiffUtil.areSameFile(false, true));
         }).collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(DirDiff::getDirName))));
 
     // assert - asset all DirDiff are put to blob store
@@ -369,7 +369,7 @@ public class TestBlobStoreBackupManager {
         .stream()
         .map(localRemoteSnapshotPair ->
             DirDiffUtil.getDirDiff(new File(localRemoteSnapshotPair.getLeft() + "-" + checkpointId.serialize()),
-            localRemoteSnapshotPair.getRight().getDirIndex(), DirDiffUtil.areSameFile(false)))
+            localRemoteSnapshotPair.getRight().getDirIndex(), DirDiffUtil.areSameFile(false, true)))
         .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(DirDiff::getDirName))));
 
     // assert - asset all DirDiff are put to blob store

--- a/samza-core/src/test/java/org/apache/samza/storage/blobstore/TestBlobStoreRestoreManager.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/blobstore/TestBlobStoreRestoreManager.java
@@ -141,7 +141,7 @@ public class TestBlobStoreRestoreManager {
     StorageConfig storageConfig = mock(StorageConfig.class);
     when(storageConfig.cleanLoggedStoreDirsOnStart(anyString())).thenReturn(false);
     DirDiffUtil dirDiffUtil = mock(DirDiffUtil.class);
-    when(dirDiffUtil.areSameDir(anySet(), anyBoolean())).thenReturn((arg1, arg2) -> false);
+    when(dirDiffUtil.areSameDir(anySet(), anyBoolean(), anyBoolean())).thenReturn((arg1, arg2) -> false);
 
     boolean shouldRestore = BlobStoreRestoreManager.shouldRestore(
         taskName, storeName, dirIndex, storeCheckpointDir, storageConfig, dirDiffUtil);
@@ -158,12 +158,12 @@ public class TestBlobStoreRestoreManager {
     StorageConfig storageConfig = mock(StorageConfig.class);
     when(storageConfig.cleanLoggedStoreDirsOnStart(anyString())).thenReturn(false);
     DirDiffUtil dirDiffUtil = mock(DirDiffUtil.class);
-    when(dirDiffUtil.areSameDir(anySet(), anyBoolean())).thenReturn((arg1, arg2) -> true); // are same dir
+    when(dirDiffUtil.areSameDir(anySet(), anyBoolean(), anyBoolean())).thenReturn((arg1, arg2) -> true); // are same dir
 
     boolean shouldRestore = BlobStoreRestoreManager.shouldRestore(
         taskName, storeName, dirIndex, storeCheckpointDir, storageConfig, dirDiffUtil);
 
-    verify(dirDiffUtil, times(1)).areSameDir(anySet(), anyBoolean());
+    verify(dirDiffUtil, times(1)).areSameDir(anySet(), anyBoolean(), anyBoolean());
     assertFalse(shouldRestore); // should not restore, should retain checkpoint dir instead
   }
 
@@ -200,11 +200,11 @@ public class TestBlobStoreRestoreManager {
     // return immediately without restoring.
     when(blobStoreUtil.restoreDir(eq(storeDir.toFile()), eq(dirIndex), any(Metadata.class), anyBoolean()))
         .thenReturn(CompletableFuture.completedFuture(null));
-    when(dirDiffUtil.areSameDir(anySet(), anyBoolean())).thenReturn((arg1, arg2) -> true);
+    when(dirDiffUtil.areSameDir(anySet(), anyBoolean(), anyBoolean())).thenReturn((arg1, arg2) -> true);
 
     BlobStoreRestoreManager.restoreStores(jobName, jobId, taskName, storesToRestore, prevStoreSnapshotIndexes,
         loggedBaseDir.toFile(), storageConfig, metrics,
-        storageManagerUtil, blobStoreUtil, dirDiffUtil, EXECUTOR, false);
+        storageManagerUtil, blobStoreUtil, dirDiffUtil, EXECUTOR, false, true);
 
     // verify that the store directory restore was called and skipped (i.e. shouldRestore == true)
     verify(blobStoreUtil, times(1)).restoreDir(eq(storeDir.toFile()), eq(dirIndex), any(Metadata.class), anyBoolean());
@@ -249,14 +249,14 @@ public class TestBlobStoreRestoreManager {
     BlobStoreUtil blobStoreUtil = mock(BlobStoreUtil.class);
     DirDiffUtil dirDiffUtil = mock(DirDiffUtil.class);
 
-    when(dirDiffUtil.areSameDir(anySet(), anyBoolean())).thenReturn((arg1, arg2) -> true);
+    when(dirDiffUtil.areSameDir(anySet(), anyBoolean(), anyBoolean())).thenReturn((arg1, arg2) -> true);
     // return immediately without restoring.
     when(blobStoreUtil.restoreDir(eq(storeDir.toFile()), eq(dirIndex), any(Metadata.class), anyBoolean()))
         .thenReturn(CompletableFuture.completedFuture(null));
 
     BlobStoreRestoreManager.restoreStores(jobName, jobId, taskName, storesToRestore, prevStoreSnapshotIndexes,
         loggedBaseDir.toFile(), storageConfig, metrics,
-        storageManagerUtil, blobStoreUtil, dirDiffUtil, EXECUTOR, false);
+        storageManagerUtil, blobStoreUtil, dirDiffUtil, EXECUTOR, false, true);
 
     // verify that the store directory restore was called and skipped (i.e. shouldRestore == true)
     verify(blobStoreUtil, times(1)).restoreDir(eq(storeDir.toFile()), eq(dirIndex), any(Metadata.class), anyBoolean());
@@ -305,14 +305,14 @@ public class TestBlobStoreRestoreManager {
     DirDiffUtil dirDiffUtil = mock(DirDiffUtil.class);
 
     // ensures shouldRestore is not called
-    when(dirDiffUtil.areSameDir(anySet(), anyBoolean())).thenReturn((arg1, arg2) -> true);
+    when(dirDiffUtil.areSameDir(anySet(), anyBoolean(), anyBoolean())).thenReturn((arg1, arg2) -> true);
     // return immediately without restoring.
     when(blobStoreUtil.restoreDir(eq(storeDir.toFile()), eq(dirIndex), any(Metadata.class), anyBoolean()))
         .thenReturn(CompletableFuture.completedFuture(null));
 
     BlobStoreRestoreManager.restoreStores(jobName, jobId, taskName, storesToRestore, prevStoreSnapshotIndexes,
         loggedBaseDir.toFile(), storageConfig, metrics,
-        storageManagerUtil, blobStoreUtil, dirDiffUtil, EXECUTOR, false);
+        storageManagerUtil, blobStoreUtil, dirDiffUtil, EXECUTOR, false, true);
 
     // verify that the store directory restore was not called (should have restored from checkpoint dir)
     verify(blobStoreUtil, times(0)).restoreDir(eq(storeDir.toFile()), eq(dirIndex), any(Metadata.class), anyBoolean());
@@ -349,7 +349,7 @@ public class TestBlobStoreRestoreManager {
 
     BlobStoreRestoreManager.restoreStores(jobName, jobId, taskName, storesToRestore, prevStoreSnapshotIndexes,
         loggedBaseDir.toFile(), storageConfig, metrics,
-        storageManagerUtil, blobStoreUtil, dirDiffUtil, EXECUTOR, false);
+        storageManagerUtil, blobStoreUtil, dirDiffUtil, EXECUTOR, false, true);
 
     // verify that we checked the previously checkpointed SCMs.
     verify(prevStoreSnapshotIndexes, times(1)).containsKey(eq("newStoreName"));

--- a/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestBlobStoreUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestBlobStoreUtil.java
@@ -782,16 +782,16 @@ public class TestBlobStoreUtil {
 
     BlobStoreManager mockBlobStoreManager = mock(BlobStoreManager.class);
     when(mockBlobStoreManager.get(anyString(), any(OutputStream.class), any(Metadata.class), any(Boolean.class))).thenAnswer(
-        (Answer<CompletionStage<Void>>) invocationOnMock -> {
-          String blobId = invocationOnMock.getArgumentAt(0, String.class);
-          OutputStream outputStream = invocationOnMock.getArgumentAt(1, OutputStream.class);
-          // blob contents = blob id
-          outputStream.write(blobId.getBytes());
+      (Answer<CompletionStage<Void>>) invocationOnMock -> {
+        String blobId = invocationOnMock.getArgumentAt(0, String.class);
+        OutputStream outputStream = invocationOnMock.getArgumentAt(1, OutputStream.class);
+        // blob contents = blob id
+        outputStream.write(blobId.getBytes());
 
-          // force flush so that the checksum calculation later uses the full file contents.
-          ((FileOutputStream) outputStream).getFD().sync();
-          return CompletableFuture.completedFuture(null);
-        });
+        // force flush so that the checksum calculation later uses the full file contents.
+        ((FileOutputStream) outputStream).getFD().sync();
+        return CompletableFuture.completedFuture(null);
+      });
 
     BlobStoreConfig config = mock(BlobStoreConfig.class);
     when(config.shouldCompareFileOwnersOnRestore()).thenReturn(false);

--- a/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestBlobStoreUtil.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestBlobStoreUtil.java
@@ -540,12 +540,12 @@ public class TestBlobStoreUtil {
     // checksum should be ignored for sst file. Set any dummy value
     FileIndex sstFileIndex = new FileIndex(sstFile.getFileName().toString(), Collections.emptyList(), sstFileMetadata, 0L);
 
-    assertTrue(DirDiffUtil.areSameFile(false).test(sstFile.toFile(), sstFileIndex));
+    assertTrue(DirDiffUtil.areSameFile(false, true).test(sstFile.toFile(), sstFileIndex));
 
     // 2. test with sst file with different timestamps
     // Update last modified time
     Files.setLastModifiedTime(sstFile, FileTime.fromMillis(System.currentTimeMillis() + 1000L));
-    assertTrue(DirDiffUtil.areSameFile(false).test(sstFile.toFile(), sstFileIndex));
+    assertTrue(DirDiffUtil.areSameFile(false, true).test(sstFile.toFile(), sstFileIndex));
 
     // 3. test with non-sst files with same metadata and content
     Path tmpFile = Files.createTempFile("samza-testAreSameFiles-", ".tmp");
@@ -559,18 +559,18 @@ public class TestBlobStoreUtil {
     FileIndex tmpFileIndex = new FileIndex(tmpFile.getFileName().toString(), Collections.emptyList(), tmpFileMetadata,
         FileUtils.checksumCRC32(tmpFile.toFile()));
 
-    assertTrue(DirDiffUtil.areSameFile(false).test(tmpFile.toFile(), tmpFileIndex));
+    assertTrue(DirDiffUtil.areSameFile(false, true).test(tmpFile.toFile(), tmpFileIndex));
 
     // 4. test with non-sst files with different attributes
     // change lastModifiedTime of local file
     FileTime prevLastModified = tmpFileAttribs.lastModifiedTime();
     Files.setLastModifiedTime(tmpFile, FileTime.fromMillis(System.currentTimeMillis() + 1000L));
-    assertTrue(DirDiffUtil.areSameFile(false).test(tmpFile.toFile(), tmpFileIndex));
+    assertTrue(DirDiffUtil.areSameFile(false, true).test(tmpFile.toFile(), tmpFileIndex));
 
     // change content/checksum of local file
     Files.setLastModifiedTime(tmpFile, prevLastModified); // reset attributes to match with remote file
     fileUtil.writeToTextFile(tmpFile.toFile(), RandomStringUtils.random(1000), false); //new content
-    assertFalse(DirDiffUtil.areSameFile(false).test(tmpFile.toFile(), tmpFileIndex));
+    assertFalse(DirDiffUtil.areSameFile(false, true).test(tmpFile.toFile(), tmpFileIndex));
   }
 
   @Test
@@ -626,7 +626,7 @@ public class TestBlobStoreUtil {
     blobStoreUtil.restoreDir(restoreDirBasePath.toFile(), mockDirIndex, metadata, false).join();
 
     assertTrue(
-        new DirDiffUtil().areSameDir(Collections.emptySet(), false).test(restoreDirBasePath.toFile(), mockDirIndex));
+        new DirDiffUtil().areSameDir(Collections.emptySet(), false, true).test(restoreDirBasePath.toFile(), mockDirIndex));
   }
 
   @Test
@@ -684,7 +684,7 @@ public class TestBlobStoreUtil {
     blobStoreUtil.restoreDir(restoreDirBasePath.toFile(), mockDirIndex, metadata, false).join();
 
     assertTrue(
-        new DirDiffUtil().areSameDir(Collections.emptySet(), false).test(restoreDirBasePath.toFile(), mockDirIndex));
+        new DirDiffUtil().areSameDir(Collections.emptySet(), false, true).test(restoreDirBasePath.toFile(), mockDirIndex));
   }
 
   @Test
@@ -742,6 +742,66 @@ public class TestBlobStoreUtil {
     }
   }
 
+
+  @Test
+  public void testRestoreIgnoresDifferentFileOwnersOnConfig() throws IOException {
+    Path restoreDirBasePath = Files.createTempDirectory(BlobStoreTestUtil.TEMP_DIR_PREFIX);
+
+    // remote file == 26 blobs, blob ids from a to z, blob contents from a to z, offsets 0 to 25.
+    DirIndex mockDirIndex = mock(DirIndex.class);
+    when(mockDirIndex.getDirName()).thenReturn(DirIndex.ROOT_DIR_NAME);
+    FileIndex mockFileIndex = mock(FileIndex.class);
+    when(mockFileIndex.getFileName()).thenReturn("1.sst");
+
+    // setup mock file attributes. create a temp file to get current user/group/permissions so that they
+    // match with restored files.
+    File tmpFile = Paths.get(restoreDirBasePath.toString(), "tempfile-" + new Random().nextInt()).toFile();
+    tmpFile.createNewFile();
+    PosixFileAttributes attrs = Files.readAttributes(tmpFile.toPath(), PosixFileAttributes.class);
+    // create remote file with different owner than local file
+    FileMetadata fileMetadata = new FileMetadata(1234L, 1243L, 26, // ctime mtime does not matter. size == 26
+        attrs.owner().getName() + "_different", attrs.group().getName(), PosixFilePermissions.toString(attrs.permissions()));
+    when(mockFileIndex.getFileMetadata()).thenReturn(fileMetadata);
+    Files.delete(tmpFile.toPath()); // delete so that it doesn't show up in restored dir contents.
+
+    List<FileBlob> mockFileBlobs = new ArrayList<>();
+    StringBuilder fileContents = new StringBuilder();
+    for (int i = 0; i < 26; i++) {
+      FileBlob mockFileBlob = mock(FileBlob.class);
+      char c = (char) ('a' + i);
+      fileContents.append(c); // blob contents == blobId
+      when(mockFileBlob.getBlobId()).thenReturn(String.valueOf(c));
+      when(mockFileBlob.getOffset()).thenReturn(i);
+      mockFileBlobs.add(mockFileBlob);
+    }
+    when(mockFileIndex.getBlobs()).thenReturn(mockFileBlobs);
+    CRC32 checksum = new CRC32();
+    checksum.update(fileContents.toString().getBytes());
+    when(mockFileIndex.getChecksum()).thenReturn(checksum.getValue());
+    when(mockDirIndex.getFilesPresent()).thenReturn(ImmutableList.of(mockFileIndex));
+
+    BlobStoreManager mockBlobStoreManager = mock(BlobStoreManager.class);
+    when(mockBlobStoreManager.get(anyString(), any(OutputStream.class), any(Metadata.class), any(Boolean.class))).thenAnswer(
+        (Answer<CompletionStage<Void>>) invocationOnMock -> {
+          String blobId = invocationOnMock.getArgumentAt(0, String.class);
+          OutputStream outputStream = invocationOnMock.getArgumentAt(1, OutputStream.class);
+          // blob contents = blob id
+          outputStream.write(blobId.getBytes());
+
+          // force flush so that the checksum calculation later uses the full file contents.
+          ((FileOutputStream) outputStream).getFD().sync();
+          return CompletableFuture.completedFuture(null);
+        });
+
+    BlobStoreConfig config = mock(BlobStoreConfig.class);
+    when(config.shouldCompareFileOwnersOnRestore()).thenReturn(false);
+    BlobStoreUtil blobStoreUtil = new BlobStoreUtil(mockBlobStoreManager, EXECUTOR, blobStoreConfig, null, null);
+    blobStoreUtil.restoreDir(restoreDirBasePath.toFile(), mockDirIndex, metadata, false).join();
+
+    assertTrue(
+        new DirDiffUtil().areSameDir(Collections.emptySet(), false, config.shouldCompareFileOwnersOnRestore()).test(restoreDirBasePath.toFile(), mockDirIndex));
+  }
+
   @Test
   @Ignore // TODO remove
   public void testRestoreDirRecreatesEmptyFilesAndDirs() throws IOException {
@@ -758,7 +818,7 @@ public class TestBlobStoreUtil {
         outputStream.write(blobId.getBytes());
         return CompletableFuture.completedFuture(null);
       });
-    boolean result = new DirDiffUtil().areSameDir(new TreeSet<>(), false).test(localSnapshot.toFile(), dirIndex);
+    boolean result = new DirDiffUtil().areSameDir(new TreeSet<>(), false, true).test(localSnapshot.toFile(), dirIndex);
     assertFalse(result);
     //ToDo complete
   }
@@ -788,7 +848,7 @@ public class TestBlobStoreUtil {
     BlobStoreUtil blobStoreUtil = new BlobStoreUtil(mockBlobStoreManager, EXECUTOR, blobStoreConfig, null, null);
     blobStoreUtil.restoreDir(restoreDirBasePath.toFile(), dirIndex, metadata, false).join();
 
-    assertTrue(new DirDiffUtil().areSameDir(Collections.emptySet(), false).test(restoreDirBasePath.toFile(), dirIndex));
+    assertTrue(new DirDiffUtil().areSameDir(Collections.emptySet(), false, true).test(restoreDirBasePath.toFile(), dirIndex));
   }
 
   /**
@@ -950,7 +1010,7 @@ public class TestBlobStoreUtil {
    * This test verifies that a retriable exception is retried more than 3 times (default retry is limited to 3 attempts)
    */
   @Test
-  public void testPutFileRetriedMorethanThreeTimes() throws Exception {
+  public void testPutFileRetriedMoreThanThreeTimes() throws Exception {
     SnapshotMetadata snapshotMetadata = new SnapshotMetadata(checkpointId, jobName, jobId, taskName, storeName);
     Path path = Files.createTempFile("samza-testPutFileChecksum-", ".tmp");
     FileUtil fileUtil = new FileUtil();

--- a/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestDirDiffUtilAreSameFile.java
+++ b/samza-core/src/test/java/org/apache/samza/storage/blobstore/util/TestDirDiffUtilAreSameFile.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -60,7 +60,7 @@ public class TestDirDiffUtilAreSameFile {
 
   @Before
   public void testSetup() throws Exception {
-    areSameFile = DirDiffUtil.areSameFile(false);
+    areSameFile = DirDiffUtil.areSameFile(false, true);
     createFile(SMALL_FILE);
   }
 
@@ -127,6 +127,18 @@ public class TestDirDiffUtilAreSameFile {
         PosixFilePermissions.toString(localFileAttrs.permissions()));
     remoteFile = new FileIndex(localFile.getName(), new ArrayList<>(), remoteFileMetadata, localChecksum);
     Assert.assertFalse(areSameFile.test(localFile, remoteFile));
+  }
+
+  @Test
+  public void testAreSameFile_IgnoreDifferentOwner() {
+    areSameFile = DirDiffUtil.areSameFile(false, false);
+    remoteFileMetadata = new FileMetadata(0, 0,
+        localContentLength,
+        localFileAttrs.owner().getName() + "_different",
+        localFileAttrs.group().getName(),
+        PosixFilePermissions.toString(localFileAttrs.permissions()));
+    remoteFile = new FileIndex(localFile.getName(), new ArrayList<>(), remoteFileMetadata, localChecksum);
+    Assert.assertTrue(areSameFile.test(localFile, remoteFile));
   }
 
   @Test
@@ -197,7 +209,7 @@ public class TestDirDiffUtilAreSameFile {
     createFile(LARGE_FILE);
 
     for (int i = 0; i < 5; i++) {
-      BiPredicate<File, FileIndex> areSameFile = DirDiffUtil.areSameFile(false);
+      BiPredicate<File, FileIndex> areSameFile = DirDiffUtil.areSameFile(false, true);
       for (int j = 0; j < 20; j++) {
         localFile = mock(File.class);
         when(localFile.getName()).thenReturn("name");


### PR DESCRIPTION
Issue:
When a samza job is moved to a new set of hosts and a full restore from Blob store is performed, the restore (and the job) fails with an error that the owner of the remote and local files are different. While this is an unexpected and correctly identified as an issue with the restore from blob store, some times this is not desirable. In this case, since the job moved to a new host, the gid/uid are different and restore/container starts fail. 

Fix:
Ignore the uid/gid match after restoring the state, if a config "blob.store.compare.file.owners.on.restore" is set.
By default we always match the owners, except for the verify restore step after a restore from blob store. In this case, we check this new config to see if we should match the owners of the restores files/dirs or not. 

Test:
Added unit tests