### PR TITLE
Update org.ysb33r.gradle:grolifant version and use io.github.rburgst instead of com.burgstaller

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,15 @@ buildscript {
     mavenCentral()
   }
 
+  configurations.classpath {
+    resolutionStrategy.eachDependency {  details ->
+      if (details.requested.group == 'com.burgstaller' && details.requested.name == 'okhttp-digest' && details.requested.version == '1.10') {
+        details.useTarget "io.github.rburgst:${details.requested.name}:1.21"
+        details.because 'Dependency has moved'
+      }
+    }
+  }
+
   apply from: file('gradle/buildscript.gradle'), to: buildscript
 }
 

--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -30,4 +30,5 @@ dependencies {
   classpath 'de.obqo.gradle:gradle-lesscss-plugin:1.0-1.3.3'
   classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
   classpath 'com.github.jruby-gradle:jruby-gradle-plugin:2.0.2'
+  classpath 'org.ysb33r.gradle:grolifant:0.12.1'
 }


### PR DESCRIPTION
**Symptom**: 
Master build doesn't work. We run into the following exception:

```
 What went wrong:
A problem occurred configuring root project 'samza'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not find grolifant-0.12.jar (org.ysb33r.gradle:grolifant:0.12).
     Searched in the following locations:
         https://jcenter.bintray.com/org/ysb33r/gradle/grolifant/0.12/grolifant-0.12.jar
   > Could not find okhttp-digest-1.10.jar (com.burgstaller:okhttp-digest:1.10).
     Searched in the following locations:
         https://jcenter.bintray.com/com/burgstaller/okhttp-digest/1.10/okhttp-digest-1.10.jar
```

**Cause**:
- `okhttp-digest`'s group has been changed from `com.burgstaller` to `io.github.rburgst`
- `org.ysb33r.gradle:grolifant` v0.12 isn't available anymore on jcenter. This version gets transitively pulled in today.

**Changes**:
- Override `okhttp-digest`'s group from `com.burgstaller` to `io.github.rburgst`
- Pull in `org.ysb33r.gradle:grolifant` `0.12.1` instead

**Tests**:
- ./gradlew build

**API Changes**:
None

**Upgrade Instructions**: 
None

**Usage Instructions**: 
None