### PR TITLE
fix: Add required ASF policy links to footer

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -51,6 +51,16 @@
 
         <p>
           <script>document.write(new Date().getFullYear());</script> &copy; samza.apache.org</p>
+        <p>Apache Samza, Samza, Apache, the Apache logo, and the Apache Samza project logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.</p>
+        <p>
+          <a href="https://www.apache.org/">Foundation</a> |
+          <a href="https://www.apache.org/events/current-event.html">Events</a> |
+          <a href="https://www.apache.org/licenses/">License</a> |
+          <a href="https://www.apache.org/security/">Security</a> |
+          <a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a> |
+          <a href="https://www.apache.org/foundation/thanks.html">Thanks</a> |
+          <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</a>
+        </p>
       </div>
 
     </div>


### PR DESCRIPTION
The Samza website is failing 8 of 9 ASF website policy checks (https://whimsy.apache.org/site/):

- Foundation link (missing)
- Events (missing)
- License (missing)
- Thanks (missing)
- Security (missing)
- Sponsorship (missing)
- Trademarks (missing)
- Privacy (missing)

This adds trademark attribution and the standard ASF policy links to the Jekyll footer template.

See: https://www.apache.org/foundation/marks/pmcs
Checker: https://whimsy.apache.org/site/