### PR TITLE
Publish build scans to develocity.apache.org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         java-version: [ 8.0.232 ]
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - name: Cache Gradle packages
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           distribution: 'zulu'
 
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v4
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         java-version: [ 8.0.232 ]
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - name: Cache Gradle packages
         uses: actions/cache@v2

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,21 +17,20 @@
  * under the License.
  */
 plugins {
-  id 'com.gradle.enterprise' version '3.13.1'
-  id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.10'
+  id 'com.gradle.develocity' version '3.18.2'
+  id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
 }
 
 def isGithubActions = System.getenv('GITHUB_ACTIONS') != null
 def isJenkins = System.getenv('JENKINS_URL') != null
 def isCI = isGithubActions || isJenkins
 
-gradleEnterprise {
+develocity {
   server = "https://develocity.apache.org"
+  projectId = "samza"
   buildScan {
-    capture { taskInputFiles = true }
     uploadInBackground = !isCI
-    publishAlways()
-    publishIfAuthenticated()
+    publishing.onlyIf { it.isAuthenticated() }
     obfuscation {
       // This obfuscates the IP addresses of the build machine in the build scan.
       // Alternatively, the build scan will provide the hostname for troubleshooting host-specific issues.
@@ -45,7 +44,7 @@ buildCache {
     enabled = !isCI
   }
 
-  remote(gradleEnterprise.buildCache) {
+  remote(develocity.buildCache) {
     enabled = false
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,7 +26,7 @@ def isJenkins = System.getenv('JENKINS_URL') != null
 def isCI = isGithubActions || isJenkins
 
 gradleEnterprise {
-  server = "https://ge.apache.org"
+  server = "https://develocity.apache.org"
   buildScan {
     capture { taskInputFiles = true }
     uploadInBackground = !isCI

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,8 +17,8 @@
  * under the License.
  */
 plugins {
-  id 'com.gradle.develocity' version '3.18.2'
-  id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
+  id 'com.gradle.develocity' version '4.2.2'
+  id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.4.0'
 }
 
 def isGithubActions = System.getenv('GITHUB_ACTIONS') != null


### PR DESCRIPTION
This PR migrates the Samza project to publish Build Scans to the the new Develocity instance at develocity.apache.org.

Additionally, this PR migrates from the legacy Gradle Enterprise plugin to the renamed Develocity plugin and sets a projectId for use by Develocity.