### PR TITLE
SAMZA-2801: Support excluding tasks from watermark computation when exceeding idle time

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
@@ -151,6 +151,9 @@ public class TaskConfig extends MapConfig {
   // so that the watermarks will still be generated from other active tasks.
   public static final String WATERMARK_IDLE_TIMEOUT_MS = "task.watermark.idle.timeout.ms";
   public static final long DEFAULT_TASK_WATERMARK_IDLE_TIMEOUT_MS = -1L;
+  // The quorum size required to generate watermarks when there are idle tasks.
+  public static final String WATERMARK_QUORUM_SIZE_PERCENTAGE = "task.watermark.quorum.size,percentage";
+  public static final double DEFAULT_WATERMARK_QUORUM_SIZE_PERCENTAGE = 0.5;
 
   public TaskConfig(Config config) {
     super(config);
@@ -410,5 +413,9 @@ public class TaskConfig extends MapConfig {
 
   public long getWatermarkIdleTimeoutMs() {
     return getLong(WATERMARK_IDLE_TIMEOUT_MS, DEFAULT_TASK_WATERMARK_IDLE_TIMEOUT_MS);
+  }
+
+  public double getWatermarkQuorumSizePercentage() {
+    return getDouble(WATERMARK_QUORUM_SIZE_PERCENTAGE, DEFAULT_WATERMARK_QUORUM_SIZE_PERCENTAGE);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
@@ -148,7 +148,7 @@ public class TaskConfig extends MapConfig {
   private static final boolean DEFAULT_TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE = true;
 
   public static final String WATERMARK_IDLE_MS = "task.watermark.idle.ms";
-  public static final long DEFAULT_TASK_WATERMARK_IDLE_MS = 600000;
+  public static final long DEFAULT_TASK_WATERMARK_IDLE_MS = -1L;
 
   public TaskConfig(Config config) {
     super(config);

--- a/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
@@ -147,6 +147,9 @@ public class TaskConfig extends MapConfig {
       "task.transactional.state.retain.existing.state";
   private static final boolean DEFAULT_TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE = true;
 
+  public static final String WATERMARK_IDLE_MS = "task.watermark.idle.ms";
+  public static final long DEFAULT_TASK_WATERMARK_IDLE_MS = 600000;
+
   public TaskConfig(Config config) {
     super(config);
   }
@@ -401,5 +404,9 @@ public class TaskConfig extends MapConfig {
 
   public boolean getTransactionalStateRetainExistingState() {
     return getBoolean(TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE, DEFAULT_TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE);
+  }
+
+  public long getWatermarkIdleMs() {
+    return getLong(WATERMARK_IDLE_MS, DEFAULT_TASK_WATERMARK_IDLE_MS);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
+++ b/samza-core/src/main/java/org/apache/samza/config/TaskConfig.java
@@ -147,8 +147,10 @@ public class TaskConfig extends MapConfig {
       "task.transactional.state.retain.existing.state";
   private static final boolean DEFAULT_TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE = true;
 
-  public static final String WATERMARK_IDLE_MS = "task.watermark.idle.ms";
-  public static final long DEFAULT_TASK_WATERMARK_IDLE_MS = -1L;
+  // This config allows excluding the tasks that have been "idle" in generating watermark for the configured time,
+  // so that the watermarks will still be generated from other active tasks.
+  public static final String WATERMARK_IDLE_TIMEOUT_MS = "task.watermark.idle.timeout.ms";
+  public static final long DEFAULT_TASK_WATERMARK_IDLE_TIMEOUT_MS = -1L;
 
   public TaskConfig(Config config) {
     super(config);
@@ -406,7 +408,7 @@ public class TaskConfig extends MapConfig {
     return getBoolean(TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE, DEFAULT_TRANSACTIONAL_STATE_RETAIN_EXISTING_STATE);
   }
 
-  public long getWatermarkIdleMs() {
-    return getLong(WATERMARK_IDLE_MS, DEFAULT_TASK_WATERMARK_IDLE_MS);
+  public long getWatermarkIdleTimeoutMs() {
+    return getLong(WATERMARK_IDLE_TIMEOUT_MS, DEFAULT_TASK_WATERMARK_IDLE_TIMEOUT_MS);
   }
 }

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImplGraph.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImplGraph.java
@@ -123,7 +123,7 @@ public class OperatorImplGraph {
     internalTaskContext.registerObject(WatermarkStates.class.getName(),
         new WatermarkStates(internalTaskContext.getSspsExcludingSideInputs(), producerTaskCounts,
             context.getContainerContext().getContainerMetricsRegistry(),
-            taskConfig.getWatermarkIdleMs()));
+            taskConfig.getWatermarkIdleTimeoutMs()));
 
     // set states for drain; don't include side inputs (see SAMZA-2303)
     internalTaskContext.registerObject(DrainStates.class.getName(),

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImplGraph.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/OperatorImplGraph.java
@@ -123,7 +123,8 @@ public class OperatorImplGraph {
     internalTaskContext.registerObject(WatermarkStates.class.getName(),
         new WatermarkStates(internalTaskContext.getSspsExcludingSideInputs(), producerTaskCounts,
             context.getContainerContext().getContainerMetricsRegistry(),
-            taskConfig.getWatermarkIdleTimeoutMs()));
+            taskConfig.getWatermarkIdleTimeoutMs(),
+            taskConfig.getWatermarkQuorumSizePercentage()));
 
     // set states for drain; don't include side inputs (see SAMZA-2303)
     internalTaskContext.registerObject(DrainStates.class.getName(),

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/WatermarkStates.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/WatermarkStates.java
@@ -58,6 +58,7 @@ class WatermarkStates {
     private final long createTime;
     private final LongSupplier systemTimeFunc;
     private volatile long watermarkTime = WATERMARK_NOT_EXIST;
+    private volatile int quorumCount = 0;
 
     WatermarkState(
             int expectedTotal,
@@ -107,6 +108,13 @@ class WatermarkStates {
 
           // Active tasks must exceed the quorum size
           minWatermark = (updateCount >= quorumSize && min != Long.MAX_VALUE) ? min : WATERMARK_NOT_EXIST;
+
+          // Log the current quorum count
+          if (this.quorumCount != updateCount) {
+            this.quorumCount = updateCount;
+            LOG.info("Current quorum count is {} for watermark aggregation, and the expected quorum size is {}",
+                    this.quorumCount, this.quorumSize);
+          }
         }
         watermarkTime = Math.max(watermarkTime, minWatermark);
       }

--- a/samza-core/src/main/java/org/apache/samza/operators/impl/WatermarkStates.java
+++ b/samza-core/src/main/java/org/apache/samza/operators/impl/WatermarkStates.java
@@ -80,11 +80,15 @@ class WatermarkStates {
       } else if (timestamps.size() == expectedTotal) {
         // For any intermediate streams, the expectedTotal is the upstream task count.
         // Check whether we got all the watermarks, and set the watermark to be the min.
-        // Exclude the tasks that have been idle in watermark emission.
-        Optional<Long> min = timestamps.entrySet().stream()
-                .filter(t -> currentTime - lastUpdateTime.get(t.getKey()) < watermarkIdleTime)
-                .map(Map.Entry::getValue)
-                .min(Long::compare);
+        Optional<Long> min;
+        if (watermarkIdleTime <= 0) {
+          min = timestamps.values().stream().min(Long::compare);
+        } else {
+          // Exclude the tasks that have been idle in watermark emission.
+          min = timestamps.entrySet().stream()
+                  .filter(t -> currentTime - lastUpdateTime.get(t.getKey()) < watermarkIdleTime)
+                  .map(Map.Entry::getValue).min(Long::compare);
+        }
         watermarkTime = min.orElse(timestamp);
       }
     }

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestWatermarkStates.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestWatermarkStates.java
@@ -23,12 +23,16 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.LongSupplier;
+
 import org.apache.samza.Partition;
+import org.apache.samza.config.TaskConfig;
 import org.apache.samza.metrics.MetricsRegistryMap;
 import org.apache.samza.system.IncomingMessageEnvelope;
 import org.apache.samza.system.SystemStream;
 import org.apache.samza.system.SystemStreamPartition;
 import org.apache.samza.system.WatermarkMessage;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -36,25 +40,37 @@ import static org.junit.Assert.assertEquals;
 import static org.apache.samza.operators.impl.WatermarkStates.WATERMARK_NOT_EXIST;
 
 public class TestWatermarkStates {
+  SystemStream input;
+  SystemStream intermediate;
+  Set<SystemStreamPartition> ssps;
+  SystemStreamPartition inputPartition0;
+  SystemStreamPartition intPartition0;
+  SystemStreamPartition intPartition1;
+  Map<SystemStream, Integer> producerCounts;
 
-  @Test
-  public void testUpdate() {
-    SystemStream input = new SystemStream("system", "input");
-    SystemStream intermediate = new SystemStream("system", "intermediate");
+  @Before
+  public void setup() {
+    input = new SystemStream("system", "input");
+    intermediate = new SystemStream("system", "intermediate");
 
-    Set<SystemStreamPartition> ssps = new HashSet<>();
-    SystemStreamPartition inputPartition0 = new SystemStreamPartition(input, new Partition(0));
-    SystemStreamPartition intPartition0 = new SystemStreamPartition(intermediate, new Partition(0));
-    SystemStreamPartition intPartition1 = new SystemStreamPartition(intermediate, new Partition(1));
+    ssps = new HashSet<>();
+    inputPartition0 = new SystemStreamPartition(input, new Partition(0));
+    intPartition0 = new SystemStreamPartition(intermediate, new Partition(0));
+    intPartition1 = new SystemStreamPartition(intermediate, new Partition(1));
     ssps.add(inputPartition0);
     ssps.add(intPartition0);
     ssps.add(intPartition1);
 
-    Map<SystemStream, Integer> producerCounts = new HashMap<>();
+    producerCounts = new HashMap<>();
     producerCounts.put(intermediate, 2);
+  }
 
+
+  @Test
+  public void testUpdate() {
     // advance watermark on input to 5
-    WatermarkStates watermarkStates = new WatermarkStates(ssps, producerCounts, new MetricsRegistryMap());
+    WatermarkStates watermarkStates = new WatermarkStates(ssps, producerCounts, new MetricsRegistryMap(),
+            TaskConfig.DEFAULT_TASK_WATERMARK_IDLE_MS);
     IncomingMessageEnvelope envelope = IncomingMessageEnvelope.buildWatermarkEnvelope(inputPartition0, 5L);
     watermarkStates.update((WatermarkMessage) envelope.getMessage(),
         envelope.getSystemStreamPartition());
@@ -100,4 +116,48 @@ public class TestWatermarkStates {
     // verify we got a watermark 6 (min) for int stream
     assertEquals(watermarkStates.getWatermark(intermediate), 6L);
   }
+
+  @Test
+  public void testIdle() {
+    WatermarkStates watermarkStates = new WatermarkStates(ssps, producerCounts, new MetricsRegistryMap(),
+            TaskConfig.DEFAULT_TASK_WATERMARK_IDLE_MS, new MockSystemTime());
+
+    WatermarkMessage watermarkMessage = new WatermarkMessage(1L, "task 0");
+    watermarkStates.update(watermarkMessage, intPartition0);
+    assertEquals(watermarkStates.getWatermarkPerSSP(intPartition0), WATERMARK_NOT_EXIST);
+    assertEquals(watermarkStates.getWatermark(intermediate), WATERMARK_NOT_EXIST);
+
+    watermarkMessage = new WatermarkMessage(5L, "task 1");
+    watermarkStates.update(watermarkMessage, intPartition0);
+    assertEquals(watermarkStates.getWatermarkPerSSP(intPartition0), 5L);
+    assertEquals(watermarkStates.getWatermark(intermediate), WATERMARK_NOT_EXIST);
+
+    watermarkMessage = new WatermarkMessage(6L, "task 0");
+    watermarkStates.update(watermarkMessage, intPartition1);
+    assertEquals(watermarkStates.getWatermarkPerSSP(intPartition1), WATERMARK_NOT_EXIST);
+    assertEquals(watermarkStates.getWatermark(intermediate), WATERMARK_NOT_EXIST);
+
+    // watermark from task 1 on int p1 to 4
+    watermarkMessage = new WatermarkMessage(10L, "task 1");
+    watermarkStates.update(watermarkMessage, intPartition1);
+    assertEquals(watermarkStates.getWatermarkPerSSP(intPartition1), 6L);
+    // verify we got a watermark 3 (min) for int stream
+    assertEquals(watermarkStates.getWatermark(intermediate), 5L);
+  }
+
+  static class MockSystemTime implements LongSupplier {
+    boolean firstTime = true;
+
+    @Override
+    public long getAsLong() {
+      if (firstTime) {
+        firstTime = false;
+        // Make the first task idle
+        return System.currentTimeMillis() - TaskConfig.DEFAULT_TASK_WATERMARK_IDLE_MS;
+      } else {
+        return System.currentTimeMillis();
+      }
+    }
+  }
+
 }

--- a/samza-core/src/test/java/org/apache/samza/operators/impl/TestWatermarkStates.java
+++ b/samza-core/src/test/java/org/apache/samza/operators/impl/TestWatermarkStates.java
@@ -40,6 +40,8 @@ import static org.junit.Assert.assertEquals;
 import static org.apache.samza.operators.impl.WatermarkStates.WATERMARK_NOT_EXIST;
 
 public class TestWatermarkStates {
+  static final long TASK_WATERMARK_IDLE_MS = 600000;
+
   SystemStream input;
   SystemStream intermediate;
   Set<SystemStreamPartition> ssps;
@@ -47,6 +49,8 @@ public class TestWatermarkStates {
   SystemStreamPartition intPartition0;
   SystemStreamPartition intPartition1;
   Map<SystemStream, Integer> producerCounts;
+
+
 
   @Before
   public void setup() {
@@ -120,7 +124,7 @@ public class TestWatermarkStates {
   @Test
   public void testIdle() {
     WatermarkStates watermarkStates = new WatermarkStates(ssps, producerCounts, new MetricsRegistryMap(),
-            TaskConfig.DEFAULT_TASK_WATERMARK_IDLE_MS, new MockSystemTime());
+            TASK_WATERMARK_IDLE_MS, new MockSystemTime());
 
     WatermarkMessage watermarkMessage = new WatermarkMessage(1L, "task 0");
     watermarkStates.update(watermarkMessage, intPartition0);
@@ -153,11 +157,10 @@ public class TestWatermarkStates {
       if (firstTime) {
         firstTime = false;
         // Make the first task idle
-        return System.currentTimeMillis() - TaskConfig.DEFAULT_TASK_WATERMARK_IDLE_MS;
+        return System.currentTimeMillis() - TASK_WATERMARK_IDLE_MS;
       } else {
         return System.currentTimeMillis();
       }
     }
   }
-
 }


### PR DESCRIPTION
Currently in the Samza event-time watermark aggregation logic, it will compute the watermark as the min of watermarks from all upstream tasks. However, in the lagging cases, the upstream task might not generate watermark for a long period. In this case, the new watermarks will not be generated and the downstream aggregation will be stuck.

To address this issue, this patch adds the logic to exclude the tasks that have been "idle" in generating watermark for a configured time, so that the aggregated watermarks will still be generated. Note this mechanism will unblock downstream, but also at the risk of moving event-time clock faster and the events from lagging tasks will become late arrivals.