### PR TITLE
SAMZA-2797: Add flush to CoordinatorStreamSystemProducer and call it during CoordinatorStreamWriter stop

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/coordinator/stream/CoordinatorStreamSystemProducer.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/stream/CoordinatorStreamSystemProducer.java
@@ -111,6 +111,14 @@ public class CoordinatorStreamSystemProducer {
   }
 
   /**
+   * Flushes underlying system producer.
+   * */
+  public void flush(String source) {
+    log.info("Flushing coordinator stream producer.");
+    systemProducer.flush(source);
+  }
+
+  /**
    * Serialize and send a coordinator stream message.
    *
    * @param message

--- a/samza-core/src/main/java/org/apache/samza/coordinator/stream/CoordinatorStreamWriter.java
+++ b/samza-core/src/main/java/org/apache/samza/coordinator/stream/CoordinatorStreamWriter.java
@@ -65,6 +65,7 @@ public class CoordinatorStreamWriter {
    */
   public void stop() {
     log.info("Stopping the coordinator stream producer.");
+    coordinatorStreamSystemProducer.flush(SOURCE);
     coordinatorStreamSystemProducer.stop();
   }
 


### PR DESCRIPTION
# Description
- Some implementations of `SystemProducer` can have an async implementation of the send API. 
- `CoordinatorStreamWriter` writes only one message and closes the underlying `CoordinatorStreamSystemProducer` right after writes. There is a chance that the producer close will be called before the async write can complete.

# Changes
- This PR adds `flush` API to `CoordinatorStreamSystemProducer`
- We will call `flush` prior to `stop` in `CoordinatorStreamWriter` so that async messages are flushed out prior to stop

# Tests
- `./gradlew build`
- Tested with sample apps

# API Changes
None

# Usage Instructions
None

# Upgrade Instructions
None