### PR TITLE
SAMZA-2799: Remove worker.opts handling in shell command builder

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/job/ShellCommandBuilder.java
+++ b/samza-core/src/main/java/org/apache/samza/job/ShellCommandBuilder.java
@@ -46,8 +46,6 @@ public class ShellCommandBuilder extends CommandBuilder {
     envBuilder.put(ShellCommandConfig.ENV_JAVA_OPTS, shellCommandConfig.getTaskOpts().orElse(""));
     envBuilder.put(ShellCommandConfig.ENV_ADDITIONAL_CLASSPATH_DIR,
         shellCommandConfig.getAdditionalClasspathDir().orElse(""));
-    shellCommandConfig.getWorkerOpts()
-        .ifPresent(workerOpts -> envBuilder.put(ShellCommandConfig.WORKER_JVM_OPTS, workerOpts));
     shellCommandConfig.getJavaHome().ifPresent(javaHome -> envBuilder.put(ShellCommandConfig.ENV_JAVA_HOME, javaHome));
     return envBuilder.build();
   }

--- a/samza-core/src/test/java/org/apache/samza/job/TestShellCommandBuilder.java
+++ b/samza-core/src/test/java/org/apache/samza/job/TestShellCommandBuilder.java
@@ -60,7 +60,6 @@ public class TestShellCommandBuilder {
     Config config = new MapConfig(new ImmutableMap.Builder<String, String>()
         .put(ShellCommandConfig.COMMAND_SHELL_EXECUTE, "foo")
         .put(ShellCommandConfig.TASK_JVM_OPTS, "-Xmx4g")
-        .put(ShellCommandConfig.WORKER_JVM_OPTS, "-Xmx2g")
         .put(ShellCommandConfig.ADDITIONAL_CLASSPATH_DIR, "/path/to/additional/classpath")
         .put(ShellCommandConfig.TASK_JAVA_HOME, "/path/to/java/home")
         .build());
@@ -72,7 +71,6 @@ public class TestShellCommandBuilder {
         .put(ShellCommandConfig.ENV_CONTAINER_ID, "1")
         .put(ShellCommandConfig.ENV_COORDINATOR_URL, URL_STRING)
         .put(ShellCommandConfig.ENV_JAVA_OPTS, "-Xmx4g")
-        .put(ShellCommandConfig.WORKER_JVM_OPTS, "-Xmx2g")
         .put(ShellCommandConfig.ENV_ADDITIONAL_CLASSPATH_DIR, "/path/to/additional/classpath")
         .put(ShellCommandConfig.ENV_JAVA_HOME, "/path/to/java/home")
         .build();


### PR DESCRIPTION
**Description**
Remove worker.opts handling within `ShellCommandBuilder`. It is handled by beam internally and there is no other integration currently to have this integrated as part of the `ShellCommandBuilder` yet.

**Changes**
Remove worker.opts related changes in `ShellCommandBuilder`

**Tests**
Updated unit tests

**API Changes**: None; It shouldn't affect anything as it isn't used in samza container.

**Upgrade Instructions**: None

**Usage Instructions**: None