### PR TITLE
BUG FIX: set target file size multiplier

### DIFF
--- a/samza-kv-rocksdb/src/main/java/org/apache/samza/storage/kv/RocksDbOptionsHelper.java
+++ b/samza-kv-rocksdb/src/main/java/org/apache/samza/storage/kv/RocksDbOptionsHelper.java
@@ -180,7 +180,7 @@ public class RocksDbOptionsHelper {
     }
 
     if (storeConfig.containsKey(ROCKSDB_COMPACTION_TARGET_FILE_SIZE_MULTIPLIER)) {
-      options.setTargetFileSizeBase(storeConfig.getLong(ROCKSDB_COMPACTION_TARGET_FILE_SIZE_MULTIPLIER));
+      options.setTargetFileSizeMultiplier(storeConfig.getInt(ROCKSDB_COMPACTION_TARGET_FILE_SIZE_MULTIPLIER));
     }
 
     if (storeConfig.containsKey(ROCKSDB_MAX_BACKGROUND_JOBS)) {


### PR DESCRIPTION
### Overview

documentation of `targetFileSizeBase` and `targetFileSizeMultiplier` is located [here](https://javadoc.io/static/org.rocksdb/rocksdbjni/7.8.3/org/rocksdb/Options.html#targetFileSizeBase--) (texted copied below)

> targetFileSizeBase determines a level-1 file size. Target file size for level L can be calculated by targetFileSizeBase * (targetFileSizeMultiplier ^ (L-1)) For example, if targetFileSizeBase is 2MB and target_file_size_multiplier is 10, then each file on level-1 will be 2MB, and each file on level 2 will be 20MB, and each file on level-3 will be 200MB. by default targetFileSizeBase is 64MB.

#### Before the change
https://github.com/apache/samza/blob/f9c3241b87ce5d7a568368d3ffec5dea174f7692/samza-kv-rocksdb/src/main/java/org/apache/samza/storage/kv/RocksDbOptionsHelper.java#L178-L184 
Behavior: 
- If `ROCKSDB_COMPACTION_TARGET_FILE_SIZE_BASE` is configured, the value of `ROCKSDB_COMPACTION_TARGET_FILE_SIZE_BASE` will be set as the target file size base. 
- If `ROCKSDB_COMPACTION_TARGET_FILE_SIZE_MULTIPLIER` is configured, the value of `ROCKSDB_COMPACTION_TARGET_FILE_SIZE_MULTIPLIER` will be set as the target file size base (it's wrong, and the file size multiplier should be set instead). 

#### After the change
Behavior: 
- If `ROCKSDB_COMPACTION_TARGET_FILE_SIZE_BASE` is configured, the value of `ROCKSDB_COMPACTION_TARGET_FILE_SIZE_BASE` will be set as the target file size base. 
- If `ROCKSDB_COMPACTION_TARGET_FILE_SIZE_MULTIPLIER` is configured, the value of `ROCKSDB_COMPACTION_TARGET_FILE_SIZE_MULTIPLIER` will be set as the file size multiplier.

---

### Tests
- [x] Run ./gradlew build