### PR TITLE
Fix exception message in BlobStoreUtil's getSnapshotIndex

### DIFF
--- a/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/BlobStoreUtil.java
+++ b/samza-core/src/main/java/org/apache/samza/storage/blobstore/util/BlobStoreUtil.java
@@ -185,7 +185,7 @@ public class BlobStoreUtil {
           .thenApplyAsync(f -> snapshotIndexSerde.fromBytes(indexBlobStream.toByteArray()), executor)
           .handle((snapshotIndex, ex) -> {
             if (ex != null) {
-              throw new SamzaException(String.format("Unable to deserialize SnapshotIndex bytes for blob ID: %s", blobId), ex);
+              throw new SamzaException(String.format("Unable to get SnapshotIndex blob. The blob ID is : %s", blobId), ex);
             }
             return snapshotIndex;
           });


### PR DESCRIPTION
**Bug**: 
`BlobStoreUtil`'s `getSnapshotIndex` method currently gets the `SnapshotIndex` blob using `BlobStoreManager#get` and deserializes it using `SnapshotIndexSerde`. We handle the exceptions encountered in the get step and deserialization step using the chained `handle` step. 
The error log ,however, tells thats the exception was due to deserialization. This is incorrect as the `handle` will get exceptions from any of the previous steps i.e get and not just the deserialization step.

**Changes**:
- Change `handle` message to reflect the correct exception message

**Tests**:
- ./gradlew build
- Added unit tests to assert if appropriate exception is thrown

**API Changes**:
None

**Upgrade Instructions**: 
None

**Usage Instructions**: 
None