### PR TITLE
Upgrade Gradle Enterprise plugin to Develocity 4.3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,14 @@ jobs:
     env:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          key: samza-ci-gradle-cache
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+
       - uses: actions/checkout@v2
 
       - name: Set up JDK ${{ matrix.java-version }}
@@ -37,8 +45,8 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: 'zulu'
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,16 +27,8 @@ jobs:
       matrix:
         java-version: [ 8.0.232 ]
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          key: samza-ci-gradle-cache
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-
       - uses: actions/checkout@v2
 
       - name: Set up JDK ${{ matrix.java-version }}
@@ -45,8 +37,8 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: 'zulu'
 
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,21 +17,20 @@
  * under the License.
  */
 plugins {
-  id 'com.gradle.enterprise' version '3.13.1'
-  id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.10'
+  id 'com.gradle.develocity' version '4.3.2'
+  id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.4.0'
 }
 
 def isGithubActions = System.getenv('GITHUB_ACTIONS') != null
 def isJenkins = System.getenv('JENKINS_URL') != null
 def isCI = isGithubActions || isJenkins
 
-gradleEnterprise {
-  server = "https://ge.apache.org"
+develocity {
+  server = "https://develocity.apache.org"
   buildScan {
-    capture { taskInputFiles = true }
+    capture { fileFingerprints = true }
     uploadInBackground = !isCI
-    publishAlways()
-    publishIfAuthenticated()
+    publishing.onlyIf { it.authenticated }
     obfuscation {
       // This obfuscates the IP addresses of the build machine in the build scan.
       // Alternatively, the build scan will provide the hostname for troubleshooting host-specific issues.
@@ -45,8 +44,9 @@ buildCache {
     enabled = !isCI
   }
 
-  remote(gradleEnterprise.buildCache) {
-    enabled = false
+  remote(develocity.buildCache) {
+    enabled = true
+    push = isCI
   }
 }
 


### PR DESCRIPTION
## Summary

- Upgrade `com.gradle.enterprise` 3.13.1 → `com.gradle.develocity` 4.3.2
- Upgrade `com.gradle.common-custom-user-data-gradle-plugin` 1.10 → 2.4.0
- Migrate `gradleEnterprise {}` DSL → `develocity {}` DSL
- Update server URL from `ge.apache.org` to `develocity.apache.org`
- Enable remote build cache (read-only for local builds, push on CI)

The Gradle Enterprise plugin was renamed to Develocity in version 3.17. The old `com.gradle.enterprise` plugin ID and `gradleEnterprise {}` DSL are deprecated. This aligns Samza with other Apache projects (Kafka, Groovy) that have already migrated.

The Develocity plugin 4.3.2 is compatible with Gradle 6.0+ and maintains full backward compatibility with the Samza build.