### PR TITLE
Handle transitive buildscript dependencies that were only present in JCenter

### DIFF
--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -19,10 +19,15 @@
 repositories {
   repositories {
     // For plugins listed below
-    maven {
-      url "https://plugins.gradle.org/m2/"
-    }
-    jcenter()
+    gradlePluginPortal()
+  }
+}
+
+configurations.classpath {
+  resolutionStrategy.dependencySubstitution {
+    substitute(module("com.burgstaller:okhttp-digest"))
+            .using(module("io.github.rburgst:okhttp-digest:1.21"))
+            .because('JCenter Shutdown - okhttp-digest 1.21 the minimum version available in Maven Central, but under the io.github.rburgst group')
   }
 }
 
@@ -30,4 +35,9 @@ dependencies {
   classpath 'de.obqo.gradle:gradle-lesscss-plugin:1.0-1.3.3'
   classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
   classpath 'com.github.jruby-gradle:jruby-gradle-plugin:2.0.2'
+  constraints {
+    classpath('org.ysb33r.gradle:grolifant:0.12.1') {
+      because 'JCenter Shutdown - grolifant 0.12.1 the minimum version available in Maven Central'
+    }
+  }
 }


### PR DESCRIPTION
The Samza build seems to be broken currently due to dependencies that were only downloadable from JCenter, which is now shutdown. In particular, `com.burgstaller:okhttp-digest:1.10` and `org.ysb33r.gradle:grolifant:0.12`, transitive dependencies of `com.github.jruby-gradle:jruby-gradle-plugin:2.0.2`, only existed in JCenter. This change fixes the broken Samza build by rewriting some buildscript dependencies that were only present in JCenter:

* Rewrites the group of `okhttp-digest` from `com.burgstaller` to `io.github.rburgst`
* Updates `okhttp-digest` from `1.10` to `1.21`
* Updates `grolifant` from `0.12` to `0.12.1`

Ideally, `jruby-gradle-plugin`, which transitively depends on these plugins would be updated to resolve these issue, but this change fixes the problems in the meantime. The plugin has not been updated or released in quite some time. 

**This PR has not well-tested to see how compatible these new versions are with the Samza build. My hope is that CI builds will verify functionality isn't affected.**

For more information, see:
* [Impact of final JCenter shutdown on Gradle Plugin Portal | Gradle Blog](https://blog.gradle.org/portal-jcenter-impact)
* https://github.com/jruby-gradle/jruby-gradle-plugin/issues/451
* https://github.com/rburgst/okhttp-digest/issues/86