### PR TITLE
SAMZA-2795: Set thread to daemon thread for operator executor service

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/task/DefaultTaskExecutorFactory.java
+++ b/samza-core/src/main/java/org/apache/samza/task/DefaultTaskExecutorFactory.java
@@ -68,7 +68,9 @@ public class DefaultTaskExecutorFactory implements TaskExecutorFactory {
       } else {
         LOG.info("Using single threaded thread pool as operator thread pool for task {}", key.getTaskName());
         operatorExecutor = Executors.newSingleThreadExecutor(
-            new ThreadFactoryBuilder().setNameFormat("Samza " + key.getTaskName() + " Thread-%d").build());
+            new ThreadFactoryBuilder().setNameFormat("Samza " + key.getTaskName() + " Thread-%d")
+                .setDaemon(true)
+                .build());
       }
 
       return operatorExecutor;


### PR DESCRIPTION
**Description**
As part of [SAMZA-2781](https://issues.apache.org/jira/browse/SAMZA-2781), we introduced operator executors to manage operator handoff execution. However, the threads created by the executor service are non-daemon and hence prevent the JVM from shutting down.

**Changes** 
Make the threads spawned by the operator executor to be non-daemon

**Tests**
None

**API Changes**
None

**Upgrade Instructions**
None

**Usage Instructions**
None