### PR TITLE
Create store directory paths in CSM constructor for disk space monitor

### DIFF
--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -44,7 +44,6 @@ import org.apache.samza.context.ContainerContext;
 import org.apache.samza.context.JobContext;
 import org.apache.samza.job.model.ContainerModel;
 import org.apache.samza.job.model.TaskMode;
-import org.apache.samza.job.model.TaskModel;
 import org.apache.samza.serializers.Serde;
 import org.apache.samza.serializers.SerdeManager;
 import org.apache.samza.storage.blobstore.BlobStoreStateBackendFactory;

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -200,10 +200,11 @@ public class ContainerStorageManager {
         ContainerStorageManagerUtil.getNonSideInputNonInMemoryStores(storageEngineFactories, sideInputStoreNames, config);
     for (String storeName : storesToCreate) {
       for (Map.Entry<TaskName, TaskModel> task : containerModel.getTasks().entrySet()) {
-            File storeDirPath = ContainerStorageManagerUtil.getStoreDirPath(storeName, config, activeTaskChangelogSystemStreams,
+        File storeDirPath =
+            ContainerStorageManagerUtil.getStoreDirPath(storeName, config, activeTaskChangelogSystemStreams,
                 sideInputStoreNames, task.getKey(), task.getValue(), storageManagerUtil, loggedStoreBaseDirectory,
                 nonLoggedStoreBaseDirectory);
-            storeDirectoryPaths.add(storeDirPath.toPath());
+        storeDirectoryPaths.add(storeDirPath.toPath());
       }
     }
 

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManager.java
@@ -23,8 +23,6 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManagerUtil.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManagerUtil.java
@@ -401,18 +401,6 @@ public class ContainerStorageManagerUtil {
     return sideInputStores;
   }
 
-  public static Set<String> getNonSideInputNonInMemoryStores(Map<String, StorageEngineFactory<Object, Object>> storageEngineFactories,
-      Set<String> sideInputStoreNames, Config config) {
-    Set<String> inMemoryStoreNames =
-        ContainerStorageManagerUtil.getInMemoryStoreNames(storageEngineFactories, config);
-    Set<String> nonSideInputStoreNames =
-        storageEngineFactories.keySet().stream().filter(storeName -> !sideInputStoreNames.contains(storeName))
-            .collect(Collectors.toSet());
-    Set<String> storeNames = nonSideInputStoreNames.stream()
-        .filter(s -> !inMemoryStoreNames.contains(s)).collect(Collectors.toSet());
-    return storeNames;
-  }
-
   public static Set<Path> getStoreDirPaths(Config config, Map<String, StorageEngineFactory<Object, Object>> storageEngineFactories,
       Map<String, SystemStream> activeTaskChangelogSystemStreams, Set<String> sideInputStoreNames,
       ContainerModel containerModel, StorageManagerUtil storageManagerUtil, File loggedStoreBaseDirectory,

--- a/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManagerUtil.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/ContainerStorageManagerUtil.java
@@ -70,7 +70,6 @@ public class ContainerStorageManagerUtil {
       Map<String, StorageEngineFactory<Object, Object>> storageEngineFactories,
       Set<String> sideInputStoreNames,
       Map<String, SystemStream> activeTaskChangelogSystemStreams,
-      Set<Path> storeDirectoryPaths,
       ContainerModel containerModel, JobContext jobContext, ContainerContext containerContext,
       Map<String, Serde<Object>> serdes,
       Map<TaskName, TaskInstanceMetrics> taskInstanceMetrics,
@@ -91,7 +90,6 @@ public class ContainerStorageManagerUtil {
       for (String storeName : storesToCreate) {
         File storeDirectory = getStoreDirPath(storeName, config, activeTaskChangelogSystemStreams,
             sideInputStoreNames, taskName, taskModel, storageManagerUtil, loggedStoreBaseDirectory, nonLoggedStoreBaseDirectory);
-        storeDirectoryPaths.add(storeDirectory.toPath());
 
         // if taskInstanceMetrics are specified use those for store metrics,
         // otherwise (in case of StorageRecovery) use a blank MetricsRegistryMap
@@ -156,7 +154,6 @@ public class ContainerStorageManagerUtil {
       Map<String, SystemStream> activeTaskChangelogSystemStreams,
       Map<String, StorageEngineFactory<Object, Object>> storageEngineFactories,
       Set<String> sideInputStoreNames,
-      Set<Path> storeDirectoryPaths,
       ContainerModel containerModel, JobContext jobContext, ContainerContext containerContext,
       Map<TaskName, TaskInstanceMetrics> taskInstanceMetrics,
       Map<TaskName, TaskInstanceCollector> taskInstanceCollectors,
@@ -167,8 +164,7 @@ public class ContainerStorageManagerUtil {
     Set<String> inMemoryStoreNames = getInMemoryStoreNames(storageEngineFactories, config);
     return ContainerStorageManagerUtil.createTaskStores(
         inMemoryStoreNames, storageEngineFactories, sideInputStoreNames,
-        activeTaskChangelogSystemStreams, storeDirectoryPaths,
-        containerModel, jobContext, containerContext, serdes,
+        activeTaskChangelogSystemStreams, containerModel, jobContext, containerContext, serdes,
         taskInstanceMetrics, taskInstanceCollectors, storageManagerUtil,
         loggedStoreBaseDirectory, nonLoggedStoreBaseDirectory, config);
   }
@@ -417,6 +413,28 @@ public class ContainerStorageManagerUtil {
     return storeNames;
   }
 
+  public static Set<Path> getStoreDirPaths(Config config, Map<String, StorageEngineFactory<Object, Object>> storageEngineFactories,
+      Map<String, SystemStream> activeTaskChangelogSystemStreams, Set<String> sideInputStoreNames,
+      ContainerModel containerModel, StorageManagerUtil storageManagerUtil, File loggedStoreBaseDirectory,
+      File nonLoggedStoreBaseDirectory) {
+    Set<Path> storeDirectoryPaths = new HashSet<>();
+    StorageConfig storageConfig = new StorageConfig(config);
+    Set<String> storeNames = new HashSet<>();
+    // Add all side input and regular stores
+    storeNames.addAll(storageConfig.getStoreNames());
+    // Add all in-memory store names
+    storeNames.addAll(getInMemoryStoreNames(storageEngineFactories, config));
+
+    for (String storeName : storeNames) {
+      for (Map.Entry<TaskName, TaskModel> task : containerModel.getTasks().entrySet()) {
+        File storeDirPath =
+            getStoreDirPath(storeName, config, activeTaskChangelogSystemStreams, sideInputStoreNames, task.getKey(),
+                task.getValue(), storageManagerUtil, loggedStoreBaseDirectory, nonLoggedStoreBaseDirectory);
+        storeDirectoryPaths.add(storeDirPath.toPath());
+      }
+    }
+    return storeDirectoryPaths;
+  }
   public static File getStoreDirPath(String storeName, Config config, Map<String, SystemStream> activeTaskChangelogSystemStreams,
       Set<String> sideInputStoreNames, TaskName taskName, TaskModel taskModel, StorageManagerUtil storageManagerUtil,
       File loggedStoreBaseDirectory, File nonLoggedStoreBaseDirectory) {

--- a/samza-core/src/main/scala/org/apache/samza/storage/SideInputsManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/SideInputsManager.java
@@ -119,7 +119,6 @@ public class SideInputsManager {
       Map<String, SystemStream> changelogSystemStreams,
       Map<String, SystemStream> activeTaskChangelogSystemStreams,
       Map<String, StorageEngineFactory<Object, Object>> storageEngineFactories,
-      Set<Path> storeDirectoryPaths,
       ContainerModel containerModel, JobContext jobContext, ContainerContext containerContext,
       SamzaContainerMetrics samzaContainerMetrics,
       Map<TaskName, TaskInstanceMetrics> taskInstanceMetrics,
@@ -147,8 +146,7 @@ public class SideInputsManager {
     // create side input taskStores for all tasks in the containerModel and each store in storageEngineFactories
     this.sideInputStores = ContainerStorageManagerUtil.createTaskStores(
         sideInputStoreNames, storageEngineFactories, sideInputStoreNames,
-        activeTaskChangelogSystemStreams, storeDirectoryPaths,
-        containerModel, jobContext, containerContext, serdes,
+        activeTaskChangelogSystemStreams, containerModel, jobContext, containerContext, serdes,
         taskInstanceMetrics, taskInstanceCollectors, storageManagerUtil,
         loggedStoreBaseDirectory, nonLoggedStoreBaseDirectory, config);
 

--- a/samza-core/src/main/scala/org/apache/samza/storage/SideInputsManager.java
+++ b/samza-core/src/main/scala/org/apache/samza/storage/SideInputsManager.java
@@ -26,7 +26,6 @@ import org.apache.samza.config.RunLoopConfig;
 import scala.collection.JavaConversions;
 
 import java.io.File;
-import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;


### PR DESCRIPTION
Fix for the bug: https://issues.apache.org/jira/browse/SAMZA-2752

What:
Set durable store names in a set in the ContainerStorageManager constructor

Why:
During previous refractoring, the createStore for durable stores was moved outside of constructor. However, the store directory paths are required to be set in constructor so that SamzaContainer class can set monitors for them. This patch sets the store names without creating the stores, so that monitoring can be set properly. 