### PR TITLE
Improve Samza AM retry count logging

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerProcessManager.java
+++ b/samza-core/src/main/java/org/apache/samza/clustermanager/ContainerProcessManager.java
@@ -572,9 +572,10 @@ public class ContainerProcessManager implements ClusterResourceManager.Callback 
 
       // if fail count is (1 initial failure + max retries) then fail job.
       if (currentFailCount > retryCount) {
-        LOG.error("Processor ID: {} (current Container ID: {}) has failed {} times, with last failure {} ms ago. " +
-                "This is greater than retry count of {} and window of {} ms, ",
-            processorId, containerId, currentFailCount, durationSinceLastRetryMs, retryCount, retryWindowMs);
+        LOG.error("Processor ID: {} (current Container ID: {}) has failed {} times. "
+                + "This is greater that the retry count of {}."
+                + "The failure occurred {} ms after the previous one, which is less than the retry window of {} ms.",
+            processorId, containerId, currentFailCount, retryCount, durationSinceLastRetryMs, retryWindowMs);
 
         // We have too many failures, and we're within the window
         // boundary, so reset shut down the app master.


### PR DESCRIPTION
LISAMZA-43659

**Description**: According to `org/apache/samza/clustermanager/ContainerProcessManager.java:520`

The rules to shut down the whole app if too many container failures have happened:

1. Failure count for a task group id must be > the configured retry count
2. The last failure (the one prior to this one) must have happened less than retry window ms ago

**Issue**: `org/apache/samza/clustermanager/ContainerProcessManager.java:575` doesn't reflect point 2 of the counting behavior well

> Processor ID: {} (current Container ID: {}) has failed {} times, with last failure {} ms ago. This is greater than retry count of {} and window of {} ms

**Fix**: Add to the logs information about point 2

> Processor ID: {} (current Container ID: {}) has failed {} times. This is greater than the retry count of {}. The failure occurred {} ms after the previous one, which is less than the retry window of {} ms."