### PR TITLE
SAMZA-2796: Introduce config knob for framework thread sub DAG execution

### DIFF
--- a/docs/learn/documentation/versioned/jobs/configuration-table.html
+++ b/docs/learn/documentation/versioned/jobs/configuration-table.html
@@ -495,6 +495,16 @@
                 </tr>
 
                 <tr>
+                    <td class="property" id="job.operator.framework.executor.enabled">job.operator.framework.executor.enabled</td>
+                    <td class="default">false</td>
+                    <td class="description">
+                        If enabled, framework thread pool will be used for message hand off and sub DAG execution. Otherwise, the
+                        execution will fall back to using caller thread or java fork join pool depending on the type of work
+                        chained as part of message hand off.
+                    </td>
+                </tr>
+
+                <tr>
                                               <!-- change link to StandAlone design/tutorial doc. SAMZA-1299 -->
                 <th colspan="3" class="section" id="ZkBasedJobCoordination"><a href="../index.html">Zookeeper-based job configuration</a></th>
                 </tr>

--- a/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/JobConfig.java
@@ -196,6 +196,10 @@ public class JobConfig extends MapConfig {
   public static final String JOB_ELASTICITY_FACTOR = "job.elasticity.factor";
   public static final int DEFAULT_JOB_ELASTICITY_FACTOR = 1;
 
+  public static final String JOB_OPERATOR_FRAMEWORK_EXECUTOR_ENABLED = "job.operator.framework.executor.enabled";
+
+  public static final boolean DEFAULT_JOB_OPERATOR_FRAMEWORK_EXECUTOR_ENABLED = false;
+
   public JobConfig(Config config) {
     super(config);
   }
@@ -526,5 +530,9 @@ public class JobConfig extends MapConfig {
 
   public String getCoordinatorExecuteCommand() {
     return get(COORDINATOR_EXECUTE_COMMAND, DEFAULT_COORDINATOR_EXECUTE_COMMAND);
+  }
+
+  public boolean getOperatorFrameworkExecutorEnabled() {
+    return getBoolean(JOB_OPERATOR_FRAMEWORK_EXECUTOR_ENABLED, DEFAULT_JOB_OPERATOR_FRAMEWORK_EXECUTOR_ENABLED);
   }
 }

--- a/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
+++ b/samza-core/src/main/scala/org/apache/samza/container/TaskInstance.scala
@@ -93,9 +93,13 @@ class TaskInstance(
     val jobConfig = new JobConfig(jobContext.getConfig)
     val taskExecutorFactory = ReflectionUtil.getObj(jobConfig.getTaskExecutorFactory, classOf[TaskExecutorFactory])
 
+    var operatorExecutor = Option.empty[java.util.concurrent.ExecutorService].orNull
+    if (jobConfig.getOperatorFrameworkExecutorEnabled) {
+      operatorExecutor = taskExecutorFactory.getOperatorExecutor(taskName, jobContext.getConfig)
+    }
     new TaskContextImpl(taskModel, metrics.registry, kvStoreSupplier, tableManager,
       new CallbackSchedulerImpl(epochTimeScheduler), offsetManager, jobModel, streamMetadataCache,
-      systemStreamPartitions, taskExecutorFactory.getOperatorExecutor(taskName, jobContext.getConfig))
+      systemStreamPartitions, operatorExecutor)
   }
   // need separate field for this instead of using it through Context, since Context throws an exception if it is null
   private val applicationTaskContextOption = applicationTaskContextFactoryOption

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImpl.java
@@ -35,7 +35,6 @@ import org.apache.samza.context.ContainerContext;
 import org.apache.samza.context.Context;
 import org.apache.samza.context.InternalTaskContext;
 import org.apache.samza.context.JobContext;
-import org.apache.samza.context.MockContext;
 import org.apache.samza.context.TaskContext;
 import org.apache.samza.job.model.TaskModel;
 import org.apache.samza.metrics.Counter;

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImpl.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestOperatorImpl.java
@@ -18,16 +18,25 @@
  */
 package org.apache.samza.operators.impl;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.apache.samza.config.Config;
+import org.apache.samza.config.MapConfig;
+import org.apache.samza.context.ContainerContext;
 import org.apache.samza.context.Context;
 import org.apache.samza.context.InternalTaskContext;
+import org.apache.samza.context.JobContext;
 import org.apache.samza.context.MockContext;
+import org.apache.samza.context.TaskContext;
 import org.apache.samza.job.model.TaskModel;
 import org.apache.samza.metrics.Counter;
 import org.apache.samza.metrics.MetricsRegistryMap;
@@ -44,33 +53,111 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
 
 public class TestOperatorImpl {
   private Context context;
   private InternalTaskContext internalTaskContext;
 
+  private JobContext jobContext;
+
+  private TaskContext taskContext;
+
+  private ContainerContext containerContext;
+
   @Before
   public void setup() {
-    this.context = new MockContext();
+    this.context = mock(Context.class);
     this.internalTaskContext = mock(InternalTaskContext.class);
+    this.jobContext = mock(JobContext.class);
+    this.taskContext = mock(TaskContext.class);
+    this.containerContext = mock(ContainerContext.class);
     when(this.internalTaskContext.getContext()).thenReturn(this.context);
     // might be necessary in the future
     when(this.internalTaskContext.fetchObject(EndOfStreamStates.class.getName())).thenReturn(mock(EndOfStreamStates.class));
     when(this.internalTaskContext.fetchObject(WatermarkStates.class.getName())).thenReturn(mock(WatermarkStates.class));
-    when(this.context.getTaskContext().getTaskMetricsRegistry()).thenReturn(new MetricsRegistryMap());
-    when(this.context.getTaskContext().getTaskModel()).thenReturn(mock(TaskModel.class));
-    when(this.context.getTaskContext().getOperatorExecutor()).thenReturn(Executors.newSingleThreadExecutor());
-    when(this.context.getContainerContext().getContainerMetricsRegistry()).thenReturn(new MetricsRegistryMap());
+    when(this.context.getJobContext()).thenReturn(jobContext);
+    when(this.context.getTaskContext()).thenReturn(taskContext);
+    when(this.taskContext.getTaskMetricsRegistry()).thenReturn(new MetricsRegistryMap());
+    when(this.taskContext.getTaskModel()).thenReturn(mock(TaskModel.class));
+    when(this.taskContext.getOperatorExecutor()).thenReturn(Executors.newSingleThreadExecutor());
+    when(this.context.getContainerContext()).thenReturn(containerContext);
+    when(containerContext.getContainerMetricsRegistry()).thenReturn(new MetricsRegistryMap());
   }
 
+  @Test
+  public void testComposeFutureWithExecutorWithFrameworkExecutorEnabled() {
+    OperatorImpl<Object, Object> opImpl = new TestOpImpl(mock(Object.class));
+    ExecutorService mockExecutor = mock(ExecutorService.class);
+    CompletionStage<Object> mockFuture = mock(CompletionStage.class);
+    Function<Object, CompletionStage<Object>> mockFunction = mock(Function.class);
+
+    Config config = new MapConfig(ImmutableMap.of("job.operator.framework.executor.enabled", "true"));
+
+    when(this.taskContext.getOperatorExecutor()).thenReturn(mockExecutor);
+    when(this.jobContext.getConfig()).thenReturn(config);
+
+    opImpl.init(this.internalTaskContext);
+    opImpl.composeFutureWithExecutor(mockFuture, mockFunction);
+
+    verify(mockFuture).thenComposeAsync(eq(mockFunction), eq(mockExecutor));
+  }
+
+  @Test
+  public void testComposeFutureWithExecutorWithFrameworkExecutorDisabled() {
+    OperatorImpl<Object, Object> opImpl = new TestOpImpl(mock(Object.class));
+    ExecutorService mockExecutor = mock(ExecutorService.class);
+    CompletionStage<Object> mockFuture = mock(CompletionStage.class);
+    Function<Object, CompletionStage<Object>> mockFunction = mock(Function.class);
+
+    Config config = new MapConfig(ImmutableMap.of("job.operator.framework.executor.enabled", "false"));
+
+    when(this.taskContext.getOperatorExecutor()).thenReturn(mockExecutor);
+    when(this.jobContext.getConfig()).thenReturn(config);
+
+    opImpl.init(this.internalTaskContext);
+    opImpl.composeFutureWithExecutor(mockFuture, mockFunction);
+
+    verify(mockFuture).thenCompose(eq(mockFunction));
+  }
+
+  @Test
+  public void testAcceptFutureWithExecutorWithFrameworkExecutorDisabled() {
+    OperatorImpl<Object, Object> opImpl = new TestOpImpl(mock(Object.class));
+    ExecutorService mockExecutor = mock(ExecutorService.class);
+    CompletionStage<Object> mockFuture = mock(CompletionStage.class);
+    Consumer<Object> mockConsumer = mock(Consumer.class);
+
+    Config config = new MapConfig(ImmutableMap.of("job.operator.framework.executor.enabled", "false"));
+
+    when(this.taskContext.getOperatorExecutor()).thenReturn(mockExecutor);
+    when(this.jobContext.getConfig()).thenReturn(config);
+
+    opImpl.init(this.internalTaskContext);
+    opImpl.acceptFutureWithExecutor(mockFuture, mockConsumer);
+
+    verify(mockFuture).thenAccept(eq(mockConsumer));
+  }
+
+  @Test
+  public void testAcceptFutureWithExecutorWithFrameworkExecutorEnabled() {
+    OperatorImpl<Object, Object> opImpl = new TestOpImpl(mock(Object.class));
+    ExecutorService mockExecutor = mock(ExecutorService.class);
+    CompletionStage<Object> mockFuture = mock(CompletionStage.class);
+    Consumer<Object> mockConsumer = mock(Consumer.class);
+
+    Config config = new MapConfig(ImmutableMap.of("job.operator.framework.executor.enabled", "true"));
+
+    when(this.taskContext.getOperatorExecutor()).thenReturn(mockExecutor);
+    when(this.jobContext.getConfig()).thenReturn(config);
+
+    opImpl.init(this.internalTaskContext);
+    opImpl.acceptFutureWithExecutor(mockFuture, mockConsumer);
+
+    verify(mockFuture).thenAcceptAsync(eq(mockConsumer), eq(mockExecutor));
+  }
   @Test(expected = IllegalStateException.class)
   public void testMultipleInitShouldThrow() {
     OperatorImpl<Object, Object> opImpl = new TestOpImpl(mock(Object.class));


### PR DESCRIPTION
**Description**
As part of  [SAMZA-2781](https://issues.apache.org/jira/browse/SAMZA-2781), we use framework thread pool to execute hand-offs and sub-DAG execution. We want to add a config knob to enable users opt-in to the feature as opposed to enable it by default.

**Changes**
- Introduce config knob to use the framework executor

**Tests**
- Added unit tests

**API Changes**
None

**Usage Instructions**
Refer to the configuration documentation. To enable framework thread pool for sub-DAG execution and message hand off, set `job.operator.framework.executor.enabled` to `true`

**Upgrade Instructions**
None