### PR TITLE
Output Current Timestamp at run-class.sh script

### DIFF
--- a/docs/learn/documentation/versioned/api/beam-api.md
+++ b/docs/learn/documentation/versioned/api/beam-api.md
@@ -26,7 +26,7 @@ title: Apache Beam API
 
 ### Introduction
 
-Apache Beam brings an easy-to-usen but powerful API and model for state-of-art stream and batch data processing with portability across a variety of languages. The Beam API and model has the following characteristics:
+Apache Beam brings an easy-to-use but powerful API and model for state-of-art stream and batch data processing with portability across a variety of languages. The Beam API and model has the following characteristics:
 
 - *Simple constructs, powerful semantics*: the whole beam API can be simply described by a `Pipeline` object, which captures all your data processing steps from input to output. Beam SDK supports over [20 data IOs](https://beam.apache.org/documentation/io/built-in/), and data transformations from simple [Map](https://beam.apache.org/releases/javadoc/2.11.0/org/apache/beam/sdk/transforms/MapElements.html) to complex [Combines and Joins](https://beam.apache.org/releases/javadoc/2.11.0/index.html?org/apache/beam/sdk/transforms/Combine.html).
 

--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -22,6 +22,7 @@ repositories {
     maven {
       url "https://plugins.gradle.org/m2/"
     }
+    jcenter()
   }
 }
 

--- a/samza-shell/src/main/bash/run-class.sh
+++ b/samza-shell/src/main/bash/run-class.sh
@@ -28,6 +28,8 @@ cd $base_dir
 base_dir=`pwd`
 cd $home_dir
 
+echo "Current time: $(date '+%Y-%m-%d %H:%M:%S')"
+
 echo home_dir=$home_dir
 echo "framework base (location of this script). base_dir=$base_dir"
 


### PR DESCRIPTION
### Changes
1. Fix the typo in the beam API documentation
2. Print out the current timestamp at `run-class.sh` with stdout. Before making the change, which helps better monitor the job during container launch time, before container logs are available
3. Fix the build issue, which has the same symptom mentioned in https://issues.apache.org/jira/browse/SAMZA-2786

---
### Test

- [x] Tested in terminal: 
```
$ echo "Current time: $(date '+%Y-%m-%d %H:%M:%S')"
Current time: 2024-07-29 17:20:03
```

- [x] Ran `./gradlew build` sccessfully


